### PR TITLE
Add release notes workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,19 @@
+name: Release Notes
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  generate-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          generate_release_notes: true

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -10,6 +10,7 @@ This document describes the basic continuous integration and deployment strategy
 - **Build Docker images** and push them to a container registry.
 - **Deploy to Kubernetes** when changes are merged into designated branches (e.g., `main` or `release/*`).
 - Keep the workflow configuration easy to maintain and extensible for future security scans or nightly jobs.
+- **Generate release notes automatically** whenever version tags are pushed.
 
 The main workflow runs formatting and lint checks followed by the Gradle `check` task, which compiles and tests all modules while running Spotless, Checkstyle, and SpotBugs. It then generates JaCoCo coverage reports and performs a Trivy security scan. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
 
@@ -106,6 +107,15 @@ Cluster credentials and registry secrets are stored as encrypted repository secr
 ### Rollback Strategy
 
 New service versions are deployed alongside existing ones. If issues appear after a rollout, prior releases can be reinstated and the newer copies scaled down or removed.
+
+---
+
+## 📝 Automated Release Notes
+
+When a version tag like `v1.2.3` is pushed, the `release-notes.yml` workflow
+creates a GitHub release and uses the `generate_release_notes` option to produce
+change logs automatically. This keeps release documentation consistent without
+manual steps.
 
 ---
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -183,6 +183,7 @@ This checklist is structured to **build foundational features first**, followed 
     - [ ] Integrate SpotBugs for static bug detection
     - [ ] Generate JaCoCo coverage reports in CI
   - [ ] Integrate container and dependency scanning (Trivy) in CI
+  - [ ] Automate release notes generation with GitHub Actions
   - [ ] Schedule continuous security scanning for dependencies and container images
   - [ ] Establish base integration test setup using Spring Boot Test with Testcontainers for PostgreSQL and Redis
   - [ ] Finalize API schemas from concrete gameplay flows


### PR DESCRIPTION
## Summary
- create `release-notes.yml` workflow triggered by version tags
- document release note generation in CI/CD architecture doc
- list release notes automation task in project task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869e4895750833081c4151a04d987a6