### PR TITLE
Update logging stack docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
  - **CI/CD**: [GitHub Actions](design/architecture/system-architecture-cicd.md)
-- **Monitoring and Logging**: Prometheus, Grafana, Loki, Alertmanager
+ - **Monitoring and Logging**: Prometheus, Grafana, Elasticsearch, Alertmanager
 
 #### Monetization
 

--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -18,6 +18,10 @@ This directory contains core documentation for the shared infrastructure that po
 
 ---
 
+## 📜 Logging Stack
+
+Logs from each service are collected by Fluent Bit sidecars and forwarded to Elasticsearch for indexing and search.
+
 ## 🧭 Usage
 
 All service-level design documents should refer to this directory for shared infrastructure context, rather than duplicating gateway, deployment, or protocol behavior.

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -64,6 +64,11 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - Alertmanager notifies on failures or latency spikes.
 - See [System Architecture Overview](../system-architecture-overview.md#📊-observability-and-monitoring) for design details.
 
+### 📜 Logging Stack
+
+- Fluent Bit collects structured logs from each service.
+- Logs are forwarded to Elasticsearch for indexing and search.
+
 ---
 
 ## 🔁 Spring Profile Configuration

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -6,7 +6,8 @@ Centralized logging and administration tools for the platform. Collects log data
 
 ## Architecture / Design Notes
 
-- Aggregates logs and metrics using the ELK/Prometheus stack with Alertmanager for alerting.
+- Aggregates logs using Fluent Bit and Elasticsearch.
+- Prometheus collects metrics with Alertmanager handling alerts.
 - Exposes admin endpoints for reviewing logs and applying moderation actions.
 
 ## Key Features

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -17,7 +17,7 @@ This document outlines high-level design and technology assumptions for the Fire
 - **Real-Time Networking**: WebSocket/TCP
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
-- **Monitoring & Logging**: Prometheus, Grafana, Loki, Alertmanager
+- **Monitoring & Logging**: Prometheus, Grafana, Elasticsearch, Alertmanager
 - **CI/CD**: [GitHub Actions](../architecture/system-architecture-cicd.md)
 - **Payment Gateway**: Stripe (with custom subscription integration)
 


### PR DESCRIPTION
## Summary
- clarify the chosen logging solution in README and design assumptions
- describe Fluent Bit -> Elasticsearch flow in deployment docs
- adjust logging-admin-service notes for Elasticsearch
- add logging stack section to infrastructure README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6864f174046483308b12efaf10e2f5eb