### PR TITLE
Add documentation for database migrations

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -9,6 +9,7 @@ The architecture section describes the platform infrastructure and each microser
 - [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
 - [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
 - [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
+- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
 - [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
 - [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
 - [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -46,3 +46,8 @@ This document defines the backup schedule and disaster recovery procedures for F
 | **Docker Compose** | `pg_restore` local backup → restart containers → Redis repopulates automatically |
 
 Redis always uses AOF for crash recovery during runtime but is **never** restored from backup images. Gameplay resumes after services restart and Redis repopulates from PostgreSQL.
+
+## 📚 Related Documentation
+
+- [CI/CD Pipeline](./system-architecture-cicd.md)
+- [Database Migrations](./system-architecture-database-migrations.md)

--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -1,0 +1,35 @@
+# 🛠️ FireMUD System Architecture: Database Migrations
+
+This document explains how FireMUD manages PostgreSQL schema changes across its microservices. Each service owns its tables and applies migrations independently.
+
+---
+
+## 🚀 Migration Tool
+
+- **Flyway** is used for all schema migrations.
+- Versioned SQL files live under each service in `src/main/resources/db/migration/`.
+- Migrations follow the `V<version>__<description>.sql` naming convention.
+- Java-based callbacks are avoided; migrations remain SQL-only for portability.
+
+## 📂 Per-Service Organization
+
+- Every microservice maintains its own migration folder and changelog.
+- Schemas are isolated: services never modify each other's tables.
+- Common tables shared by multiple services reside in a small `shared` module with its own migrations.
+- New migrations are committed alongside service code so history stays with the owning service.
+
+## 🔄 CI/CD Execution
+
+- Flyway runs automatically when a service container starts.
+- In development you can run `./gradlew flywayMigrate` for a single service.
+- During deployment GitHub Actions builds the Docker image, pushes it, and Kubernetes restarts the service.
+- On startup the container executes Flyway against its database schema before the Spring application fully starts.
+
+Migrations are therefore applied consistently in every environment without manual steps.
+
+---
+
+## 📚 Related Documentation
+
+- [CI/CD Pipeline](./system-architecture-cicd.md)
+- [Backup & Disaster Recovery](./system-architecture-backup-recovery.md)


### PR DESCRIPTION
## Summary
- document Flyway-based migration process
- link backup recovery doc to new guide
- update architecture README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686659126e2c8330817a2febe8e5eba0