### PR TITLE
Improve microservice docs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -10,6 +10,7 @@ Manages user accounts and authentication for the platform. Stores profile data a
 - Passwords are hashed with strong salts and stored only in PostgreSQL.
 - Session information is stored in Redis as transient data for quick reconnections.
 - Emits account lifecycle events (creation, ban, recovery) for auditing by the Logging & Admin Service.
+- Maintains account-to-character relationships so players can own characters across multiple games.
 
 ## Key Features
 
@@ -17,6 +18,7 @@ Manages user accounts and authentication for the platform. Stores profile data a
 - Profile management and email notifications.
 - Password reset and verification flows.
 - Banning and subscription tracking.
+- Links accounts to player characters for ownership and permissions.
 - gRPC APIs for account creation, authentication, and profile queries.
 
 ### Data Model
@@ -53,6 +55,7 @@ The gRPC schemas for this service live in
 
 - [Authentication & Authorization](../system-architecture-authentication.md)
 - [System Architecture Overview](../system-architecture-overview.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -17,6 +17,8 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Rule processing for combat and progression.
 - Emote and roleplay action handling.
 - Effect stacking and cooldown calculation.
+- Environmental effect resolution (weather, lighting) influencing gameplay.
+- Economy logic for trading, shops, and pricing adjustments.
 
 ### Command Flow
 
@@ -47,6 +49,7 @@ the generated code with `./gradlew generateProto` after making changes.
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -11,6 +11,7 @@ Orchestrates live game sessions, including tick execution, player input validati
 - Communicates game lifecycle changes to other services via gRPC so they can react to games starting or ending.
 - Provides a single point of truth for current tick and world time.
 - Ensures atomic command execution using Redis transactions and Lua scripts.
+- Restores sessions after disconnects and enforces single-session control as outlined in the Reconnection Strategy.
 
 ## Key Features
 
@@ -19,6 +20,7 @@ Orchestrates live game sessions, including tick execution, player input validati
 - **Runtime Configuration** — stores runtime flag values created in the Game Design Service and activates published game versions.
 - **Termination Handling** — cleans up resources and logs results when a game ends.
 - **Instance Initialization** — starts new games from published templates.
+- **Reconnection Handling** — resumes gameplay via Redis-backed session state as described in [Reconnection Strategy](../system-architecture-reconnection.md).
 - **State Queries** — exposes gRPC methods to retrieve current game or player state for the web UI.
 
 ### Tick Execution Model
@@ -48,7 +50,9 @@ Service definitions reside in
 
 ## 📚 Related Documentation
 
-See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) for how game instances load published versions and runtime flags.
+ - [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) — how game instances load published versions and runtime flags.
+ - [Reconnection Strategy](../system-architecture-reconnection.md)
+ - [Authentication & Authorization](../system-architecture-authentication.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -49,6 +49,8 @@ these change, run `./gradlew generateProto` to refresh generated sources.
 ## 📚 Related Documentation
 
 See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for details on the shared observability stack.
+- [Security Architecture](../system-architecture-security.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -51,6 +51,8 @@ files change.
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [User Journeys](../user-journeys.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -8,6 +8,7 @@ This service exposes WebSocket and HTTP endpoints for all clients. It routes req
 - Event-driven updates synchronize game state across connected players.
 - Includes a fallback mechanism so players with unstable connections can rejoin seamlessly.
 - Applies rate limiting and authentication filters for admin endpoints.
+- Relies on the Game Session Service for gameplay login and session management.
 
 ## Key Features
 
@@ -46,6 +47,8 @@ After edits, run `./gradlew generateProto` to regenerate gateway stubs.
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
+- [Reconnection Strategy](../system-architecture-reconnection.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -55,6 +55,8 @@ regenerated via `./gradlew generateProto` when the proto files change.
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
+- [Reconnection Strategy](../system-architecture-reconnection.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -52,6 +52,7 @@ Run `./gradlew generateProto` to regenerate sources after editing these files.
 ## 📚 Related Documentation
 
 - [System Architecture Overview](../system-architecture-overview.md)
+- [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements
 


### PR DESCRIPTION
## Summary
- document account-to-character linking in the Account Service
- mention reconnection flow in the Game Session Service
- note environment and economy logic handled by Game Logic Service
- link microservice docs to Service Responsibility Matrix and other docs

## Testing
- `./gradlew build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6867ce8670ec8330800e47280bf726aa