### PR TITLE
Add backup & disaster recovery documentation

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -7,6 +7,7 @@ The architecture section describes the platform infrastructure and each microser
 - **service-responsibility-matrix.md** – Summary of which service handles what.
 - **system-architecture-overview.md** – High-level diagrams and interactions.
 - **system-architecture-cicd.md** – CI/CD pipeline design using GitHub Actions.
+- **system-architecture-backup-recovery.md** – Backup strategy and disaster recovery procedures.
 - **system-architecture-grpc.mc** – Conventions for proto layout, versioning, and tooling.
 
 Refer to the README files within each subdirectory for more details.

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -1,0 +1,48 @@
+# 💾 FireMUD System Architecture: Backup & Disaster Recovery
+
+This document defines the backup schedule and disaster recovery procedures for FireMUD. Backups are taken only for **production**. Development and staging environments rely on ad hoc snapshots as needed.
+
+---
+
+## 📦 PostgreSQL Snapshots
+
+- Snapshots are taken **every 15 minutes**.
+- Retention policy:
+  - **24 hours** of 15‑minute snapshots
+  - **3 weekly** snapshots
+  - **3 monthly** snapshots
+- If the database service fails completely:
+  1. Restore the latest snapshot.
+  2. Restart services to resume operation.
+  3. Redis repopulates transient state from PostgreSQL on access.
+
+## 🗃️ Redis Persistence
+
+- Redis stores only **transient gameplay state**.
+- **AOF (Append‑Only File)** is enabled for crash recovery while the cluster is running.
+- Redis is **not restored** from backup during a cold start; it is repopulated from PostgreSQL after recovery.
+
+## ☁️ Kubernetes Production
+
+- **Velero** backs up StatefulSets, PersistentVolumeClaims, ConfigMaps, and Secrets.
+- Restoration process:
+  1. Use Velero to rehydrate the PostgreSQL volume from the latest snapshot.
+  2. Restore other resources (StatefulSets, ConfigMaps, Secrets).
+  3. Restart the affected pods; Redis starts empty and fills itself from PostgreSQL.
+
+## 🐳 Local Development
+
+- Backups are restored manually using `pg_restore` from local snapshot files.
+- Services are restarted with **Docker Compose**.
+- Redis starts empty and repopulates when services access the database.
+
+---
+
+## 🔄 Restore Workflow Summary
+
+| Environment      | Steps |
+|------------------|-------------------------------------------------------------|
+| **Kubernetes**   | Restore PostgreSQL via Velero → restore other resources → restart pods → allow Redis to repopulate |
+| **Docker Compose** | `pg_restore` local backup → restart containers → Redis repopulates automatically |
+
+Redis always uses AOF for crash recovery during runtime but is **never** restored from backup images. Gameplay resumes after services restart and Redis repopulates from PostgreSQL.

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -240,7 +240,7 @@ This checklist is structured to **build foundational features first**, followed 
 - [ ] **Scale & Optimize Performance**
   - [ ] Implement horizontal scaling (Auto-scaling, Load Balancer)
   - [ ] Optimize database queries & network traffic handling
-  - [ ] Define backup & disaster recovery strategy
+  - [ ] Define backup & disaster recovery strategy (see [Backup & Disaster Recovery Plan](../architecture/system-architecture-backup-recovery.md))
 
 - [ ] **Iterate on Features & Add More Game Customization**
   - [ ] Expand game customization options for hosted games


### PR DESCRIPTION
## Summary
- document snapshot policies, Redis behaviour and recovery steps
- link from architecture overview to new plan
- reference backup plan in project task list

## Testing
- `ls design/architecture | grep backup`

------
https://chatgpt.com/codex/tasks/task_e_6865fa2f1aa08330ae8e7d4aea7a5ce1