### PR TITLE
Reorder docs lists for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 
 ### Key Features
 
+- **Microservice Architecture**: Modular services for scalability and maintainability.
+- **Multi-Server Hosting**: Support for hosting multiple MUD games simultaneously.
 - **Real-Time Game Server**: Backend for gameplay mechanics, player actions, and world state management.
-- **Web Frontend**: React-based interface for players and creators.
-- **Integrated Game Editor**: Tools for designing rooms, entities, quests, and dialogues.
 - **Extensible Command Parsing**: Flexible system to interpret player commands.
 - **Dynamic Scripting Support**: For events and interactions within the game world.
-- **Multi-Server Hosting**: Support for hosting multiple MUD games simultaneously.
+- **Integrated Game Editor**: Tools for designing rooms, entities, quests, and dialogues.
+- **Web Frontend**: React-based interface for players and creators.
 - **Moderation Tools**: Comprehensive tools for administrators and moderators.
-- **Microservice Architecture**: Modular services for scalability and maintainability.
 
 ### Tech Stack
 
@@ -153,18 +153,18 @@ Before contributing, we recommend reviewing the following key documents:
 
 ### Ways to Contribute
 
-- **Improve Documentation**:
-  Help keep our docs accurate and beginner-friendly by fixing typos, clarifying explanations, adding examples, or expanding the FAQ.
-
-- **Report Bugs or Suggest Features**:
-  Open an issue in the relevant repository with detailed information. Be clear, respectful, and constructive.
-
 - **Contribute Code**:
   See our [Contributing Guidelines](./CONTRIBUTING.md) for branching strategy,
   coding standards, and how to submit a pull request.
 
 - **Review Pull Requests**:
   Provide thoughtful, constructive feedback on open pull requests.
+
+- **Improve Documentation**:
+  Help keep our docs accurate and beginner-friendly by fixing typos, clarifying explanations, adding examples, or expanding the FAQ.
+
+- **Report Bugs or Suggest Features**:
+  Open an issue in the relevant repository with detailed information. Be clear, respectful, and constructive.
 
 - **Report Security Issues**:
   If you discover a security vulnerability, please **do not** file a public issue.
@@ -185,8 +185,8 @@ AI coding conventions are documented in [Local Rules](design/project-management/
 
 Your support can make a significant difference in the development and success of the FireMUD Game Platform. If you're interested in supporting the project, here are some ways you can help:
 
-- **Spread the Word**: Share the project with friends, colleagues, and on social media platforms to help us reach a wider audience.
 - **Contribute**: See the [Getting Started and Contributing](#getting-started-and-contributing) section for ways to contribute code, documentation, or ideas.
+- **Spread the Word**: Share the project with friends, colleagues, and on social media platforms to help us reach a wider audience.
 - **Financial Contributions**: *[TODO: Set up financial contribution options]*
 
   We plan to set up options for financial support in the near future, including:

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -5,25 +5,27 @@ The architecture section describes the platform infrastructure and each microser
 - [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
-- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
-- [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
-- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
-- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
-- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
-- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
-- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
-- [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
-- [**system-architecture-multi-tenancy.md**](./system-architecture-multi-tenancy.md) – Hosting multiple games on shared infrastructure.
+
 - [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
+- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
+- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
+
+- [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
+- [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
 - [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.
+- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
+- [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
 - [**system-architecture-reconnection.md**](./system-architecture-reconnection.md) – Client reconnect flow across services.
 - [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.
-- [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
+- [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
+- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
+- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
+- [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
+- [**system-architecture-multi-tenancy.md**](./system-architecture-multi-tenancy.md) – Hosting multiple games on shared infrastructure.
+- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
 - [**system-architecture-shared-libraries.md**](./system-architecture-shared-libraries.md) – Common libraries for microservices.
 - [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
-- [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
 - [**system-architecture-versioning-runtime.md**](./system-architecture-versioning-runtime.md) – How versions are published and runtime flags are controlled.
-- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
 - [**user-journeys.md**](./user-journeys.md) – Example creator and player workflows.
 
 Refer to the README files within each subdirectory for more details.

--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -11,12 +11,12 @@ This directory contains core documentation for the shared infrastructure that po
 | [System Architecture Overview](../system-architecture-overview.md) | High-level design with observability and service interactions. |
 | [System Architecture Diagram](../system-architecture-diagram.md) | Visual representation of component relationships and client flows. |
 | [System Context Diagram](../system-context-diagram.md) | Shows clients, DMZ components, internal services, and datastores. |
+| [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
 | [Gateway Architecture](./gateway-architecture.md)       | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
 | [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
-| [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
+| [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md) | Conventions for service APIs. |
 | [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
 | [Security Architecture](../system-architecture-security.md) | TLS termination, mTLS usage, and network policy overview. |
-| [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md) | Conventions for service APIs. |
 | [CI/CD Pipeline](../system-architecture-cicd.md)        | Overview of GitHub Actions workflows for building, testing, and deployment. |
 | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | Snapshot schedules and restore workflow. |
 
@@ -51,6 +51,6 @@ For example:
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
-- [Gateway Architecture](./gateway-architecture.md)
 - [Deployment Environments](./deployment-environments.md)
+- [Gateway Architecture](./gateway-architecture.md)
 - [Protocol Bridging](./protocol-bridging.md)

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -151,16 +151,16 @@ Game Session governs pacing, conflict handling, and orchestration across distrib
 
 ## 📚 Related Documentation
 
-- [Tick System and Runtime Design](./system-architecture-ticks.md)
-- [Redis Architecture](./system-architecture-redis.md)
-- [Reconnection Strategy](./system-architecture-reconnection.md)
-- [Authentication & Authorization](./system-architecture-authentication.md)
-- [Security Architecture](./system-architecture-security.md)
-- [Multi-Tenancy Architecture](./system-architecture-multi-tenancy.md)
-- [Microservices Responsibility Matrix](./service-responsibility-matrix.md)
 - [System Architecture Diagram](./system-architecture-diagram.md)
 - [System Context Diagram](./system-context-diagram.md)
 - [Infrastructure Overview](./infrastructure/README.md)
 - [Gateway Architecture](./infrastructure/gateway-architecture.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)
 - [Protocol Bridging](./infrastructure/protocol-bridging.md)
+- [Redis Architecture](./system-architecture-redis.md)
+- [Tick System and Runtime Design](./system-architecture-ticks.md)
+- [Reconnection Strategy](./system-architecture-reconnection.md)
+- [Authentication & Authorization](./system-architecture-authentication.md)
+- [Security Architecture](./system-architecture-security.md)
+- [Multi-Tenancy Architecture](./system-architecture-multi-tenancy.md)
+- [Microservices Responsibility Matrix](./service-responsibility-matrix.md)


### PR DESCRIPTION
## Summary
- reorder feature list and contribution steps in README
- organize architecture docs list
- arrange infrastructure docs list and references
- tidy related docs section in architecture overview

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6867ab9239488330aed1d505f0ec36dc