### PR TITLE
Improve microservice docs

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -18,6 +18,9 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
   this value so character data for different games remains isolated; Redis keys
   mirror this prefix. Details are in the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
   document.
+- gRPC endpoints are secured with JWT tokens validated via the Account Service's
+  JWKS endpoint, and all traffic between services uses mutual TLS certificates as
+  outlined in the [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 
@@ -82,6 +85,8 @@ proto files, run `./gradlew generateProto` to update generated sources.
 - [Database Migrations](../system-architecture-database-migrations.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../system-architecture-authentication.md)
+- [Security Architecture](../system-architecture-security.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -16,6 +16,10 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Design assets are stored per `tenantId` so multiple games can coexist in the
   same database schema. Queries and version publishing workflows enforce this
   tenant filter. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+- All APIs require JWT authentication and are validated using the Account
+  Service's JWKS endpoint. Service-to-service traffic is protected with mutual
+  TLS certificates managed by cert-manager as described in the
+  [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 
@@ -90,6 +94,8 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 - [Database Migrations](../system-architecture-database-migrations.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../system-architecture-authentication.md)
+- [Security Architecture](../system-architecture-security.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -17,6 +17,9 @@ Executes the core gameplay rules and command parsing. It processes player action
 - All commands are scoped by `tenantId` so that rules execute only against data
   for the active game instance. The Game Session Service passes this context on
   every request. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+- gRPC requests are authenticated with JWTs issued by the Account Service and
+  validated via its JWKS endpoint. Communications use mutual TLS certificates as
+  outlined in the [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 
@@ -79,6 +82,9 @@ the generated code with `./gradlew generateProto` after making changes.
 - [Tick System and Runtime Design](../system-architecture-ticks.md)
 - [Redis Architecture](../system-architecture-redis.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+- [Authentication & Authorization](../system-architecture-authentication.md)
+- [Security Architecture](../system-architecture-security.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Testing Strategy](../system-architecture-testing.md)

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -88,6 +88,8 @@ See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for 
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Authentication & Authorization](../system-architecture-authentication.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -16,6 +16,9 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Chat history and guild data are stored with a `tenantId` so conversations are
   isolated per game. Redis stream keys also include this prefix. See
   [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+- APIs require authenticated JWTs from the Account Service and all inter-service
+  communication is encrypted via mutual TLS, following the
+  [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 
@@ -86,6 +89,8 @@ files change.
 - [Database Migrations](../system-architecture-database-migrations.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../system-architecture-authentication.md)
+- [Security Architecture](../system-architecture-security.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -18,6 +18,9 @@ The World Management Service stores and manages game world data such as rooms, r
 - All world tables are keyed by `tenantId`; background jobs and gRPC queries
   include this filter so one game's world data never mixes with another's. See
   [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+- All gRPC operations require JWT authentication validated via the Account
+  Service's JWKS endpoint and use mutual TLS between services, per the
+  [Security Architecture](../system-architecture-security.md).
 
 ## Key Features
 
@@ -85,6 +88,8 @@ Run `./gradlew generateProto` to regenerate sources after editing these files.
 - [Database Migrations](../system-architecture-database-migrations.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../system-architecture-authentication.md)
+- [Security Architecture](../system-architecture-security.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 


### PR DESCRIPTION
## Summary
- expand microservice docs with JWT/mTLS details
- link authentication and security architecture sections across service docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68691d48ee188330b3a7ad9c879c359a