### PR TITLE
Implement network policies and script entity

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -44,7 +44,7 @@ For example:
 > Redis-backed session state is described in detail in [**Redis Architecture**](../system-architecture-redis.md).
 > Observability integrations are summarized in [**Logging & Monitoring**](../system-architecture-logging-monitoring.md).
 > Client reconnection flow is covered in the [**Reconnection Strategy**](../system-architecture-reconnection.md).
-> TLS, certificate rotation, and network policies are detailed in the [**Security Architecture**](../system-architecture-security.md).
+> TLS, certificate rotation, and network policies are detailed in the [**Security Architecture**](../system-architecture-security.md). Example manifests live in [`k8s/network-policies/`](../../../k8s/network-policies) and provide a default ingress policy for internal services.
 > Backup procedures and disaster recovery steps are outlined in [**Backup & Disaster Recovery**](../system-architecture-backup-recovery.md).
 > Service developers should follow the [**gRPC API Style & Versioning Guidelines**](../system-architecture-grpc.md) when defining new APIs.
 > Distributed workflows are explained in [**Transaction Strategies**](../system-architecture-transactions.md).

--- a/design/architecture/system-architecture-security.md
+++ b/design/architecture/system-architecture-security.md
@@ -43,7 +43,8 @@ This document outlines how FireMUD secures service communication, manages authen
 
 - The **Spring Cloud Gateway** and **TCP Proxy Service** reside in the **network DMZ** and serve as the only ingress points for client traffic.
 - Internal microservices are not directly exposed externally.
-- Traffic flow is controlled via **NetworkPolicies**, which whitelist internal service access.
+ - Traffic flow is controlled via **NetworkPolicies**, which whitelist internal service access.
+   A baseline policy restricts **ingress** for all microservice pods (except the Gateway and TCP proxy) so they only accept traffic from other pods in the namespace. The manifests are provided under [`k8s/network-policies/`](../../k8s/network-policies).
 - **Zero-trust** principles are **not currently required** or implemented beyond mTLS and JWT-based validation, but may be reconsidered in future hardening efforts.
 
 ---

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -51,8 +51,8 @@ This checklist is structured to **build foundational features first**, followed 
     - [x] spring-cloud-gateway
     - [x] tcp-proxy-service
     - [x] world-management-service
-  - [ ] Create Kubernetes `NetworkPolicy` manifests to restrict service communication
-    - [ ] Document network policy usage in architecture docs
+  - [x] Create Kubernetes `NetworkPolicy` manifests to restrict service communication
+    - [x] Document network policy usage in architecture docs
 
 ---
 
@@ -94,7 +94,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Game Design Service: design-time schema entities
   - [x] Social & Groups Service: `ChatMessage`, `Guild`, `FriendLink` entities
   - [x] Logging & Admin Service: `LogEvent` and `ModerationAction` entities
-  - [ ] Automation & Scripting Service: `ScriptDefinition` entity
+  - [x] Automation & Scripting Service: `ScriptDefinition` entity
   - [x] Create DTO records and MapStruct mappers
 - [ ] **Create a Common Package for Shared Microservice Code**
   - [x] Implement common request/response DTOs for inter-service communication

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -18,6 +18,13 @@ kubectl apply -f base/world-management-service.yaml
 kubectl apply -f base/spring-cloud-gateway.yaml
 ```
 
+After the services are running, apply the default network policies found in
+`network-policies/` to restrict traffic to internal pods only:
+
+```bash
+kubectl apply -f network-policies/internal-services.yaml
+```
+
 Customize these manifests with proper image repositories and resource limits before running in production.
 All Spring Boot services are configured to run with the `prod` profile by default via the `SPRING_PROFILES_ACTIVE` environment variable.
 

--- a/k8s/network-policies/README.md
+++ b/k8s/network-policies/README.md
@@ -1,0 +1,11 @@
+# Kubernetes Network Policies
+
+This folder contains baseline `NetworkPolicy` manifests for the FireMUD cluster. These policies restrict **ingress** traffic so only other pods inside the namespace can connect to the internal microservices.
+
+Apply the policies after the base service deployments:
+
+```bash
+kubectl apply -f network-policies/internal-services.yaml
+```
+
+The gateway and TCP proxy remain accessible to external clients, while all other services accept connections only from within the cluster.

--- a/k8s/network-policies/internal-services.yaml
+++ b/k8s/network-policies/internal-services.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: internal-services
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: NotIn
+        values:
+          - spring-cloud-gateway
+          - tcp-proxy-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -14,5 +14,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
+    runtimeOnly("org.postgresql:postgresql:42.7.2")
     implementation(project(":common-library"))
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/dto/ScriptDefinitionDto.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/dto/ScriptDefinitionDto.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ScriptDefinitionDto(
+        Long id,
+        @NotNull Long tenantId,
+        @NotNull @Size(max = 100) String name,
+        @NotNull @Size(max = 20) String version,
+        @NotNull String definition
+) {}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/ScriptDefinition.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/ScriptDefinition.java
@@ -1,0 +1,25 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "scripts")
+public class ScriptDefinition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long tenantId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String version;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String definition;
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/mapper/ScriptDefinitionMapper.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/mapper/ScriptDefinitionMapper.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.ScriptDefinitionDto;
+import net.firedevops.firemud.entity.ScriptDefinition;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ScriptDefinitionMapper {
+    ScriptDefinitionDto toDto(ScriptDefinition entity);
+    ScriptDefinition toEntity(ScriptDefinitionDto dto);
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/ScriptDefinitionRepository.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/ScriptDefinitionRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.ScriptDefinition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScriptDefinitionRepository extends JpaRepository<ScriptDefinition, Long> {
+}


### PR DESCRIPTION
## Summary
- add baseline Kubernetes network policies
- document network policy usage in security and infrastructure docs
- mark tasks complete in the project task list
- add ScriptDefinition JPA entity with DTO, mapper, repository
- update build file for JPA dependencies
- mention network policies in k8s README
- clarify network policy is ingress-only

## Testing
- `./gradlew :automation-scripting-service:compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68694b4916c08330af15409155819fad