### PR TITLE
Update proto tasks and service docs

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -141,15 +141,15 @@ This checklist is structured to **build foundational features first**, followed 
     - [x] Game Session Service proto definitions
     - [x] World Management Service proto definitions
     - [x] Entity Management Service proto definitions
-    - [ ] Game Logic Service proto definitions
-    - [ ] Automation & Scripting Service proto definitions
+    - [x] Game Logic Service proto definitions
+    - [x] Automation & Scripting Service proto definitions
     - [x] Game Design Service proto definitions
     - [x] Social & Groups Service proto definitions
     - [x] Logging & Admin Service proto definitions
     - [ ] Payment & Monetization proto definitions (Account Service)
-    - [ ] TCP Proxy Service proto definitions
-    - [ ] Spring Cloud Gateway proto definitions
-    - [ ] Shared common types
+    - [x] TCP Proxy Service proto definitions
+    - [x] Spring Cloud Gateway proto definitions
+    - [x] Shared common types
   - [x] Integrate proto generation into CI workflow
   - [x] Expose `/actuator/health` endpoints for service monitoring
     - [x] Add `spring-boot-starter-actuator` dependency to each service
@@ -206,14 +206,14 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Document REST endpoints and gRPC method flows in each microservice README
     - [x] account-service/design/README.md
     - [x] automation-scripting-service/design/README.md
-    - [ ] entity-management-service/design/README.md
-    - [ ] game-design-service/design/README.md
+    - [x] entity-management-service/design/README.md
+    - [x] game-design-service/design/README.md
     - [x] game-logic-service/design/README.md
-    - [ ] game-session-service/design/README.md
-    - [ ] logging-admin-service/design/README.md
-    - [ ] social-groups-service/design/README.md
-    - [ ] spring-cloud-gateway/design/README.md
-    - [ ] tcp-proxy-service/design/README.md
+    - [x] game-session-service/design/README.md
+    - [x] logging-admin-service/design/README.md
+    - [x] social-groups-service/design/README.md
+    - [x] spring-cloud-gateway/design/README.md
+    - [x] tcp-proxy-service/design/README.md
     - [x] world-management-service/design/README.md
     - [ ] Summarize controller routes in each service `design/README.md`
     - [ ] Include example request/response payloads

--- a/services/entity-management-service/design/README.md
+++ b/services/entity-management-service/design/README.md
@@ -5,3 +5,24 @@ The design for this service is located here:
 [📄 Central Architecture: Entity Management Service Design](../../../design/architecture/microservices/entity-management-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`entity_management_service.proto`](../../../protos/entity-management/v1/entity_management_service.proto).
+- `CreateCharacter(CreateCharacterRequest) returns (CreateCharacterResponse)` – builds a new player character.
+- `UpdateEntity(UpdateEntityRequest) returns (UpdateEntityResponse)` – updates stats or equipment.
+- `QueryInventory(QueryInventoryRequest) returns (QueryInventoryResponse)` – lists items for an entity.
+
+```bash
+grpcurl -plaintext localhost:6565 entity_management.v1.EntityManagementService/Ping
+```

--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -5,3 +5,24 @@ The design for this service is located here:
 [📄 Central Architecture: Game Design Service Design](../../../design/architecture/microservices/game-design-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_design_service.proto`](../../../protos/game-design/v1/game_design_service.proto).
+- `SaveRevision(SaveRevisionRequest) returns (SaveRevisionResponse)` – persists a design change.
+- `PublishVersion(PublishVersionRequest) returns (PublishVersionResponse)` – publishes a frozen version.
+- `ListVersions(ListVersionsRequest) returns (ListVersionsResponse)` – lists available versions.
+
+```bash
+grpcurl -plaintext localhost:6565 game_design.v1.GameDesignService/Ping
+```

--- a/services/game-session-service/design/README.md
+++ b/services/game-session-service/design/README.md
@@ -5,3 +5,24 @@ The design for this service is located here:
 [📄 Central Architecture: Game Session Service Design](../../../design/architecture/microservices/game-session-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_session_service.proto`](../../../protos/game-session/v1/game_session_service.proto).
+- `StartSession(StartSessionRequest) returns (StartSessionResponse)` – creates a new game instance.
+- `EnqueueCommand(EnqueueCommandRequest) returns (EnqueueCommandResponse)` – queues a player action.
+- `QueryState(QueryStateRequest) returns (QueryStateResponse)` – retrieves current game or player state.
+
+```bash
+grpcurl -plaintext localhost:6565 game_session.v1.GameSessionService/Ping
+```

--- a/services/logging-admin-service/design/README.md
+++ b/services/logging-admin-service/design/README.md
@@ -5,3 +5,23 @@ The design for this service is located here:
 [📄 Central Architecture: Logging Admin Service Design](../../../design/architecture/microservices/logging-admin-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`logging_admin_service.proto`](../../../protos/logging-admin/v1/logging_admin_service.proto).
+- `QueryLogs(QueryLogsRequest) returns (QueryLogsResponse)` – searches collected logs.
+- `ApplyModerationAction(ApplyModerationActionRequest) returns (ApplyModerationActionResponse)` – records a moderation event.
+
+```bash
+grpcurl -plaintext localhost:6565 logging_admin.v1.LoggingAdminService/Ping
+```

--- a/services/spring-cloud-gateway/design/README.md
+++ b/services/spring-cloud-gateway/design/README.md
@@ -5,3 +5,23 @@ The design for this service is located here:
 [📄 Central Architecture: Spring Cloud Gateway Design](../../../design/architecture/microservices/spring-cloud-gateway/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`gateway_management_service.proto`](../../../protos/spring-cloud-gateway/v1/gateway_management_service.proto).
+- `UpsertRoute(RouteDefinition) returns (RouteResponse)` – adds or updates a gateway route.
+- `RemoveRoute(RouteRequest) returns (RouteResponse)` – deletes a route.
+
+```bash
+grpcurl -plaintext localhost:6565 spring_cloud_gateway.v1.GatewayManagementService/Ping
+```

--- a/services/tcp-proxy-service/design/README.md
+++ b/services/tcp-proxy-service/design/README.md
@@ -5,3 +5,21 @@ The design for this service is located here:
 [📄 Central Architecture: TCP Proxy Service Design](../../../design/architecture/microservices/tcp-proxy-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+
+## REST & gRPC Endpoints
+
+### REST
+
+- `GET /ping` – basic health check returning `"pong"`.
+
+```bash
+curl http://localhost:8080/ping
+```
+
+### gRPC
+
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
+
+```bash
+grpcurl -plaintext localhost:6565 tcp_proxy.v1.TcpProxyService/Ping
+```

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
@@ -1,7 +1,11 @@
 package net.firedevops.firemud;
 
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
 public class TcpProxyServiceApplication {
   public static void main(String[] args) {
-    // TODO: initialize proxy logic
+    SpringApplication.run(TcpProxyServiceApplication.class, args);
   }
 }


### PR DESCRIPTION
## Summary
- flesh out design stubs with REST & gRPC ping endpoints
- add Spring Boot skeleton for TcpProxyService
- mark completed proto and doc tasks in `task-list.md`

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869d9f46b148330b91fda72a9a21224