### PR TITLE
Fix service design readme formatting

### DIFF
--- a/services/account-service/design/README.md
+++ b/services/account-service/design/README.md
@@ -1,8 +1,8 @@
-# \U0001F517 Design Document for Account Service
+# 🔗 Design Document for Account Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Account Service Design](../../../design/architecture/microservices/account-service/README.md)
+[📄 Central Architecture: Account Service Design](../../../design/architecture/microservices/account-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
 

--- a/services/automation-scripting-service/design/README.md
+++ b/services/automation-scripting-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Automation Scripting Service
+# 🔗 Design Document for Automation Scripting Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Automation Scripting Service Design](../../../design/architecture/microservices/automation-scripting-service/README.md)
+[📄 Central Architecture: Automation Scripting Service Design](../../../design/architecture/microservices/automation-scripting-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/common-library/design/README.md
+++ b/services/common-library/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Common Library
+# 🔗 Design Document for Common Library
 
 The shared utility library is documented in detail here:
 
-[\U0001F4C4 Central Architecture: Shared Libraries Overview](../../../design/architecture/system-architecture-shared-libraries.md)
+[📄 Central Architecture: Shared Libraries Overview](../../../design/architecture/system-architecture-shared-libraries.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/entity-management-service/design/README.md
+++ b/services/entity-management-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Entity Management Service
+# 🔗 Design Document for Entity Management Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Entity Management Service Design](../../../design/architecture/microservices/entity-management-service/README.md)
+[📄 Central Architecture: Entity Management Service Design](../../../design/architecture/microservices/entity-management-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Game Design Service
+# 🔗 Design Document for Game Design Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Game Design Service Design](../../../design/architecture/microservices/game-design-service/README.md)
+[📄 Central Architecture: Game Design Service Design](../../../design/architecture/microservices/game-design-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/game-logic-service/design/README.md
+++ b/services/game-logic-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Game Logic Service
+# 🔗 Design Document for Game Logic Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Game Logic Service Design](../../../design/architecture/microservices/game-logic-service/README.md)
+[📄 Central Architecture: Game Logic Service Design](../../../design/architecture/microservices/game-logic-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/game-session-service/design/README.md
+++ b/services/game-session-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Game Session Service
+# 🔗 Design Document for Game Session Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Game Session Service Design](../../../design/architecture/microservices/game-session-service/README.md)
+[📄 Central Architecture: Game Session Service Design](../../../design/architecture/microservices/game-session-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/logging-admin-service/design/README.md
+++ b/services/logging-admin-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Logging Admin Service
+# 🔗 Design Document for Logging Admin Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Logging Admin Service Design](../../../design/architecture/microservices/logging-admin-service/README.md)
+[📄 Central Architecture: Logging Admin Service Design](../../../design/architecture/microservices/logging-admin-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/social-groups-service/design/README.md
+++ b/services/social-groups-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Social Groups Service
+# 🔗 Design Document for Social Groups Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Social Groups Service Design](../../../design/architecture/microservices/social-groups-service/README.md)
+[📄 Central Architecture: Social Groups Service Design](../../../design/architecture/microservices/social-groups-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/spring-cloud-gateway/design/README.md
+++ b/services/spring-cloud-gateway/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Spring Cloud Gateway
+# 🔗 Design Document for Spring Cloud Gateway
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Spring Cloud Gateway Design](../../../design/architecture/microservices/spring-cloud-gateway/README.md)
+[📄 Central Architecture: Spring Cloud Gateway Design](../../../design/architecture/microservices/spring-cloud-gateway/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/tcp-proxy-service/design/README.md
+++ b/services/tcp-proxy-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for Tcp Proxy Service
+# 🔗 Design Document for TCP Proxy Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: Tcp Proxy Service Design](../../../design/architecture/microservices/tcp-proxy-service/README.md)
+[📄 Central Architecture: TCP Proxy Service Design](../../../design/architecture/microservices/tcp-proxy-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.

--- a/services/world-management-service/design/README.md
+++ b/services/world-management-service/design/README.md
@@ -1,7 +1,7 @@
-# \U0001F517 Design Document for World Management Service
+# 🔗 Design Document for World Management Service
 
 The design for this service is located here:
 
-[\U0001F4C4 Central Architecture: World Management Service Design](../../../design/architecture/microservices/world-management-service/README.md)
+[📄 Central Architecture: World Management Service Design](../../../design/architecture/microservices/world-management-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.


### PR DESCRIPTION
## Summary
- use actual emoji icons in service design readme stubs
- fix heading for TCP Proxy Service

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6869b3344dd0833099f97005e977a47d