### PR TITLE
Update docs for backup reference and gateway notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Welcome to the **FireMUD Game Platform**, a modular and scalable system under th
 
 *This project uses the [Business Source License 1.1](LICENSE.md). Each release converts to the Apache 2.0 License two years after publication. See our [FAQ](FAQ.md) for details.*
 
+## Start Here
+
+For an overview of all architecture and design documents, see [Architecture Overview](design/architecture/README.md).
+
 ---
 
 ## 📚 Table of Contents

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -37,7 +37,7 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - Services are deployed as Pods and exposed via Kubernetes Services.
 - The **TCP Proxy Service** and **Spring Cloud Gateway** are typically exposed using
   Kubernetes `LoadBalancer` Services so external clients can connect directly.
-- The TCP Proxy Service buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here, while the Gateway remains stateless.
+ - The TCP Proxy Service buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here. See [Gateway Architecture](./gateway-architecture.md) for how the stateless Gateway handles reconnects.
 - DNS-based discovery is built into Kubernetes (e.g., `game-session-service.default.svc.cluster.local`).
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Internal microservices communicate directly over gRPC, bypassing the Gateway.

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -10,9 +10,8 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 - **Spring Cloud Gateway** serves as the unified HTTP/WebSocket entry point for all clients  
 - **TCP Proxy Service** accepts Telnet connections and upgrades them to WebSocket for the Gateway  
 - **Consistent end-to-end WebSocket flow**: Telnet (TCP) → TCP Proxy Service (WebSocket upgrade) → Spring Cloud Gateway → Game Session Service
-- **All client traffic is routed through the Spring Cloud Gateway**, ensuring centralized **traffic routing, monitoring, and observability**  
-  > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens
-- **Spring Cloud Gateway is fully horizontally scalable and stateless**, with no sticky session requirements  
+ - **All client traffic is routed through the Spring Cloud Gateway**, ensuring centralized **traffic routing, monitoring, and observability**. See [Gateway Architecture](./infrastructure/gateway-architecture.md) for deployment details and stateless behavior.
+   > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens
 - **Telnet clients maintain sticky TCP connections only to the TCP Proxy Service**, which buffers **active input**, but **discards it across reconnects**
 - **Reconnection logic is handled in layers** to preserve gameplay continuity  
 - **All internal service-to-service communication from the Game Session Service onward uses gRPC**, with strict schema enforcement and low latency  

--- a/design/project-management/core-requirements.md
+++ b/design/project-management/core-requirements.md
@@ -146,8 +146,7 @@ This document outlines the **core functional and non-functional requirements** f
 - Infrastructure should allow **horizontal scaling** for high-concurrency use cases.
 - Supports **multi-region deployments** to provide better latency for global users.
 - **Central logging and metrics** use the stack described in [Logging & Monitoring](../architecture/system-architecture-logging-monitoring.md).
-- **Velero** backs up Kubernetes resources and PostgreSQL volumes for disaster recovery.
-- Production databases are snapshotted **every 15 minutes** with **24 hours of retention**.
+ - **Velero** backs up Kubernetes resources and PostgreSQL volumes for disaster recovery. The production snapshot schedule is defined in [Backup & Disaster Recovery](../architecture/system-architecture-backup-recovery.md).
 
 
 ### **3.4 Gameplay Session Architecture**

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -27,8 +27,7 @@ This document outlines high-level design and technology assumptions for the Fire
 - **CI/CD**: [GitHub Actions](../architecture/system-architecture-cicd.md)
 - **Payment Gateway**: Stripe (with custom subscription integration)
 - **Certificate Management**: TLS and mTLS certificates issued by **cert-manager** and stored as Kubernetes Secrets
-- **Cluster Backups**: **Velero** snapshots StatefulSets and persistent volumes
-- Snapshots are taken **every 15 minutes** in production with **24 hours of retention**
+- **Cluster Backups**: **Velero** snapshots StatefulSets and persistent volumes. See [Backup & Disaster Recovery](../architecture/system-architecture-backup-recovery.md) for the snapshot schedule.
 
 ## Frontend
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -258,7 +258,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Optimize database queries & network traffic handling
   - [ ] Define backup & disaster recovery strategy (see [Backup & Disaster Recovery Plan](../architecture/system-architecture-backup-recovery.md))
   - [ ] Deploy **Velero** for scheduled Kubernetes and PostgreSQL backups
-  - [ ] Configure production snapshots every **15 minutes** with **24 hours of retention**
+  - [ ] Configure production snapshots as described in [Backup & Disaster Recovery Plan](../architecture/system-architecture-backup-recovery.md)
 
 - [ ] **Iterate on Features & Add More Game Customization**
   - [ ] Expand game customization options for hosted games


### PR DESCRIPTION
## Summary
- link to architecture docs in README
- centralize the backup schedule reference
- trim repeated Gateway details with cross-references

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6867a0e2893c833094827fa9de2b65b0