### PR TITLE
Expand service design overviews

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -4,6 +4,12 @@
 
 Manages user accounts and authentication for the platform. Stores profile data and issues tokens so the Game Session Service can validate connections.
 
+### Responsibilities
+- Registration and login flows, including password resets
+- Issuing JWT tokens consumed by other microservices
+- Tracking profiles, achievements, and external account links
+- Managing subscription status and bans
+
 ## Architecture / Design Notes
 
 - Stateless authentication using JWT tokens.

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -4,6 +4,12 @@
 
 The Automation & Scripting Service drives non-player character (NPC) behavior and world automation. It executes custom scripts and AI routines so worlds stay alive even when no players are online.
 
+### Responsibilities
+- Executes sandboxed scripts triggered by world and player events
+- Provides a visual DSL for designers to build behaviors
+- Stores persistent NPC memory and automation queues
+- Integrates with Game Session and World Management services for real-time updates
+
 For details on how scripts are authored and executed safely, see [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
 
 ## Architecture / Design Notes

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -4,6 +4,12 @@
 
 Handles player characters, NPCs, items, and inventory. Provides CRUD operations for entities and exposes them to other services.
 
+### Responsibilities
+- Persist characters, NPCs, and items with optimistic locking
+- Provide CRUD and query APIs for other services
+- Manage inventories and instanced zones
+- Coordinate deferred writes through Game Session Service
+
 ## Architecture / Design Notes
 
 - Uses JPA for persistence of entity data.

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -4,6 +4,12 @@
 
 Offers tools for building worlds, items, actions, and events that make up each game. Used by creators to design content without touching the underlying code. It also maintains versioned game configurations and templates so new game instances can be created with predefined rules and administrators.
 
+### Responsibilities
+- Provide web and gRPC tools for editing game assets
+- Version and publish immutable game configurations
+- Track revision history for rollback
+- Notify downstream services when new versions are available
+
 ## Architecture / Design Notes
 
 - Provides REST/gRPC APIs for editing game data.

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -4,6 +4,12 @@
 
 Executes the core gameplay rules and command parsing. It processes player actions and determines outcomes.
 
+### Responsibilities
+- Parse player commands and resolve actions
+- Apply combat rules, cooldowns, and environmental effects
+- Interact with entity and world services for context data
+- Push results back to the Game Session Service for distribution
+
 ## Architecture / Design Notes
 
 - Stateless service accessed over gRPC by other microservices.

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -4,6 +4,12 @@
 
 Orchestrates live game sessions, including tick execution, player input validation, and runtime feature toggles. Acts as the central hub for gameplay state.
 
+### Responsibilities
+- Maintain session state and tick timing in Redis
+- Queue player commands and dispatch them to Game Logic Service
+- Broadcast lifecycle events and world updates to other services
+- Support reconnection and recovery of running games
+
 ## Architecture / Design Notes
 
 - Coordinates with Redis to store volatile session state and command queues.

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -4,6 +4,12 @@
 
 Centralized logging and administration tools for the platform. Collects log data from all services and provides moderation capabilities for game operators.
 
+### Responsibilities
+- Aggregate logs and metrics from every microservice
+- Offer dashboards and search for operators and moderators
+- Enforce moderation actions such as bans via secured APIs
+- Record audit trails for feature flag changes and account events
+
 ## Architecture / Design Notes
 
 Uses the common stack outlined in [Logging & Monitoring](../../system-architecture-logging-monitoring.md) and exposes admin endpoints for reviewing logs and applying moderation actions.

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -4,6 +4,12 @@
 
 Provides chat, guild, and social networking features across games. Enables players to form groups and communicate in real time.
 
+### Responsibilities
+- Deliver real-time chat and presence notifications
+- Manage guild creation, membership, and roles
+- Maintain friend lists and cross-game social graphs
+- Feed chat logs to the Logging & Admin Service for moderation
+
 ## Architecture / Design Notes
 
 - Uses WebSocket channels for chat delivery.

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -4,6 +4,12 @@
 
 This service exposes WebSocket and HTTP endpoints for all clients. It routes requests to backend services and integrates with the TCP Proxy Service for Telnet clients.
 
+### Responsibilities
+- Terminate TLS and enforce authentication for admin routes
+- Upgrade WebSocket connections and route to the correct tenant
+- Apply rate limits and basic abuse protections
+- Relay traffic to the Game Session Service and other backends
+
 ## Architecture / Design Notes
 
 - Maintains persistent WebSocket sessions and supports raw TCP through a proxy.

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -4,6 +4,12 @@
 
 Bridges legacy Telnet clients into the platform by converting raw TCP traffic into WebSocket connections for the Spring Cloud Gateway.
 
+### Responsibilities
+- Accept Telnet connections and perform protocol negotiation
+- Proxy buffered input to Spring Cloud Gateway as WebSocket frames
+- Tag connections with tenant information for accurate routing
+- Provide graceful disconnect and reconnection handling
+
 ## Architecture / Design Notes
 
 - Lightweight custom service separate from Spring Boot.

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -4,6 +4,12 @@
 
 The World Management Service stores and manages game world data such as rooms, regions, and maps. It persists world state beyond player sessions and handles scheduled world events, notifying other services over gRPC when the environment changes.
 
+### Responsibilities
+- Persist region, zone, and room data with tenant isolation
+- Execute scheduled world events and procedural generation
+- Provide pathfinding and navmesh information
+- Notify Game Session and Automation services when the world changes
+
 ## Architecture / Design Notes
 
 - World data is stored in PostgreSQL. Redis holds only transient active state used during gameplay.

--- a/services/common-library/design/README.md
+++ b/services/common-library/design/README.md
@@ -1,0 +1,7 @@
+# \U0001F517 Design Document for Common Library
+
+The shared utility library is documented in detail here:
+
+[\U0001F4C4 Central Architecture: Shared Libraries Overview](../../../design/architecture/system-architecture-shared-libraries.md)
+
+This stub exists to make the design easy to find from the service source tree.


### PR DESCRIPTION
## Summary
- add design stub for common-library
- expand overviews of each microservice with key responsibilities

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686941589b388330af8a6fd64d2b0f92