### PR TITLE
Expand service design docs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -11,6 +11,12 @@ Manages user accounts and authentication for the platform. Stores profile data a
 - Session information is stored in Redis as transient data for quick reconnections.
 - Emits account lifecycle events (creation, ban, recovery) for auditing by the Logging & Admin Service.
 - Maintains account-to-character relationships so players can own characters across multiple games.
+- Provides a JWKS endpoint for other services to validate tokens. Keys are rotated
+  via cert-manager as described in the [Security Architecture](../system-architecture-security.md).
+- All service-to-service communication is protected by mutual TLS.
+- Non-gameplay workflows such as account creation or billing updates are
+  orchestrated using the Saga pattern outlined in
+  [Transaction Strategies](../system-architecture-transactions.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -12,6 +12,10 @@ For details on how scripts are authored and executed safely, see [System Archite
 - Scripts run inside a sandboxed engine to prevent malicious behavior.
 - AI computations are optimized for large worlds using tick-based batching.
 - NPCs that are far from active players are deprioritized and only "wake up" on interaction.
+- Script definitions are versioned and can be hot reloaded without downtime as
+  described in [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
+- Uploading or replacing scripts is handled as a Saga workflow so that failures
+  can be rolled back. See [Transaction Strategies](../system-architecture-transactions.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -12,6 +12,8 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Applies **optimistic locking** to avoid conflicting updates on the same entity.
 - **Database writes are deferred and batched**, not triggered on every gameplay action. The Game Session Service coordinates real-time updates using Redis; the database is only updated during safe persistence boundaries (e.g. logout, autosave).
 - This design reduces write frequency and contention, making optimistic locking a natural fit — most entities are updated by only one process at a time, and conflicts are rare.
+- Cross-service operations such as item transfers use Saga orchestration so that
+  partial failures can be rolled back. See [Transaction Strategies](../system-architecture-transactions.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -10,6 +10,9 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Works closely with World Management and Automation & Scripting Service to apply changes.
 - Stores versioned configuration data so new game instances can be generated from templates.
 - Maintains history of revisions so designers can roll back to prior versions.
+- Publishing a new game version triggers a Saga that copies data to other
+  services as outlined in
+  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -10,6 +10,8 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Uses a modular command parser for extensibility.
 - Deterministic rule execution; random seeds come from the Game Session Service.
 - Fetches contextual world and entity data on demand via gRPC.
+- Integrates with the tick system described in [Tick System and Runtime Design](../system-architecture-ticks.md) to ensure deterministic command ordering.
+- When combat or trade spans multiple services, compensating actions are coordinated via the Saga model in [Transaction Strategies](../system-architecture-transactions.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -12,6 +12,9 @@ Orchestrates live game sessions, including tick execution, player input validati
 - Provides a single point of truth for current tick and world time.
 - Ensures atomic command execution using Redis transactions and Lua scripts.
 - Restores sessions after disconnects and enforces single-session control as outlined in the Reconnection Strategy.
+- Certain operations such as game startup and shutdown are implemented as Sagas
+  so that all dependent services remain in sync. See
+  [Transaction Strategies](../system-architecture-transactions.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -8,6 +8,9 @@ Centralized logging and administration tools for the platform. Collects log data
 
 Uses the common stack outlined in [Logging & Monitoring](../../system-architecture-logging-monitoring.md) and exposes admin endpoints for reviewing logs and applying moderation actions.
 All admin APIs are secured via role-based access control integrated with the Account Service.
+- Access to this service is protected by mTLS and JWT validation through the
+  JWKS endpoint provided by the Account Service. See
+  [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 
@@ -18,6 +21,8 @@ All admin APIs are secured via role-based access control integrated with the Acc
 - UI and APIs for toggling runtime feature flags. See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
 - Audit trail for account actions and world changes.
 - Transaction logs for purchases and subscription events.
+- Works with Saga workflows to record state changes across services. See
+  [Transaction Strategies](../system-architecture-transactions.md).
 
 ### Data Model
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -9,6 +9,10 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Uses WebSocket channels for chat delivery.
 - Stores guild and friend relationships in PostgreSQL.
 - Integrates with the Logging & Admin Service for moderation events.
+- Messages are briefly cached in Redis streams to smooth bursts of activity and
+  enable delivery retries.
+- Guild creation and membership changes participate in Saga workflows so other
+  services remain consistent. See [Transaction Strategies](../system-architecture-transactions.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -11,6 +11,8 @@ This service exposes WebSocket and HTTP endpoints for all clients. It routes req
 - Includes a fallback mechanism so players with unstable connections can rejoin seamlessly.
 - Applies rate limiting and authentication filters for admin endpoints.
 - Relies on the Game Session Service for gameplay login and session management.
+- Terminates external TLS and forwards traffic to backend services using mutual
+  TLS, as described in the [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -10,6 +10,9 @@ Bridges legacy Telnet clients into the platform by converting raw TCP traffic in
 - Buffers incoming input during brief disconnects and clears it on connection loss.
 - Handles Telnet negotiation and character encoding quirks.
 - Works with the Reconnection Strategy to resume sessions transparently.
+- Can optionally terminate Telnet-over-TLS and then forward traffic to the
+  gateway using mutual TLS. See
+  [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -12,6 +12,9 @@ The World Management Service stores and manages game world data such as rooms, r
 - Supports procedural generation with options for dynamic world expansion.
 - Uses a region → zone → room hierarchy for efficient lookups.
 - Publishes world event notifications for NPC scripts and game logic processing.
+- During version publishing the service participates in a Saga that copies design
+  data into its schema, ensuring world data matches the active version. See
+  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- flesh out microservice design docs with information from existing architecture docs
- describe saga usage, security details, and versioning links

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686887b870908330bad0e6158cf64968