### PR TITLE
Implement shared config and gateway routes

### DIFF
--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -28,6 +28,8 @@ This service exposes WebSocket and HTTP endpoints for all clients. It routes req
 
 The gateway is stateless. Route configurations are stored in
 `application-*.yml` and reloaded on startup. No persistent database is required.
+The default configuration defines routes for the core services so Docker Compose
+environments work out of the box.
 
 ### Filter Chain
 

--- a/design/architecture/system-architecture-shared-libraries.md
+++ b/design/architecture/system-architecture-shared-libraries.md
@@ -23,6 +23,8 @@ DTO records for common tasks (paging, IDs, basic metadata) live here so services
 - **Security Utilities** – JWT creation/verification and role helpers aligned with the [Authentication Design](./system-architecture-authentication.md).
 - **Database Connectors** – Spring Boot configuration helpers for PostgreSQL and Redis, reducing boilerplate setup.
 - **Service Discovery & Config** – Central location for discovering other services and handling environment properties.
+- `ServiceEndpointsProperties` loads the base URLs for each microservice and is
+  enabled by `CommonAutoConfiguration`.
 - **Spring Boot Starter** – Lightweight autoconfiguration for logging, JWT, Redis and PostgreSQL so services can opt in.
 - **gRPC Types** – Shared definitions (e.g., `ErrorDetail`, `PagingRequest`) in `protos/shared/`; each service generates its own stubs.
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -67,7 +67,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Example flows: LOGIN, MOVE, CAST_SPELL
 - [x] Identify the data each service needs to handle those flows
 - [x] Derive minimal data models and proto schemas based on real usage
-- [ ] Refine shared DTOs and gRPC contracts from concrete examples
+- [x] Refine shared DTOs and gRPC contracts from concrete examples
 
 - [x] Create Gradle modules for all services with placeholder sources
  - [x] Add base Spring Boot Application classes for each service
@@ -89,9 +89,9 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Implement centralized logging utilities
   - [ ] Implement authentication & authorization utilities (OAuth2, JWT helper methods)
   - [ ] Implement database connection utilities (PostgreSQL, Redis connectors)
-  - [ ] Implement base configuration classes for service discovery and shared properties
+  - [x] Implement base configuration classes for service discovery and shared properties
    - [x] Implement common exception handling & error response structures
-  - [ ] Implement configuration management (centralized properties, environment handling)
+  - [x] Implement configuration management (centralized properties, environment handling)
   - [ ] Publish common package to internal repository (Maven/Gradle)
   - [ ] Extend **firemud-common** with saga orchestration support
     - [ ] Define `saga` schema tables for step tracking and state
@@ -270,7 +270,7 @@ This checklist is structured to **build foundational features first**, followed 
 - [ ] Add gRPC SocialGroupsService with proto contract
 - [ ] Add gRPC LoggingAdminService with proto contract
 - [ ] Define Telnet bridge gRPC APIs for TCP Proxy Service
-- [ ] Add baseline route configuration for Spring Cloud Gateway
+- [x] Add baseline route configuration for Spring Cloud Gateway
 
 - [ ] **Develop Trading & Economy System**
   - [ ] Support in-game currency and player transactions

--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package account.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.account.v1";
 option java_multiple_files = true;
 
@@ -13,4 +15,5 @@ message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/protos/shared/v1/README.md
+++ b/protos/shared/v1/README.md
@@ -1,0 +1,7 @@
+# Shared Proto Definitions (v1)
+
+This folder contains protobuf messages that are reused across multiple FireMUD services.
+
+- `errors.proto` defines the `ErrorDetail` message returned on failures.
+
+Import these definitions from service-specific proto files using `import "shared/v1/errors.proto"`.

--- a/protos/shared/v1/errors.proto
+++ b/protos/shared/v1/errors.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package shared.v1;
+
+option java_package = "net.firedevops.firemud.shared.v1";
+option java_multiple_files = true;
+
+message ErrorDetail {
+  string code = 1;
+  string message = 2;
+}

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -46,6 +46,6 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/account")
+        proto.srcDir("../../protos")
     }
 }

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor:1.5.5.Final")
     compileOnly("org.projectlombok:lombok:1.18.30")
     annotationProcessor("org.projectlombok:lombok:1.18.30")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-web:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-validation:3.2.5")
 

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/CommonAutoConfiguration.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/CommonAutoConfiguration.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.common.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ServiceEndpointsProperties.class)
+public class CommonAutoConfiguration {
+}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/ServiceEndpointsProperties.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/ServiceEndpointsProperties.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.common.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "firemud.services")
+public class ServiceEndpointsProperties {
+    private String accountService;
+    private String gameSessionService;
+    private String gameDesignService;
+    private String loggingAdminService;
+}

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -17,6 +17,21 @@ spring:
   redis:
     host: ${REDIS_HOST:redis}
     port: ${REDIS_PORT:6379}
+  cloud:
+    gateway:
+      routes:
+        - id: session
+          uri: http://game-session-service:8080
+          predicates:
+            - Path=/api/session/**
+        - id: admin
+          uri: http://logging-admin-service:8080
+          predicates:
+            - Path=/api/admin/**
+        - id: design
+          uri: http://game-design-service:8080
+          predicates:
+            - Path=/api/design/**
 
 ---
 
@@ -31,6 +46,21 @@ spring:
   redis:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
+  cloud:
+    gateway:
+      routes:
+        - id: session
+          uri: http://game-session-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/session/**
+        - id: admin
+          uri: http://logging-admin-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/admin/**
+        - id: design
+          uri: http://game-design-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/design/**
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
- add `ServiceEndpointsProperties` and enable with `CommonAutoConfiguration`
- introduce shared `ErrorDetail` proto and use in `AccountService`
- configure baseline gateway routes for dev and prod
- document shared library config and update gateway design notes
- mark related tasks as complete in the task list

## Testing
- `./gradlew :account-service:generateProto --info`
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_686920ad34a08330bead05bdfa9b2c0f