### PR TITLE
Add contributor guidelines and infrastructure tasks

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Contributor Covenant Code of Conduct
+
+This project adheres to the [Contributor Covenant](https://www.contributor-covenant.org) to foster a welcoming and harassment-free community.
+
+## Our Pledge
+
+We pledge to make participation in our project and community a respectful experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Showing empathy towards other community members
+
+Unacceptable behaviors include:
+
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers at [contact@firedevops.net](mailto:contact@firedevops.net). All complaints will be reviewed and investigated.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Before contributing, we recommend reviewing the following key documents:
 - **Contribute Code**: See our [Contributing Guidelines](./CONTRIBUTING.md) for branching strategy, coding standards, and how to submit a pull request.
 - **Review Pull Requests**: Provide thoughtful, constructive feedback on open pull requests.
 - **Improve Documentation**: Help keep our docs accurate and beginner-friendly by fixing typos, clarifying explanations, adding examples, or expanding the FAQ.
+- **Follow the [Code of Conduct](CODE_OF_CONDUCT.md)**: Treat everyone with respect and help maintain a welcoming community.
 - **Report Bugs or Suggest Features**: Open an issue in the relevant repository with detailed information. Be clear, respectful, and constructive.
 - **Report Security Issues**: If you discover a security vulnerability, please **do not** file a public issue. Instead, report it privately to [Ben.Hook@firedevops.net](mailto:Ben.Hook@firedevops.net). We take security seriously and will respond promptly.
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -57,7 +57,24 @@ This checklist is structured to **build foundational features first**, followed 
     - [x] world-management-service
   - [x] Create Kubernetes `NetworkPolicy` manifests to restrict service communication
     - [x] Document network policy usage in architecture docs
-  - [ ] Provide infrastructure-as-code (Terraform or Helm) for replicating Kubernetes environments
+- [ ] Create sample Terraform module to provision a local Kubernetes environment (e.g., using Kind or Minikube)  
+  > ⚠️ Note: These Terraform files are **for reference only** and **will not be used yet**
+- [ ] Write sample Terraform code to:
+  - [ ] Define `firemud` namespace and basic RBAC
+  - [ ] Optionally configure local Redis or Helm releases
+- [ ] Prepare Helm charts for FireMUD services:
+  - [ ] Game Session Service
+  - [ ] Redis (clustered, tick-safe config)
+  - [ ] Account, Entity, and World services
+  - [ ] TCP Proxy and Spring Gateway
+- [ ] Add example `values.yaml` files for local and dev environments
+- [ ] Support Helm-based config overrides for:
+  - [ ] Redis connection info
+  - [ ] Tick interval
+  - [ ] Runtime feature flags
+- [ ] Document deployment steps:
+  - [ ] Use `helm install` (or `helmfile`) to deploy FireMUD services locally
+  - [ ] Reference Terraform files as optional future cloud setup
 
 ---
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -37,6 +37,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Expand `CONTRIBUTING.md` with onboarding instructions
   - [x] Populate `FAQ.md` with common questions
   - [x] Add service-level design README links to central architecture docs
+  - [ ] Publish a `CODE_OF_CONDUCT.md` outlining community expectations
   - [ ] Create issue template and maintain backlog for tasks and bugs
   - [ ] Provide contributor guide with local setup commands and code review expectations
   - [ ] Document environment variables and secrets management strategy
@@ -56,6 +57,7 @@ This checklist is structured to **build foundational features first**, followed 
     - [x] world-management-service
   - [x] Create Kubernetes `NetworkPolicy` manifests to restrict service communication
     - [x] Document network policy usage in architecture docs
+  - [ ] Provide infrastructure-as-code (Terraform or Helm) for replicating Kubernetes environments
 
 ---
 
@@ -181,6 +183,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Add Docker Compose health checks for PostgreSQL, Redis, and all services
   - [x] Enable Spotless plugin for code formatting
   - [x] Add GitHub Actions workflow to build and publish Docker images for each service
+  - [ ] Provision ephemeral preview environments for pull requests
   - [x] Integrate `markdownlint` in CI build
   - [x] Add pre-commit hooks for Spotless and markdownlint
   - [ ] Add pre-commit hooks for static analysis tools (Checkstyle, SpotBugs)
@@ -193,11 +196,13 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Schedule continuous security scanning for dependencies and container images
   - [ ] Define schedule for dependency updates and routine security scans
   - [ ] Establish base integration test setup using Spring Boot Test with Testcontainers for PostgreSQL and Redis
+  - [ ] Expand integration tests to cover cross-service workflows using Testcontainers
   - [ ] Finalize API schemas from concrete gameplay flows
     - [ ] Database schema diagrams for each microservice
     - [ ] Example Flyway migration scripts
   - [ ] Create ERD diagrams and baseline Flyway scripts for all services
     - [ ] Produce entity relationship diagrams for initial domain models
+  - [ ] Automate architecture and ERD diagram generation in CI
     - [x] Add `V1__init.sql` migrations for each service database
       - [x] account-service
       - [x] automation-scripting-service


### PR DESCRIPTION
## Summary
- create a CODE_OF_CONDUCT
- reference Code of Conduct in README
- add community and infrastructure tasks to the task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869ed633ca08330ada642f6479f916e