### PR TITLE
Clarify event handling via gRPC

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -6,7 +6,7 @@ The Automation & Scripting Service drives non-player character (NPC) behavior an
 
 ## Architecture / Design Notes
 
-- Event-driven execution engine triggered by world or player events.
+- Executes scripts in response to world or player events received via gRPC callbacks.
 - AI computations are optimized for large worlds using tick-based batching.
 - NPCs that are far from active players are deprioritized and only "wake up" on interaction.
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -8,7 +8,7 @@ Orchestrates live game sessions, including tick execution, player input validati
 
 - Coordinates with Redis to store volatile session state and command queues.
 - Communicates with other microservices exclusively via gRPC.
-- Emits lifecycle events so other services can react to games starting or ending.
+- Communicates game lifecycle changes to other services via gRPC so they can react to games starting or ending.
 
 ## Key Features
 

--- a/design/architecture/microservices/service-template.md
+++ b/design/architecture/microservices/service-template.md
@@ -6,7 +6,7 @@
 
 ## Architecture / Design Notes
 
-- {{ Key architecture choice or pattern (e.g., event-driven, REST). }}
+- {{ Key architecture choice or pattern (e.g., gRPC, REST). }}
 - {{ State management approach or other design considerations. }}
 
 ## Key Features

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-The World Management Service stores and manages game world data such as rooms, regions, and maps. It persists world state beyond player sessions and handles scheduled events that affect the environment.
+The World Management Service stores and manages game world data such as rooms, regions, and maps. It persists world state beyond player sessions and handles scheduled world events, notifying other services over gRPC when the environment changes.
 
 ## Architecture / Design Notes
 
 - World data is stored in PostgreSQL. Redis holds only transient active state used during gameplay.
 - Changes are persisted incrementally to avoid heavy writes.
-- Background jobs manage scheduled events like daily resets or seasonal changes.
+- Background tasks trigger scheduled world changes (daily resets or seasonal shifts) and notify relevant services via gRPC.
 - Supports procedural generation with options for dynamic world expansion.
 
 ## Key Features
@@ -16,7 +16,7 @@ The World Management Service stores and manages game world data such as rooms, r
 - Region and location management with shard support.
 - Persistent world state with incremental saves.
 - Procedural generation tools for rooms and terrain.
-- Event scheduling for world-wide holidays or timed modifiers.
+- Event scheduling for world-wide holidays or timed modifiers, communicating changes over gRPC.
 
 ## Dependencies
 

--- a/design/architecture/system-architecture-grpc.md
+++ b/design/architecture/system-architecture-grpc.md
@@ -48,7 +48,7 @@ Each service folder typically includes:
 
 - `*_service.proto` — defines the gRPC service and its RPC methods
 - `*_types.proto` — defines request/response messages and shared types
-- Optional `*_events.proto` — streaming or pubsub interfaces
+- Optional `*_events.proto` — server-side streaming RPCs for event notifications (no separate message bus)
 
 Shared message types (for example `EntitySummary` or `ErrorDetail`) live under `protos/shared/`.
 


### PR DESCRIPTION
## Summary
- clean up event references in service docs
- clarify event streaming in gRPC guidelines
- update service template architecture example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866608a6aa88330b559aa3e3a1b5326