### PR TITLE
Align architecture and infrastructure docs

### DIFF
--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -17,8 +17,10 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
+- Telnet clients keep a **persistent TCP connection** to the TCP Proxy; the Gateway
+  itself does not hold session state between reconnects
 
-> **Important:**  
+> **Important:**
 > Spring Cloud Gateway is responsible for routing **only external client requests**.  
 > **Internal microservice-to-microservice communication does not pass through the Gateway**.
 > Microservices use Kubernetes native service discovery and DNS for direct communication.
@@ -75,6 +77,14 @@ Spring Cloud Gateway provides centralized management of client traffic, offering
 - Service isolation through route-based access control
 - Easy expansion of routes for new microservices
 
+## 🔗 Internal gRPC Communication
+
+Internal services communicate directly with each other over **gRPC**.
+Spring Cloud Gateway does not handle these calls. Each service discovers
+its peers via Docker or Kubernetes DNS and connects using the service name.
+This approach minimizes latency and matches the protocol table in the
+[System Architecture Overview](../system-architecture-overview.md#🌐-communication-flows).
+
 ---
 
 ## 🔧 Dev vs. Prod Configuration
@@ -93,5 +103,6 @@ Spring profiles (`application-dev.yml`, `application-prod.yml`) are used to conf
 - [Infrastructure Overview](./README.md)
 - [Deployment Environments](./deployment-environments.md)
 - [Protocol Bridging](./protocol-bridging.md)
+- [Reconnection Strategy](../system-architecture-reconnection.md)
 
 ---

--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -83,3 +83,4 @@ Both connection types interface with:
 - [Infrastructure Overview](./README.md)
 - [Gateway Architecture](./gateway-architecture.md)
 - [Deployment Environments](./deployment-environments.md)
+- [Reconnection Strategy](../system-architecture-reconnection.md)

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -142,6 +142,10 @@ FireMUD uses a unified observability pipeline:
 | Service Layer          | Microservices (Account, Entity, World, Logic, etc.)          |
 | Infrastructure Layer   | Kubernetes with IPVS, Docker Compose (for local development) |
 
+Deployment health checks (readiness and liveness probes) for these layers are
+described in detail in
+[Deployment Environments](./infrastructure/deployment-environments.md).
+
 ---
 
 ## 🔎 Notes on Responsibility Alignment


### PR DESCRIPTION
## Summary
- clarify sticky connections and gateway state
- document internal gRPC communication
- cross-link reconnection strategy in infrastructure docs
- link deployment health checks from architecture overview

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6864dfad116c83308e97bbf6a18ff3e6