### PR TITLE
Update task list with additional setup items

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -34,7 +34,6 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Remove legacy Game Management Service and redistribute duties
   - [x] Conduct final review of all design documentation
   - [x] Address any missing diagrams or cross-references discovered during review
-  - [ ] Create Architectural Decision Records (ADRs) for major design changes
   - [x] Expand `CONTRIBUTING.md` with onboarding instructions
   - [x] Populate `FAQ.md` with common questions
   - [x] Add service-level design README links to central architecture docs

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -34,6 +34,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Remove legacy Game Management Service and redistribute duties
   - [x] Conduct final review of all design documentation
   - [x] Address any missing diagrams or cross-references discovered during review
+  - [ ] Create Architectural Decision Records (ADRs) for major design changes
   - [x] Expand `CONTRIBUTING.md` with onboarding instructions
   - [x] Populate `FAQ.md` with common questions
   - [x] Add service-level design README links to central architecture docs
@@ -156,10 +157,12 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Enable Spotless plugin for code formatting
   - [ ] Add GitHub Actions workflow to build and publish Docker images for each service
   - [ ] Integrate `markdownlint` in CI build
+  - [ ] Add pre-commit hooks for Spotless, Checkstyle, and markdownlint
   - [ ] Configure static analysis tools
     - [ ] Add Checkstyle rules for code style enforcement
     - [ ] Integrate SpotBugs for static bug detection
     - [ ] Generate JaCoCo coverage reports in CI
+  - [ ] Integrate container and dependency scanning (Trivy) in CI
   - [ ] Establish base integration test setup using Spring Boot Test with Testcontainers for PostgreSQL and Redis
   - [ ] Finalize API schemas from concrete gameplay flows
     - [ ] Database schema diagrams for each microservice
@@ -174,6 +177,7 @@ This checklist is structured to **build foundational features first**, followed 
     - [ ] Summarize controller routes in service `design/README.md`
     - [ ] Include example request/response payloads
     - [ ] Link to corresponding proto files
+    - [ ] Generate OpenAPI specs and publish Swagger UI
 
 ---
 


### PR DESCRIPTION
## Summary
- extend task list with ADR tracking, pre-commit hooks, container scanning and OpenAPI docs

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_686928db31d88330bbd99afcb70e1cec