### PR TITLE
docs: clarify BSL conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@
 [![Containerization: Docker](https://img.shields.io/badge/Containerization-Docker-blue)](https://www.docker.com/)
 [![Orchestration: Kubernetes](https://img.shields.io/badge/Orchestration-Kubernetes-blue)](https://kubernetes.io/)
 
+
 Welcome to the **FireMUD Game Platform**, a modular and scalable system under the [Fire-DevOps.net](https://fire-devops.net) umbrella for creating and running Multi-User Dungeon (MUD) games.
 
-*This project is licensed under the [Business Source License 1.1](LICENSE.md). For common questions, please refer to our [FAQ](FAQ.md).*
+*This project is licensed under the [Business Source License 1.1](LICENSE.md). For common questions, please refer to our [FAQ](FAQ.md).* 
+
+*The BSL automatically converts to the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) on April 2, 2027, as noted in [LICENSE.md](LICENSE.md) and [FAQ.md](FAQ.md). Each new FireMUD release starts its own two‑year BSL period, so the conversion date rolls forward with every version.*
 
 ---
 


### PR DESCRIPTION
## Summary
- note BSL converts to Apache 2.0 on April 2, 2027
- explain rolling 2‑year window for new FireMUD versions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68677757ec848330978f9b36b8412954