### PR TITLE
Improve documentation alignment

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -50,9 +50,17 @@ More details on deployment environments and gateway routing can be found in the 
 
 - [Deployment Environments](design/architecture/infrastructure/deployment-environments.md)
 - [Gateway Architecture](design/architecture/infrastructure/gateway-architecture.md)
+- [Infrastructure Overview](design/architecture/infrastructure/README.md) – explains TLS/mTLS certificates, multi-tenancy, and network boundaries.
 
 These documents explain how the compose setup differs from production and provide examples of the configuration files.
 
 ---
 
 You are now ready to explore the codebase and contribute!
+
+## 📚 Related Documentation
+
+- [Infrastructure Overview](design/architecture/infrastructure/README.md)
+- [Deployment Environments](design/architecture/infrastructure/deployment-environments.md)
+- [Gateway Architecture](design/architecture/infrastructure/gateway-architecture.md)
+- [System Architecture Overview](design/architecture/system-architecture-overview.md)

--- a/FAQ.md
+++ b/FAQ.md
@@ -6,30 +6,30 @@ This document collects common questions and answers about the FireMUD Game Platf
 
 ## General
 
-- **What is the purpose of FireMUD?**  
+- **What is the purpose of FireMUD?**
   FireMUD is a modular platform for hosting and creating text-based MUD games. It provides real-time multiplayer services and integrated tools for game creators.
 
-- **Is FireMUD open source?**  
-  The project is released under the Business Source License 1.1, which converts to the Apache 2.0 License in April 2027. Non-commercial use is permitted without a separate license.
+- **Is FireMUD open source?**
+  The project is released under the Business Source License 1.1. Each version automatically switches to the Apache 2.0 License two years after it is published. Non-commercial use is permitted without a separate license.
 
 ---
 
 ## Architecture and Design
 
-- **What technologies does FireMUD use?**  
+- **What technologies does FireMUD use?**
   The backend is composed of Java Spring Boot microservices communicating through gRPC. The web frontend is built with React and Material‑UI. Data is stored in PostgreSQL, while Redis holds only transient session and gameplay state.
 
-- **Why a microservice architecture?**  
+- **Why a microservice architecture?**
   Separating functionality into services like account management, world management, and session management keeps the platform modular and allows each part to scale independently.
 
 ---
 
 ## Development and Contribution
 
-- **How can I contribute to FireMUD?**  
+- **How can I contribute to FireMUD?**
   Fork this repository, create a feature branch, make your changes, and open a pull request against `main`. Follow the coding standards described in the README and design documents.
 
-- **Where do I find design resources?**  
+- **Where do I find design resources?**
   The `design/` directory contains architecture diagrams, service descriptions, and planning documents that explain how the system fits together.
 
 ---
@@ -42,9 +42,15 @@ This document collects common questions and answers about the FireMUD Game Platf
 - **Can GitHub Actions work with Docker and Kubernetes?**
   Yes. GitHub Actions can build Docker images, run tests, and push images to a registry. From there you can deploy those images to any Kubernetes cluster using actions that invoke `kubectl` or Helm. Many projects use this workflow for CI/CD.
 
+- **How are new versions published?**
+  Each FireMUD service is tagged and released through GitHub Actions. The resulting Docker images are pushed to a registry and deployed to Kubernetes. Every release enters its own two‑year BSL period before converting to Apache 2.0.
+
+- **How are mTLS certificates issued?**
+  The Kubernetes cluster runs `cert-manager`, which automatically issues and renews TLS and mTLS certificates for each service. Certificates are stored as Kubernetes Secrets and mounted into the pods.
+
 ---
 
 ## Other
 
-- **Who maintains FireMUD?**  
+- **Who maintains FireMUD?**
   The project is led by Ben Hook under the Fire‑DevOps.net umbrella. Contact details are listed in the README.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@
 
 Welcome to the **FireMUD Game Platform**, a modular and scalable system under the [Fire-DevOps.net](https://fire-devops.net) umbrella for creating and running Multi-User Dungeon (MUD) games.
 
-*This project is licensed under the [Business Source License 1.1](LICENSE.md). For common questions, please refer to our [FAQ](FAQ.md).* 
-
-*The BSL automatically converts to the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) on April 2, 2027, as noted in [LICENSE.md](LICENSE.md) and [FAQ.md](FAQ.md). Each new FireMUD release starts its own two‑year BSL period, so the conversion date rolls forward with every version.*
+*This project uses the [Business Source License 1.1](LICENSE.md). Each release converts to the Apache 2.0 License two years after publication. See our [FAQ](FAQ.md) for details.*
 
 ---
 

