### PR TITLE
Add resource limits for k8s manifests

### DIFF
--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: account-service
           image: account-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: automation-scripting-service
           image: automation-scripting-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: entity-management-service
           image: entity-management-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: game-design-service
           image: game-design-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: game-logic-service
           image: game-logic-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: game-session-service
           image: game-session-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/gateway.yaml
+++ b/k8s/base/gateway.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: spring-cloud-gateway
           image: spring-cloud-gateway:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: logging-admin-service
           image: logging-admin-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: social-groups-service
           image: social-groups-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: tcp-proxy-service
           image: tcp-proxy-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 2323
           readinessProbe:

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -15,6 +15,13 @@ spec:
       containers:
         - name: world-management-service
           image: world-management-service:latest
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 8080
           readinessProbe:


### PR DESCRIPTION
## Summary
- add CPU and memory requests/limits in baseline Kubernetes manifests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868bf6b1dbc8330b96d1551d74836f2