### PR TITLE
Add service READMEs and update task list

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -142,15 +142,15 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Add baseline `Dockerfile` for each service
   - [ ] Create Gradle tasks to build Docker images for each service
   - [ ] Verify `./gradlew :<service>:build` succeeds for every module
-  - [ ] Add a minimal `README.md` in each service with local run instructions
+  - [x] Add a minimal `README.md` in each service with local run instructions
   - [ ] Configure Flyway and add initial `V1__init.sql` for all microservices
   - [x] Implement basic JPA entities and repositories in Account Service
   - [x] Set up protobuf generation with gRPC stubs
   - [x] Implement `PingController` endpoint in each service for basic health check
   - [ ] Add unit tests for `PingController` endpoints to verify service startup
   - [ ] Add gRPC `PingService` stub in each service to validate connectivity
-  - [ ] Update each service `README.md` with links to design docs and proto definitions
-  - [ ] Add Docker Compose health checks for PostgreSQL, Redis, and all services
+  - [x] Update each service `README.md` with links to design docs and proto definitions
+  - [x] Add Docker Compose health checks for PostgreSQL, Redis, and all services
   - [ ] Enable Spotless plugin for code formatting
   - [ ] Add GitHub Actions workflow for build and format checks
   - [ ] Configure static analysis tools

--- a/services/account-service/README.md
+++ b/services/account-service/README.md
@@ -1,0 +1,21 @@
+# Account Service
+
+Manages user accounts and authentication.
+
+- **Design docs**: [design/README.md](design/README.md)
+- **Proto definitions**: [../../protos/account/v1](../../protos/account/v1)
+
+## Running Locally
+
+Run the service only:
+
+```bash
+./gradlew :account-service:bootRun
+```
+
+Or start all services:
+
+```bash
+docker compose up --build
+```
+

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -1,0 +1,18 @@
+# Automation Scripting Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/automation-scripting/v1](../../protos/automation-scripting/v1)
+
+## Running Locally
+
+```bash
+./gradlew :automation-scripting-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -1,0 +1,18 @@
+# Entity Management Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/entity-management/v1](../../protos/entity-management/v1)
+
+## Running Locally
+
+```bash
+./gradlew :entity-management-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -1,0 +1,18 @@
+# Game Design Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/game-design/v1](../../protos/game-design/v1)
+
+## Running Locally
+
+```bash
+./gradlew :game-design-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -1,0 +1,18 @@
+# Game Logic Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/game-logic/v1](../../protos/game-logic/v1)
+
+## Running Locally
+
+```bash
+./gradlew :game-logic-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -1,0 +1,18 @@
+# Game Session Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/game-session/v1](../../protos/game-session/v1)
+
+## Running Locally
+
+```bash
+./gradlew :game-session-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -1,0 +1,18 @@
+# Logging Admin Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/logging-admin/v1](../../protos/logging-admin/v1)
+
+## Running Locally
+
+```bash
+./gradlew :logging-admin-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/social-groups-service/README.md
+++ b/services/social-groups-service/README.md
@@ -1,0 +1,18 @@
+# Social Groups Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/social-groups/v1](../../protos/social-groups/v1)
+
+## Running Locally
+
+```bash
+./gradlew :social-groups-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/spring-cloud-gateway/README.md
+++ b/services/spring-cloud-gateway/README.md
@@ -1,0 +1,18 @@
+# Spring Cloud Gateway Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/spring-cloud-gateway/v1](../../protos/spring-cloud-gateway/v1)
+
+## Running Locally
+
+```bash
+./gradlew :spring-cloud-gateway:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/tcp-proxy-service/README.md
+++ b/services/tcp-proxy-service/README.md
@@ -1,0 +1,18 @@
+# TCP Proxy Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/tcp-proxy/v1](../../protos/tcp-proxy/v1)
+
+## Running Locally
+
+```bash
+./gradlew :tcp-proxy-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+

--- a/services/world-management-service/README.md
+++ b/services/world-management-service/README.md
@@ -1,0 +1,18 @@
+# World Management Service
+
+Refer to [design/README.md](design/README.md) for architecture details.
+
+- **Proto definitions**: [../../protos/world-management/v1](../../protos/world-management/v1)
+
+## Running Locally
+
+```bash
+./gradlew :world-management-service:bootRun
+```
+
+To run the entire stack:
+
+```bash
+docker compose up --build
+```
+


### PR DESCRIPTION
## Summary
- add README.md files to each service with links to design docs and proto directories
- mark relevant tasks as complete in `task-list.md`

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6869245460f08330a3361443e8acf3d1