### PR TITLE
Organize documentation lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Before contributing, we recommend reviewing the following key documents:
 
 - **[Core Requirements](design/project-management/core-requirements.md)**: Review the high-level product requirements for the platform.
 - **[System Architecture Overview](design/architecture/system-architecture-overview.md)**: Understand the overall platform design, service layout, and communication flows.
+- **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
 - **[Infrastructure Overview](design/architecture/infrastructure/README.md)**: Learn about deployment environments, shared systems, and networking architecture.
 - **[Security Architecture](design/architecture/system-architecture-security.md)**: See how JWT secrets, TLS, and cross-service trust are managed.
-- **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
 - **[Frontend Architecture](design/architecture/system-architecture-frontend.md)**: Understand how the React interface integrates with backend services.
 - **[Versioning & Runtime Configuration](design/architecture/system-architecture-versioning-runtime.md)**: Learn how versions are published and how runtime flags are controlled.
 - **[Example User Journeys](design/architecture/user-journeys.md)**: Step-by-step workflows for creators and players.

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -5,25 +5,25 @@ The architecture section describes the platform infrastructure and each microser
 - [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
-- [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
-- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
-- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
-- [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
+- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
 - [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
+- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
 - [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
+- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
+- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
 - [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
 - [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
 - [**system-architecture-multi-tenancy.md**](./system-architecture-multi-tenancy.md) – Hosting multiple games on shared infrastructure.
-- [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.
-- [**system-architecture-shared-libraries.md**](./system-architecture-shared-libraries.md) – Common libraries for microservices.
-- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
-- [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
+- [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
 - [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.
 - [**system-architecture-reconnection.md**](./system-architecture-reconnection.md) – Client reconnect flow across services.
-- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
-- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
+- [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.
+- [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
+- [**system-architecture-shared-libraries.md**](./system-architecture-shared-libraries.md) – Common libraries for microservices.
+- [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
 - [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
 - [**system-architecture-versioning-runtime.md**](./system-architecture-versioning-runtime.md) – How versions are published and runtime flags are controlled.
+- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
 - [**user-journeys.md**](./user-journeys.md) – Example creator and player workflows.
 
 Refer to the README files within each subdirectory for more details.

--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -15,11 +15,11 @@ This directory contains detailed design documents for each core microservice in 
 | [Game Logic Service](./game-logic-service/)              | Implements core gameplay mechanics, command parsing, and actions. |
 | [Game Session Service](./game-session-service/)          | Orchestrates live gameplay sessions and tick execution. |
 | [Logging & Admin Service](./logging-admin-service/)      | Provides centralized logging, analytics, and administration tools. |
-| [Service Template](./service-template.md)                | Template for creating new microservice docs. |
 | [Social & Groups Service](./social-groups-service/)      | Manages chat, guilds, and cross-game social networking features. |
 | [Spring Cloud Gateway](./spring-cloud-gateway/)          | Routes WebSocket and HTTP traffic to backend services. |
 | [TCP Proxy Service](./tcp-proxy-service/)                | Bridges Telnet clients into the WebSocket-based backend. |
 | [World Management Service](./world-management-service/)  | Handles world maps, regions, pathfinding data, and procedural generation. |
+| [Service Template](./service-template.md)                | Template for creating new microservice docs. |
 
 ---
 


### PR DESCRIPTION
## Summary
- alphabetize architecture doc links
- rearrange microservices table
- reorder getting started reading list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867a2a036688330ad2ca0f69c18c059