### PR TITLE
Clarify Redis failover mechanism

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -43,7 +43,7 @@ FireMUD runs Redis in a **clustered, replicated configuration**:
 
 - Multiple **shards and replicas** for tick region and session partitioning
 - Partitioning aligns with tick region boundaries (typically per-room or per-segment)
-- **Kubernetes-native failover** (no Redis Sentinel)
+- Kubernetes-native failover
 - **Failover behavior is tested under live tick loads**
 - Tick lock and retry keys are **retained across failover** due to AOF and synchronous Lua-based commit policies, ensuring ticks can resume safely after leadership handoff.
 

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -43,7 +43,7 @@ FireMUD runs Redis in a **clustered, replicated configuration**:
 
 - Multiple **shards and replicas** for tick region and session partitioning
 - Partitioning aligns with tick region boundaries (typically per-room or per-segment)
-- Redis Sentinel or **Kubernetes-native failover**
+- **Kubernetes-native failover** (no Redis Sentinel)
 - **Failover behavior is tested under live tick loads**
 - Tick lock and retry keys are **retained across failover** due to AOF and synchronous Lua-based commit policies, ensuring ticks can resume safely after leadership handoff.
 


### PR DESCRIPTION
## Summary
- clarify that Kubernetes-native failover is used for Redis

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867a5c148b083308feb94a4d39804a3