### PR TITLE
Add base application classes and common DTO utilities

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -31,14 +31,14 @@ This checklist is structured to **build foundational features first**, followed 
 
 ## 🛠️ Phase 1: Core Infrastructure & Basic Services
 - [x] Create Gradle modules for all services with placeholder sources
-- [ ] Add base Spring Boot Application classes for each service
+ - [x] Add base Spring Boot Application classes for each service
 
 - [ ] **Create a Common Package for Shared Microservice Code**
-  - [ ] Implement common request/response DTOs for inter-service communication
-  - [ ] Implement centralized logging utilities
+   - [x] Implement common request/response DTOs for inter-service communication
+   - [x] Implement centralized logging utilities
   - [ ] Implement authentication & authorization utilities (OAuth2, JWT helper methods)
   - [ ] Implement database connection utilities (PostgreSQL, Redis connectors)
-  - [ ] Implement common exception handling & error response structures
+   - [x] Implement common exception handling & error response structures
   - [ ] Implement configuration management (centralized properties, environment handling)
   - [ ] Publish common package to internal repository (Maven/Gradle)
 

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/account-service/src/main/java/net/fire_devops/firemud/AccountServiceApplication.java
+++ b/services/account-service/src/main/java/net/fire_devops/firemud/AccountServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AccountServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AccountServiceApplication.class, args);
+    }
+}

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/automation-scripting-service/src/main/java/net/fire_devops/firemud/AutomationScriptingServiceApplication.java
+++ b/services/automation-scripting-service/src/main/java/net/fire_devops/firemud/AutomationScriptingServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AutomationScriptingServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AutomationScriptingServiceApplication.class, args);
+    }
+}

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -6,3 +6,8 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.2.5")
+}

--- a/services/common-library/src/main/java/net/fire_devops/firemud/common/ApiResponse.java
+++ b/services/common-library/src/main/java/net/fire_devops/firemud/common/ApiResponse.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.common;
+
+public record ApiResponse<T>(ResultStatus status, T data, ErrorDetail error) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(ResultStatus.SUCCESS, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorDetail error) {
+        return new ApiResponse<>(ResultStatus.ERROR, null, error);
+    }
+}

--- a/services/common-library/src/main/java/net/fire_devops/firemud/common/ErrorDetail.java
+++ b/services/common-library/src/main/java/net/fire_devops/firemud/common/ErrorDetail.java
@@ -1,0 +1,5 @@
+package net.fire_devops.firemud.common;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ErrorDetail(@NotBlank String code, @NotBlank String message) { }

--- a/services/common-library/src/main/java/net/fire_devops/firemud/common/GlobalExceptionHandler.java
+++ b/services/common-library/src/main/java/net/fire_devops/firemud/common/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package net.fire_devops.firemud.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<ErrorDetail>> handleIllegalArgument(IllegalArgumentException ex) {
+        ErrorDetail detail = new ErrorDetail("INVALID_ARGUMENT", ex.getMessage());
+        return new ResponseEntity<>(ApiResponse.error(detail), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ErrorDetail>> handleException(Exception ex) {
+        ErrorDetail detail = new ErrorDetail("INTERNAL_ERROR", ex.getMessage());
+        return new ResponseEntity<>(ApiResponse.error(detail), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/services/common-library/src/main/java/net/fire_devops/firemud/common/LoggingUtil.java
+++ b/services/common-library/src/main/java/net/fire_devops/firemud/common/LoggingUtil.java
@@ -1,0 +1,12 @@
+package net.fire_devops.firemud.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class LoggingUtil {
+    private LoggingUtil() { }
+
+    public static Logger getLogger(Class<?> clazz) {
+        return LoggerFactory.getLogger(clazz);
+    }
+}

--- a/services/common-library/src/main/java/net/fire_devops/firemud/common/ResultStatus.java
+++ b/services/common-library/src/main/java/net/fire_devops/firemud/common/ResultStatus.java
@@ -1,0 +1,6 @@
+package net.fire_devops.firemud.common;
+
+public enum ResultStatus {
+    SUCCESS,
+    ERROR
+}

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/EntityManagementServiceApplication.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/EntityManagementServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EntityManagementServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(EntityManagementServiceApplication.class, args);
+    }
+}

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/game-design-service/src/main/java/net/fire_devops/firemud/GameDesignServiceApplication.java
+++ b/services/game-design-service/src/main/java/net/fire_devops/firemud/GameDesignServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GameDesignServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GameDesignServiceApplication.class, args);
+    }
+}

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/game-logic-service/src/main/java/net/fire_devops/firemud/GameLogicServiceApplication.java
+++ b/services/game-logic-service/src/main/java/net/fire_devops/firemud/GameLogicServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GameLogicServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GameLogicServiceApplication.class, args);
+    }
+}

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/game-session-service/src/main/java/net/fire_devops/firemud/GameSessionServiceApplication.java
+++ b/services/game-session-service/src/main/java/net/fire_devops/firemud/GameSessionServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GameSessionServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GameSessionServiceApplication.class, args);
+    }
+}

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/logging-admin-service/src/main/java/net/fire_devops/firemud/LoggingAdminServiceApplication.java
+++ b/services/logging-admin-service/src/main/java/net/fire_devops/firemud/LoggingAdminServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class LoggingAdminServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(LoggingAdminServiceApplication.class, args);
+    }
+}

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/social-groups-service/src/main/java/net/fire_devops/firemud/SocialGroupsServiceApplication.java
+++ b/services/social-groups-service/src/main/java/net/fire_devops/firemud/SocialGroupsServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SocialGroupsServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SocialGroupsServiceApplication.class, args);
+    }
+}

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/spring-cloud-gateway/src/main/java/net/fire_devops/firemud/SpringCloudGatewayApplication.java
+++ b/services/spring-cloud-gateway/src/main/java/net/fire_devops/firemud/SpringCloudGatewayApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringCloudGatewayApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SpringCloudGatewayApplication.class, args);
+    }
+}

--- a/services/tcp-proxy-service/src/main/java/net/fire_devops/firemud/TcpProxyServiceApplication.java
+++ b/services/tcp-proxy-service/src/main/java/net/fire_devops/firemud/TcpProxyServiceApplication.java
@@ -1,0 +1,7 @@
+package net.fire_devops.firemud;
+
+public class TcpProxyServiceApplication {
+    public static void main(String[] args) {
+        // TODO: initialize proxy logic
+    }
+}

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" apply false
+    id("org.springframework.boot") version "3.2.5" 
 }
 
 repositories {
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation(project(":common-library"))
 }

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/WorldManagementServiceApplication.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/WorldManagementServiceApplication.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class WorldManagementServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(WorldManagementServiceApplication.class, args);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ApiResponse`, `ResultStatus`, `ErrorDetail` and `GlobalExceptionHandler`
- provide a `LoggingUtil`
- add Spring Boot application classes to each microservice and simple entrypoint for the TCP proxy
- wire Spring Boot dependencies in module build files
- mark completed tasks in `task-list.md`

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6867d1a070a8833086d4d18009a0f505