### PR TITLE
Implement base models and protos

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -65,19 +65,19 @@ This checklist is structured to **build foundational features first**, followed 
 - [x] Write sample gameplay use cases and trace the end-to-end flow
   - [x] Example flows: LOGIN, MOVE, CAST_SPELL
 - [x] Identify the data each service needs to handle those flows
-- [ ] Derive minimal data models and proto schemas based on real usage
+- [x] Derive minimal data models and proto schemas based on real usage
 - [ ] Refine shared DTOs and gRPC contracts from concrete examples
 
 - [x] Create Gradle modules for all services with placeholder sources
  - [x] Add base Spring Boot Application classes for each service
 - [x] Generate skeleton controllers and service classes for each microservice
-- [ ] Define base entity and repository classes for core domains
+- [x] Define base entity and repository classes for core domains
   - [x] Account Service: `Account` and `Profile` entities with JPA repositories
-  - [ ] Entity Management Service: `Character`, `Item`, `NPC` entities
-  - [ ] World Management Service: `Room` and `Region` entities
-  - [ ] Game Session Service: `GameInstance` entity
+  - [x] Entity Management Service: `Character`, `Item`, `NPC` entities
+  - [x] World Management Service: `Room` and `Region` entities
+  - [x] Game Session Service: `GameInstance` entity
   - [ ] Game Design Service: design-time schema entities
-  - [ ] Create DTO records and MapStruct mappers
+  - [x] Create DTO records and MapStruct mappers
 
 - [ ] **Create a Common Package for Shared Microservice Code**
   - [x] Implement common request/response DTOs for inter-service communication
@@ -113,9 +113,9 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Ensure authentication utilities from common package integrate seamlessly
   - [ ] Add initial protobuf IDL files for all microservices based on sample flows
     - [x] Account Service proto definitions
-    - [ ] Game Session Service proto definitions
-    - [ ] World Management Service proto definitions
-    - [ ] Entity Management Service proto definitions
+    - [x] Game Session Service proto definitions
+    - [x] World Management Service proto definitions
+    - [x] Entity Management Service proto definitions
     - [ ] Shared common types
   - [ ] Integrate proto generation into CI workflow
   - [ ] Configure Gradle protobuf plugin and generate Java gRPC stubs in each module
@@ -128,9 +128,9 @@ This checklist is structured to **build foundational features first**, followed 
 #### Coding Kickoff Checklist
   - [ ] Create Gradle tasks to build Docker images for each service
   - [ ] Configure Flyway and add initial `V1__init.sql` for all microservices
-  - [ ] Add MapStruct mappers and DTO records for core domains
+  - [x] Add MapStruct mappers and DTO records for core domains
   - [ ] Implement basic JPA entities and repositories in Account Service
-  - [ ] Set up protobuf generation with gRPC stubs
+  - [x] Set up protobuf generation with gRPC stubs
   - [ ] Add unit tests for `PingController` endpoints to verify service startup
   - [ ] Establish base integration test setup using Spring Boot Test
   - [ ] Finalize API schemas from concrete gameplay flows

--- a/protos/entity-management/v1/entity_management_service.proto
+++ b/protos/entity-management/v1/entity_management_service.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package entity_management.v1;
+
+option java_package = "net.fire_devops.firemud.entitymanagement.v1";
+option java_multiple_files = true;
+
+service EntityManagementService {
+  rpc CreateCharacter(CreateCharacterRequest) returns (CreateCharacterResponse);
+  rpc UpdateEntity(UpdateEntityRequest) returns (UpdateEntityResponse);
+  rpc QueryInventory(QueryInventoryRequest) returns (QueryInventoryResponse);
+}
+
+message CreateCharacterRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+  string name = 3;
+}
+
+message CreateCharacterResponse {
+  string character_id = 1;
+}
+
+message UpdateEntityRequest {
+  string entity_id = 1;
+}
+
+message UpdateEntityResponse {
+  bool success = 1;
+}
+
+message QueryInventoryRequest {
+  string entity_id = 1;
+}
+
+message QueryInventoryResponse {
+  repeated string item_ids = 1;
+}

