### PR TITLE
Add baseline Flyway migrations

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -129,7 +129,7 @@ This checklist is structured to **build foundational features first**, followed 
 - [x] **Define high-level architecture & microservices boundaries**
 - [x] **Choose technology stack (Spring Boot, PostgreSQL, Redis, WebSockets, Kubernetes, etc.)**
 - [x] **Set up Docker and Kubernetes for containerized deployment**
-- [ ] **Configure Flyway-based database migrations for each microservice**
+  - [x] **Configure Flyway-based database migrations for each microservice**
 - [ ] **Implement service discovery for internal microservices (Spring Cloud, Eureka, Consul, or Kubernetes-native)**
   - [ ] Ensure common package includes service discovery utilities
 - [x] **Set up centralized logging & monitoring (Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager)**
@@ -165,7 +165,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Create Gradle tasks to build Docker images for each service
   - [x] Verify `./gradlew :<service>:build` succeeds for every module
   - [x] Add a minimal `README.md` in each service with local run instructions
-  - [ ] Configure Flyway and add initial `V1__init.sql` for all microservices
+  - [x] Configure Flyway and add initial `V1__init.sql` for all microservices
   - [x] Implement basic JPA entities and repositories in Account Service
   - [x] Set up protobuf generation with gRPC stubs
   - [x] Implement `PingController` endpoint in each service for basic health check
@@ -188,19 +188,19 @@ This checklist is structured to **build foundational features first**, followed 
     - [ ] Example Flyway migration scripts
   - [ ] Create ERD diagrams and baseline Flyway scripts for all services
     - [ ] Produce entity relationship diagrams for initial domain models
-    - [ ] Add `V1__init.sql` migrations for each service database
+    - [x] Add `V1__init.sql` migrations for each service database
       - [x] account-service
-      - [ ] automation-scripting-service
-      - [ ] entity-management-service
-      - [ ] game-design-service
-      - [ ] game-logic-service
-      - [ ] game-session-service
-      - [ ] logging-admin-service
-      - [ ] social-groups-service
-      - [ ] spring-cloud-gateway
-      - [ ] tcp-proxy-service
-      - [ ] world-management-service
-    - [ ] Configure Flyway plugin in each service build file
+      - [x] automation-scripting-service
+      - [x] entity-management-service
+      - [x] game-design-service
+      - [x] game-logic-service
+      - [x] game-session-service
+      - [x] logging-admin-service
+      - [x] social-groups-service
+      - [x] spring-cloud-gateway
+      - [x] tcp-proxy-service
+      - [x] world-management-service
+    - [x] Configure Flyway plugin in each service build file
     - [ ] Verify migrations run on startup
   - [ ] Provide optional dev data seeding scripts for each service
   - [ ] Document REST endpoints and gRPC method flows in each microservice README

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("org.springframework.boot") version "3.2.5" 
+    id("org.flywaydb.flyway") version "9.22.3"
 }
 
 repositories {
@@ -16,5 +17,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: automation-scripting-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/automation-scripting-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/automation-scripting-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE script (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    version INT NOT NULL,
+    content TEXT NOT NULL
+);
+
+CREATE TABLE npc_memory (
+    id BIGSERIAL PRIMARY KEY,
+    npc_id BIGINT NOT NULL,
+    key VARCHAR(100) NOT NULL,
+    value VARCHAR(255),
+    tenant_id BIGINT NOT NULL
+);

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
+    id("org.flywaydb.flyway") version "9.22.3"
     id("com.google.protobuf")
 }
 
@@ -19,6 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }
 

--- a/services/entity-management-service/src/main/resources/application.yml
+++ b/services/entity-management-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: entity-management-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/entity-management-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/entity-management-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,25 @@
+CREATE TABLE character (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    tenant_id BIGINT NOT NULL
+);
+
+CREATE TABLE npc (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    tenant_id BIGINT NOT NULL
+);
+
+CREATE TABLE item (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    tenant_id BIGINT NOT NULL
+);
+
+CREATE TABLE inventory (
+    character_id BIGINT NOT NULL REFERENCES character(id),
+    item_id BIGINT NOT NULL REFERENCES item(id),
+    quantity INT NOT NULL,
+    PRIMARY KEY (character_id, item_id)
+);

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
+    id("org.flywaydb.flyway") version "9.22.3"
     id("com.google.protobuf")
 }
 
@@ -19,6 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }
 

--- a/services/game-design-service/src/main/resources/application.yml
+++ b/services/game-design-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: game-design-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/game-design-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,27 @@
+CREATE TABLE game (
+    id BIGSERIAL PRIMARY KEY,
+    owner_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    tenant_id BIGINT NOT NULL
+);
+
+CREATE TABLE revision (
+    id BIGSERIAL PRIMARY KEY,
+    game_id BIGINT NOT NULL REFERENCES game(id),
+    author_id BIGINT NOT NULL,
+    data JSONB NOT NULL
+);
+
+CREATE TABLE version (
+    id BIGSERIAL PRIMARY KEY,
+    game_id BIGINT NOT NULL REFERENCES game(id),
+    revision_ids INTEGER[] NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE runtime_flag (
+    id BIGSERIAL PRIMARY KEY,
+    game_id BIGINT NOT NULL REFERENCES game(id),
+    name VARCHAR(100) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE
+);

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("org.springframework.boot") version "3.2.5" 
+    id("org.flywaydb.flyway") version "9.22.3"
 }
 
 repositories {

--- a/services/game-logic-service/src/main/resources/application.yml
+++ b/services/game-logic-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: game-logic-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/game-logic-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/game-logic-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,1 @@
+-- Game Logic Service is currently stateless; no tables required.

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
+    id("org.flywaydb.flyway") version "9.22.3"
     id("com.google.protobuf")
 }
 
