### PR TITLE
Update microservice docs with design references

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -60,6 +60,10 @@ The gRPC schemas for this service live in
 - [System Architecture Overview](../system-architecture-overview.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys](../user-journeys.md#9-purchases-and-subscriptions) – payment and subscription workflow.
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -66,6 +66,10 @@ stubs.
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [System Architecture Overview](../system-architecture-overview.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -54,6 +54,10 @@ proto files, run `./gradlew generateProto` to update generated sources.
 - [Redis Architecture](../system-architecture-redis.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -62,6 +62,10 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [System Architecture Overview](../system-architecture-overview.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -58,6 +58,10 @@ the generated code with `./gradlew generateProto` after making changes.
 - [Tick System and Runtime Design](../system-architecture-ticks.md)
 - [Redis Architecture](../system-architecture-redis.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
 ## Future Enhancements

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -61,6 +61,10 @@ Service definitions reside in
 - [Tick System and Runtime Design](../system-architecture-ticks.md)
 - [Redis Architecture](../system-architecture-redis.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 - [System Architecture Overview](../system-architecture-overview.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -60,6 +60,10 @@ See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for 
 - [Security Architecture](../system-architecture-security.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -60,6 +60,10 @@ files change.
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys](../user-journeys.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -58,6 +58,10 @@ After edits, run `./gradlew generateProto` to regenerate gateway stubs.
 - [Security Architecture](../system-architecture-security.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -64,6 +64,10 @@ regenerated via `./gradlew generateProto` when the proto files change.
 - [Security Architecture](../system-architecture-security.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -57,6 +57,10 @@ Run `./gradlew generateProto` to regenerate sources after editing these files.
 - [Redis Architecture](../system-architecture-redis.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
+- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Testing Strategy](../system-architecture-testing.md)
+- [CI/CD Pipeline](../system-architecture-cicd.md)
 
 ## Future Enhancements
 


### PR DESCRIPTION
## Summary
- expand related docs sections for each service design
- link to gRPC guidelines, shared libraries, testing strategy and CI/CD docs

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_6868777ad17883308eeff36d9bc488fa