### PR TITLE
Add markdownlint integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,11 @@
 # Java build artifacts
 /target/
 /.gradle/
+**/.gradle/
 /build/
 
 # Node.js dependencies
-/node_modules/
+**/node_modules/
 
 # Logs and temporary files
 *.log

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,18 @@
+{
+  "default": true,
+  "ignores": [
+    "**/node_modules/**",
+    "**/.gradle/**",
+    "**/build/**"
+  ],
+  "gitignore": true,
+  "MD013": false,
+  "MD032": false,
+  "MD022": false,
+  "MD007": false,
+  "MD005": false,
+  "MD012": false,
+  "MD026": false,
+  "MD031": false,
+  "MD040": false
+}

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -40,6 +40,22 @@ Build all modules with:
 
 Gradle compiles the services and prepares Docker images using the included Dockerfiles.
 
+## ✅ Markdown Linting via Gradle
+
+This project uses `markdownlint-cli2` to lint Markdown files. The `check` task automatically runs linting in check-only mode:
+
+```bash
+./gradlew check
+```
+
+To manually fix correctable issues, run:
+
+```bash
+./gradlew lintMarkdownFix
+```
+
+Linting rules are defined in `.markdownlint.json` at the project root. Auto-fixing is not part of the `check` phase so that CI runs remain non-destructive.
+
 ## Lombok and MapStruct
 
 The microservices use **Lombok** to cut down on boilerplate and **MapStruct** for DTO mapping. Each service's `build.gradle.kts` already declares these dependencies:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,13 @@
+import com.github.gradle.node.npm.task.NpxTask
+
 plugins {
     java
+    id("com.github.node-gradle.node") version "7.1.0"
+}
+
+node {
+    version.set("20.11.0")
+    download.set(true)
 }
 
 allprojects {
@@ -20,4 +28,29 @@ subprojects {
     tasks.test {
         useJUnitPlatform()
     }
+}
+
+tasks.register<NpxTask>("lintMarkdown") {
+    command.set("markdownlint-cli2")
+    args.set(listOf(
+        "**/*.md",
+        "!**/node_modules/**",
+        "!**/build/**",
+        "!**/.gradle/**"
+    ))
+}
+
+tasks.register<NpxTask>("lintMarkdownFix") {
+    command.set("markdownlint-cli2")
+    args.set(listOf(
+        "--fix",
+        "**/*.md",
+        "!**/node_modules/**",
+        "!**/build/**",
+        "!**/.gradle/**"
+    ))
+}
+
+tasks.named("check") {
+    dependsOn("lintMarkdown")
 }


### PR DESCRIPTION
## Summary
- add Node plugin and markdownlint tasks to `build.gradle.kts`
- configure markdownlint rules and ignore directories
- ignore nested node_modules and .gradle dirs
- document markdown linting in `DEVELOPER_SETUP.md`

## Testing
- `./gradlew lintMarkdown`
- `./gradlew lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6868771904808330ba3e6e5a2769ffc3