### PR TITLE
Normalize TCP Proxy naming

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -34,9 +34,9 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 ### 🔧 Kubernetes Characteristics
 
 - Services are deployed as Pods and exposed via Kubernetes Services.
-- The **TCP Proxy** and **Spring Cloud Gateway** are typically exposed using
+- The **TCP Proxy Service** and **Spring Cloud Gateway** are typically exposed using
   Kubernetes `LoadBalancer` Services so external clients can connect directly.
-- The TCP Proxy buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here, while the Gateway remains stateless.
+- The TCP Proxy Service buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here, while the Gateway remains stateless.
 - DNS-based discovery is built into Kubernetes (e.g., `game-session-service.default.svc.cluster.local`).
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Configuration and secrets are managed through ConfigMaps and Secrets.

--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -17,7 +17,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
-- Telnet clients keep a **persistent TCP connection** to the TCP Proxy; the Gateway
+- Telnet clients keep a **persistent TCP connection** to the TCP Proxy Service; the Gateway
   itself does not hold session state between reconnects
 
 > **Important:**

--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -43,7 +43,7 @@ Despite their differences, both protocols are normalized into the same internal 
   - Proxies I/O between the TCP client and the backend game session.
   - Buffers active input while the client remains connected and discards it if
     the TCP connection drops.
-  - Telnet clients keep a sticky connection to the TCP Proxy; reconnection and
+  - Telnet clients keep a sticky connection to the TCP Proxy Service; reconnection and
     session recovery are handled as described in
     [Reconnection Strategy](../system-architecture-reconnection.md).
 

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -9,11 +9,11 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 - **Microservices-based** domain-driven architecture with clearly separated responsibilities  
 - **Spring Cloud Gateway** serves as the unified HTTP/WebSocket entry point for all clients  
 - **TCP Proxy Service** accepts Telnet connections and upgrades them to WebSocket for the Gateway  
-- **Consistent end-to-end WebSocket flow**: Telnet (TCP) → TCP Proxy (WebSocket upgrade) → Spring Cloud Gateway → Game Session Service  
+- **Consistent end-to-end WebSocket flow**: Telnet (TCP) → TCP Proxy Service (WebSocket upgrade) → Spring Cloud Gateway → Game Session Service
 - **All client traffic is routed through the Spring Cloud Gateway**, ensuring centralized **traffic routing, monitoring, and observability**  
   > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens
 - **Spring Cloud Gateway is fully horizontally scalable and stateless**, with no sticky session requirements  
-- **Telnet clients maintain sticky TCP connections only to the TCP Proxy**, which buffers **active input**, but **discards it across reconnects**  
+- **Telnet clients maintain sticky TCP connections only to the TCP Proxy Service**, which buffers **active input**, but **discards it across reconnects**
 - **Reconnection logic is handled in layers** to preserve gameplay continuity  
 - **All internal service-to-service communication from the Game Session Service onward uses gRPC**, with strict schema enforcement and low latency  
 - **Session state is stored in Redis** to keep services stateless and support gameplay recovery  
@@ -32,7 +32,7 @@ FireMUD supports seamless gameplay recovery through a layered reconnection model
 
 | Layer               | Responsibility                                               |
 |--------------------|---------------------------------------------------------------|
-| TCP Proxy          | Buffers Telnet input; clears on disconnect                    |
+| TCP Proxy Service          | Buffers Telnet input; clears on disconnect                    |
 | Spring Cloud Gateway     | Stateless; re-establishes backend connections on reconnect    |
 | Game Session       | Restores gameplay session using Redis                         |
 

--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -8,7 +8,7 @@ FireMUD enables seamless gameplay recovery across network interruptions, client 
 
 | Layer              | Responsibility                                                               |
 |-------------------|-------------------------------------------------------------------------------|
-| **TCP Proxy**      | Parses Telnet input; clears input buffer on disconnect                        |
+| **TCP Proxy Service**      | Parses Telnet input; clears input buffer on disconnect                        |
 | **Spring Cloud Gateway** | Stateless WebSocket passthrough; re-establishes backend connection automatically |
 | **Game Session**   | Restores session from Redis; rebinds socket, tick region, and timers          |
 
@@ -20,7 +20,7 @@ Infra restarts (Proxy, Gateway, Session) are **transparent** if the client remai
 
 ## 🛰️ Layer Behavior Breakdown
 
-### **TCP Proxy (Telnet Clients)**
+### **TCP Proxy Service (Telnet Clients)**
 
 - Accepts raw TCP input and assembles it into commands
 - Buffers input **during connection**, but **clears on disconnect**


### PR DESCRIPTION
## Summary
- update docs to consistently refer to the TCP Proxy Service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865f0ac12948330a1b201a10750faae