### PR TITLE
Refine transaction docs

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -47,6 +47,7 @@ For example:
 > TLS, certificate rotation, and network policies are detailed in the [**Security Architecture**](../system-architecture-security.md).
 > Backup procedures and disaster recovery steps are outlined in [**Backup & Disaster Recovery**](../system-architecture-backup-recovery.md).
 > Service developers should follow the [**gRPC API Style & Versioning Guidelines**](../system-architecture-grpc.md) when defining new APIs.
+> Distributed workflows are explained in [**Transaction Strategies**](../system-architecture-transactions.md).
 
 ## 📚 Related Documentation
 
@@ -54,3 +55,4 @@ For example:
 - [Deployment Environments](./deployment-environments.md)
 - [Gateway Architecture](./gateway-architecture.md)
 - [Protocol Bridging](./protocol-bridging.md)
+- [Transaction Strategies](../system-architecture-transactions.md)

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -2,7 +2,7 @@
 
 This document outlines FireMUD’s usage of Redis as a **transient, high-performance, distributed coordination layer**. It focuses on Redis's responsibilities, safety guarantees, key patterns, and operational practices.
 
-> 🔗 For full tick execution, retries, and lock behavior, see [Tick System and Runtime Design](./system-architecture-ticks.md).
+> 🔗 For full tick execution, retries, and lock behavior, see [Tick System and Runtime Design](./system-architecture-ticks.md). Cross-service workflows rely on the **gRPC-based Saga approach** described in [Transaction Strategies](./system-architecture-transactions.md).
 
 ---
 
@@ -193,3 +193,4 @@ Redis in FireMUD is:
 
 - [Tick System and Runtime Design](./system-architecture-ticks.md)
 - [System Architecture Overview](./system-architecture-overview.md)
+- [Transaction Strategies](./system-architecture-transactions.md)

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -1,6 +1,6 @@
 # ⏱️ FireMUD System Architecture: Tick System and Runtime Design
 
-📄 This document expands on the [Game Loop / Tick Model](./system-architecture-overview.md#⏱️-game-loop--tick-model) section of the FireMUD System Architecture Overview. It defines how ticks execute, resolve concurrency, handle crashes, and preserve deterministic, fair game logic under load.
+📄 This document expands on the [Game Loop / Tick Model](./system-architecture-overview.md#⏱️-game-loop--tick-model) section of the FireMUD System Architecture Overview. It defines how ticks execute, resolve concurrency, handle crashes, and preserve deterministic, fair game logic under load. Cross-service operations triggered by ticks follow the **gRPC-based Saga approach** in [Transaction Strategies](./system-architecture-transactions.md).
 
 > 🔗 For Redis keys, Lua-based atomicity, and operational guarantees, see the [Redis Architecture](./system-architecture-redis.md).
 
@@ -212,3 +212,11 @@ This supports **idempotent, replayable** ticks — without risk of duplicate eff
 - ✅ No in-service volatile state — everything recoverable via Redis
 
 > FireMUD treats time as **localized pulses**, not a global clock. Each tick is a self-contained transaction — safely composing gameplay logic in a world that never stops evolving.
+
+---
+
+📚 **Related Documentation**
+
+- [Redis Architecture](./system-architecture-redis.md)
+- [Transaction Strategies](./system-architecture-transactions.md)
+- [System Architecture Overview](./system-architecture-overview.md)

--- a/design/architecture/system-architecture-transactions.md
+++ b/design/architecture/system-architecture-transactions.md
@@ -1,0 +1,36 @@
+# ⚙️ FireMUD System Architecture: Transaction Strategies
+
+This document explains how FireMUD coordinates data consistency across its independent microservices. It complements the [System Architecture Overview](./system-architecture-overview.md) by outlining patterns for cross-service workflows. Traditional distributed transactions are impractical in a polyglot environment, so the platform favors lighter approaches. Tick execution itself is handled atomically in Redis; see [Redis Architecture](./system-architecture-redis.md) and [Tick System](./system-architecture-ticks.md) for details on those local transactions.
+
+---
+
+## 📚 Options Considered
+
+- **Two-Phase Commit (2PC)**
+  - Guarantees atomicity across services but adds heavy coordination overhead.
+  - Requires all services to share a transaction coordinator and can block progress during failures.
+- **Event-Driven Saga Pattern**
+  - Orchestrates a multi-step workflow as a sequence of local transactions.
+  - Each service emits an event after completing its step; compensating actions undo work on failure.
+- **Choreography with Asynchronous Messaging**
+  - Services react to published events without a centralized orchestrator.
+  - Simpler but harder to trace; compensations still required for rollbacks.
+
+## ✅ FireMUD Approach
+
+FireMUD adopts the **Saga pattern** executed over **gRPC** calls rather than a message broker. Each service owns its data and exposes gRPC endpoints for local transaction steps. A lightweight orchestrator invokes these services in sequence, propagating transaction context between them. If a step fails, the orchestrator triggers compensating gRPC calls to roll back prior work.
+
+- **Consistency Level** — eventual consistency is acceptable for gameplay state that spans services.
+- **Failure Handling** — compensating calls roll back partial state, while the orchestrator logs unfinished sagas for manual review.
+- **Implementation** — the orchestrator stores Saga state in PostgreSQL and uses standard gRPC retry semantics to ensure commands are delivered.
+
+This design keeps services loosely coupled while providing a clear strategy for multi-step operations such as account creation, game publishing, or in-game purchases.
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](./system-architecture-overview.md)
+- [Game Session Service](./microservices/game-session-service/README.md) — atomic command execution using Redis transactions
+- [Logging & Admin Service](./microservices/logging-admin-service/README.md)
+- [Redis Architecture](./system-architecture-redis.md)
+- [Tick System and Runtime Design](./system-architecture-ticks.md)
+

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -21,7 +21,11 @@ This checklist is structured to **build foundational features first**, followed 
 
 - [x] **Miscellaneous**
   - [x] Write initial design for each microservice
-  - [ ] Investigate transaction support for microservices
+  - [x] Investigate transaction support for microservices
+    - See [Transaction Strategies](../architecture/system-architecture-transactions.md)
+    - Document gRPC endpoints and compensating actions
+    - Implement lightweight Saga orchestrator service
+    - Provide example workflows (e.g., user registration)
   - [x] Implement dedicated **TCP Proxy Service** bridging Telnet clients to the Gateway
   - [x] Finalize [Spring Cloud Gateway design](../architecture/infrastructure/gateway-architecture.md)
   - [x] Update README after all services are defined


### PR DESCRIPTION
## Summary
- clarify cross-service Saga coordination uses gRPC
- update related docs to mention gRPC-based saga
- tweak task list bullet for transaction investigation

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6867d2cfc86c8330b73079a10aa901c7