### PR TITLE
Improve multi-tenancy notes

### DIFF
--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -20,6 +20,8 @@ This directory contains detailed design documents for each core microservice in 
 | [TCP Proxy Service](./tcp-proxy-service/)                | Bridges Telnet clients into the WebSocket-based backend. |
 | [World Management Service](./world-management-service/)  | Handles world maps, regions, pathfinding data, and procedural generation. |
 | [Service Template](./service-template.md)                | Template for creating new microservice docs. |
+All services share the same cluster and databases. Each table stores a `tenantId` and Redis keys use a matching prefix so data stays isolated between games. See [Multi-Tenancy](../system-architecture-multi-tenancy.md) for details.
+
 
 ---
 

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -11,6 +11,10 @@ Manages user accounts and authentication for the platform. Stores profile data a
 - Session information is stored in Redis as transient data for quick reconnections.
 - Emits account lifecycle events (creation, ban, recovery) for auditing by the Logging & Admin Service.
 - Maintains account-to-character relationships so players can own characters across multiple games.
+- All tables include a `tenantId` column so the same platform account can join
+  multiple games without data leakage. Every query enforces this tenant filter as
+  described in the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+  design.
 - Provides a JWKS endpoint for other services to validate tokens. Keys are rotated
   via cert-manager as described in the [Security Architecture](../system-architecture-security.md).
 - All service-to-service communication is protected by mutual TLS.

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -16,6 +16,9 @@ For details on how scripts are authored and executed safely, see [System Archite
   described in [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
 - Uploading or replacing scripts is handled as a Saga workflow so that failures
   can be rolled back. See [Transaction Strategies](../system-architecture-transactions.md).
+- Each game's scripts live in tables keyed by `tenantId`, ensuring automation for
+  one game cannot access another's data. Redis queues also include the tenant
+  prefix; see [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -14,6 +14,10 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - This design reduces write frequency and contention, making optimistic locking a natural fit — most entities are updated by only one process at a time, and conflicts are rare.
 - Cross-service operations such as item transfers use Saga orchestration so that
   partial failures can be rolled back. See [Transaction Strategies](../system-architecture-transactions.md).
+- All entity tables include a `tenantId` column. Service methods always filter on
+  this value so character data for different games remains isolated; Redis keys
+  mirror this prefix. Details are in the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+  document.
 
 ## Key Features
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -13,6 +13,9 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Publishing a new game version triggers a Saga that copies data to other
   services as outlined in
   [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
+- Design assets are stored per `tenantId` so multiple games can coexist in the
+  same database schema. Queries and version publishing workflows enforce this
+  tenant filter. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -12,6 +12,9 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Fetches contextual world and entity data on demand via gRPC.
 - Integrates with the tick system described in [Tick System and Runtime Design](../system-architecture-ticks.md) to ensure deterministic command ordering.
 - When combat or trade spans multiple services, compensating actions are coordinated via the Saga model in [Transaction Strategies](../system-architecture-transactions.md).
+- All commands are scoped by `tenantId` so that rules execute only against data
+  for the active game instance. The Game Session Service passes this context on
+  every request. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -14,6 +14,10 @@ Orchestrates live game sessions, including tick execution, player input validati
 - Crash recovery replays ticks stored in Redis using AOF persistence and `WAIT`
   semantics, ensuring deterministic recovery as described in
   [Tick System and Runtime Design](../system-architecture-ticks.md#crash-recovery-and-replay).
+- Every session record includes a `tenantId` identifying the game instance.
+  Redis keys and database tables prefix this value so sessions from different
+  games remain isolated. Details are in the
+  [Multi-Tenancy](../system-architecture-multi-tenancy.md) document.
 - Restores sessions after disconnects and enforces single-session control as outlined in the Reconnection Strategy.
 - Certain operations such as game startup and shutdown are implemented as Sagas
   so that all dependent services remain in sync. See

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -11,6 +11,10 @@ All admin APIs are secured via role-based access control integrated with the Acc
 - Access to this service is protected by mTLS and JWT validation through the
   JWKS endpoint provided by the Account Service. See
   [Security Architecture](../system-architecture-security.md).
+- Moderation data and log indices include a `tenantId` field so administrators
+  only see information for the games they manage. Cross-tenant queries are
+  rejected per the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+  strategy.
 
 ## Key Features
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -13,6 +13,9 @@ Provides chat, guild, and social networking features across games. Enables playe
   enable delivery retries.
 - Guild creation and membership changes participate in Saga workflows so other
   services remain consistent. See [Transaction Strategies](../system-architecture-transactions.md).
+- Chat history and guild data are stored with a `tenantId` so conversations are
+  isolated per game. Redis stream keys also include this prefix. See
+  [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -13,6 +13,9 @@ This service exposes WebSocket and HTTP endpoints for all clients. It routes req
 - Relies on the Game Session Service for gameplay login and session management.
 - Terminates external TLS and forwards traffic to backend services using mutual
   TLS, as described in the [Security Architecture](../system-architecture-security.md).
+- Hostnames or path prefixes map incoming connections to a `tenantId` so the
+  gateway can route players to the correct game instance. See
+  [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -13,6 +13,9 @@ Bridges legacy Telnet clients into the platform by converting raw TCP traffic in
 - Can optionally terminate Telnet-over-TLS and then forward traffic to the
   gateway using mutual TLS. See
   [Security Architecture](../system-architecture-security.md).
+- During the login handshake the proxy tags the connection with the selected
+  `tenantId` so the gateway can route commands to the proper game. See
+  [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -15,6 +15,9 @@ The World Management Service stores and manages game world data such as rooms, r
 - During version publishing the service participates in a Saga that copies design
   data into its schema, ensuring world data matches the active version. See
   [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
+- All world tables are keyed by `tenantId`; background jobs and gRPC queries
+  include this filter so one game's world data never mixes with another's. See
+  [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- mention multi-tenancy data separation across all microservice docs
- explain tenantId storage in service docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868c6b292d88330a57dfea4616ead72