### PR TITLE
Implement GatewayManagementService proto

### DIFF
--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -32,6 +32,7 @@ This service exposes WebSocket and HTTP endpoints for all clients. It routes req
 - Real-time state synchronization for multiplayer actions.
 - Reconnection support for dropped clients.
 - Routes REST and gRPC traffic to appropriate backend services.
+- Supports dynamic route management via the `GatewayManagementService` gRPC API.
 
 ### Data Model
 
@@ -80,6 +81,8 @@ details on shared infrastructure components.
 Gateway-related proto definitions are stored in
 [../../../../protos/spring-cloud-gateway/v1](../../../../protos/spring-cloud-gateway/v1).
 After edits, run `./gradlew generateProto` to regenerate gateway stubs.
+The `gateway_management_service.proto` file defines gRPC endpoints for remotely
+adding or removing routes at runtime.
 
 ## 📚 Related Documentation
 
@@ -102,3 +105,4 @@ After edits, run `./gradlew generateProto` to regenerate gateway stubs.
 
 - Connection metrics and throttling.
 - Horizontal scaling for high concurrency.
+- Remote route configuration over gRPC.

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -401,7 +401,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Create gateway route configuration files for all services
   - [ ] Create `GatewayController` endpoints for dynamic route management
     - [ ] Allow creation of custom gateway routes via API
-  - [ ] Add gRPC `GatewayManagementService` for remote route configuration
+  - [x] Add gRPC `GatewayManagementService` for remote route configuration
 
 - [ ] **Develop Social & Groups Service**
   - [ ] Enable cross-game friend lists and social graph

--- a/protos/spring-cloud-gateway/v1/README.md
+++ b/protos/spring-cloud-gateway/v1/README.md
@@ -4,4 +4,6 @@ This directory contains version 1 protocol buffer definitions for the spring clo
 They describe the gRPC API exposed by the service.
 
 Generate Java stubs with `./gradlew generateProto` from the repository root.
-For details see the [design docs](../../../design/architecture/microservices/spring-cloud-gateway-service/README.md).
+For details see the [design docs](../../../design/architecture/microservices/spring-cloud-gateway/README.md).
+
+New: gateway_management_service.proto defines remote route APIs.

--- a/protos/spring-cloud-gateway/v1/gateway_management_service.proto
+++ b/protos/spring-cloud-gateway/v1/gateway_management_service.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package gateway.v1;
+
+import "shared/v1/errors.proto";
+
+option java_package = "net.firedevops.firemud.gateway.v1";
+option java_multiple_files = true;
+
+// GatewayManagementService allows remote configuration of Spring Cloud Gateway routes.
+service GatewayManagementService {
+  // Adds or updates a custom route for the gateway.
+  rpc UpsertRoute(RouteDefinition) returns (RouteResponse);
+  // Removes a route by ID.
+  rpc RemoveRoute(RouteRequest) returns (RouteResponse);
+}
+
+// Route configuration details for dynamic updates.
+message RouteDefinition {
+  string route_id = 1; // Unique identifier for the route
+  string uri = 2;      // Target service URI
+  repeated string predicates = 3; // Spring Cloud Gateway predicates
+  repeated string filters = 4;    // Additional filters to apply
+}
+
+// Request to operate on a specific route.
+message RouteRequest {
+  string route_id = 1; // Identifier of the route to remove
+}
+
+// Standard response wrapper.
+message RouteResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}

--- a/services/spring-cloud-gateway/README.md
+++ b/services/spring-cloud-gateway/README.md
@@ -3,6 +3,7 @@
 Refer to [design/README.md](design/README.md) for architecture details.
 
 - **Proto definitions**: [../../protos/spring-cloud-gateway/v1](../../protos/spring-cloud-gateway/v1)
+  - `gateway_management_service.proto` exposes remote route APIs
 
 ## Running Locally
 


### PR DESCRIPTION
## Summary
- add new proto for `GatewayManagementService`
- document remote route configuration in gateway design docs
- fix proto README path and reference
- note new proto in service README
- mark related task complete in `task-list.md`

## Testing
- `./gradlew check` *(fails: spotless formatting on generated sources)*

------
https://chatgpt.com/codex/tasks/task_e_6869b551560083308fd174bcca3d4a26