### PR TITLE
Add testing architecture document

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -7,6 +7,7 @@ The architecture section describes the platform infrastructure and each microser
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 - [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
 - [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
+- [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
 - [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
 - [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
 - [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -11,6 +11,8 @@ This document describes the basic continuous integration and deployment strategy
 - **Deploy to Kubernetes** when changes are merged into designated branches (e.g., `main` or `release/*`).
 - Keep the workflow configuration easy to maintain and extensible for future security scans or nightly jobs.
 
+To save on cloud costs, this pipeline only builds and deploys services. Contributors run all unit, integration, and cross-service tests locally as part of manual code review. See [System Architecture Testing](./system-architecture-testing.md) for details.
+
 ---
 
 ## 🛠️ Workflow Structure
@@ -117,3 +119,4 @@ These can be added as separate workflows or additional jobs in the main pipeline
 
 - [Infrastructure Overview](./infrastructure/README.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)
+- [Testing Strategy](./system-architecture-testing.md)

--- a/design/architecture/system-architecture-testing.md
+++ b/design/architecture/system-architecture-testing.md
@@ -1,0 +1,49 @@
+# 🧪 FireMUD System Architecture: Testing Strategy
+
+FireMUD employs a layered testing approach to keep services reliable while avoiding excessive CI/CD costs. This document describes the scope of each test type, the tooling in use, and how these tests fit into our development workflow.
+
+---
+
+## 📝 Testing Scope
+
+Each microservice has its own unit and integration tests. Cross‑service scenarios are also covered in a dedicated suite. Load tests run independently using Gatling.
+
+- **Unit tests** live under each service in `src/test/java/unit/`.
+- **Integration tests** for that service live in `src/test/java/integration/` and may start Redis, Postgres, or other dependencies on demand.
+- **Cross-service integration tests** exercise workflows that span multiple services. They are triggered via separate Gradle tasks and can orchestrate several services with Docker or Testcontainers.
+- **Load tests** reside in `src/gatling` and simulate real usage patterns. These tests are run manually when preparing a major release.
+
+Test data seeding strategies are still under discussion. For now, tests set up their own minimal fixtures programmatically.
+
+---
+
+## 🛠 Tooling and Gradle Layout
+
+- **JUnit & Mockito** provide the core framework for unit and integration tests.
+- **Spring Test** bootstraps service contexts and external resources.
+- **Gatling** drives load testing scenarios.
+
+The repository uses a hierarchical Gradle setup. The root `build.gradle` delegates to per‑service builds so each service defines its own `test`, `integrationTest`, and cross‑service tasks. This allows running:
+
+```bash
+./gradlew :service-name:test
+./gradlew :service-name:integrationTest
+./gradlew crossServiceTest
+```
+
+Separate jobs exist for unit, integration, and cross-service tests during manual merge review, but they are not executed in CI.
+
+---
+
+## 🚦 CI/CD Integration
+
+To keep cloud usage minimal, GitHub Actions only builds and deploys services. Developers run the full test suite locally before merging. The [CI/CD Pipeline](./system-architecture-cicd.md) document references this manual step.
+
+Load testing is executed on demand outside of CI and does not block deployments.
+
+---
+
+## 📚 Related Documentation
+
+- [CI/CD Pipeline](./system-architecture-cicd.md)
+- [System Architecture Overview](./system-architecture-overview.md)


### PR DESCRIPTION
## Summary
- create `system-architecture-testing.md` describing unit, integration, cross-service, and load testing
- mention manual test execution in the CI/CD pipeline doc and link to the new testing document
- add the testing doc to the architecture index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865fe93060c833092abf6ceba813020