### PR TITLE
Organize long bullet lists

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -11,9 +11,9 @@ FireMUD uses Docker Compose for local development and testing:
 ### 🔧 Docker Compose Characteristics
 
 - All services, including the gateway, are built locally via `Dockerfile`s.
+- Docker Compose orchestrates container startup, but not readiness.
 - Service discovery is handled by Docker's internal DNS (e.g., `game-session-service:8080`).
 - Route URIs in Spring Cloud Gateway use static hostnames defined in `application-dev.yml`.
-- Docker Compose orchestrates container startup, but not readiness.
 
 ### 🩺 Docker Health Checks
 
@@ -35,22 +35,20 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 ### 🔧 Kubernetes Characteristics
 
 - Services are deployed as Pods and exposed via Kubernetes Services.
-- The **TCP Proxy Service** and **Spring Cloud Gateway** are typically exposed using
-  Kubernetes `LoadBalancer` Services so external clients can connect directly.
- - The TCP Proxy Service buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here. See [Gateway Architecture](./gateway-architecture.md) for how the stateless Gateway handles reconnects.
 - DNS-based discovery is built into Kubernetes (e.g., `game-session-service.default.svc.cluster.local`).
 - Route URIs in Spring Cloud Gateway use service names configured in `application-prod.yml`.
 - Internal microservices communicate directly over gRPC, bypassing the Gateway.
-- Configuration and secrets are managed through ConfigMaps and Secrets.
-- Certificates for TLS termination and mTLS are issued by **cert-manager** and mounted from Kubernetes Secrets.
+- The **TCP Proxy Service** and **Spring Cloud Gateway** are typically exposed using Kubernetes `LoadBalancer` Services so external clients can connect directly.
+  - The TCP Proxy Service buffers active Telnet input but clears it when the TCP connection closes. Sticky TCP sessions terminate here. See [Gateway Architecture](./gateway-architecture.md) for how the stateless Gateway handles reconnects.
 - The external load balancer exposes only the Gateway and TCP Proxy Service, forming a DMZ that shields internal services.
 - See [Security Architecture](../system-architecture-security.md) for TLS termination, mTLS certificates, and network policy details.
+- Configuration and secrets are managed through ConfigMaps and Secrets.
+- Certificates for TLS termination and mTLS are issued by **cert-manager** and mounted from Kubernetes Secrets.
 - The cluster uses **IPVS** (or a similar load-balancing mode) to route service traffic efficiently.
 - Redis runs as a clustered StatefulSet with automatic failover. Details are in [Redis Architecture](../system-architecture-redis.md). Redis persistence uses **AOF**, as described there.
 - PostgreSQL is deployed within the cluster (or provided as a managed database service) to store persistent domain data. See [System Architecture Overview](../system-architecture-overview.md#📦-data-and-state-management). Backup and restore procedures are outlined in [Backup & Disaster Recovery](../system-architecture-backup-recovery.md).
 - Deployments are managed via Helm charts in the CI/CD pipeline. See [CI/CD Pipeline](../system-architecture-cicd.md#🚢-deploying-to-kubernetes) for details.
 - All tenants share this cluster with data separated by `tenantId` per service. See [Multi-Tenancy](../system-architecture-multi-tenancy.md) for more.
-
 ### 🩺 Kubernetes Health Monitoring
 
 - Kubernetes uses Spring Boot’s `/actuator/health` for both:

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -10,11 +10,11 @@ This document outlines FireMUD’s usage of Redis as a **transient, high-perform
 
 Redis is used **exclusively for non-authoritative, transient data**, including:
 
-- Gameplay session state and real-time coordination data  
-  _(e.g., command queues, timers, tick participation — see [Session Keys](#-session-keys-and-gameplay-binding))_
 - In-flight command queues
 - Tick locks and staged results
 - Cooldowns and timer expirations (stored in milliseconds)
+- Gameplay session state and real-time coordination data
+  _(e.g., command queues, timers, tick participation — see [Session Keys](#-session-keys-and-gameplay-binding))_
 - Retry metadata and **inter-tick conflict tracking**
 - AI/scripted action injection
 
@@ -62,9 +62,9 @@ FireMUD runs Redis in a **clustered, replicated configuration**:
 Redis keys follow strict naming conventions to ensure:
 
 - Shard-aware key locality
+- Clean atomic execution across tick regions
 - Conflict and retry isolation
 - Debuggable and traceable behavior
-- Clean atomic execution across tick regions
 
 ### Key Format Examples
 
@@ -87,8 +87,8 @@ Redis’s single-threaded model is extended using **Lua scripts** for atomic ope
 
 - Entity lock acquisition (`tick:lock:*`)
 - Tick staging, commit, and rollback (`tick:pending:*`)
-- Session rebinding and deduplication (`session:*` keys)
 - Timer lifecycle management
+- Session rebinding and deduplication (`session:*` keys)
 - Retry queue updates
 - AI/scripted action injection
 
@@ -110,10 +110,10 @@ Redis is essential for **coordinating tick execution** across distributed worker
 It provides:
 
 - Per-entity **command queues**
-- Distributed **locks** and **retry tracking**
 - Durable **tick staging**
-- Accurate **cooldown and timer tracking**
+- Distributed **locks** and **retry tracking**
 - **Conflict metadata** for retry prioritization
+- Accurate **cooldown and timer tracking**
 
 > 🔁 Ticks are replayable and deterministic due to Lua-based staging, lock control, and AOF durability.  
 > 🔗 See [Tick Execution Flow](./system-architecture-ticks.md#🔄-tick-execution-flow)
@@ -179,13 +179,13 @@ This state is used by the **Game Session Service** to:
 Redis in FireMUD is:
 
 - A **transient, high-performance coordination layer**
-- Used for **ticks, timers, locks, retries, and gameplay session state**  
+- Used for **ticks, timers, locks, retries, and gameplay session state**
   _(see [Session Keys](#-session-keys-and-gameplay-binding))_
-- Not a source of truth — but treated as **critical infrastructure**
-- Durable via **AOF** and `WAIT` guarantees
 - Scripted via **Lua** for atomic tick and session control
+- Durable via **AOF** and `WAIT` guarantees
 - Always **shard-local** to avoid cross-node inconsistencies
 - Tightly coupled with the **Game Session Service**, which orchestrates all tick-related flow
+- Not a source of truth — but treated as **critical infrastructure**
 
 ---
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -59,9 +59,9 @@ When an action fails due to contention:
 - Redis logs the **blocking lock** and conflicting region
 - The Game Session Service:
   - Reschedules the action within the blocked region
+  - **Prioritizes retries** to minimize player-visible delays
   - Staggers or delays conflicting ticks to avoid churn
   - Prevents retry storms and wasted CPU
-  - **Prioritizes retries** to minimize player-visible delays
 
 Future enhancements may include:
 


### PR DESCRIPTION
## Summary
- reorder examples of Redis usage
- adjust key naming section order
- clarify retry list in tick architecture
- sort Docker Compose and Kubernetes details

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6867a640e18483309fcbfc87ac562a8b