--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -47,3 +47,10 @@ For example:
 > TLS, certificate rotation, and network policies are detailed in the [**Security Architecture**](../system-architecture-security.md).
 > Backup procedures and disaster recovery steps are outlined in [**Backup & Disaster Recovery**](../system-architecture-backup-recovery.md).
 > Service developers should follow the [**gRPC API Style & Versioning Guidelines**](../system-architecture-grpc.md) when defining new APIs.
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](../system-architecture-overview.md)
+- [Deployment Environments](./deployment-environments.md)
+- [Gateway Architecture](./gateway-architecture.md)
+- [Protocol Bridging](./protocol-bridging.md)

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -100,7 +100,7 @@ Spring Boot services use environment-specific profiles:
 
 ---
 
-## 📚 Related Docs
+## 📚 Related Documentation
 
 - [Infrastructure Overview](./README.md)
 - [Gateway Architecture](./gateway-architecture.md)

--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -18,7 +18,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
   itself does not hold session state between reconnects
 
 > **Important:**
-> Spring Cloud Gateway is responsible for routing **only external client requests**.  
+> Spring Cloud Gateway is responsible for routing **only external client requests**.
 > **Internal microservice-to-microservice communication does not pass through the Gateway**.
 > Microservices use Kubernetes native service discovery and DNS for direct communication.
 > Services communicate with each other over **gRPC**.
@@ -96,7 +96,7 @@ Spring profiles (`application-dev.yml`, `application-prod.yml`) are used to conf
 
 ---
 
-## 📚 Related Docs
+## 📚 Related Documentation
 
 - [Infrastructure Overview](./README.md)
 - [Deployment Environments](./deployment-environments.md)

