### PR TITLE
Add frontend architecture doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Before contributing, we recommend reviewing the following key documents:
 - **[System Architecture Overview](design/architecture/system-architecture-overview.md)**: Understand the overall platform design, service layout, and communication flows.
 - **[Infrastructure Overview](design/architecture/infrastructure/README.md)**: Learn about our deployment environments, shared systems, and networking architecture.
 - **[Security Architecture](design/architecture/system-architecture-security.md)**: Understand how JWT secrets, TLS, and cross-service trust are managed.
+- **[Frontend Architecture](design/architecture/system-architecture-frontend.md)**: Learn how the React interface is structured and integrated with backend services.
 - **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
 - **[FAQ](FAQ.md)**: Browse frequently asked questions to get quick context.
 

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -6,6 +6,7 @@ The architecture section describes the platform infrastructure and each microser
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 - [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
+- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
 - [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
 - [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
 - [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.

--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -1,0 +1,58 @@
+# 🎨 FireMUD System Architecture: Frontend Architecture
+
+This document describes the structure and tooling for FireMUD's browser-based user interfaces. React and Material-UI are assumed, but this guide explains how the components, state management, and API calls are organized.
+
+---
+
+## 📐 Component Hierarchy
+
+FireMUD uses React components with a **feature-first** organization. Each feature folder contains its own components, tests, and styling:
+
+```
+frontend/
+  src/
+    features/
+      account/
+        AccountPage.tsx
+        accountSlice.ts
+      gameplay/
+        GameplayPage.tsx
+        gameplaySlice.ts
+      ...
+```
+
+- **Pages** represent top-level routes and compose smaller **UI widgets**.
+- Reusable UI elements live under a shared `components/` directory.
+- Material-UI provides the base widgets and theme customization.
+
+## ⚛️ State Management
+
+Application state is handled by **Redux Toolkit** with slices per feature. Slices contain reducers, actions, and async thunks for API calls. This keeps business logic out of components and promotes predictable state updates.
+
+- The global store is created in `src/store.ts` and provided via `<Provider>`.
+- Components dispatch actions and select state using hooks (`useAppDispatch`, `useAppSelector`).
+- Thunks interact with backend services through the API layer.
+
+## 🔗 API Usage Patterns
+
+All HTTP requests are made through a centralized wrapper built on **Axios**:
+
+- `src/api/client.ts` configures the base URL and interceptors for authentication tokens and error handling.
+- Feature slices call typed API helpers in `src/api/` (e.g., `loginUser`, `fetchCharacter`).
+- Responses are converted into domain-specific models before updating state.
+
+WebSocket interactions for real-time gameplay are handled by a single service in `src/websocket.ts` that manages connection lifecycle and message routing to Redux actions.
+
+## 🛠️ Build Tooling
+
+The frontend uses **Vite** for fast development and production builds:
+
+- `npm run dev` starts the local development server with hot module replacement.
+- `npm run build` produces an optimized bundle under `dist/`.
+- `npm run test` runs unit tests with Jest and React Testing Library.
+
+TypeScript configuration lives in `tsconfig.json`, and ESLint/Prettier enforce coding standards consistent with the rest of the project.
+
+---
+
+This architecture keeps the web client modular and maintainable while aligning with the backend microservices. Additional frontend services or features can follow the same patterns for consistency.


### PR DESCRIPTION
## Summary
- document React UI structure, Redux usage and API patterns
- link new doc from architecture README and root README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68665987ba98833095b01d9bffacf7f3