### PR TITLE
Add Alertmanager to monitoring docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
 - **CI/CD**: GitHub Actions
-- **Monitoring and Logging**: Prometheus, Grafana, Loki
+- **Monitoring and Logging**: Prometheus, Grafana, Loki, Alertmanager
 
 #### Monetization
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -6,7 +6,7 @@ Centralized logging and administration tools for the platform. Collects log data
 
 ## Architecture / Design Notes
 
-- Aggregates logs and metrics using the ELK/Prometheus stack.
+- Aggregates logs and metrics using the ELK/Prometheus stack with Alertmanager for alerting.
 - Exposes admin endpoints for reviewing logs and applying moderation actions.
 
 ## Key Features
@@ -17,9 +17,9 @@ Centralized logging and administration tools for the platform. Collects log data
 
 ## Dependencies
 
-- **External:** Elasticsearch, Prometheus, and Grafana for storage and visualization.
+- **External:** Elasticsearch, Prometheus, Grafana, and Alertmanager for storage, visualization, and alerting.
 
 ## Future Enhancements
 
 - Role-based admin UI.
-- Automated alerting for suspicious activity.
+- Automated alerting for suspicious activity via Prometheus Alertmanager.

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -124,8 +124,9 @@ FireMUD uses a unified observability pipeline:
 
 ### 📈 Metrics and Tracing
 
-- Prometheus metrics from all services  
-- OpenTelemetry spans across ticks  
+- Prometheus metrics from all services
+- Prometheus Alertmanager triggers alerts for outages or latency spikes
+- OpenTelemetry spans across ticks
 - 🔗 See [Redis Architecture](./system-architecture-redis.md#📈-observability-and-reliability) for Redis-specific metrics
 
 ---

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -143,6 +143,7 @@ FireMUD actively monitors Redis performance and tick health:
   - Retry queue depth
   - Keyspace and memory usage
 - **Grafana dashboards** visualize tick throughput and hotspots
+- **Prometheus Alertmanager** sends alerts if metrics exceed thresholds
 - **Graceful degradation** logic reduces gameplay interruption if Redis temporarily stalls
 - Redis is the **only** volatile coordination layer — no per-service caches are used
 

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -41,7 +41,7 @@ Deployment:
 
 - Docker, Kubernetes
 - GitHub Actions (CI/CD)
-- Prometheus, Grafana, Loki
+- Prometheus, Grafana, Loki, Alertmanager
 
 Testing:
 

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -17,7 +17,7 @@ This document outlines high-level design and technology assumptions for the Fire
 - **Real-Time Networking**: WebSocket/TCP
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
-- **Monitoring & Logging**: Prometheus, Grafana, Loki
+- **Monitoring & Logging**: Prometheus, Grafana, Loki, Alertmanager
 - **CI/CD**: GitHub Actions
 - **Payment Gateway**: Stripe (with custom subscription integration)
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -49,7 +49,7 @@ This checklist is structured to **build foundational features first**, followed 
 - [ ] **Set up Docker and Kubernetes for containerized deployment**
 - [ ] **Implement service discovery for internal microservices (Spring Cloud, Eureka, Consul, or Kubernetes-native)**
   - [ ] Ensure common package includes service discovery utilities
-- [ ] **Set up centralized logging & monitoring (ELK Stack, Grafana, Prometheus, Loki)**
+- [ ] **Set up centralized logging & monitoring (ELK Stack, Grafana, Prometheus, Loki, Alertmanager)**
 - [ ] **Define security best practices (OAuth2, JWT, RBAC, input validation, rate-limiting)**
   - [ ] Ensure authentication utilities from common package integrate seamlessly
 


### PR DESCRIPTION
## Summary
- document use of Prometheus Alertmanager across the platform
- mention alerting in Logging & Admin Service design
- update monitoring stack references in project docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864d33adf408330bda99514077c8f40