### PR TITLE
Update docs to remove Game Management Service

### DIFF
--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -73,7 +73,8 @@ The `game-session-service` is the central component responsible for:
 Both connection types interface with:
 
 - **Player Management** — for identity, login, and session tracking.
-- **Game Management** — for assigning or creating new game instances.
+- **Game Design Service** — for game templates and version data.
+- **Game Session Service** — for starting or joining live game instances.
 - **World Management** — for game world data, rooms, NPCs, etc.
 
 ---

--- a/design/architecture/system-architecture-diagram.md
+++ b/design/architecture/system-architecture-diagram.md
@@ -22,9 +22,9 @@
        +--------------------+----------------------------+--------------------+
        |                    |                            |                    |
        v                    v                            v                    v
-Game Management      Account Service              Entity Management     World Management
+Game Design         Account Service              Entity Management     World Management
     Service              (Auth)                    Service (Players,        Service
- (Backups, Rules)                                  NPCs, Items)          (Maps/Rooms)
+ (Templates, Backups)                             NPCs, Items)          (Maps/Rooms)
 
                               +-----------+-------------+
                               | Game Logic Service      |

--- a/design/project-management/issues-working.md
+++ b/design/project-management/issues-working.md
@@ -33,12 +33,12 @@ List of things in Design currently being worked on.
   - [ ] Holding current `version_id`/manifest for each live game.
 - [ ] Clarify distinction between **player session management** and **game instance orchestration**.
 
-### 📦 Deprecating Game Management Service
+### 📦 Game Management Service Deprecation (Completed)
 
-- [ ] Eliminate `Game Management Service` as a standalone service.
-- [ ] Redistribute responsibilities:
-  - [ ] Game creation, templates → `Game Design Service`.
-  - [ ] Game instance start/stop → `Game Session Service`.
-  - [ ] Game metadata/versioning → `Game Design Service`.
-  - [ ] Moderation policies → `Logging & Admin Service`.
-  - [ ] Ownership relations → `Account Service`.
+The former Game Management Service has been removed. Responsibilities were redistributed:
+
+- Game creation and templates → `Game Design Service`.
+- Game instance start/stop → `Game Session Service`.
+- Game metadata/versioning → `Game Design Service`.
+- Moderation policies → `Logging & Admin Service`.
+- Ownership relations → `Account Service`.

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -55,7 +55,7 @@ This checklist is structured to **build foundational features first**, followed 
 
 ---
 
-## **🛠️ Phase 2: Account & Game Management**
+## **🛠️ Phase 2: Account & Game Operations**
 
 - [ ] **Develop Account Service**
   - [ ] Implement user registration and authentication (OAuth2, JWT)
@@ -65,10 +65,12 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Implement profile system with achievements, game history, and social features
   - [ ] Implement player data export & deletion (GDPR compliance)
 
-- [ ] **Develop Game Management Service**
-  - [ ] Implement game creation and configuration
-  - [ ] Implement multi-tenancy support for multiple hosted games
-  - [ ] Implement game templates for hosted game creation
+- [ ] **Expand Game Session Service**
+  - [ ] Implement game instance lifecycle (start, stop, restart)
+  - [ ] Support multi-tenancy for hosted games
+- [ ] **Expand Game Design Service**
+  - [ ] Provide game templates and configuration tools
+  - [ ] Enable publishing of game versions
 
 - [ ] **Develop Email & Notification System**
   - [ ] Implement email verification & password resets


### PR DESCRIPTION
## Summary
- remove Game Management Service from system architecture diagram
- fix protocol bridging integration points to reference new services
- mark Game Management Service as deprecated in issues-working doc
- revise task list for new game operation services

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864f1893d588330ab9876aed69f62eb