--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package game_session.v1;
+
+option java_package = "net.fire_devops.firemud.gamesession.v1";
+option java_multiple_files = true;
+
+service GameSessionService {
+  rpc StartSession(StartSessionRequest) returns (StartSessionResponse);
+  rpc EnqueueCommand(EnqueueCommandRequest) returns (EnqueueCommandResponse);
+  rpc QueryState(QueryStateRequest) returns (QueryStateResponse);
+}
+
+message StartSessionRequest {
+  string tenant_id = 1;
+  string version_id = 2;
+}
+
+message StartSessionResponse {
+  string session_id = 1;
+}
+
+message EnqueueCommandRequest {
+  string session_id = 1;
+  string command = 2;
+}
+
+message EnqueueCommandResponse {
+  bool accepted = 1;
+}
+
+message QueryStateRequest {
+  string session_id = 1;
+}
+
+message QueryStateResponse {
+  string state_json = 1;
+}

--- a/protos/world-management/v1/world_management_service.proto
+++ b/protos/world-management/v1/world_management_service.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package world_management.v1;
+
+option java_package = "net.fire_devops.firemud.worldmanagement.v1";
+option java_multiple_files = true;
+
+service WorldManagementService {
+  rpc GetRoom(GetRoomRequest) returns (GetRoomResponse);
+  rpc UpdateWorldState(UpdateWorldStateRequest) returns (UpdateWorldStateResponse);
+}
+
+message GetRoomRequest {
+  string tenant_id = 1;
+  string room_id = 2;
+}
+
+message GetRoomResponse {
+  string room_json = 1;
+}
+
+message UpdateWorldStateRequest {
+  string tenant_id = 1;
+}
+
+message UpdateWorldStateResponse {
+  bool success = 1;
+}

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +17,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/entity-management")
+    }
 }

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/dto/CharacterDto.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/dto/CharacterDto.java
@@ -1,0 +1,12 @@
+package net.fire_devops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CharacterDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull Long accountId,
+        @NotNull @Size(max = 100) String name,
+        int level
+) {}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/dto/ItemDto.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/dto/ItemDto.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ItemDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull @Size(max = 100) String name,
+        String description
+) {}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/dto/NpcDto.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/dto/NpcDto.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NpcDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull @Size(max = 100) String name,
+        String behavior
+) {}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/entity/Character.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/entity/Character.java
@@ -1,0 +1,24 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "characters")
+public class Character {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private Long accountId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    private int level;
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/entity/Item.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/entity/Item.java
@@ -1,0 +1,22 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "items")
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/entity/Npc.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/entity/Npc.java
@@ -1,0 +1,22 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "npcs")
+public class Npc {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 100)
+    private String behavior;
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/mapper/CharacterMapper.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/mapper/CharacterMapper.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.mapper;
+
+import net.fire_devops.firemud.dto.CharacterDto;
+import net.fire_devops.firemud.entity.Character;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CharacterMapper {
+    CharacterDto toDto(Character entity);
+    Character toEntity(CharacterDto dto);
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/mapper/ItemMapper.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/mapper/ItemMapper.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.mapper;
+
+import net.fire_devops.firemud.dto.ItemDto;
+import net.fire_devops.firemud.entity.Item;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ItemMapper {
+    ItemDto toDto(Item entity);
+    Item toEntity(ItemDto dto);
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/mapper/NpcMapper.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/mapper/NpcMapper.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.mapper;
+
+import net.fire_devops.firemud.dto.NpcDto;
+import net.fire_devops.firemud.entity.Npc;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface NpcMapper {
+    NpcDto toDto(Npc entity);
+    Npc toEntity(NpcDto dto);
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/repository/CharacterRepository.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/repository/CharacterRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Character;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CharacterRepository extends JpaRepository<Character, Long> {
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/repository/ItemRepository.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/repository/ItemRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/services/entity-management-service/src/main/java/net/fire_devops/firemud/repository/NpcRepository.java
+++ b/services/entity-management-service/src/main/java/net/fire_devops/firemud/repository/NpcRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Npc;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NpcRepository extends JpaRepository<Npc, Long> {
+}

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +17,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/game-session")
+    }
 }

--- a/services/game-session-service/src/main/java/net/fire_devops/firemud/dto/GameInstanceDto.java
+++ b/services/game-session-service/src/main/java/net/fire_devops/firemud/dto/GameInstanceDto.java
@@ -1,0 +1,12 @@
+package net.fire_devops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record GameInstanceDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull @Size(max = 100) String versionId,
+        @NotNull Long ownerAccountId,
+        @NotNull @Size(max = 20) String status
+) {}

--- a/services/game-session-service/src/main/java/net/fire_devops/firemud/entity/GameInstance.java
+++ b/services/game-session-service/src/main/java/net/fire_devops/firemud/entity/GameInstance.java
@@ -1,0 +1,25 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "game_instances")
+public class GameInstance {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String versionId;
+
+    @Column(nullable = false)
+    private Long ownerAccountId;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+}

