### PR TITLE
Add ops references to service docs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -68,6 +68,9 @@ The gRPC schemas for this service live in
 - [User Journeys](../user-journeys.md#9-purchases-and-subscriptions) – payment and subscription workflow.
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Database Migrations](../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -72,6 +72,9 @@ stubs.
 - [System Architecture Overview](../system-architecture-overview.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Database Migrations](../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -58,6 +58,9 @@ proto files, run `./gradlew generateProto` to update generated sources.
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Database Migrations](../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -67,6 +67,9 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Database Migrations](../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -66,6 +66,9 @@ files change.
 - [User Journeys](../user-journeys.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Database Migrations](../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -62,6 +62,9 @@ Run `./gradlew generateProto` to regenerate sources after editing these files.
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Database Migrations](../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 


### PR DESCRIPTION
## Summary
- link backup, migrations, and logging docs from each stateful service design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868b97ca2288330b45ff5fe15ed1dbe