### PR TITLE
Align infra docs with architecture

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -12,6 +12,7 @@ This directory contains core documentation for the shared infrastructure that po
 | [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
 | [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
 | [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
+| [System Architecture Overview](../system-architecture-overview.md) | High-level design with observability and service interactions. |
 
 ---
 
@@ -23,3 +24,4 @@ For example:
 
 > See [**Gateway Architecture**](./gateway-architecture.md), [**Deployment Environments**](./deployment-environments.md), or [**Protocol Bridging**](./protocol-bridging.md) for relevant infrastructure details.
 > Redis-backed session state is described in detail in [**Redis Architecture**](../system-architecture-redis.md).
+> Observability and metrics integrations are outlined in the [**System Architecture Overview**](../system-architecture-overview.md#📊-observability-and-monitoring).

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -40,6 +40,8 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Configuration and secrets are managed through ConfigMaps and Secrets.
 - The cluster uses **IPVS** (or a similar load-balancing mode) to route service traffic efficiently.
+- Redis runs as a clustered StatefulSet with automatic failover. Details are in [Redis Architecture](../system-architecture-redis.md).
+- PostgreSQL is deployed within the cluster (or provided as a managed database service) to store persistent domain data. See [System Architecture Overview](../system-architecture-overview.md#📦-data-and-state-management).
 
 ### 🩺 Kubernetes Health Monitoring
 
@@ -53,6 +55,13 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
   - Removes unready pods from Services
   - Restarts failing pods based on probe failures
   - Scales services up/down via deployments or Horizontal Pod Autoscalers (HPA)
+
+### 📈 Monitoring Stack
+
+- Prometheus scrapes metrics from all services.
+- Grafana dashboards visualize performance metrics.
+- Alertmanager notifies on failures or latency spikes.
+- See [System Architecture Overview](../system-architecture-overview.md#📊-observability-and-monitoring) for design details.
 
 ---
 
@@ -68,7 +77,7 @@ Spring Boot services use environment-specific profiles:
 - `application-prod.yml`:
   - Used in Kubernetes
   - DNS-based routing to Kubernetes Services
-  - Integration with persistent infrastructure (e.g., cloud-hosted databases)
+  - Integration with persistent infrastructure such as the PostgreSQL cluster
 
 ---
 

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -33,7 +33,7 @@ FireMUD supports seamless gameplay recovery through a layered reconnection model
 | Layer               | Responsibility                                               |
 |--------------------|---------------------------------------------------------------|
 | TCP Proxy          | Buffers Telnet input; clears on disconnect                    |
-| Spring Gateway     | Stateless; re-establishes backend connections on reconnect    |
+| Spring Cloud Gateway     | Stateless; re-establishes backend connections on reconnect    |
 | Game Session       | Restores gameplay session using Redis                         |
 
 > 🔗 See [Reconnection Strategy](./system-architecture-reconnection.md) for full details on session resumption, reauthentication, and failure handling.
@@ -128,6 +128,7 @@ FireMUD uses a unified observability pipeline:
 - Prometheus Alertmanager triggers alerts for outages or latency spikes
 - OpenTelemetry spans across ticks
 - 🔗 See [Redis Architecture](./system-architecture-redis.md#📈-observability-and-reliability) for Redis-specific metrics
+- 🔗 See [Infrastructure Overview](./infrastructure/README.md#🔀-core-infrastructure-docs) for deployment-specific monitoring integration
 
 ---
 

--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -9,7 +9,7 @@ FireMUD enables seamless gameplay recovery across network interruptions, client 
 | Layer              | Responsibility                                                               |
 |-------------------|-------------------------------------------------------------------------------|
 | **TCP Proxy**      | Parses Telnet input; clears input buffer on disconnect                        |
-| **Spring Gateway** | Stateless WebSocket passthrough; re-establishes backend connection automatically |
+| **Spring Cloud Gateway** | Stateless WebSocket passthrough; re-establishes backend connection automatically |
 | **Game Session**   | Restores session from Redis; rebinds socket, tick region, and timers          |
 
 Each layer handles fault tolerance independently.  


### PR DESCRIPTION
## Summary
- fix naming for Spring Cloud Gateway in architecture docs
- link to metrics and monitoring details from infrastructure and architecture docs
- note Redis cluster and PostgreSQL deployment in Kubernetes
- add monitoring stack details for production

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864e77045cc8330bf7684252ff77431