@@ -19,6 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }
 

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: game-session-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/game-session-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/game-session-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE game_session (
+    id BIGSERIAL PRIMARY KEY,
+    version_id BIGINT NOT NULL,
+    owner_account_id BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    tenant_id BIGINT NOT NULL
+);

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
+    id("org.flywaydb.flyway") version "9.22.3"
     id("com.google.protobuf")
 }
 
@@ -19,6 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }
 

--- a/services/logging-admin-service/src/main/resources/application.yml
+++ b/services/logging-admin-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: logging-admin-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/logging-admin-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/logging-admin-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,12 @@
+CREATE TABLE moderation_action (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL,
+    reason VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE feature_flag (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE
+);

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
+    id("org.flywaydb.flyway") version "9.22.3"
     id("com.google.protobuf")
 }
 
@@ -19,6 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }
 

--- a/services/social-groups-service/src/main/resources/application.yml
+++ b/services/social-groups-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: social-groups-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/social-groups-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/social-groups-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,27 @@
+CREATE TABLE guild (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    owner_id BIGINT NOT NULL,
+    tenant_id BIGINT NOT NULL
+);
+
+CREATE TABLE guild_member (
+    guild_id BIGINT NOT NULL REFERENCES guild(id),
+    account_id BIGINT NOT NULL,
+    role VARCHAR(50) NOT NULL,
+    PRIMARY KEY (guild_id, account_id)
+);
+
+CREATE TABLE chat_message (
+    id BIGSERIAL PRIMARY KEY,
+    sender_id BIGINT NOT NULL,
+    channel VARCHAR(50),
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE friend_link (
+    account_id BIGINT NOT NULL,
+    friend_account_id BIGINT NOT NULL,
+    PRIMARY KEY (account_id, friend_account_id)
+);

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("org.springframework.boot") version "3.2.5" 
+    id("org.flywaydb.flyway") version "9.22.3"
 }
 
 repositories {
@@ -14,5 +15,6 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     implementation("org.springframework.boot:spring-boot-starter:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: spring-cloud-gateway
+  flyway:
+    enabled: true
 
 ---
 

--- a/services/spring-cloud-gateway/src/main/resources/db/migration/V1__init.sql
+++ b/services/spring-cloud-gateway/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,4 @@
+CREATE TABLE route_config (
+    id VARCHAR(100) PRIMARY KEY,
+    definition JSONB NOT NULL
+);

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     java
     id("org.springframework.boot") version "3.2.5" apply false
+    id("org.flywaydb.flyway") version "9.22.3"
 }
 
 repositories {
@@ -12,5 +13,6 @@ dependencies {
     annotationProcessor("org.mapstruct:mapstruct-processor:1.5.5.Final")
     compileOnly("org.projectlombok:lombok:1.18.30")
     annotationProcessor("org.projectlombok:lombok:1.18.30")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }

--- a/services/tcp-proxy-service/src/main/resources/application.yml
+++ b/services/tcp-proxy-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: tcp-proxy-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/tcp-proxy-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/tcp-proxy-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,1 @@
+-- TCP Proxy Service does not persist data currently.

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -3,6 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
+    id("org.flywaydb.flyway") version "9.22.3"
     id("com.google.protobuf")
 }
 
@@ -19,6 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.2.5")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.2.5")
     runtimeOnly("org.postgresql:postgresql:42.7.2")
+    implementation("org.flywaydb:flyway-core:9.22.3")
     implementation(project(":common-library"))
 }
 

--- a/services/world-management-service/src/main/resources/application.yml
+++ b/services/world-management-service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: dev
   application:
     name: world-management-service
+  flyway:
+    enabled: true
 
 management:
   endpoints:

--- a/services/world-management-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/world-management-service/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,25 @@
+CREATE TABLE region (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    tenant_id BIGINT NOT NULL
+);
+
+CREATE TABLE zone (
+    id BIGSERIAL PRIMARY KEY,
+    region_id BIGINT NOT NULL REFERENCES region(id),
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE room (
+    id BIGSERIAL PRIMARY KEY,
+    zone_id BIGINT NOT NULL REFERENCES zone(id),
+    name VARCHAR(100) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE instance (
+    id BIGSERIAL PRIMARY KEY,
+    zone_id BIGINT NOT NULL REFERENCES zone(id),
+    owner_account_id BIGINT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add Flyway plugin and configuration to each service
- create initial V1__init.sql migrations
- enable Flyway in service application configs
- mark related tasks complete in task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869ded017b4833081b4775a7a02d64c