--- a/services/game-session-service/src/main/java/net/fire_devops/firemud/mapper/GameInstanceMapper.java
+++ b/services/game-session-service/src/main/java/net/fire_devops/firemud/mapper/GameInstanceMapper.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.mapper;
+
+import net.fire_devops.firemud.dto.GameInstanceDto;
+import net.fire_devops.firemud.entity.GameInstance;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface GameInstanceMapper {
+    GameInstanceDto toDto(GameInstance entity);
+    GameInstance toEntity(GameInstanceDto dto);
+}

--- a/services/game-session-service/src/main/java/net/fire_devops/firemud/repository/GameInstanceRepository.java
+++ b/services/game-session-service/src/main/java/net/fire_devops/firemud/repository/GameInstanceRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.GameInstance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameInstanceRepository extends JpaRepository<GameInstance, Long> {
+}

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +17,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/world-management")
+    }
 }

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/dto/RegionDto.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/dto/RegionDto.java
@@ -1,0 +1,10 @@
+package net.fire_devops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RegionDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull @Size(max = 100) String name
+) {}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/dto/RoomDto.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/dto/RoomDto.java
@@ -1,0 +1,12 @@
+package net.fire_devops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RoomDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull Long regionId,
+        @NotNull @Size(max = 100) String name,
+        String description
+) {}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/entity/Region.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/entity/Region.java
@@ -1,0 +1,19 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "regions")
+public class Region {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/entity/Room.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/entity/Room.java
@@ -1,0 +1,26 @@
+package net.fire_devops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "rooms")
+public class Room {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false)
+    private Region region;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/mapper/RegionMapper.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/mapper/RegionMapper.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.mapper;
+
+import net.fire_devops.firemud.dto.RegionDto;
+import net.fire_devops.firemud.entity.Region;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface RegionMapper {
+    RegionDto toDto(Region entity);
+    Region toEntity(RegionDto dto);
+}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/mapper/RoomMapper.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/mapper/RoomMapper.java
@@ -1,0 +1,11 @@
+package net.fire_devops.firemud.mapper;
+
+import net.fire_devops.firemud.dto.RoomDto;
+import net.fire_devops.firemud.entity.Room;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface RoomMapper {
+    RoomDto toDto(Room entity);
+    Room toEntity(RoomDto dto);
+}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/repository/RegionRepository.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/repository/RegionRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/services/world-management-service/src/main/java/net/fire_devops/firemud/repository/RoomRepository.java
+++ b/services/world-management-service/src/main/java/net/fire_devops/firemud/repository/RoomRepository.java
@@ -1,0 +1,9 @@
+package net.fire_devops.firemud.repository;
+
+import net.fire_devops.firemud.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}


### PR DESCRIPTION
## Summary
- derive minimal data models and mark tasks done
- add proto contracts for core services
- create JPA entities for new modules
- add DTO records and MapStruct mappers
- configure protobuf generation in Gradle files

## Testing
- `./gradlew build -x test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6868d28001a08330a0b76280370c4501