### PR TITLE
Fix documentation duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,30 +116,8 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 
 ### Microservices
 
-For details on each service, see the [Microservices documentation](design/architecture/microservices/README.md).
-
-1. **[Account Service](design/architecture/microservices/account-service/)**
-   - Handles user accounts, authentication, and profiles.
-1. **[Automation & Scripting Service](design/architecture/microservices/automation-scripting-service/)**
-   - Handles AI behaviors, scripted events, and dynamic interactions.
-1. **[Entity Management Service](design/architecture/microservices/entity-management-service/)**
-   - Manages in-game entities, including NPCs, items, and inventory.
-1. **[Game Design Service](design/architecture/microservices/game-design-service/)**
-   - Provides tools for game editing and customization.
-1. **[Game Logic Service](design/architecture/microservices/game-logic-service/)**
-   - Implements core game mechanics and rules.
-1. **[Game Session Service](design/architecture/microservices/game-session-service/)**
-   - Orchestrates live sessions and tick execution.
-1. **[Logging & Admin Service](design/architecture/microservices/logging-admin-service/)**
-   - Provides centralized logging and administration tools.
-1. **[Social & Groups Service](design/architecture/microservices/social-groups-service/)**
-   - Manages player groups, chat, and social features.
-1. **[Spring Cloud Gateway](design/architecture/microservices/spring-cloud-gateway/)**
-   - Routes WebSocket and HTTP traffic to backend services.
-1. **[TCP Proxy Service](design/architecture/microservices/tcp-proxy-service/)**
-   - Bridges Telnet clients into the WebSocket backend.
-1. **[World Management Service](design/architecture/microservices/world-management-service/)**
-   - Manages world maps, regions, pathfinding data, and procedural generation.
+The platform is composed of multiple Spring Boot services that communicate over gRPC. The complete list and responsibilities are maintained in the
+[Microservices documentation](design/architecture/microservices/README.md).
 
 ### Service Interactions
 
@@ -182,14 +160,8 @@ Before contributing, we recommend reviewing the following key documents:
   Open an issue in the relevant repository with detailed information. Be clear, respectful, and constructive.
 
 - **Contribute Code**:
-  1. **Fork** the repository you want to contribute to.
-  2. **Create a new branch**:
-     `git checkout -b feature/your-feature-name`
-  3. **Make your changes**, following our coding standards.
-  4. **Commit with clear messages**.
-  5. **Push to your fork**:
-     `git push origin feature/your-feature-name`
-  6. **Open a pull request** against the `main` branch.
+  See our [Contributing Guidelines](./CONTRIBUTING.md) for branching strategy,
+  coding standards, and how to submit a pull request.
 
 - **Review Pull Requests**:
   Provide thoughtful, constructive feedback on open pull requests.
@@ -203,13 +175,9 @@ Before contributing, we recommend reviewing the following key documents:
 
 ### Additional Guidelines
 
