### PR TITLE
Update task list with additional creation tasks

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -266,6 +266,8 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Configure SMTP provider and test templates
   - [ ] Document email and notification design in `account-service/design/README.md`
   - [ ] Add asynchronous NotificationService components with gRPC endpoints
+  - [ ] Create `NotificationController` REST endpoints
+    - [ ] Provide APIs for sending in-game notifications to accounts
 
 ---
 
@@ -470,6 +472,7 @@ This checklist is structured to **build foundational features first**, followed 
 - [ ] **Implement Automated Unit & Integration Tests**
   - [ ] Develop unit tests for core services (command parsing, actions, world updates)
   - [ ] Implement integration tests for multi-service interactions
+  - [ ] Add integration tests for each service's create endpoints
   - [ ] Perform API testing with Postman, RestAssured
 
 - [ ] **Conduct Load & Security Testing**


### PR DESCRIPTION
## Summary
- add NotificationController step to email and notification system tasks
- add integration tests for service creation endpoints

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_68694d76902c8330a74c1c6383f8e5e2