### PR TITLE
Implement gRPC proto generation and account entities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.github.gradle.node.npm.task.NpxTask
 plugins {
     java
     id("com.github.node-gradle.node") version "7.1.0"
+    id("com.google.protobuf") version "0.9.4" apply false
 }
 
 node {
@@ -18,11 +19,17 @@ allprojects {
 
 subprojects {
     apply(plugin = "java")
+    apply(plugin = "com.google.protobuf")
     group = "net.fire-devops.firemud"
     version = "0.1.0-SNAPSHOT"
 
     dependencies {
         testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
+        implementation("io.grpc:grpc-stub:1.61.0")
+        implementation("io.grpc:grpc-protobuf:1.61.0")
+        implementation("io.grpc:grpc-netty-shaded:1.61.0")
+        implementation("com.google.protobuf:protobuf-java:3.25.3")
+        implementation("javax.annotation:javax.annotation-api:1.3.2")
     }
 
     tasks.test {

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -45,9 +45,9 @@ This checklist is structured to **build foundational features first**, followed 
 ## 🛠️ Phase 1: Core Infrastructure & Basic Services
 
 ### Immediate Next Steps
-- [ ] Configure Gradle protobuf plugin and generate gRPC stubs
-  - [ ] Apply `com.google.protobuf` Gradle plugin in each service module
-  - [ ] Verify Java sources are generated under `build/generated` after `./gradlew build`
+- [x] Configure Gradle protobuf plugin and generate gRPC stubs
+  - [x] Apply `com.google.protobuf` Gradle plugin in each service module
+  - [x] Verify Java sources are generated under `build/generated` after `./gradlew build`
 - [x] Add base `application.yml` configuration and profiles
   - [x] Create default `application.yml` with dev and prod profiles
   - [x] Externalize database and Redis settings via environment variables
@@ -72,7 +72,7 @@ This checklist is structured to **build foundational features first**, followed 
  - [x] Add base Spring Boot Application classes for each service
 - [x] Generate skeleton controllers and service classes for each microservice
 - [ ] Define base entity and repository classes for core domains
-  - [ ] Account Service: `Account` and `Profile` entities with JPA repositories
+  - [x] Account Service: `Account` and `Profile` entities with JPA repositories
   - [ ] Entity Management Service: `Character`, `Item`, `NPC` entities
   - [ ] World Management Service: `Room` and `Region` entities
   - [ ] Game Session Service: `GameInstance` entity
@@ -112,7 +112,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] **Define security best practices (OAuth2, JWT, RBAC, input validation, rate-limiting)**
   - [ ] Ensure authentication utilities from common package integrate seamlessly
   - [ ] Add initial protobuf IDL files for all microservices based on sample flows
-    - [ ] Account Service proto definitions
+    - [x] Account Service proto definitions
     - [ ] Game Session Service proto definitions
     - [ ] World Management Service proto definitions
     - [ ] Entity Management Service proto definitions

--- a/protos/account/v1/README.md
+++ b/protos/account/v1/README.md
@@ -1,7 +1,8 @@
 # Account Service Proto (v1)
 
 This directory houses the version 1 protocol buffer definitions for the Account Service. These
-files define registration, authentication, profile, and session management APIs.
+files define registration, authentication, profile, and session management APIs. The
+initial schema provides a simple `Ping` RPC for connectivity testing.
 
 Generate Java stubs via `./gradlew generateProto` from the repository root.
 

--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package account.v1;
+
+option java_package = "net.fire_devops.firemud.account.v1";
+option java_multiple_files = true;
+
+service AccountService {
+  rpc Ping(PingRequest) returns (PingResponse);
+}
+
+message PingRequest {}
+
+message PingResponse {
+  string message = 1;
+}

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -1,6 +1,8 @@
+import com.google.protobuf.gradle.*
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +16,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/account")
+    }
 }

--- a/services/account-service/src/main/java/net/fire_devops/firemud/entity/Account.java
+++ b/services/account-service/src/main/java/net/fire_devops/firemud/entity/Account.java
@@ -1,0 +1,22 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "accounts")
+public class Account {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String passwordHash;
+}

--- a/services/account-service/src/main/java/net/fire_devops/firemud/entity/Profile.java
+++ b/services/account-service/src/main/java/net/fire_devops/firemud/entity/Profile.java
@@ -1,0 +1,23 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "profiles")
+public class Profile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @Column(length = 100)
+    private String displayName;
+
+    @Column(length = 255)
+    private String bio;
+}

--- a/services/account-service/src/main/java/net/fire_devops/firemud/repository/AccountRepository.java
+++ b/services/account-service/src/main/java/net/fire_devops/firemud/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/services/account-service/src/main/java/net/fire_devops/firemud/repository/ProfileRepository.java
+++ b/services/account-service/src/main/java/net/fire_devops/firemud/repository/ProfileRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+}


### PR DESCRIPTION
## Summary
- enable protobuf & gRPC dependencies in Gradle
- configure protobuf plugin for account-service
- add Account and Profile JPA entities with repositories
- create v1 `AccountService` proto and document
- check off related tasks in task list

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6868cce0fcc88330a5f3b7cd3799e062