### PR TITLE
Implement Game Design proto and schema

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -77,7 +77,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Entity Management Service: `Character`, `Item`, `NPC` entities
   - [x] World Management Service: `Room` and `Region` entities
   - [x] Game Session Service: `GameInstance` entity
-  - [ ] Game Design Service: design-time schema entities
+  - [x] Game Design Service: design-time schema entities
   - [ ] Social & Groups Service: `ChatMessage`, `Guild`, `FriendLink` entities
   - [ ] Logging & Admin Service: `LogEvent` and `ModerationAction` entities
   - [x] Create DTO records and MapStruct mappers
@@ -122,7 +122,7 @@ This checklist is structured to **build foundational features first**, followed 
     - [x] Entity Management Service proto definitions
     - [ ] Game Logic Service proto definitions
     - [ ] Automation & Scripting Service proto definitions
-    - [ ] Game Design Service proto definitions
+    - [x] Game Design Service proto definitions
     - [ ] Social & Groups Service proto definitions
     - [ ] Logging & Admin Service proto definitions
     - [ ] TCP Proxy Service proto definitions
@@ -192,7 +192,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Enable publishing of game versions
   - [ ] Use saga orchestrator for game publishing workflow
   - [ ] Ensure domain services copy data by `version_id` and never query the design database at runtime
-  - [ ] Create gRPC GameDesignService and design-time database models
+  - [x] Create gRPC GameDesignService and design-time database models
 
 - [ ] **Develop Email & Notification System**
   - [ ] Implement email verification & password resets

--- a/protos/game-design/v1/README.md
+++ b/protos/game-design/v1/README.md
@@ -1,7 +1,7 @@
 # Game-design Service Proto (v1)
 
-This directory contains version 1 protocol buffer definitions for the game design service.
-They describe the gRPC API exposed by the service.
+This directory contains version 1 protocol buffer definitions for the Game Design Service.
+The primary file is `game_design_service.proto`, which defines the gRPC API for saving revisions and publishing versions.
 
 Generate Java stubs with `./gradlew generateProto` from the repository root.
 For details see the [design docs](../../../design/architecture/microservices/game-design-service/README.md).

--- a/protos/game-design/v1/game_design_service.proto
+++ b/protos/game-design/v1/game_design_service.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package gamedesign.v1;
+
+option java_package = "net.firedevops.firemud.gamedesign.v1";
+option java_multiple_files = true;
+
+service GameDesignService {
+  rpc SaveRevision(SaveRevisionRequest) returns (SaveRevisionResponse);
+  rpc PublishVersion(PublishVersionRequest) returns (PublishVersionResponse);
+  rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse);
+}
+
+message SaveRevisionRequest {
+  string data = 1;
+  int64 game_id = 2;
+  int64 author_account_id = 3;
+}
+
+message SaveRevisionResponse {
+  int64 revision_id = 1;
+}
+
+message PublishVersionRequest {
+  int64 game_id = 1;
+  string notes = 2;
+}
+
+message PublishVersionResponse {
+  int64 version_id = 1;
+}
+
+message ListVersionsRequest {
+  int64 game_id = 1;
+}
+
+message ListVersionsResponse {
+  repeated Version versions = 1;
+}
+
+message Version {
+  int64 id = 1;
+  int32 version_number = 2;
+  string notes = 3;
+}

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +17,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/game-design")
+    }
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameDto.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record GameDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull @Size(max = 100) String name,
+        String description
+) {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/dto/RevisionDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/dto/RevisionDto.java
@@ -1,0 +1,14 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record RevisionDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull Long gameId,
+        @NotNull Long authorAccountId,
+        @NotNull @Size(min = 1) String data,
+        LocalDateTime createdAt
+) {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/dto/VersionDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/dto/VersionDto.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record VersionDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull Long gameId,
+        int versionNumber,
+        String notes,
+        LocalDateTime createdAt
+) {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Game.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Game.java
@@ -1,0 +1,22 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "games")
+public class Game {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
@@ -1,0 +1,31 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "revisions")
+public class Revision {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    @Column(nullable = false)
+    private Long authorAccountId;
+
+    @Lob
+    @Column(nullable = false)
+    private String data;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "versions")
+public class Version {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    @Column(nullable = false)
+    private int versionNumber;
+
+    @Column(length = 255)
+    private String notes;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/GameMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/GameMapper.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GameDto;
+import net.firedevops.firemud.entity.Game;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface GameMapper {
+    GameDto toDto(Game entity);
+    Game toEntity(GameDto dto);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/RevisionMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/RevisionMapper.java
@@ -1,0 +1,14 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.RevisionDto;
+import net.firedevops.firemud.entity.Revision;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RevisionMapper {
+    @Mapping(target = "gameId", expression = "java(entity.getGame() != null ? entity.getGame().getId() : null)")
+    RevisionDto toDto(Revision entity);
+
+    Revision toEntity(RevisionDto dto);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/VersionMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/VersionMapper.java
@@ -1,0 +1,14 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.VersionDto;
+import net.firedevops.firemud.entity.Version;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface VersionMapper {
+    @Mapping(target = "gameId", expression = "java(entity.getGame() != null ? entity.getGame().getId() : null)")
+    VersionDto toDto(Version entity);
+
+    Version toEntity(VersionDto dto);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.Game;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameRepository extends JpaRepository<Game, Long> {
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/repository/RevisionRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/repository/RevisionRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.Revision;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RevisionRepository extends JpaRepository<Revision, Long> {
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/repository/VersionRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/repository/VersionRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.Version;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VersionRepository extends JpaRepository<Version, Long> {
+}


### PR DESCRIPTION
## Summary
- add entity definitions and repositories for Game Design Service
- add DTOs and MapStruct mappers
- configure protobuf plugin and JPA dependencies
- create `game_design_service.proto`
- mark relevant tasks done in `task-list.md`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_686916f34a208330a5541636f98e9b74