### PR TITLE
Improve service docs

### DIFF
--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -85,6 +85,7 @@ the generated code with `./gradlew generateProto` after making changes.
 - [Authentication & Authorization](../system-architecture-authentication.md)
 - [Security Architecture](../system-architecture-security.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [User Journeys – Player Login and Gameplay](../user-journeys.md#5-player-login-and-gameplay)

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -88,6 +88,8 @@ Service definitions reside in
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 - [System Architecture Overview](../system-architecture-overview.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys – Publish and Start a Game Instance](../user-journeys.md#4-publish-and-start-a-game-instance)

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -81,6 +81,8 @@ After edits, run `./gradlew generateProto` to regenerate gateway stubs.
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 
 ## Future Enhancements
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -87,6 +87,8 @@ regenerated via `./gradlew generateProto` when the proto files change.
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
+- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 
 ## Future Enhancements
 


### PR DESCRIPTION
## Summary
- add references to Logging & Monitoring and Backup docs in service design files

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686923533f8083309b025597c499494e