### PR TITLE
docs: cross-reference multi-service features

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -95,6 +95,7 @@ The gRPC schemas for this service live in
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys – Sign Up and Game Creation](../user-journeys.md#1-sign-up-and-game-creation)
 - [User Journeys](../user-journeys.md#9-purchases-and-subscriptions) – payment and subscription workflow.
+- [Redis Architecture](../system-architecture-redis.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Database Migrations](../system-architecture-database-migrations.md)

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -12,7 +12,8 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Maintains history of revisions so designers can roll back to prior versions.
 - Publishing a new game version triggers a Saga that copies data to other
   services as outlined in
-  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
+  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
+  and [Transaction Strategies](../system-architecture-transactions.md).
 - Design assets are stored per `tenantId` so multiple games can coexist in the
   same database schema. Queries and version publishing workflows enforce this
   tenant filter. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -84,6 +84,7 @@ files change.
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys – Social Interaction](../user-journeys.md#6-social-interaction)
+- [Redis Architecture](../system-architecture-redis.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Database Migrations](../system-architecture-database-migrations.md)

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -14,7 +14,8 @@ The World Management Service stores and manages game world data such as rooms, r
 - Publishes world event notifications for NPC scripts and game logic processing.
 - During version publishing the service participates in a Saga that copies design
   data into its schema, ensuring world data matches the active version. See
-  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
+  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
+  and [Transaction Strategies](../system-architecture-transactions.md).
 - All world tables are keyed by `tenantId`; background jobs and gRPC queries
   include this filter so one game's world data never mixes with another's. See
   [Multi-Tenancy](../system-architecture-multi-tenancy.md).


### PR DESCRIPTION
## Summary
- link account service docs to Redis architecture
- add Redis reference in social-groups service
- mention transaction strategies in world management service
- cross-link transaction strategies in game design service

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_68693e3002e08330973b5d8491918bda