### PR TITLE
Organize long doc lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,16 @@ For local environment setup instructions, see [Developer Setup](./DEVELOPER_SETU
 
 Before contributing, we recommend reviewing the following key documents:
 
-- **[System Architecture Overview](design/architecture/system-architecture-overview.md)**: Understand the overall platform design, service layout, and communication flows.
-- **[Infrastructure Overview](design/architecture/infrastructure/README.md)**: Learn about our deployment environments, shared systems, and networking architecture.
-- **[Security Architecture](design/architecture/system-architecture-security.md)**: Understand how JWT secrets, TLS, and cross-service trust are managed.
-- **[Frontend Architecture](design/architecture/system-architecture-frontend.md)**: Learn how the React interface is structured and integrated with backend services.
-- **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
-- **[Example User Journeys](design/architecture/user-journeys.md)**: See step-by-step workflows for creators and players.
-- **[Versioning & Runtime Configuration](design/architecture/system-architecture-versioning-runtime.md)**: Learn how versions are published and how runtime flags are controlled.
 - **[Core Requirements](design/project-management/core-requirements.md)**: Review the high-level product requirements for the platform.
+- **[System Architecture Overview](design/architecture/system-architecture-overview.md)**: Understand the overall platform design, service layout, and communication flows.
+- **[Infrastructure Overview](design/architecture/infrastructure/README.md)**: Learn about deployment environments, shared systems, and networking architecture.
+- **[Security Architecture](design/architecture/system-architecture-security.md)**: See how JWT secrets, TLS, and cross-service trust are managed.
+- **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
+- **[Frontend Architecture](design/architecture/system-architecture-frontend.md)**: Understand how the React interface integrates with backend services.
+- **[Versioning & Runtime Configuration](design/architecture/system-architecture-versioning-runtime.md)**: Learn how versions are published and how runtime flags are controlled.
+- **[Example User Journeys](design/architecture/user-journeys.md)**: Step-by-step workflows for creators and players.
 - **[Task List](design/project-management/task-list.md)**: Track planned features and development progress.
-- **[FAQ](FAQ.md)**: Browse frequently asked questions to get quick context.
+- **[FAQ](FAQ.md)**: Browse frequently asked questions for quick context.
 
 ---
 

--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -8,17 +8,17 @@ This directory contains core documentation for the shared infrastructure that po
 
 | Document                          | Description                                                                 |
 |-----------------------------------|-----------------------------------------------------------------------------|
-| [Gateway Architecture](./gateway-architecture.md)       | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
-| [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
-| [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
-| [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
-| [CI/CD Pipeline](../system-architecture-cicd.md)        | Overview of GitHub Actions workflows for building, testing, and deployment. |
 | [System Architecture Overview](../system-architecture-overview.md) | High-level design with observability and service interactions. |
 | [System Architecture Diagram](../system-architecture-diagram.md) | Visual representation of component relationships and client flows. |
 | [System Context Diagram](../system-context-diagram.md) | Shows clients, DMZ components, internal services, and datastores. |
+| [Gateway Architecture](./gateway-architecture.md)       | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
+| [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
+| [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
+| [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
 | [Security Architecture](../system-architecture-security.md) | TLS termination, mTLS usage, and network policy overview. |
-| [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | Snapshot schedules and restore workflow. |
 | [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md) | Conventions for service APIs. |
+| [CI/CD Pipeline](../system-architecture-cicd.md)        | Overview of GitHub Actions workflows for building, testing, and deployment. |
+| [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | Snapshot schedules and restore workflow. |
 
 ---
 
@@ -51,6 +51,6 @@ For example:
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
-- [Deployment Environments](./deployment-environments.md)
 - [Gateway Architecture](./gateway-architecture.md)
+- [Deployment Environments](./deployment-environments.md)
 - [Protocol Bridging](./protocol-bridging.md)

--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -15,11 +15,11 @@ This directory contains detailed design documents for each core microservice in 
 | [Game Logic Service](./game-logic-service/)              | Implements core gameplay mechanics, command parsing, and actions. |
 | [Game Session Service](./game-session-service/)          | Orchestrates live gameplay sessions and tick execution. |
 | [Logging & Admin Service](./logging-admin-service/)      | Provides centralized logging, analytics, and administration tools. |
-| [Social & Groups Service](./social-groups-service/)    | Manages chat, guilds, and cross-game social networking features. |
-| [Spring Cloud Gateway](./spring-cloud-gateway/) | Routes WebSocket and HTTP traffic to backend services. |
+| [Service Template](./service-template.md)                | Template for creating new microservice docs. |
+| [Social & Groups Service](./social-groups-service/)      | Manages chat, guilds, and cross-game social networking features. |
+| [Spring Cloud Gateway](./spring-cloud-gateway/)          | Routes WebSocket and HTTP traffic to backend services. |
 | [TCP Proxy Service](./tcp-proxy-service/)                | Bridges Telnet clients into the WebSocket-based backend. |
 | [World Management Service](./world-management-service/)  | Handles world maps, regions, pathfinding data, and procedural generation. |
-| [Service Template](./service-template.md) | Template for creating new microservice docs. |
 
 ---
 


### PR DESCRIPTION
## Summary
- reorder README's "Learn About the Platform" list
- alphabetize the microservice table
- group infrastructure docs in more logical order

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6867a0e863448330ba76251793fcdb4a