### PR TITLE
Improve Kubernetes manifest style

### DIFF
--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -35,6 +35,8 @@ Despite their differences, both protocols are normalized into the same internal 
 
 - Used by traditional MUD clients (e.g., MUDlet, TinTin++, GMud).
 - Clients connect using raw TCP (typically Telnet-compatible).
+- The proxy listens on port `2323` by default so Telnet clients can simply
+  connect without additional configuration.
 - Handled by a dedicated **TCP Proxy Service**.
 - The service:
   - Accepts and parses Telnet line-based input.

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,4 +52,5 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      protocol: TCP
   type: LoadBalancer

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,4 +46,5 @@ spec:
   ports:
     - port: 2323
       targetPort: 2323
+      protocol: TCP
   type: LoadBalancer

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,4 +51,5 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
   type: ClusterIP


### PR DESCRIPTION
## Summary
- add YAML document start markers
- specify port protocol in services
- clarify TCP proxy default port in design docs

## Testing
- `yamllint k8s/base/*.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6868cc95da9083309ca8696a1bc515c6