### PR TITLE
Document endpoints for automation, logic, world services

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -205,16 +205,16 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Provide optional dev data seeding scripts for each service
   - [ ] Document REST endpoints and gRPC method flows in each microservice README
     - [x] account-service/design/README.md
-    - [ ] automation-scripting-service/design/README.md
+    - [x] automation-scripting-service/design/README.md
     - [ ] entity-management-service/design/README.md
     - [ ] game-design-service/design/README.md
-    - [ ] game-logic-service/design/README.md
+    - [x] game-logic-service/design/README.md
     - [ ] game-session-service/design/README.md
     - [ ] logging-admin-service/design/README.md
     - [ ] social-groups-service/design/README.md
     - [ ] spring-cloud-gateway/design/README.md
     - [ ] tcp-proxy-service/design/README.md
-    - [ ] world-management-service/design/README.md
+    - [x] world-management-service/design/README.md
     - [ ] Summarize controller routes in each service `design/README.md`
     - [ ] Include example request/response payloads
     - [ ] Provide sample cURL commands for REST create endpoints

--- a/services/automation-scripting-service/design/README.md
+++ b/services/automation-scripting-service/design/README.md
@@ -5,3 +5,29 @@ The design for this service is located here:
 [📄 Central Architecture: Automation Scripting Service Design](../../../design/architecture/microservices/automation-scripting-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`automation_scripting_service.proto`](../../../protos/automation-scripting/v1/automation_scripting_service.proto).
+
+```bash
+grpcurl -plaintext localhost:6565 automation_scripting.v1.AutomationScriptingService/Ping
+```
+
+Expected response:
+
+```json
+{
+  "message": "pong"
+}
+```

--- a/services/game-logic-service/design/README.md
+++ b/services/game-logic-service/design/README.md
@@ -5,3 +5,29 @@ The design for this service is located here:
 [📄 Central Architecture: Game Logic Service Design](../../../design/architecture/microservices/game-logic-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_logic_service.proto`](../../../protos/game-logic/v1/game_logic_service.proto).
+
+```bash
+grpcurl -plaintext localhost:6565 game_logic.v1.GameLogicService/Ping
+```
+
+Expected response:
+
+```json
+{
+  "message": "pong"
+}
+```

--- a/services/world-management-service/design/README.md
+++ b/services/world-management-service/design/README.md
@@ -5,3 +5,33 @@ The design for this service is located here:
 [📄 Central Architecture: World Management Service Design](../../../design/architecture/microservices/world-management-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – basic connectivity check defined in [`world_management_service.proto`](../../../protos/world-management/v1/world_management_service.proto).
+- `GetRoom(GetRoomRequest) returns (GetRoomResponse)` – fetches a room's JSON representation.
+- `UpdateWorldState(UpdateWorldStateRequest) returns (UpdateWorldStateResponse)` – applies pending world updates.
+
+Call the `Ping` method with:
+
+```bash
+grpcurl -plaintext localhost:6565 world_management.v1.WorldManagementService/Ping
+```
+
+Expected response:
+
+```json
+{
+  "message": "pong"
+}
+```


### PR DESCRIPTION
## Summary
- expand automation scripting service design README with endpoint docs
- expand game logic service design README with endpoint docs
- expand world management service design README with endpoint docs
- mark tasks done in project checklist

## Testing
- `./gradlew spotlessCheck lintMarkdown`


------
https://chatgpt.com/codex/tasks/task_e_6869d1d9c0c4833090a1bc8f54e4859b