### PR TITLE
Update k8s docs

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -20,3 +20,7 @@ kubectl apply -f base/spring-cloud-gateway.yaml
 
 Customize these manifests with proper image repositories and resource limits before running in production.
 All Spring Boot services are configured to run with the `prod` profile by default via the `SPRING_PROFILES_ACTIVE` environment variable.
+
+Services follow the port scheme described in the infrastructure docs: most
+containers listen on `8080`, the TCP proxy exposes `2323` for Telnet clients,
+and the Spring Cloud Gateway is published on port `80`.

--- a/k8s/base/README.md
+++ b/k8s/base/README.md
@@ -20,6 +20,12 @@ kubectl apply -f spring-cloud-gateway.yaml
 
 These files expose the services internally using `ClusterIP` (except the gateway and TCP proxy which are `LoadBalancer`). See the [Deployment Environments](../../design/architecture/infrastructure/deployment-environments.md) document for production considerations.
 
+Ports align with the design documents:
+
+- Application services expose `8080`.
+- The TCP proxy listens on `2323` for Telnet connections.
+- Spring Cloud Gateway is reachable via port `80`.
+
 All deployments include basic readiness and liveness probes that hit the `/actuator/health` endpoint (or open a TCP socket for the proxy service) as described in the design docs.
 
 Spring Boot services run with the `prod` Spring profile by default. This is set via the `SPRING_PROFILES_ACTIVE` environment variable in each deployment manifest.


### PR DESCRIPTION
## Summary
- clarify which ports each service exposes in Kubernetes docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868cf06d3908330b8c848b0755d9aa9