### PR TITLE
Add gRPC API style guidelines

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -7,5 +7,6 @@ The architecture section describes the platform infrastructure and each microser
 - **service-responsibility-matrix.md** – Summary of which service handles what.
 - **system-architecture-overview.md** – High-level diagrams and interactions.
 - **system-architecture-cicd.md** – CI/CD pipeline design using GitHub Actions.
+- **system-architecture-grpc.mc** – Conventions for proto layout, versioning, and tooling.
 
 Refer to the README files within each subdirectory for more details.

--- a/design/architecture/system-architecture-grpc.mc
+++ b/design/architecture/system-architecture-grpc.mc
@@ -1,0 +1,61 @@
+# 📦 gRPC API Style & Versioning Guidelines
+
+These guidelines define how FireMUD microservices design and document their gRPC APIs. Following a consistent structure makes it easier for teams to evolve services over time and share tooling.
+
+## ✅ Service and RPC Naming
+
+- Use **PascalCase** for all service names (e.g., `PlayerService`).
+- RPC method names may use either:
+  - Standard CRUD verbs like **Get**, **List**, **Create**, **Update**, **Delete**.
+  - Domain‑specific actions such as `CastSpell`, `MoveToRoom`, or `ApplyEffect`.
+- Avoid vague or overloaded verbs like `Execute`, `Process`, or `Do`.
+- Always define explicit `Request` and `Response` messages, even if they are empty.
+
+## ✅ Versioning Strategy
+
+- Declare the API version in the package name inside the proto file:
+
+  ```proto
+  package player.v1;
+  ```
+
+- Mirror the version in the directory layout:
+
+  ```text
+  protos/player/v1/player_service.proto
+  ```
+
+## 📁 Proto File Layout
+
+All protobuf definitions live in a top‑level `protos/` directory outside service source trees. Files are organized by service folder and versioned subdirectory:
+
+```text
+protos/
+  player/
+    v1/
+      player_service.proto
+      player_types.proto
+  entity/
+    v1/
+      entity_service.proto
+      entity_types.proto
+  shared/
+    errors.proto
+    common_types.proto
+```
+
+Each service folder typically includes:
+
+- `*_service.proto` — defines the gRPC service and its RPC methods
+- `*_types.proto` — defines request/response messages and shared types
+- Optional `*_events.proto` — streaming or pubsub interfaces
+
+Shared message types (for example `EntitySummary` or `ErrorDetail`) live under `protos/shared/`.
+
+## 🛠️ Tooling
+
+- **Buf** (`buf.yaml`) — Lints proto files, detects breaking changes, and drives code generation.
+- **`protoc-gen-grpc-java`** — Generates Java service stubs for gRPC communication. The generated code is included in service builds via Gradle or a Makefile.
+- **`protoc-gen-doc`** — Produces HTML or Markdown API documentation to encourage inline comments.
+
+Adopting these conventions helps keep FireMUD services consistent and makes it easier for new contributors to work with the APIs.


### PR DESCRIPTION
## Summary
- rename gRPC guidelines to `system-architecture-grpc.mc`
- update architecture index to point to the renamed file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864f0151ec883309ce3a530f302d579