### PR TITLE
Sync observability stack & Redis usage across docs

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -28,7 +28,7 @@ Backend:
 - Lombok
 - MapStruct
 - PostgreSQL
-- Redis (caching)
+- Redis (transient session state)
 - WebSocket/TCP (real-time)
 - Spring Cloud Gateway
 
@@ -41,7 +41,7 @@ Deployment:
 
 - Docker, Kubernetes
 - GitHub Actions (CI/CD)
-- Prometheus, Grafana, Loki
+- Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager
 
 Testing:
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -17,7 +17,7 @@ This document collects common questions and answers about the FireMUD Game Platf
 ## Architecture and Design
 
 - **What technologies does FireMUD use?**  
-  The backend is composed of Java Spring Boot microservices communicating through gRPC. The web frontend is built with React and Material‑UI. Data is stored in PostgreSQL with Redis for caching.
+  The backend is composed of Java Spring Boot microservices communicating through gRPC. The web frontend is built with React and Material‑UI. Data is stored in PostgreSQL, while Redis holds only transient session and gameplay state.
 
 - **Why a microservice architecture?**  
   Separating functionality into services like account management, world management, and session management keeps the platform modular and allows each part to scale independently.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 
 - **Framework**: Java Spring Framework
 - **Database**: PostgreSQL
-- **Caching**: Redis
+- **Caching**: Redis for transient session and gameplay state
 - **Networking**: WebSocket/TCP
+- **Inter-Service Communication**: gRPC
 - **API Gateway**: Spring Cloud Gateway
 
 #### Frontend
@@ -81,7 +82,7 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
 - **CI/CD**: [GitHub Actions](design/architecture/system-architecture-cicd.md)
-- **Monitoring and Logging**: Prometheus, Grafana, Elasticsearch, Alertmanager
+- **Monitoring and Logging**: Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager
 
 #### Monetization
 

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -7,7 +7,7 @@ Manages user accounts and authentication for the platform. Stores profile data a
 ## Architecture / Design Notes
 
 - Stateless authentication using JWT tokens.
-- Session information is cached in Redis for fast lookups and reconnections.
+- Session information is stored in Redis as transient data for quick reconnections.
 
 ## Key Features
 
@@ -17,7 +17,7 @@ Manages user accounts and authentication for the platform. Stores profile data a
 
 ## Dependencies
 
-- **External:** PostgreSQL for account data, Redis for session caching.
+- **External:** PostgreSQL for account data, Redis for transient session data.
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -6,7 +6,7 @@ The World Management Service stores and manages game world data such as rooms, r
 
 ## Architecture / Design Notes
 
-- World data is stored in PostgreSQL with Redis caching active states for performance.
+- World data is stored in PostgreSQL. Redis holds only transient active state used during gameplay.
 - Changes are persisted incrementally to avoid heavy writes.
 - Background jobs manage scheduled events like daily resets or seasonal changes.
 - Supports procedural generation with options for dynamic world expansion.
@@ -21,7 +21,7 @@ The World Management Service stores and manages game world data such as rooms, r
 ## Dependencies
 
 - **Internal:** Game Design Service for generation rules.
-- **External:** PostgreSQL and Redis.
+- **External:** PostgreSQL for world data, Redis for transient active state.
 
 ## Future Enhancements
 

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -28,7 +28,7 @@ Backend:
 - Lombok
 - MapStruct
 - PostgreSQL
-- Redis (caching)
+- Redis (transient session state)
 - WebSocket/TCP (real-time)
 - Spring Cloud Gateway
 
@@ -41,7 +41,7 @@ Deployment:
 
 - Docker, Kubernetes
 - GitHub Actions (CI/CD)
-- Prometheus, Grafana, Loki, Alertmanager
+- Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager
 
 Testing:
 

--- a/design/project-management/core-requirements.md
+++ b/design/project-management/core-requirements.md
@@ -115,10 +115,7 @@ This document outlines the **core functional and non-functional requirements** f
 ### **3.2 Persistence & Caching**
 
 - **PostgreSQL** is the primary database for game world, entity, and account storage.
-- **Redis caching** improves performance by storing:
-  - Frequently accessed **player profiles and inventory**.
-  - **World state snapshots** to reduce database queries.
-  - **Session data** for quick reconnections.
+- **Redis** stores transient gameplay and session state only; all authoritative data remains in PostgreSQL.
 
 ### **3.3 Deployment Model**
 

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -8,16 +8,17 @@ This document outlines high-level design and technology assumptions for the Fire
 - **Architecture**: Microservices
 - **Framework**: Java Spring Framework
 - **Database**: PostgreSQL
-- **Caching**: Redis
+- **Caching**: Redis for transient session and gameplay state
 - **Database Access**: Spring Data JPA
 - **Service Discovery**:
   - **Local Development**: Docker internal DNS-based discovery
   - **Production**: Kubernetes DNS-based discovery
 - **API Gateway**: Spring Cloud Gateway
 - **Real-Time Networking**: WebSocket/TCP
+- **Inter-Service Communication**: gRPC
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
-- **Monitoring & Logging**: Prometheus, Grafana, Elasticsearch, Alertmanager
+- **Monitoring & Logging**: Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager
 - **CI/CD**: [GitHub Actions](../architecture/system-architecture-cicd.md)
 - **Payment Gateway**: Stripe (with custom subscription integration)
 

--- a/design/project-management/issues-working.md
+++ b/design/project-management/issues-working.md
@@ -6,7 +6,6 @@ List of things in Design currently being worked on.
 
 ### 🎮 Game Rules & Policies
 
-- [ ] Review Game Session service for if not required (merge into other services)
 - [ ] Clarify distinction between **mechanics rules** (e.g., damage, XP) and **moderation/social rules** (e.g., chat filters, bans).
 - [ ] Move ownership of **mechanics rules execution** to `Game Logic Service` (runtime).
 - [ ] Keep **definition of mechanics rules** in `Game Design Service`, but **not accessible at runtime**.

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -49,7 +49,7 @@ This checklist is structured to **build foundational features first**, followed 
 - [ ] **Set up Docker and Kubernetes for containerized deployment**
 - [ ] **Implement service discovery for internal microservices (Spring Cloud, Eureka, Consul, or Kubernetes-native)**
   - [ ] Ensure common package includes service discovery utilities
-- [ ] **Set up centralized logging & monitoring (ELK Stack, Grafana, Prometheus, Loki, Alertmanager)**
+- [ ] **Set up centralized logging & monitoring (Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager)**
 - [ ] **Define security best practices (OAuth2, JWT, RBAC, input validation, rate-limiting)**
   - [ ] Ensure authentication utilities from common package integrate seamlessly
 
@@ -99,7 +99,7 @@ This checklist is structured to **build foundational features first**, followed 
 
 - [ ] **Implement Persistence Strategy**
   - [ ] Use PostgreSQL for primary storage
-  - [ ] Use Redis for session caching, game state, and temporary data lookups
+  - [ ] Use Redis for transient session state and ephemeral gameplay coordination
   - [ ] Implement world saving/loading system
   - [ ] Implement per-instance state persistence
 


### PR DESCRIPTION
## Summary
- update local AI rules and `.windsurfrules` to list the finalized logging stack
- clarify Redis as a transient store in docs and FAQs
- document gRPC communication in README and design assumptions
- remove mention that Game Session service might be redundant
- align world/account service docs and project task list with these updates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68665c3f0ad4833083c00d6010a3ae26