### PR TITLE
Fix markdown lint scanning .git

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,7 +3,8 @@
   "ignores": [
     "**/node_modules/**",
     "**/.gradle/**",
-    "**/build/**"
+    "**/build/**",
+    "**/.git/**"
   ],
   "gitignore": true,
   "MD013": false,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,8 @@ tasks.register<NpxTask>("lintMarkdown") {
         "**/*.md",
         "!**/node_modules/**",
         "!**/build/**",
-        "!**/.gradle/**"
+        "!**/.gradle/**",
+        "!**/.git/**"
     ))
 }
 
@@ -54,7 +55,8 @@ tasks.register<NpxTask>("lintMarkdownFix") {
         "**/*.md",
         "!**/node_modules/**",
         "!**/build/**",
-        "!**/.gradle/**"
+        "!**/.gradle/**",
+        "!**/.git/**"
     ))
 }
 


### PR DESCRIPTION
## Summary
- exclude `.git` directories from markdownlint
- ensure the Gradle tasks ignore `.git`

## Testing
- `./gradlew lintMarkdown`
- `./gradlew lintMarkdownFix`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6869525be6148330961ccb795cfccbc8