### PR TITLE
Add redis config file for AOF

### DIFF
--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,0 +1,2 @@
+appendonly yes
+appendfsync everysec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,9 +196,10 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    command: ["redis-server", "--appendonly", "yes"]
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     volumes:
       - redis-data:/data
+      - ./config/redis.conf:/usr/local/etc/redis/redis.conf:ro
     ports:
       - "6379:6379"
     healthcheck:


### PR DESCRIPTION
## Summary
- include sample `redis.conf` to configure appendonly persistence
- mount the config file in `docker-compose.yml`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68692132bd248330ac0325f4b472d365