### PR TITLE
Fix missing trivy in security scan step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,7 @@ jobs:
       - name: Code Coverage
         run: ./gradlew jacocoTestReport
       - name: Security Scan
-        run: trivy image ghcr.io/my-org/my-service:latest
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/my-org/my-service:latest
+          exit-code: "1"


### PR DESCRIPTION
## Summary
- use the official Trivy GitHub Action for image scanning

## Testing
- `./gradlew --no-daemon lintMarkdownFix`
- `./gradlew --no-daemon spotlessApply`
- `./gradlew --no-daemon test`


------
https://chatgpt.com/codex/tasks/task_e_6869e4cbf4808330a9e8c15a8daae06e