### PR TITLE
Add manual testing tool docs

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -110,6 +110,57 @@ To stop the stack:
 docker compose down
 ```
 
+## Manual Testing Tools
+
+### Insomnia for REST and WebSocket
+
+An Insomnia project is included under `dev-tools/insomnia/`. From the
+**Import/Export** menu choose **Import From File** and select
+`firemud-insomnia.json` to quickly test login, registration, and gateway admin
+routes. The project defines a **Base Environment** with `base_url` and `jwt`
+variables so that you can reuse a JWT bearer token between requests. Open the
+environment editor and set the `jwt` value, then Insomnia will inject
+`Authorization: Bearer {{ jwt }}` on requests that require authentication.
+
+WebSocket testing is also configured. Use the `WebSocket Login` request to send
+raw commands like:
+
+```text
+LOGIN user pass
+MOVE north
+CAST "fireball"
+```
+
+Add or modify requests directly in Insomnia and re-export the workspace if you
+need to share updates.
+
+### Kreya for gRPC APIs
+
+The `dev-tools/kreya/.kreya-project.yaml` file configures Kreya to load all
+protos from `./protos/` and targets `localhost:6565` by default. Services such
+as `AccountService`, `EntityService`, and `PlayerService` are preconfigured. For
+endpoints that need authorization, JWT metadata is enabled. Open Kreya, choose
+**Open Project** and select the project file to invoke gRPC methods. When proto
+definitions change, update the project by pointing Kreya to the modified
+`.proto` files.
+
+### Redis Debugging
+
+Use the Redis CLI (`redis-cli -h localhost -p 6379`) to inspect transient game state. Useful commands include:
+
+```bash
+SCAN 0 MATCH session:*
+GET tick:lock:entity-xyz
+SCAN 0 MATCH timer:player-123:*
+```
+
+For a graphical view, a RedisInsight container runs in development via
+`docker-compose.override.yml`. Bring up the stack with `docker compose -f
+docker-compose.yml -f docker-compose.override.yml up -d`. RedisInsight is then
+available at <http://localhost:8001> and connects to the default Redis instance
+on `localhost:6379`. Typical key patterns are `session:*`, `tick:*`, and
+`timer:*`.
+
 ## Configuration Files
 
 Environment‑specific settings live in Spring Boot profile files contained within each service's `src/main/resources` directory.

--- a/dev-tools/insomnia/firemud-insomnia.json
+++ b/dev-tools/insomnia/firemud-insomnia.json
@@ -1,0 +1,85 @@
+{
+  "_type": "export",
+  "__export_format": 4,
+  "__export_date": "2025-07-06T00:00:00.000Z",
+  "__export_source": "insomnia.desktop.app:v2024.2.0",
+  "resources": [
+    {
+      "_id": "wrk_1",
+      "parentId": null,
+      "_type": "workspace",
+      "name": "FireMUD"
+    },
+    {
+      "_id": "env_1",
+      "parentId": "wrk_1",
+      "_type": "environment",
+      "name": "Base Environment",
+      "data": {
+        "base_url": "http://localhost:8080",
+        "jwt": ""
+      }
+    },
+    {
+      "_id": "req_login",
+      "parentId": "wrk_1",
+      "_type": "request",
+      "name": "Login",
+      "method": "POST",
+      "url": "{{ base_url }}/login",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"username\": \"user\",\n  \"password\": \"pass\"\n}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "_id": "req_register",
+      "parentId": "wrk_1",
+      "_type": "request",
+      "name": "Register",
+      "method": "POST",
+      "url": "{{ base_url }}/register",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n  \"username\": \"user\",\n  \"password\": \"pass\"\n}"
+      },
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "_id": "req_admin_ping",
+      "parentId": "wrk_1",
+      "_type": "request",
+      "name": "Gateway Admin Ping",
+      "method": "GET",
+      "url": "{{ base_url }}/gateway/admin/ping",
+      "headers": [
+        {
+          "name": "Authorization",
+          "value": "Bearer {{ jwt }}"
+        }
+      ]
+    },
+    {
+      "_id": "req_ws_login",
+      "parentId": "wrk_1",
+      "_type": "request",
+      "name": "WebSocket Login",
+      "url": "ws://localhost:8080/ws",
+      "method": "WEBSOCKET",
+      "body": {
+        "text": "LOGIN user pass\nMOVE north\nCAST \"fireball\""
+      }
+    }
+  ]
+}

--- a/dev-tools/kreya/.kreya-project.yaml
+++ b/dev-tools/kreya/.kreya-project.yaml
@@ -1,0 +1,22 @@
+version: 1
+name: FireMUD
+protoRoots:
+  - ../../protos
+endpoints:
+  - name: Local
+    host: localhost
+    port: 6565
+services:
+  - name: AccountService
+    protoFile: account/v1/account_service.proto
+    package: account.v1
+    endpoint: Local
+    jwtMetadata: true
+  - name: EntityService
+    protoFile: entity-management/v1/entity_management_service.proto
+    package: entity_management.v1
+    endpoint: Local
+  - name: PlayerService
+    protoFile: game-session/v1/game_session_service.proto
+    package: game_session.v1
+    endpoint: Local

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+version: '3.9'
+services:
+  redisinsight:
+    image: redis/redisinsight:latest
+    ports:
+      - "8001:8001"
+    environment:
+      - REDISINSIGHT_HOST=0.0.0.0
+    restart: unless-stopped
+    depends_on:
+      - redis


### PR DESCRIPTION
## Summary
- document Insomnia and Kreya setups in developer guide
- document Redis CLI keys and RedisInsight usage
- add RedisInsight dev compose override
- add sample Insomnia and Kreya configs for quick testing
- add depends_on for RedisInsight and clarify docs

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869e3b71f088330a288417b2ae9d335