### PR TITLE
Align infra docs with architecture

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -11,6 +11,7 @@ This directory contains core documentation for the shared infrastructure that po
 | [Gateway Architecture](./gateway-architecture.md)       | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
 | [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
 | [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
+| [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
 
 ---
 
@@ -21,3 +22,4 @@ All service-level design documents should refer to this directory for shared inf
 For example:
 
 > See [**Gateway Architecture**](./gateway-architecture.md), [**Deployment Environments**](./deployment-environments.md), or [**Protocol Bridging**](./protocol-bridging.md) for relevant infrastructure details.
+> Redis-backed session state is described in detail in [**Redis Architecture**](../system-architecture-redis.md).

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -11,7 +11,7 @@ FireMUD uses Docker Compose for local development and testing:
 ### 🔧 Docker Compose Characteristics
 
 - All services, including the gateway, are built locally via `Dockerfile`s.
-- Service discovery is handled by Docker's internal DNS (e.g., `game-server:8080`).
+- Service discovery is handled by Docker's internal DNS (e.g., `game-session-service:8080`).
 - Route URIs in Spring Cloud Gateway use static hostnames defined in `application-dev.yml`.
 - Docker Compose orchestrates container startup, but not readiness.
 
@@ -34,7 +34,7 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 ### 🔧 Kubernetes Characteristics
 
 - Services are deployed as Pods and exposed via Kubernetes Services.
-- DNS-based discovery is built into Kubernetes (e.g., `game-server.default.svc.cluster.local`).
+- DNS-based discovery is built into Kubernetes (e.g., `game-session-service.default.svc.cluster.local`).
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Configuration and secrets are managed through ConfigMaps and Secrets.
 - The cluster uses **IPVS** (or a similar load-balancing mode) to route service traffic efficiently.

--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -54,8 +54,9 @@ spring:
 ## 🔌 Telnet / TCP Bridging
 
 - Traditional MUD clients connect via **raw TCP** (Telnet protocol)
-- These are handled by a **dedicated TCP gateway service** (outside of Spring Cloud Gateway)
-- The TCP service acts as a **bridge**, creating a WebSocket connection through the Gateway to normalize legacy TCP traffic
+- These connections are terminated by a **dedicated TCP Proxy Service** outside of Spring Cloud Gateway
+- The TCP Proxy Service acts as a **bridge**, creating a WebSocket connection through the Gateway to normalize legacy TCP traffic
+  - Spring Cloud Gateway itself only handles **HTTP** and **WebSocket** traffic
 
 This pattern ensures all real-time gameplay is unified through WebSocket on the backend, regardless of client type.
 

--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -11,7 +11,7 @@ FireMUD enables real-time interaction through two types of client connections:
 | Client Type             | Protocol       | Entry Point                     |
 |-------------------------|----------------|----------------------------------|
 | Web-based clients       | WebSocket      | Spring Cloud Gateway (`/ws/**`) |
-| Traditional MUD clients | TCP (Telnet)   | TCP Gateway Service (custom)    |
+| Traditional MUD clients | TCP (Telnet)   | TCP Proxy Service (custom)      |
 
 Despite their differences, both protocols are normalized into the same internal architecture using a **WebSocket-based session layer**.
 
@@ -35,7 +35,7 @@ Despite their differences, both protocols are normalized into the same internal 
 
 - Used by traditional MUD clients (e.g., MUDlet, TinTin++, GMud).
 - Clients connect using raw TCP (typically Telnet-compatible).
-- Handled by a dedicated **TCP Gateway Service** (not Spring-based).
+- Handled by a dedicated **TCP Proxy Service** (not Spring-based).
 - The service:
   - Accepts and parses Telnet line-based input.
   - Normalizes the connection.
@@ -59,7 +59,7 @@ The `game-session-service` is the central component responsible for:
 - Sending and receiving text streams in a line-based protocol format.
 - Managing disconnects, reconnections, and session cleanup.
 
-> Whether a client is connected via WebSocket directly or tunneled through the TCP gateway, the backend **treats all sessions the same**.
+> Whether a client is connected via WebSocket directly or tunneled through the TCP Proxy Service, the backend **treats all sessions the same**.
 
 ---
 

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -22,7 +22,7 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 - **Feature flags are defined at design-time in the Game Design Service and toggled at runtime by the Game Session Service**  
 - 🔁 **One session per character is allowed** — logging in from another client forcibly transfers control to the new session and terminates the old one
 
-🖼️ See also: [System Architecture Diagram](./system-architecture/system-architecture-diagram.md)
+🖼️ See also: [System Architecture Diagram](./system-architecture-diagram.md)
 
 ---
 
@@ -145,7 +145,7 @@ FireMUD uses a unified observability pipeline:
 
 ## 🔎 Notes on Responsibility Alignment
 
-- Functional responsibilities are defined in the [Responsibility Matrix](./system-architecture/responsibility-matrix.md)  
+- Functional responsibilities are defined in the [Service Responsibility Matrix](./service-responsibility-matrix.md)  
 - **Game Session** orchestrates tick lifecycles, retries, and session management  
 - **Game Logic** resolves individual actions deterministically based on input state  
 - **Redis** acts as a passive, high-speed execution substrate — storing volatile state and enabling atomic coordination via Lua scripts
@@ -158,12 +158,12 @@ Game Session governs pacing, conflict handling, and orchestration across distrib
 
 ## 📚 Related Documentation
 
-- [Tick System and Runtime Design](./system-architecture/system-architecture-ticks.md)
+- [Tick System and Runtime Design](./system-architecture-ticks.md)
 - [Redis Architecture](./system-architecture-redis.md)
 - [Reconnection Strategy](./system-architecture-reconnection.md)
 - [Authentication & Authorization](./system-architecture-authentication.md)
-- [Microservices Responsibility Matrix](./system-architecture/responsibility-matrix.md)
-- [System Architecture Diagram](./system-architecture/system-architecture-diagram.md)
+- [Microservices Responsibility Matrix](./service-responsibility-matrix.md)
+- [System Architecture Diagram](./system-architecture-diagram.md)
 - [Infrastructure Overview](./infrastructure/README.md)
 - [Gateway Architecture](./infrastructure/gateway-architecture.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)


### PR DESCRIPTION
## Summary
- fix broken links in system architecture overview
- standardize service discovery examples
- clarify TCP Proxy Service vs Spring Cloud Gateway
- cross-reference Redis architecture from infra overview

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6864d2eff44483309903e6b68d92288c