### PR TITLE
Align infrastructure docs with architecture

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -34,6 +34,8 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 ### 🔧 Kubernetes Characteristics
 
 - Services are deployed as Pods and exposed via Kubernetes Services.
+- The **TCP Proxy** and **Spring Cloud Gateway** are typically exposed using
+  Kubernetes `LoadBalancer` Services so external clients can connect directly.
 - DNS-based discovery is built into Kubernetes (e.g., `game-session-service.default.svc.cluster.local`).
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Configuration and secrets are managed through ConfigMaps and Secrets.

--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -10,7 +10,10 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 
 - Built as a Spring Boot microservice
 - Handles **client** request routing, filtering, CORS, rate limiting, retries, and monitoring
-- May validate JWTs for admin or REST APIs, but **gameplay `LOGIN`** requests are handled by the **Game Session Service**
+- May validate JWTs for admin or REST APIs (see
+  [Authentication & Authorization](../system-architecture-authentication.md) for
+  token flow), but **gameplay `LOGIN`** requests are handled by the
+  **Game Session Service** and gameplay clients do **not** carry JWTs
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
@@ -64,9 +67,9 @@ This pattern ensures all real-time gameplay is unified through WebSocket on the 
 
 ## 🔐 Centralized Gateway Benefits
 
-Spring Cloud Gateway provides centralized management of client traffic, offering:
-
-- Optional JWT validation for admin or REST endpoints
+- Spring Cloud Gateway provides centralized management of client traffic, offering:
+- Optional JWT validation for admin or REST endpoints (gameplay clients do not
+  provide JWTs)
 - Cross-cutting filters (e.g., rate limiting, logging, CORS)
 - Service isolation through route-based access control
 - Easy expansion of routes for new microservices

--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -41,6 +41,11 @@ Despite their differences, both protocols are normalized into the same internal 
   - Normalizes the connection.
   - **Creates a WebSocket connection to the backend** on behalf of the TCP client.
   - Proxies I/O between the TCP client and the backend game session.
+  - Buffers active input while the client remains connected and discards it if
+    the TCP connection drops.
+  - Telnet clients keep a sticky connection to the TCP Proxy; reconnection and
+    session recovery are handled as described in
+    [Reconnection Strategy](../system-architecture-reconnection.md).
 
 ### 🌟 TCP Flow Benefits
 

--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -44,7 +44,7 @@ This enables:
 
 ## 🧾 JWT Format and Role Claims
 
-Internal JWTs are issued by the Account Service and used for backend gRPC authorization. Clients **never** store or transmit tokens.
+Internal JWTs are issued by the Account Service and used for backend gRPC authorization. Gameplay clients **never** store or transmit tokens. Admin UIs may supply JWTs for optional validation at the Gateway.
 
 ### 🧠 Claims
 


### PR DESCRIPTION
## Summary
- mention LoadBalancer usage for TCP Proxy and Gateway
- clarify sticky connections and buffering in protocol bridging doc
- link Gateway doc with authentication and clarify JWT usage
- clarify token usage in authentication doc

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6864d77e8f188330b00e41216723bb5b