### PR TITLE
Add missing service to context diagram

### DIFF
--- a/design/architecture/system-context-diagram.md
+++ b/design/architecture/system-context-diagram.md
@@ -24,6 +24,7 @@
                 | - Automation & Scripting Service             |
                 | - Social & Groups Service                    |
                 | - Logging & Admin Service                    |
+                | - Game Design Service                        |
                 +-----------+----------------------------------+
                             |
                             | DB/Cache/Logs


### PR DESCRIPTION
## Summary
- include the Game Design Service in the system context diagram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867b6aa156883308394de922e53602a