-Please see our [Contributing Guidelines](./CONTRIBUTING.md) for more details on:
-
-- Branching strategy
-- Code style
-- Testing requirements
-- How to submit a PR
-- **AI Coding Standards**: [Local Rules](design/project-management/ai-rules-local.md) and [Global Rules](design/project-management/ai-rules-global.md)
+See the [Contributing Guidelines](./CONTRIBUTING.md) for branching strategy, testing requirements, and coding standards. Our
+AI coding conventions are documented in [Local Rules](design/project-management/ai-rules-local.md) and
+[Global Rules](design/project-management/ai-rules-global.md).
 
 ---
 

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -1,3 +1,5 @@
+# Architecture Overview
+
 The architecture section describes the platform infrastructure and each microservice.
 
 - [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging.

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -1,11 +1,27 @@
-# Architecture Overview
-
 The architecture section describes the platform infrastructure and each microservice.
 
-- [**microservices/**](./microservices/) – Service responsibilities and APIs.
-- [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging. See the [Infrastructure README](./infrastructure/README.md) for a full list of related documents.
+- [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging.
+- [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
+- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
+- [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
+- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
+- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
+- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
+- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
+- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
+- [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
+- [**system-architecture-multi-tenancy.md**](./system-architecture-multi-tenancy.md) – Hosting multiple games on shared infrastructure.
 - [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
-- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Detailed login and session flow.
+- [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.
+- [**system-architecture-reconnection.md**](./system-architecture-reconnection.md) – Client reconnect flow across services.
+- [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.
+- [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
+- [**system-architecture-shared-libraries.md**](./system-architecture-shared-libraries.md) – Common libraries for microservices.
+- [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
+- [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
+- [**system-architecture-versioning-runtime.md**](./system-architecture-versioning-runtime.md) – How versions are published and runtime flags are controlled.
+- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
+- [**user-journeys.md**](./user-journeys.md) – Example creator and player workflows.
 
-Additional diagrams and specifications live in this directory. Refer to the README files within each subdirectory for details.
+Refer to the README files within each subdirectory for more details.

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -2,28 +2,10 @@
 
 The architecture section describes the platform infrastructure and each microservice.
 
-- [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging.
-- [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
+- [**microservices/**](./microservices/) – Service responsibilities and APIs.
+- [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging. See the [Infrastructure README](./infrastructure/README.md) for a full list of related documents.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
-- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
-- [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
-- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
-- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
-- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
-- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
-- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
-- [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
-- [**system-architecture-multi-tenancy.md**](./system-architecture-multi-tenancy.md) – Hosting multiple games on shared infrastructure.
 - [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
-- [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.
-- [**system-architecture-reconnection.md**](./system-architecture-reconnection.md) – Client reconnect flow across services.
-- [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.
-- [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
-- [**system-architecture-shared-libraries.md**](./system-architecture-shared-libraries.md) – Common libraries for microservices.
-- [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
-- [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
-- [**system-architecture-versioning-runtime.md**](./system-architecture-versioning-runtime.md) – How versions are published and runtime flags are controlled.
-- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
-- [**user-journeys.md**](./user-journeys.md) – Example creator and player workflows.
+- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Detailed login and session flow.
 
-Refer to the README files within each subdirectory for more details.
+Additional diagrams and specifications live in this directory. Refer to the README files within each subdirectory for details.

--- a/design/architecture/infrastructure/gateway-architecture.md
+++ b/design/architecture/infrastructure/gateway-architecture.md
@@ -10,7 +10,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 
 - Built as a Spring Boot microservice
 - Handles **client** request routing, filtering, CORS, rate limiting, retries, and monitoring
-- May validate JWTs for admin APIs (see [Authentication & Authorization](../system-architecture-authentication.md)). Gameplay login is processed by the **Game Session Service**. See [System Architecture Overview](../system-architecture-overview.md) for the full flow.
+- May validate JWTs for admin APIs (see [Authentication & Authorization](../system-architecture-authentication.md)). Gameplay login is processed by the **Game Session Service**; see [Authentication & Authorization](../system-architecture-authentication.md#-login-and-session-flow) for the detailed flow.
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
@@ -22,7 +22,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 > **Internal microservice-to-microservice communication does not pass through the Gateway**.
 > Microservices use Kubernetes native service discovery and DNS for direct communication.
 > Services communicate with each other over **gRPC**.
-> See [System Architecture Overview](../system-architecture-overview.md) for the complete login and gRPC flow.
+> See [System Architecture Overview](../system-architecture-overview.md) and [Authentication & Authorization](../system-architecture-authentication.md#-login-and-session-flow) for the complete login and gRPC flow.
 
 - Static URIs in `application-dev.yml` (for Docker Compose)
 - Kubernetes DNS-based service names in `application-prod.yml` (for production)

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -14,7 +14,7 @@ Uses the common stack outlined in [Logging & Monitoring](../../system-architectu
 - Basic analytics dashboards for operators.
 - Tools for banning or restricting accounts.
 - Moderation policy definitions including profanity filters.
-- UI and APIs for toggling runtime feature flags.
+- UI and APIs for toggling runtime feature flags. See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
 
 ## Dependencies
 

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -11,7 +11,7 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 - **TCP Proxy Service** accepts Telnet connections and upgrades them to WebSocket for the Gateway  
 - **Consistent end-to-end WebSocket flow**: Telnet (TCP) → TCP Proxy Service (WebSocket upgrade) → Spring Cloud Gateway → Game Session Service
  - **All client traffic is routed through the Spring Cloud Gateway**, ensuring centralized **traffic routing, monitoring, and observability**. See [Gateway Architecture](./infrastructure/gateway-architecture.md) for deployment details and stateless behavior.
-   > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens
+   > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens. See [Authentication & Authorization](./system-architecture-authentication.md#-login-and-session-flow) for the full login flow.
 - **Telnet clients maintain sticky TCP connections only to the TCP Proxy Service**, which buffers **active input**, but **discards it across reconnects**
 - **Reconnection logic is handled in layers** to preserve gameplay continuity  
 - **All internal service-to-service communication from the Game Session Service onward uses gRPC**, with strict schema enforcement and low latency  

--- a/design/project-management/core-requirements.md
+++ b/design/project-management/core-requirements.md
@@ -100,7 +100,7 @@ This document outlines the **core functional and non-functional requirements** f
 - **In-game reporting & ban system** for handling violations.
 - **Moderation policy definitions** including profanity filters.
 - **Central analytics dashboards and logging** for tracking player activity and game performance.
-- **Runtime feature flags** are defined in the **Game Design Service**, stored and managed by the **Game Session Service**, and can be toggled through the **Logging & Admin Service**.
+- **Runtime feature flags** are defined in the **Game Design Service**, stored and managed by the **Game Session Service**, and can be toggled through the **Logging & Admin Service**. See [Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md) for details.
 - **Monetization & Payment System**:
   - The platform integrates **Stripe or similar services** for in-game purchases.
   - Game creators can offer **subscriptions, one-time purchases, and donations**.
@@ -115,7 +115,7 @@ This document outlines the **core functional and non-functional requirements** f
 - The **Game Design Service** publishes immutable game versions identified by a `version_id`.
 - Domain services copy design data by `version_id` and do not query the design database at runtime.
 - The **Game Session Service** activates the desired `version_id` when starting a game instance.
-- Runtime feature flags are stored with the session and edited via the **Logging & Admin Service**.
+- Runtime feature flags are stored with the session and edited via the **Logging & Admin Service**. See [Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md).
 - The Game Design Service maintains **patch notes** for each published version so administrators can track changes over time.
 
 ---

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -74,7 +74,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Implement tick orchestration using Redis for command queues
   - [ ] Persist session state in Redis for reconnect recovery
   - [ ] Enforce single-session control per character (session takeover on new login)
-  - [ ] Manage runtime feature flags and expose toggle API via Logging & Admin Service
+  - [ ] Manage runtime feature flags and expose toggle API via Logging & Admin Service ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
   - [ ] Plan for cross-region sharding and session handoff
   - [ ] Emit gameplay analytics for operators
 - [ ] **Expand Game Design Service**
@@ -195,7 +195,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Collect logs from all services and provide search dashboards
   - [ ] Allow players to report others for abuse/violations
   - [ ] Store logs for admin moderation and auditing
-  - [ ] Expose runtime feature flag toggles
+  - [ ] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
   - [ ] Provide analytics dashboards for operators
   - [ ] Define moderation policies including profanity filters
   - [ ] Integrate Alertmanager for automated alerts


### PR DESCRIPTION
## Summary
- trim microservice list from root README
- reference CONTRIBUTING guidelines instead of repeating steps
- consolidate architecture README with shorter infrastructure references
- link login-related docs to the central authentication doc
- cross-link feature flag tasks to Versioning & Runtime doc

## Testing
- `grep -R "@Test" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_6867a5fb6d8083309c628fd83c6c28b6