--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -36,3 +36,9 @@ Each microservice document follows a consistent structure, covering:
 For cross-service systems (e.g., networking, infrastructure), refer to:
 
 > See [**Infrastructure Overview**](../infrastructure/README.md) for shared architecture, deployment environments, and networking patterns.
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](../system-architecture-overview.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [Infrastructure Overview](../infrastructure/README.md)

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -23,7 +23,7 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - **Internal:** World Management Service for map data, Automation Service for scripts.
 - **External:** PostgreSQL for storing design assets.
 
-## Related Docs
+## 📚 Related Documentation
 
 See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) for how published versions are promoted to runtime.
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -25,7 +25,7 @@ Orchestrates live game sessions, including tick execution, player input validati
 
 > See [**Gateway Architecture**](../../infrastructure/gateway-architecture.md), [**Deployment Environments**](../../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for details on shared infrastructure components.
 
-## Related Docs
+## 📚 Related Documentation
 
 See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) for how game instances load published versions and runtime flags.
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -20,7 +20,7 @@ Uses the common stack outlined in [Logging & Monitoring](../../system-architectu
 
 - **External:** Elasticsearch, Prometheus, Grafana, and Alertmanager for storage, visualization, and alerting.
 
-## Related Docs
+## 📚 Related Documentation
 
 See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for details on the shared observability stack.
 

--- a/design/architecture/service-responsibility-matrix.md
+++ b/design/architecture/service-responsibility-matrix.md
@@ -42,3 +42,7 @@
 | TCP/Telnet socket handling                    |                     |                          |                |                      |                           |                    |                               |                           |                         | ✔                 |                       |
 | Telnet → WebSocket bridging                   |                     |                          |                |                      |                           |                    |                               |                           |                         | ✔                 |                       |
 | WebSocket upgrade, routing, and auth gateway  |                     |                          |                |                      |                           |                    |                               |                           |                         |                   | ✔                     |
+## 📚 Related Documentation
+
+- [Microservices Overview](./microservices/README.md)
+- [System Architecture Overview](./system-architecture-overview.md)

--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -14,7 +14,7 @@ All clients — whether connecting via Telnet or WebSocket — must authenticate
 - `LOGIN <username> <password>` → Attempts immediate login
 - `LOGON` → Alias for `LOGIN`
 
-Clients must re-authenticate **only after disconnecting** (TCP or WebSocket loss).  
+Clients must re-authenticate **only after disconnecting** (TCP or WebSocket loss).
 If a valid Redis session exists (`accountId + playerId`), the Game Session Service resumes gameplay seamlessly.
 
 > 🔗 For session resumption and reconnect edge cases, see [Reconnection Strategy](./system-architecture-reconnection.md)
@@ -37,7 +37,7 @@ This enables:
 - Forced logins (e.g., "kick and take over")
 - Seamless resumption without gameplay loss
 
-> 🔒 All session rebinding is enforced by the Game Session Service using Redis locks.  
+> 🔒 All session rebinding is enforced by the Game Session Service using Redis locks.
 > 🔗 See [Redis Session Keys](./system-architecture-redis.md#🧠-session-keys-and-gameplay-binding)
 
 ---
@@ -121,7 +121,7 @@ The Game Session Service is responsible for:
 
 ---
 
-📚 Related:
+## 📚 Related Documentation
 
 - [Reconnection Strategy](./system-architecture-reconnection.md)
 - [Tick System and Runtime Design](./system-architecture-ticks.md)

--- a/design/architecture/system-architecture-grpc.md
+++ b/design/architecture/system-architecture-grpc.md
@@ -92,3 +92,9 @@ sourceSets["main"].java.srcDirs("gen/java")
 ```
 
 Adopting these conventions helps keep FireMUD services consistent and makes it easier for new contributors to work with the APIs.
+
+## 📚 Related Documentation
+
+- [Microservices Overview](./microservices/README.md)
+- [Infrastructure Overview](./infrastructure/README.md)
+- [System Architecture Overview](./system-architecture-overview.md)

--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -12,8 +12,8 @@ FireMUD enables seamless gameplay recovery across network interruptions, client 
 | **Spring Cloud Gateway** | Stateless WebSocket passthrough; re-establishes backend connection automatically |
 | **Game Session**   | Restores session from Redis; rebinds socket, tick region, and timers          |
 
-Each layer handles fault tolerance independently.  
-**Only client connection loss requires reauthentication.**  
+Each layer handles fault tolerance independently.
+**Only client connection loss requires reauthentication.**
 Infra restarts (Proxy, Gateway, Session) are **transparent** if the client remains connected.
 
 ---
@@ -36,7 +36,7 @@ Infra restarts (Proxy, Gateway, Session) are **transparent** if the client remai
 
 ### **Game Session Service**
 
-- Uses Redis to store and recover session state, including command queues, tick participation, cooldowns, and retry info  
+- Uses Redis to store and recover session state, including command queues, tick participation, cooldowns, and retry info
 - On reconnect, rebinds:
   - Socket connection
   - Tick region context
@@ -93,7 +93,7 @@ Gameplay resumes cleanly when a session is resumed — whether due to reconnect 
 
 ---
 
-📚 Related:
+## 📚 Related Documentation
 
 - [Tick System and Runtime Design](./system-architecture-ticks.md)
 - [Redis Architecture](./system-architecture-redis.md)

--- a/design/architecture/system-architecture-security.md
+++ b/design/architecture/system-architecture-security.md
@@ -106,7 +106,7 @@ These controls are not yet implemented but are expected to strengthen security a
 
 ---
 
-📚 Related:
+## 📚 Related Documentation
 
 - [Authentication & Authorization](./system-architecture-authentication.md)
 - [Redis Architecture](./system-architecture-redis.md)


### PR DESCRIPTION
## Summary
- shorten license details in README and FAQ
- clarify infrastructure references in Developer Setup
- add `Related Documentation` sections across design docs
- expand FAQ with versioning and mTLS questions

## Testing
- `git diff --staged --stat`


------
https://chatgpt.com/codex/tasks/task_e_68679b9684388330913dbbdb7194c7cf