### PR TITLE
Improve microservice docs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -52,6 +52,17 @@ Manages user accounts and authentication for the platform. Stores profile data a
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Deployed via Kubernetes as a horizontally scalable Deployment. Local
+  development uses Docker Compose with the same Spring profiles.
+- Exposes `/actuator/health` for readiness and liveness probes consumed by the
+  cluster.
+- Metrics are scraped by Prometheus and logs shipped through Fluent Bit to
+  Elasticsearch, with traces captured via OpenTelemetry.
+- Configuration differences between environments are described in
+  [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 The gRPC schemas for this service live in

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -55,6 +55,16 @@ For details on how scripts are authored and executed safely, see [System Archite
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Deployed as a Kubernetes Deployment with optional horizontal scaling.
+- Exposes Spring Boot health endpoints for readiness and liveness probing.
+- Prometheus and Fluent Bit collect metrics and logs for Elasticsearch analysis,
+  with traces emitted via OpenTelemetry.
+- Development under Docker Compose mirrors this setup using the same Spring
+  profiles as described in
+  [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 API definitions are located in

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -43,6 +43,16 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Runs as a scalable Deployment in Kubernetes, exposing `/actuator/health` for
+  readiness and liveness checks.
+- Prometheus scrapes service metrics while Fluent Bit ships logs to
+  Elasticsearch; tracing integrates with OpenTelemetry.
+- Local Docker Compose uses the same Spring profiles to mimic production, as
+  documented in
+  [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 Service interface definitions are stored in

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -53,6 +53,18 @@ Offers tools for building worlds, items, actions, and events that make up each g
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Runs as a Kubernetes Deployment with optional horizontal scaling controlled by
+  HPA.
+- Health and readiness are exposed via `/actuator/health` and monitored by the
+  cluster.
+- Metrics and traces integrate with Prometheus and OpenTelemetry, while logs are
+  forwarded through Fluent Bit to Elasticsearch.
+- Local Docker Compose uses the same Spring profiles; see
+  [Deployment Environments](../../infrastructure/deployment-environments.md) for
+  details.
+
 ## Proto Files
 
 The service API contract resides in

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -48,6 +48,16 @@ This service is largely stateless. It relies on:
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Deployed as a stateless Kubernetes Deployment with horizontal scaling enabled
+  for high concurrency.
+- `/actuator/health` is used for readiness and liveness probes in the cluster.
+- Prometheus collects command execution metrics while Fluent Bit forwards logs
+  to Elasticsearch with trace context from OpenTelemetry.
+- For environment-specific configuration see
+  [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 gRPC service definitions can be found in

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -50,6 +50,13 @@ Orchestrates live game sessions, including tick execution, player input validati
 
 > See [**Gateway Architecture**](../../infrastructure/gateway-architecture.md), [**Deployment Environments**](../../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for details on shared infrastructure components.
 
+## Operational Notes
+
+- Deployed in Kubernetes with multiple replicas; Redis provides the shared state needed for sticky sessions.
+- Exposes `/actuator/health` for readiness and liveness probes used by the cluster.
+- Metrics and traces flow to Prometheus and OpenTelemetry, and logs are shipped via Fluent Bit to Elasticsearch.
+- Refer to [Deployment Environments](../../infrastructure/deployment-environments.md) for differences between Docker Compose and production setups.
+
 ## Proto Files
 
 Service definitions reside in

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -53,6 +53,16 @@ All admin APIs are secured via role-based access control integrated with the Acc
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Deployed as a Kubernetes Deployment with horizontal scaling for log-processing
+  workloads.
+- Health endpoints under `/actuator/health` feed readiness and liveness probes.
+- Metrics and OpenTelemetry traces are scraped by Prometheus; Fluent Bit ships
+  structured logs to Elasticsearch for search.
+- Environment differences are outlined in
+  [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 API schemas are kept in

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -51,6 +51,16 @@ Provides chat, guild, and social networking features across games. Enables playe
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Runs as a Kubernetes Deployment. WebSocket chat traffic scales horizontally
+  with multiple replicas.
+- The service publishes metrics scraped by Prometheus and forwards logs through
+  Fluent Bit to Elasticsearch with trace IDs from OpenTelemetry.
+- Health is monitored via `/actuator/health`; see
+  [Deployment Environments](../../infrastructure/deployment-environments.md) for
+  differences between local Docker Compose and production.
+
 ## Proto Files
 
 The social APIs are defined in

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -47,6 +47,17 @@ The gateway is stateless. Route configurations are stored in
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Runs as a stateless gateway Deployment in Kubernetes, typically exposed via a
+  load balancer service.
+- `/actuator/health` endpoints are used for readiness and liveness probes.
+- Prometheus scrapes metrics such as connection counts while Fluent Bit forwards
+  structured logs to Elasticsearch; tracing integrates with OpenTelemetry.
+- [Deployment Environments](../../infrastructure/deployment-environments.md)
+  explains how routes and certificates differ between Docker Compose and
+  production clusters.
+
 ## Proto Files
 
 Gateway-related proto definitions are stored in

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -54,6 +54,15 @@ to the gateway.
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on how Telnet connections are integrated into the platform.
 
+## Operational Notes
+
+- Deployed alongside the gateway in the DMZ as a lightweight container.
+- Health is checked using a custom TCP probe defined in the Kubernetes manifest.
+- Logs are forwarded via Fluent Bit and metrics are exported for Prometheus via
+  a minimal collector endpoint.
+- Configuration for local Docker Compose versus production clusters is described
+  in [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 Even though the proxy has no public API, supporting event messages are defined

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -46,6 +46,17 @@ The World Management Service stores and manages game world data such as rooms, r
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
 details on shared infrastructure components.
 
+## Operational Notes
+
+- Runs as a Kubernetes Deployment with horizontal scaling to serve large world
+  datasets.
+- Health endpoints (`/actuator/health`) are used for readiness and liveness
+  checks.
+- Metrics and traces are collected by Prometheus and OpenTelemetry, and logs are
+  shipped via Fluent Bit to Elasticsearch.
+- Environment-specific configuration values are described in
+  [Deployment Environments](../../infrastructure/deployment-environments.md).
+
 ## Proto Files
 
 The gRPC contract for world operations is located in


### PR DESCRIPTION
## Summary
- document operational guidelines for each microservice
- include Kubernetes and monitoring info for services

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868bc0634088330a63c362368ceae13