### PR TITLE
Add schema evolution and error handling sections

### DIFF
--- a/design/architecture/system-architecture-grpc.mc
+++ b/design/architecture/system-architecture-grpc.mc
@@ -58,4 +58,37 @@ Shared message types (for example `EntitySummary` or `ErrorDetail`) live under `
 - **`protoc-gen-grpc-java`** — Generates Java service stubs for gRPC communication. The generated code is included in service builds via Gradle or a Makefile.
 - **`protoc-gen-doc`** — Produces HTML or Markdown API documentation to encourage inline comments.
 
+## 🔄 Schema Evolution Rules
+
+- Never reuse or remove field numbers — use `reserved` to prevent reuse.
+- Only **add optional fields** or new enum values to avoid breaking compatibility.
+- Use the `reserved` keyword to block deprecated field numbers or names.
+- Avoid changing the type of an existing field.
+
+## ⚠️ Error Handling (Optional)
+
+- Map application-level failures to appropriate gRPC status codes (`INVALID_ARGUMENT`, `NOT_FOUND`, etc.).
+- Use a shared `ErrorDetail` message (e.g., `shared/errors.proto`) when returning rich error info.
+- Prefer returning structured errors over using gRPC metadata for application faults.
+
+## 🧪 Example Code Generation (Java)
+
+Using `buf.gen.yaml`:
+
+```yaml
+version: v1
+plugins:
+  - name: java
+    out: gen/java
+    opt: lite
+  - name: grpc-java
+    out: gen/java
+```
+
+Then compile generated sources via Gradle:
+
+```kotlin
+sourceSets["main"].java.srcDirs("gen/java")
+```
+
 Adopting these conventions helps keep FireMUD services consistent and makes it easier for new contributors to work with the APIs.


### PR DESCRIPTION
## Summary
- expand gRPC guide with schema evolution rules and error handling
- include example codegen block for Java

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865f070c2188330b5eaa46b7a8e31a9