### PR TITLE
Fix system architecture headings

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -8,7 +8,7 @@ The architecture section describes the platform infrastructure and each microser
 - [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
 - [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
 - [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
-- [**system-architecture-grpc.mc**](./system-architecture-grpc.mc) – Conventions for proto layout, versioning, and tooling.
+- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
 - [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
 - [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
 - [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -1,4 +1,4 @@
-# 🚀 CI/CD Pipeline Overview
+# 🚀 FireMUD System Architecture: CI/CD Pipeline
 
 This document describes the basic continuous integration and deployment strategy for FireMUD using **GitHub Actions**. Every service is built, tested, containerized, and deployed automatically so that changes reach production reliably.
 

--- a/design/architecture/system-architecture-diagram.md
+++ b/design/architecture/system-architecture-diagram.md
@@ -1,4 +1,4 @@
-# 📈 System Architecture Diagram
+# 📈 FireMUD System Architecture: Diagram
 
 ```plaintext
       +------------+      TCP (Telnet)         +-------------------+

--- a/design/architecture/system-architecture-grpc.md
+++ b/design/architecture/system-architecture-grpc.md
@@ -1,4 +1,4 @@
-# 📦 gRPC API Style & Versioning Guidelines
+# 📦 FireMUD System Architecture: gRPC API Style & Versioning Guidelines
 
 These guidelines define how FireMUD microservices design and document their gRPC APIs. Following a consistent structure makes it easier for teams to evolve services over time and share tooling.
 

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -1,4 +1,4 @@
-# 🏗️ FireMUD System Architecture Overview
+# 🏗️ FireMUD System Architecture: Overview
 
 This document provides a high-level view of FireMUD’s system architecture, showing how major services, protocols, and data flows interact across the platform.
 


### PR DESCRIPTION
## Summary
- standardize headings in system-architecture documents
- fix incorrect file reference in the architecture README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68660027ccec83309f4725ccb6be7bc9