### PR TITLE
Adjust k8s replicas per design docs

### DIFF
--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: game-session-service
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: game-session-service

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: social-groups-service
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: social-groups-service


### PR DESCRIPTION
## Summary
- increase default replica count for game-session-service and social-groups-service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868bfc3524c8330a6e10ec8fcc27768