### PR TITLE
Update task list with API creation examples

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -216,6 +216,8 @@ This checklist is structured to **build foundational features first**, followed 
     - [ ] world-management-service/design/README.md
     - [ ] Summarize controller routes in each service `design/README.md`
     - [ ] Include example request/response payloads
+    - [ ] Provide sample cURL commands for REST create endpoints
+    - [ ] Provide example `grpcurl` commands for gRPC create methods
     - [ ] Link to corresponding proto files
     - [ ] Generate OpenAPI specs and publish Swagger UI
 


### PR DESCRIPTION
## Summary
- include tasks for providing cURL and grpcurl examples in the service READMEs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869c091ef448330af0a40dcfb7ce0dd