### PR TITLE
Expand microservice design docs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -33,8 +33,10 @@ Manages user accounts and authentication for the platform. Stores profile data a
 
 - Account registration and login.
 - Profile management and email notifications.
+- Profiles track optional game history and achievements for each player.
 - Password reset and verification flows.
 - Banning and subscription tracking.
+- External account linking (Google, Discord, Steam) allows unified logins.
 - Handles payment processing via **Stripe** for one-time purchases and recurring subscriptions.
 - Links accounts to player characters for ownership and permissions.
 - gRPC APIs for account creation, authentication, and profile queries.
@@ -43,6 +45,8 @@ Manages user accounts and authentication for the platform. Stores profile data a
 
 - `account` table stores username, password hash, email, and status flags.
 - `profile` table captures optional user details and preferences.
+- `achievement` table records earned achievements keyed by account and game.
+- `external_account` table links third-party OAuth IDs to platform accounts.
 - `session` keys in Redis map temporary session tokens to account IDs for quick
   reconnects.
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -10,6 +10,8 @@ For details on how scripts are authored and executed safely, see [System Archite
 
 - Executes scripts in response to world or player events received via gRPC callbacks.
 - Scripts run inside a sandboxed engine to prevent malicious behavior.
+- Scripts are authored in a **component-based DSL** using a visual editor so
+  designers can build behaviors without coding.
 - AI computations are optimized for large worlds using tick-based batching.
 - NPCs that are far from active players are deprioritized and only "wake up" on interaction.
 - Script definitions are versioned and can be hot reloaded without downtime as

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -25,12 +25,16 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Item storage and inventory handling.
 - Experience and level tracking.
 - Character creation templates pulled from the Game Design Service.
+- Supports instance-based spaces so characters can enter private dungeons or
+  personalized housing without affecting the main world state.
 
 ### Data Model
 
 - `character` and `npc` tables share a base entity for stats and inventory slots.
 - `item` table stores equipment, consumables, and quest objects.
 - Many-to-many tables define inventory and equipment relationships.
+- `instance_member` table tracks which characters are present in optional
+  instance-based spaces.
 
 ### gRPC APIs
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -22,6 +22,8 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - World and room editors.
 - Ability and action design tools.
 - Scripting and event workflow creation.
+- Visual editor for building scripts in the same component-based DSL used by the
+  Automation & Scripting Service.
 - Game templates with predefined rulesets and administrators.
 - Version and patch note management for published games.
 - Import/export of design assets for sharing between game worlds.

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -10,6 +10,8 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Uses a modular command parser for extensibility.
 - Deterministic rule execution; random seeds come from the Game Session Service.
 - Fetches contextual world and entity data on demand via gRPC.
+- Gameplay rules are imported from the Game Design Service when a version is
+  published; the runtime service does not query design databases.
 - Integrates with the tick system described in [Tick System and Runtime Design](../system-architecture-ticks.md) to ensure deterministic command ordering.
 - When combat or trade spans multiple services, compensating actions are coordinated via the Saga model in [Transaction Strategies](../system-architecture-transactions.md).
 - All commands are scoped by `tenantId` so that rules execute only against data

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -16,8 +16,8 @@ Orchestrates live game sessions, including tick execution, player input validati
   [Tick System and Runtime Design](../system-architecture-ticks.md#crash-recovery-and-replay).
 - Every session record includes a `tenantId` identifying the game instance.
   Redis keys and database tables prefix this value so sessions from different
-  games remain isolated. Details are in the
-  [Multi-Tenancy](../system-architecture-multi-tenancy.md) document.
+  games remain isolated. The platform may enforce per-game resource quotas at this level so one tenant cannot exhaust cluster capacity.
+  See the [Multi-Tenancy](../system-architecture-multi-tenancy.md) document.
 - Restores sessions after disconnects and enforces single-session control as outlined in the Reconnection Strategy.
 - Certain operations such as game startup and shutdown are implemented as Sagas
   so that all dependent services remain in sync. See

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -23,6 +23,8 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Private messaging and presence indicators.
 - Guild creation and membership management.
 - Friend lists scoped both to individual games and to overall accounts.
+- Cross-game presence lets players know when friends are online in any hosted
+  game.
 - In-game social chat plus account-to-account direct messaging.
 
 ### Data Model

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -22,6 +22,8 @@ The World Management Service stores and manages game world data such as rooms, r
 ## Key Features
 
 - Region and location management with shard support.
+- Instance-based zones allow temporary dungeons or housing separate from the
+  shared world map.
 - Persistent world state with incremental saves.
 - Procedural generation tools for rooms and terrain.
 - Pathfinding algorithms and navmesh data for movement calculations.
@@ -32,6 +34,7 @@ The World Management Service stores and manages game world data such as rooms, r
 
 - Tables for `region`, `zone`, and `room` define the world hierarchy.
 - `terrain` and `object_spawn` tables support procedural generation.
+- `instance` table tracks temporary copies of zones for instanced gameplay.
 - Redis caches hot rooms for active sessions to speed up lookups.
 
 ### gRPC APIs


### PR DESCRIPTION
## Summary
- describe account achievements and external logins
- highlight component-based scripting DSL
- mention instanced areas in entity management and world management
- note rule import from design service and per-tenant quotas
- add cross-game presence in social groups

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868d6cfd51883309156c3e7d9a013e5