### PR TITLE
Improve service docs cross links

### DIFF
--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -49,3 +49,5 @@ corresponding versioned proto folders.
 - [System Architecture Overview](../system-architecture-overview.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [Infrastructure Overview](../infrastructure/README.md)
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -103,6 +103,8 @@ The gRPC schemas for this service live in
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - OAuth2 support for social logins.

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -97,6 +97,8 @@ stubs.
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Web UI for creating and testing scripts.

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -91,6 +91,8 @@ proto files, run `./gradlew generateProto` to update generated sources.
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Entity graph caching for faster lookups.

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -103,6 +103,8 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Web-based visual design interface.

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -93,6 +93,8 @@ the generated code with `./gradlew generateProto` after making changes.
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Scripting hooks for custom actions.

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -96,6 +96,8 @@ Service definitions reside in
 - [User Journeys – Publish and Start a Game Instance](../user-journeys.md#4-publish-and-start-a-game-instance)
 - [User Journeys – Player Login and Gameplay](../user-journeys.md#5-player-login-and-gameplay)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Cross-region sharding for massive worlds.

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -95,6 +95,8 @@ See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for 
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Role-based admin UI.

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -94,6 +94,8 @@ files change.
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Rich moderation tools for chat.

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -86,6 +86,8 @@ After edits, run `./gradlew generateProto` to regenerate gateway stubs.
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Connection metrics and throttling.

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -90,6 +90,8 @@ regenerated via `./gradlew generateProto` when the proto files change.
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Connection throttling and rate limits.

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -94,6 +94,8 @@ Run `./gradlew generateProto` to regenerate sources after editing these files.
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 
+- [System Architecture Diagram](../system-architecture-diagram.md)
+- [System Context Diagram](../system-context-diagram.md)
 ## Future Enhancements
 
 - Tools for fine-tuning procedural generation rules.


### PR DESCRIPTION
## Summary
- add links to architecture diagrams in all service design docs
- link diagrams from microservices index

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_686926bfb3cc83308f42d52326a38a0d