### PR TITLE
Improve doc list organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ For local environment setup instructions, see [Developer Setup](./DEVELOPER_SETU
 
 Before contributing, we recommend reviewing the following key documents:
 
-- **[Core Requirements](design/project-management/core-requirements.md)**: Review the high-level product requirements for the platform.
-- **[Example User Journeys](design/architecture/user-journeys.md)**: Step-by-step workflows for creators and players.
-- **[System Architecture Overview](design/architecture/system-architecture-overview.md)**: Understand the overall platform design, service layout, and communication flows.
-- **[Service Design Documents](design/architecture/microservices/README.md)**: Explore detailed designs for each microservice.
-- **[Infrastructure Overview](design/architecture/infrastructure/README.md)**: Learn about deployment environments, shared systems, and networking architecture.
-- **[Frontend Architecture](design/architecture/system-architecture-frontend.md)**: Understand how the React interface integrates with backend services.
-- **[Security Architecture](design/architecture/system-architecture-security.md)**: See how JWT secrets, TLS, and cross-service trust are managed.
-- **[Versioning & Runtime Configuration](design/architecture/system-architecture-versioning-runtime.md)**: Learn how versions are published and how runtime flags are controlled.
-- **[Task List](design/project-management/task-list.md)**: Track planned features and development progress.
-- **[FAQ](FAQ.md)**: Browse frequently asked questions for quick context.
+- **[Core Requirements](design/project-management/core-requirements.md)** – high-level product requirements.
+- **[System Architecture Overview](design/architecture/system-architecture-overview.md)** – platform design and service interactions.
+- **[Service Design Documents](design/architecture/microservices/README.md)** – details for each microservice.
+- **[Infrastructure Overview](design/architecture/infrastructure/README.md)** – deployment environments and shared systems.
+- **[Frontend Architecture](design/architecture/system-architecture-frontend.md)** – how the React interface integrates with backend services.
+- **[Security Architecture](design/architecture/system-architecture-security.md)** – JWT secrets, TLS, and cross-service trust.
+- **[Versioning & Runtime Configuration](design/architecture/system-architecture-versioning-runtime.md)** – publishing versions and controlling runtime flags.
+- **[Example User Journeys](design/architecture/user-journeys.md)** – step-by-step workflows for creators and players.
+- **[Task List](design/project-management/task-list.md)** – planned features and development progress.
+- **[FAQ](FAQ.md)** – frequently asked questions for quick context.
 
 ---
 

--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -2,30 +2,37 @@
 
 The architecture section describes the platform infrastructure and each microservice.
 
+### High-Level Diagrams
+- [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
+- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
+- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Component relationships.
+
+### Directories & Responsibilities
 - [**infrastructure/**](./infrastructure/) – Deployment environments, gateway design, and protocol bridging.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 
-- [**system-architecture-overview.md**](./system-architecture-overview.md) – High-level diagrams and interactions.
-- [**system-architecture-diagram.md**](./system-architecture-diagram.md) – Diagram of component relationships.
-- [**system-context-diagram.md**](./system-context-diagram.md) – Shows clients, DMZ components, services, and datastores.
-
+### Runtime Architecture
 - [**system-architecture-authentication.md**](./system-architecture-authentication.md) – Authentication mechanisms and session handling.
 - [**system-architecture-security.md**](./system-architecture-security.md) – Cross-service security and secret management.
+- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout and versioning.
 - [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.
-- [**system-architecture-grpc.md**](./system-architecture-grpc.md) – Conventions for proto layout, versioning, and tooling.
-- [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
 - [**system-architecture-reconnection.md**](./system-architecture-reconnection.md) – Client reconnect flow across services.
+- [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
 - [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.
-- [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
-- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – How Flyway manages schema changes per service.
-- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
-- [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
+- [**system-architecture-versioning-runtime.md**](./system-architecture-versioning-runtime.md) – Publishing versions and runtime flags.
 - [**system-architecture-multi-tenancy.md**](./system-architecture-multi-tenancy.md) – Hosting multiple games on shared infrastructure.
-- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure, state management, and build tooling.
+- [**system-architecture-frontend.md**](./system-architecture-frontend.md) – React UI structure and state management.
 - [**system-architecture-shared-libraries.md**](./system-architecture-shared-libraries.md) – Common libraries for microservices.
+- [**system-architecture-logging-monitoring.md**](./system-architecture-logging-monitoring.md) – Logging and observability stack.
+- [**system-architecture-database-migrations.md**](./system-architecture-database-migrations.md) – Managing schema changes per service.
 - [**system-architecture-testing.md**](./system-architecture-testing.md) – Unit, integration, and load testing strategy.
-- [**system-architecture-versioning-runtime.md**](./system-architecture-versioning-runtime.md) – How versions are published and runtime flags are controlled.
+
+### Operations
+- [**system-architecture-cicd.md**](./system-architecture-cicd.md) – CI/CD pipeline design using GitHub Actions.
+- [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
+
+### Additional Resources
 - [**user-journeys.md**](./user-journeys.md) – Example creator and player workflows.
 
 Refer to the README files within each subdirectory for more details.

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -151,16 +151,26 @@ Game Session governs pacing, conflict handling, and orchestration across distrib
 
 ## 📚 Related Documentation
 
+**Diagrams**
 - [System Architecture Diagram](./system-architecture-diagram.md)
 - [System Context Diagram](./system-context-diagram.md)
+
+**Infrastructure & Deployment**
 - [Infrastructure Overview](./infrastructure/README.md)
-- [Gateway Architecture](./infrastructure/gateway-architecture.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)
+- [Gateway Architecture](./infrastructure/gateway-architecture.md)
 - [Protocol Bridging](./infrastructure/protocol-bridging.md)
+- [Multi-Tenancy Architecture](./system-architecture-multi-tenancy.md)
+
+**Runtime & Security**
 - [Redis Architecture](./system-architecture-redis.md)
 - [Tick System and Runtime Design](./system-architecture-ticks.md)
 - [Reconnection Strategy](./system-architecture-reconnection.md)
 - [Authentication & Authorization](./system-architecture-authentication.md)
 - [Security Architecture](./system-architecture-security.md)
-- [Multi-Tenancy Architecture](./system-architecture-multi-tenancy.md)
+- [Logging & Monitoring](./system-architecture-logging-monitoring.md)
+- [Database Migrations](./system-architecture-database-migrations.md)
+- [Testing Strategy](./system-architecture-testing.md)
+
+**Responsibilities**
 - [Microservices Responsibility Matrix](./service-responsibility-matrix.md)


### PR DESCRIPTION
## Summary
- reorder "Learn About the Platform" references
- break architecture README into grouped lists
- group related links for system architecture overview
- move logging, migration, and testing docs under Runtime Architecture

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867af08a9ec8330b5914e8f120cd566