### PR TITLE
Update compose env handling

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -14,6 +14,8 @@ FireMUD uses Docker Compose for local development and testing:
 - Docker Compose orchestrates container startup, but not readiness.
 - Service discovery is handled by Docker's internal DNS (e.g., `game-session-service:8080`).
 - Route URIs in Spring Cloud Gateway use static hostnames defined in `application-dev.yml`.
+- Connection settings for PostgreSQL and Redis are loaded from a `.env` file.
+  A sample `.env.sample` is provided with default credentials.
 
 ### 🩺 Docker Health Checks
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ services:
       - "8081:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -33,6 +36,9 @@ services:
       - "8080:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -44,6 +50,9 @@ services:
       - "8082:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -55,6 +64,9 @@ services:
       - "8083:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -66,6 +78,9 @@ services:
       - "8084:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -77,6 +92,9 @@ services:
       - "8085:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -88,6 +106,9 @@ services:
       - "8086:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -99,6 +120,9 @@ services:
       - "8087:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -110,6 +134,9 @@ services:
       - "8088:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -121,6 +148,9 @@ services:
       - "2323:2323"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis
@@ -132,6 +162,9 @@ services:
       - "8089:8080"
     environment:
       <<: *service-env
+    env_file:
+      - .env
+    restart: unless-stopped
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Summary
- reference `.env.sample` for dev DB credentials
- load `.env` automatically in compose and restart on failure

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6868cd8e67588330b69a960c3c9c4358