### PR TITLE
Add docs for common library and monetization

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Your support can make a significant difference in the development and success of
 - **Contribute**: See the [Getting Started and Contributing](#getting-started-and-contributing) section for ways to contribute code, documentation, or ideas.
 - **Spread the Word**: Share the project with friends, colleagues, and on social media platforms to help us reach a wider audience.
 - **Financial Contributions**: See the [Community & Funding tasks](design/project-management/task-list.md#🛠-phase-11-community--funding) for planned donation options. Upcoming support channels include:
-  - **Donate via PayPal** *(planned)*
+  - **[Donate via PayPal](https://www.paypal.com/donate/?hosted_button_id=FIREMUDDEV)**
   - **Sponsor on GitHub** *(planned)*
   - **Patreon** *(planned)*
 

--- a/services/account-service/design/README.md
+++ b/services/account-service/design/README.md
@@ -5,3 +5,7 @@ The design for this service is located here:
 [\U0001F4C4 Central Architecture: Account Service Design](../../../design/architecture/microservices/account-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## Monetization Design
+
+The Account Service also manages billing records for purchases and subscriptions. Payment processing is handled through **Stripe** as outlined in the [Core Requirements](../../../design/project-management/core-requirements.md#2.8-moderation-administration--monetization). Planned entities include `payment_transaction` and `subscription` tables with Flyway migrations. gRPC endpoints and REST controllers will expose operations for creating payment intents and managing subscriptions.

--- a/services/common-library/README.md
+++ b/services/common-library/README.md
@@ -1,0 +1,25 @@
+# FireMUD Common Library
+
+This module contains shared utilities and DTOs used by all FireMUD microservices. The full design documentation lives under [Shared Libraries Overview](../../design/architecture/system-architecture-shared-libraries.md).
+
+## Adding the Dependency
+
+In a service's `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation(project(":common-library"))
+}
+```
+
+When published to a repository, include it via `implementation("net.firedevops.firemud.shared:firemud-common:<version>")`.
+
+## Example Usage
+
+The library provides `ApiResponse` and other helpers. Controllers typically return:
+
+```java
+return ResponseEntity.ok(ApiResponse.success(data));
+```
+
+See the [design document](../../design/architecture/system-architecture-shared-libraries.md) for more details and additional utilities.


### PR DESCRIPTION
## Summary
- add README for the common-library module with basic usage
- expand account-service design to mention monetization strategy
- update project README with PayPal donation link

## Testing
- `./gradlew tasks --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686952acf8cc8330a38a9e1b024761d0