### PR TITLE
Update compose env vars and health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,49 +1,142 @@
 version: '3.9'
+
+x-service-environment: &service-env
+  POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+  POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+  POSTGRES_DB: ${POSTGRES_DB:-firemud}
+  POSTGRES_USER: ${POSTGRES_USER:-firemud}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-firemud}
+  REDIS_HOST: ${REDIS_HOST:-redis}
+  REDIS_PORT: ${REDIS_PORT:-6379}
+
+x-service-healthcheck: &service-health
+  test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+
 services:
   account-service:
     build: ./services/account-service
     ports:
       - "8081:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   gateway:
     build: ./services/spring-cloud-gateway
     ports:
       - "8080:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   automation-scripting-service:
     build: ./services/automation-scripting-service
     ports:
       - "8082:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   entity-management-service:
     build: ./services/entity-management-service
     ports:
       - "8083:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   game-design-service:
     build: ./services/game-design-service
     ports:
       - "8084:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   game-logic-service:
     build: ./services/game-logic-service
     ports:
       - "8085:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   game-session-service:
     build: ./services/game-session-service
     ports:
       - "8086:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   logging-admin-service:
     build: ./services/logging-admin-service
     ports:
       - "8087:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   social-groups-service:
     build: ./services/social-groups-service
     ports:
       - "8088:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   tcp-proxy-service:
     build: ./services/tcp-proxy-service
     ports:
       - "2323:2323"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
   world-management-service:
     build: ./services/world-management-service
     ports:
       - "8089:8080"
+    environment:
+      <<: *service-env
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      <<: *service-health
 
   postgres:
     image: postgres:16
@@ -56,6 +149,11 @@ services:
       - postgres-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-firemud}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7
@@ -65,6 +163,11 @@ services:
       - redis-data:/data
     ports:
       - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Summary
- document DB configuration defaults in `.env.sample`
- pass DB and Redis settings to every service in `docker-compose.yml`
- add service health checks and depends_on for postgres/redis

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868cae502108330b1f1303d9f414e59