### PR TITLE
Reorder task list for behavior-first planning

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -43,6 +43,15 @@ This checklist is structured to **build foundational features first**, followed 
 ---
 
 ## 🛠️ Phase 1: Core Infrastructure & Basic Services
+### Behavior and Orchestration Planning
+- [ ] Define core service responsibilities and runtime behaviors
+  - [ ] Outline tick flow, session management, reconnect logic, and command execution
+- [ ] Write sample gameplay use cases and trace the end-to-end flow
+  - [ ] Example flows: LOGIN, MOVE, CAST_SPELL
+- [ ] Identify the data each service needs to handle those flows
+- [ ] Derive minimal data models and proto schemas based on real usage
+- [ ] Refine shared DTOs and gRPC contracts from concrete examples
+
 ### Immediate Next Steps
 - [ ] Configure Gradle protobuf plugin and generate gRPC stubs
   - [ ] Apply `com.google.protobuf` Gradle plugin in each service module
@@ -54,15 +63,6 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Add `postgres` and `redis` services to `docker-compose.yml`
   - [ ] Provide default credentials and mounted volumes for local data
   - [ ] Document connection settings in `DEVELOPER_SETUP.md`
-
-### Behavior and Orchestration Planning
-- [ ] Define core service responsibilities and runtime behaviors
-  - [ ] Outline tick flow, session management, reconnect logic, and command execution
-- [ ] Write sample gameplay use cases and trace the end-to-end flow
-  - [ ] Example flows: LOGIN, MOVE, CAST_SPELL
-- [ ] Identify the data each service needs to handle those flows
-- [ ] Derive minimal data models and proto schemas based on real usage
-- [ ] Refine shared DTOs and gRPC contracts from concrete examples
 
 - [x] Create Gradle modules for all services with placeholder sources
  - [x] Add base Spring Boot Application classes for each service


### PR DESCRIPTION
## Summary
- rearrange Phase 1 tasks in `task-list.md`
- place behavior and orchestration planning before implementation steps

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6868bf98e4e88330a9532e91b29ddd03