### PR TITLE
Align infrastructure docs with architecture

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -15,6 +15,9 @@ This directory contains core documentation for the shared infrastructure that po
 | [CI/CD Pipeline](../system-architecture-cicd.md)        | Overview of GitHub Actions workflows for building, testing, and deployment. |
 | [System Architecture Overview](../system-architecture-overview.md) | High-level design with observability and service interactions. |
 | [System Architecture Diagram](../system-architecture-diagram.md) | Visual representation of component relationships and client flows. |
+| [Security Architecture](../system-architecture-security.md) | TLS termination, mTLS usage, and network policy overview. |
+| [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | Snapshot schedules and restore workflow. |
+| [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md) | Conventions for service APIs. |
 
 ---
 
@@ -33,3 +36,6 @@ For example:
 > Observability and metrics integrations are outlined in the [**System Architecture Overview**](../system-architecture-overview.md#📊-observability-and-monitoring).
 > Log aggregation using Fluent Bit, Elasticsearch, and Kibana is covered in the [**Log Aggregation**](./deployment-environments.md#📜-log-aggregation) section of **Deployment Environments**.
 > Client reconnection flow is covered in the [**Reconnection Strategy**](../system-architecture-reconnection.md).
+> TLS, certificate rotation, and network policies are detailed in the [**Security Architecture**](../system-architecture-security.md).
+> Backup procedures and disaster recovery steps are outlined in [**Backup & Disaster Recovery**](../system-architecture-backup-recovery.md).
+> Service developers should follow the [**gRPC API Style & Versioning Guidelines**](../system-architecture-grpc.md) when defining new APIs.

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -42,9 +42,10 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Internal microservices communicate directly over gRPC, bypassing the Gateway.
 - Configuration and secrets are managed through ConfigMaps and Secrets.
+- See [Security Architecture](../system-architecture-security.md) for TLS termination, mTLS certificates, and network policy details.
 - The cluster uses **IPVS** (or a similar load-balancing mode) to route service traffic efficiently.
-- Redis runs as a clustered StatefulSet with automatic failover. Details are in [Redis Architecture](../system-architecture-redis.md).
-- PostgreSQL is deployed within the cluster (or provided as a managed database service) to store persistent domain data. See [System Architecture Overview](../system-architecture-overview.md#📦-data-and-state-management).
+- Redis runs as a clustered StatefulSet with automatic failover. Details are in [Redis Architecture](../system-architecture-redis.md). Redis persistence uses **AOF**, as described there.
+- PostgreSQL is deployed within the cluster (or provided as a managed database service) to store persistent domain data. See [System Architecture Overview](../system-architecture-overview.md#📦-data-and-state-management). Backup and restore procedures are outlined in [Backup & Disaster Recovery](../system-architecture-backup-recovery.md).
 - Deployments are managed via Helm charts in the CI/CD pipeline. See [CI/CD Pipeline](../system-architecture-cicd.md#🚢-deploying-to-kubernetes) for details.
 
 ### 🩺 Kubernetes Health Monitoring
@@ -66,6 +67,7 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - Prometheus scrapes metrics from all services.
 - Grafana dashboards visualize performance metrics.
 - Alertmanager notifies on failures or latency spikes.
+- OpenTelemetry spans are emitted by services for distributed tracing.
 - See [System Architecture Overview](../system-architecture-overview.md#📊-observability-and-monitoring) for design details.
 
 ### 📜 Log Aggregation

--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -76,6 +76,7 @@ Spring Cloud Gateway provides centralized management of client traffic, offering
 - Cross-cutting filters (e.g., rate limiting, logging, CORS)
 - Service isolation through route-based access control
 - Easy expansion of routes for new microservices
+- TLS termination and mTLS between services are described in [Security Architecture](../system-architecture-security.md).
 
 ## 🔗 Internal gRPC Communication
 


### PR DESCRIPTION
## Summary
- cross-link security, backup, and gRPC docs from infrastructure README
- mention TLS/mTLS and AOF persistence in deployment notes
- add OpenTelemetry note in monitoring section
- reference security details in gateway architecture

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6865fcae2b1c8330a231226877aac69e