### PR TITLE
Organize several long docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,13 @@ For local environment setup instructions, see [Developer Setup](./DEVELOPER_SETU
 Before contributing, we recommend reviewing the following key documents:
 
 - **[Core Requirements](design/project-management/core-requirements.md)**: Review the high-level product requirements for the platform.
+- **[Example User Journeys](design/architecture/user-journeys.md)**: Step-by-step workflows for creators and players.
 - **[System Architecture Overview](design/architecture/system-architecture-overview.md)**: Understand the overall platform design, service layout, and communication flows.
 - **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
 - **[Infrastructure Overview](design/architecture/infrastructure/README.md)**: Learn about deployment environments, shared systems, and networking architecture.
-- **[Security Architecture](design/architecture/system-architecture-security.md)**: See how JWT secrets, TLS, and cross-service trust are managed.
 - **[Frontend Architecture](design/architecture/system-architecture-frontend.md)**: Understand how the React interface integrates with backend services.
+- **[Security Architecture](design/architecture/system-architecture-security.md)**: See how JWT secrets, TLS, and cross-service trust are managed.
 - **[Versioning & Runtime Configuration](design/architecture/system-architecture-versioning-runtime.md)**: Learn how versions are published and how runtime flags are controlled.
-- **[Example User Journeys](design/architecture/user-journeys.md)**: Step-by-step workflows for creators and players.
 - **[Task List](design/project-management/task-list.md)**: Track planned features and development progress.
 - **[FAQ](FAQ.md)**: Browse frequently asked questions for quick context.
 

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -4,9 +4,12 @@ This document outlines high-level design and technology assumptions for the Fire
 
 ## Backend
 
+### Core Technologies
 - **Language**: Java
 - **Framework**: Java Spring Framework
 - **Architecture**: Microservices
+
+### Deployment & Networking
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
 - **Service Discovery**:
@@ -16,18 +19,22 @@ This document outlines high-level design and technology assumptions for the Fire
 - **TCP Proxy Service** bridges Telnet clients to the Gateway
 - **Inter-Service Communication**: gRPC secured with mTLS
 - **Real-Time Networking**: WebSocket/TCP
+
+### Data & Session Management
 - **Database**: PostgreSQL
 - **Database Access**: Spring Data JPA
 - **Caching**: Redis for transient session and gameplay state
 - **Redis Consistency**: Lua scripts enforce atomic updates with `WAIT` for replica acknowledgment
-- **Multi-Tenancy**: `tenantId` column on all tables with isolation enforced in each service
 - **Game Session Service** orchestrates ticks and runtime flags using Redis
 - **Single Session** per character with layered reconnection (Proxy → Gateway → Session)
+- **Multi-Tenancy**: `tenantId` column on all tables with isolation enforced in each service
+
+### Operations & Support
 - **Monitoring & Logging**: Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager (see [Logging & Monitoring](../architecture/system-architecture-logging-monitoring.md))
 - **CI/CD**: [GitHub Actions](../architecture/system-architecture-cicd.md)
-- **Payment Gateway**: Stripe (with custom subscription integration)
 - **Certificate Management**: TLS and mTLS certificates issued by **cert-manager** and stored as Kubernetes Secrets
 - **Cluster Backups**: **Velero** snapshots StatefulSets and persistent volumes. See [Backup & Disaster Recovery](../architecture/system-architecture-backup-recovery.md) for the snapshot schedule.
+- **Payment Gateway**: Stripe (with custom subscription integration)
 
 ## Frontend
 


### PR DESCRIPTION
## Summary
- reorganize list of reference docs in README
- group backend assumptions into clearer sections

## Testing
- `markdownlint README.md design/project-management/design-assumptions.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a47c3508833093342aa17ac08fc2