### PR TITLE
Fix microservice docs formatting

### DIFF
--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -6,8 +6,8 @@ This directory contains detailed design documents for each core microservice in 
 
 ## 🧩 Core Microservices
 
-| Microservice                    | Purpose                                                    |
-|----------------------------------|------------------------------------------------------------|
+| Microservice | Purpose |
+|-------------|---------|
 | [Account Service](./account-service/)                    | Manages user accounts, authentication, profiles, and sessions. |
 | [Automation & Scripting Service](./automation-scripting-service/) | Handles AI behaviors, event scripting, and dynamic interactions. |
 | [Entity Management Service](./entity-management-service/) | Controls player characters, NPCs, items, and inventory management. |

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -1,5 +1,7 @@
 # Spring Cloud Gateway
 
+## Overview
+
 This service exposes WebSocket and HTTP endpoints for all clients. It routes requests to backend services and integrates with the TCP Proxy Service for Telnet clients.
 
 ## Architecture / Design Notes


### PR DESCRIPTION
## Summary
- add `Overview` section in Spring Cloud Gateway docs
- simplify table header in microservices README for alignment

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867d9caa63883308997c9e655d9b8cd