### PR TITLE
Set prod profile for k8s manifests

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -19,3 +19,4 @@ kubectl apply -f base/spring-cloud-gateway.yaml
 ```
 
 Customize these manifests with proper image repositories and resource limits before running in production.
+All Spring Boot services are configured to run with the `prod` profile by default via the `SPRING_PROFILES_ACTIVE` environment variable.

--- a/k8s/base/README.md
+++ b/k8s/base/README.md
@@ -21,3 +21,5 @@ kubectl apply -f spring-cloud-gateway.yaml
 These files expose the services internally using `ClusterIP` (except the gateway and TCP proxy which are `LoadBalancer`). See the [Deployment Environments](../../design/architecture/infrastructure/deployment-environments.md) document for production considerations.
 
 All deployments include basic readiness and liveness probes that hit the `/actuator/health` endpoint (or open a TCP socket for the proxy service) as described in the design docs.
+
+Spring Boot services run with the `prod` Spring profile by default. This is set via the `SPRING_PROFILES_ACTIVE` environment variable in each deployment manifest.

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: account-service
           image: account-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: automation-scripting-service
           image: automation-scripting-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: entity-management-service
           image: entity-management-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: game-design-service
           image: game-design-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: game-logic-service
           image: game-logic-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: game-session-service
           image: game-session-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: logging-admin-service
           image: logging-admin-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: social-groups-service
           image: social-groups-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -16,6 +16,9 @@ spec:
       containers:
         - name: spring-cloud-gateway
           image: spring-cloud-gateway:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
         - name: world-management-service
           image: world-management-service:latest
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "prod"
           resources:
             requests:
               cpu: "100m"


### PR DESCRIPTION
## Summary
- add SPRING_PROFILES_ACTIVE=prod for all Spring Boot deployments
- document prod profile usage in k8s READMEs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868c7b4ec608330b52bff99b003f276