### PR TITLE
Align docs on gateway auth and reconnection

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -13,6 +13,7 @@ This directory contains core documentation for the shared infrastructure that po
 | [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
 | [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
 | [System Architecture Overview](../system-architecture-overview.md) | High-level design with observability and service interactions. |
+| [System Architecture Diagram](../system-architecture-diagram.md) | Visual representation of component relationships and client flows. |
 
 ---
 
@@ -25,3 +26,4 @@ For example:
 > See [**Gateway Architecture**](./gateway-architecture.md), [**Deployment Environments**](./deployment-environments.md), or [**Protocol Bridging**](./protocol-bridging.md) for relevant infrastructure details.
 > Redis-backed session state is described in detail in [**Redis Architecture**](../system-architecture-redis.md).
 > Observability and metrics integrations are outlined in the [**System Architecture Overview**](../system-architecture-overview.md#📊-observability-and-monitoring).
+> Client reconnection flow is covered in the [**Reconnection Strategy**](../system-architecture-reconnection.md).

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -36,6 +36,7 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - Services are deployed as Pods and exposed via Kubernetes Services.
 - The **TCP Proxy** and **Spring Cloud Gateway** are typically exposed using
   Kubernetes `LoadBalancer` Services so external clients can connect directly.
+- The TCP Proxy buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here, while the Gateway remains stateless.
 - DNS-based discovery is built into Kubernetes (e.g., `game-session-service.default.svc.cluster.local`).
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Configuration and secrets are managed through ConfigMaps and Secrets.

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -11,7 +11,7 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 - **TCP Proxy Service** accepts Telnet connections and upgrades them to WebSocket for the Gateway  
 - **Consistent end-to-end WebSocket flow**: Telnet (TCP) → TCP Proxy (WebSocket upgrade) → Spring Cloud Gateway → Game Session Service  
 - **All client traffic is routed through the Spring Cloud Gateway**, ensuring centralized **traffic routing, monitoring, and observability**  
-  > 🛑 **Authentication is not performed at the Gateway** — all `LOGIN` handling and session validation occurs in the **Game Session Service**
+  > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens
 - **Spring Cloud Gateway is fully horizontally scalable and stateless**, with no sticky session requirements  
 - **Telnet clients maintain sticky TCP connections only to the TCP Proxy**, which buffers **active input**, but **discards it across reconnects**  
 - **Reconnection logic is handled in layers** to preserve gameplay continuity  


### PR DESCRIPTION
## Summary
- clarify where gameplay login is handled in the architecture overview
- link the infrastructure docs to the system diagram and reconnection guide
- describe TCP Proxy buffering in deployment environments

## Testing
- `echo "No tests configured"`

------
https://chatgpt.com/codex/tasks/task_e_6864eac86cf48330a4a483411f76c693