### PR TITLE
Fix entity proto folder name

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -56,7 +56,7 @@ details on shared infrastructure components.
 ## Proto Files
 
 Service interface definitions are stored in
-[../../../../protos/entity/v1](../../../../protos/entity/v1). After editing the
+[../../../../protos/entity-management/v1](../../../../protos/entity-management/v1). After editing the
 proto files, run `./gradlew generateProto` to update generated sources.
 
 ## 📚 Related Documentation

--- a/protos/entity-management/v1/README.md
+++ b/protos/entity-management/v1/README.md
@@ -1,0 +1,7 @@
+# Entity Management Service Proto (v1)
+
+This directory contains version 1 protocol buffer definitions for the Entity Management Service.
+They describe the gRPC API exposed by the service.
+
+Generate Java stubs with `./gradlew generateProto` from the repository root.
+For details see the [design docs](../../../design/architecture/microservices/entity-management-service/README.md).

--- a/protos/entity/v1/README.md
+++ b/protos/entity/v1/README.md
@@ -1,7 +1,0 @@
-# Entity Service Proto (v1)
-
-This directory contains version 1 protocol buffer definitions for the entity service.
-They describe the gRPC API exposed by the service.
-
-Generate Java stubs with `./gradlew generateProto` from the repository root.
-For details see the [design docs](../../../design/architecture/microservices/entity-service/README.md).


### PR DESCRIPTION
## Summary
- rename `protos/entity` to `protos/entity-management`
- update entity management docs

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6868c8aa8c50833099ea87ec0f0dc830