### PR TITLE
Fix markdown heading spacing

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -37,6 +37,7 @@ The architecture section describes the platform infrastructure and each microser
 - [**system-architecture-backup-recovery.md**](./system-architecture-backup-recovery.md) – Backup strategy and disaster recovery procedures.
 
 ## Additional Resources
+
 - [**user-journeys.md**](./user-journeys.md) – Example creator and player workflows.
 
 Refer to the README files within each subdirectory for more details.

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -5,11 +5,13 @@ This document outlines high-level design and technology assumptions for the Fire
 ## Backend
 
 ### Core Technologies
+
 - **Language**: Java
 - **Framework**: Java Spring Framework
 - **Architecture**: Microservices
 
 ### Deployment & Networking
+
 - **Containerization**: Docker
 - **Orchestration**: Kubernetes
 - **Service Discovery**:
@@ -21,6 +23,7 @@ This document outlines high-level design and technology assumptions for the Fire
 - **Real-Time Networking**: WebSocket/TCP
 
 ### Data & Session Management
+
 - **Database**: PostgreSQL
 - **Database Access**: Spring Data JPA
 - **Caching**: Redis for transient session and gameplay state
@@ -30,6 +33,7 @@ This document outlines high-level design and technology assumptions for the Fire
 - **Multi-Tenancy**: `tenantId` column on all tables with isolation enforced in each service
 
 ### Operations & Support
+
 - **Monitoring & Logging**: Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager (see [Logging & Monitoring](../architecture/system-architecture-logging-monitoring.md))
 - **CI/CD**: [GitHub Actions](../architecture/system-architecture-cicd.md)
 - **Certificate Management**: TLS and mTLS certificates issued by **cert-manager** and stored as Kubernetes Secrets


### PR DESCRIPTION
## Summary
- address markdownlint issues around heading spacing
- add blank lines after headings in design docs for better formatting

## Testing
- `markdownlint design/architecture/README.md design/project-management/design-assumptions.md`

------
https://chatgpt.com/codex/tasks/task_e_6867bdb2575883309357a7c54bf52f71