### PR TITLE
Implement initial social and admin domain stubs

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -78,8 +78,8 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] World Management Service: `Room` and `Region` entities
   - [x] Game Session Service: `GameInstance` entity
   - [x] Game Design Service: design-time schema entities
-  - [ ] Social & Groups Service: `ChatMessage`, `Guild`, `FriendLink` entities
-  - [ ] Logging & Admin Service: `LogEvent` and `ModerationAction` entities
+  - [x] Social & Groups Service: `ChatMessage`, `Guild`, `FriendLink` entities
+  - [x] Logging & Admin Service: `LogEvent` and `ModerationAction` entities
   - [x] Create DTO records and MapStruct mappers
 
 
@@ -123,8 +123,8 @@ This checklist is structured to **build foundational features first**, followed 
     - [ ] Game Logic Service proto definitions
     - [ ] Automation & Scripting Service proto definitions
     - [x] Game Design Service proto definitions
-    - [ ] Social & Groups Service proto definitions
-    - [ ] Logging & Admin Service proto definitions
+    - [x] Social & Groups Service proto definitions
+    - [x] Logging & Admin Service proto definitions
     - [ ] TCP Proxy Service proto definitions
     - [ ] Spring Cloud Gateway proto definitions
     - [ ] Shared common types

--- a/protos/logging-admin/v1/logging_admin_service.proto
+++ b/protos/logging-admin/v1/logging_admin_service.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package logging_admin.v1;
+
+option java_package = "net.firedevops.firemud.loggingadmin.v1";
+option java_multiple_files = true;
+
+service LoggingAdminService {
+  rpc Ping(PingRequest) returns (PingResponse);
+  rpc QueryLogs(QueryLogsRequest) returns (QueryLogsResponse);
+  rpc ApplyModerationAction(ApplyModerationActionRequest) returns (ApplyModerationActionResponse);
+}
+
+message PingRequest {}
+
+message PingResponse {
+  string message = 1;
+}
+
+message QueryLogsRequest {
+  string tenant_id = 1;
+  string filter = 2;
+}
+
+message QueryLogsResponse {
+  repeated string entries = 1;
+}
+
+message ApplyModerationActionRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+  string action = 3;
+  string reason = 4;
+}
+
+message ApplyModerationActionResponse {
+  bool success = 1;
+}

--- a/protos/social-groups/v1/social_groups_service.proto
+++ b/protos/social-groups/v1/social_groups_service.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package social_groups.v1;
+
+option java_package = "net.firedevops.firemud.socialgroups.v1";
+option java_multiple_files = true;
+
+service SocialGroupsService {
+  rpc Ping(PingRequest) returns (PingResponse);
+  rpc SendMessage(SendMessageRequest) returns (SendMessageResponse);
+  rpc CreateGuild(CreateGuildRequest) returns (CreateGuildResponse);
+  rpc AddFriend(AddFriendRequest) returns (AddFriendResponse);
+}
+
+message PingRequest {}
+
+message PingResponse {
+  string message = 1;
+}
+
+message SendMessageRequest {
+  string tenant_id = 1;
+  string sender_id = 2;
+  string channel_id = 3;
+  string content = 4;
+}
+
+message SendMessageResponse {
+  bool success = 1;
+}
+
+message CreateGuildRequest {
+  string tenant_id = 1;
+  string owner_account_id = 2;
+  string name = 3;
+}
+
+message CreateGuildResponse {
+  string guild_id = 1;
+}
+
+message AddFriendRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+  string friend_account_id = 3;
+}
+
+message AddFriendResponse {
+  bool success = 1;
+}

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +17,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/logging-admin")
+    }
 }

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/entity/LogEvent.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/entity/LogEvent.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.Instant;
+
+@Data
+@Entity
+@Table(name = "log_events")
+public class LogEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 50)
+    private String type;
+
+    @Column(nullable = false, length = 255)
+    private String message;
+
+    @Column(nullable = false)
+    private Instant timestamp;
+
+    @Column
+    private Long accountId;
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/entity/ModerationAction.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/entity/ModerationAction.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.Instant;
+
+@Data
+@Entity
+@Table(name = "moderation_actions")
+public class ModerationAction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private Long accountId;
+
+    @Column(nullable = false, length = 20)
+    private String action;
+
+    @Column(length = 255)
+    private String reason;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column
+    private Instant expiresAt;
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/LogEventRepository.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/LogEventRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.LogEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LogEventRepository extends JpaRepository<LogEvent, Long> {
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/ModerationActionRepository.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/ModerationActionRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.ModerationAction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ModerationActionRepository extends JpaRepository<ModerationAction, Long> {
+}

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
+    id("com.google.protobuf")
 }
 
 repositories {
@@ -14,5 +17,36 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.3"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.61.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos/social-groups")
+    }
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/ChatMessage.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/ChatMessage.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.Instant;
+
+@Data
+@Entity
+@Table(name = "chat_messages")
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private Long senderAccountId;
+
+    @Column(length = 255, nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private Instant timestamp;
+
+    @Column
+    private Long guildId;
+
+    @Column
+    private Long recipientAccountId;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/FriendLink.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/FriendLink.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.Instant;
+
+@Data
+@Entity
+@Table(name = "friend_links")
+public class FriendLink {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false)
+    private Long accountId;
+
+    @Column(nullable = false)
+    private Long friendAccountId;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/Guild.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/Guild.java
@@ -1,0 +1,26 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.Instant;
+
+@Data
+@Entity
+@Table(name = "guilds")
+public class Guild {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false)
+    private Long ownerAccountId;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/ChatMessageRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/ChatMessageRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/FriendLinkRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/FriendLinkRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.FriendLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FriendLinkRepository extends JpaRepository<FriendLink, Long> {
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.Guild;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuildRepository extends JpaRepository<Guild, Long> {
+}


### PR DESCRIPTION
## Summary
- create basic JPA entities and repositories for social-groups and logging-admin services
- enable protobuf and database support for those modules
- add proto definitions for new services
- check off completed items in the task list

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68691d4adb948330ab1d826ab01b993e