### PR TITLE
Fix Gradle plugin order

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ allprojects {
 
 subprojects {
     apply(plugin = "java")
-    apply(plugin = "com.google.protobuf")
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "checkstyle")
     apply(plugin = "com.github.spotbugs")

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -2,8 +2,8 @@ import com.google.protobuf.gradle.*
 plugins {
     java
     id("org.springframework.boot") version "3.2.5"
-    id("com.google.protobuf")
     id("org.flywaydb.flyway") version "9.22.3"
+    id("com.google.protobuf")
 }
 
 repositories {

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -1,7 +1,10 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
     id("org.flywaydb.flyway") version "9.22.3"
+    id("com.google.protobuf")
 }
 
 repositories {

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -1,7 +1,10 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
     id("org.flywaydb.flyway") version "9.22.3"
+    id("com.google.protobuf")
 }
 
 repositories {

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -1,7 +1,10 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     java
-    id("org.springframework.boot") version "3.2.5" 
+    id("org.springframework.boot") version "3.2.5"
     id("org.flywaydb.flyway") version "9.22.3"
+    id("com.google.protobuf")
 }
 
 repositories {


### PR DESCRIPTION
## Summary
- remove protobuf plugin from global subprojects block
- fix account-service plugin order
- apply protobuf plugin across services

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869ed3a9d848330b4277688a0d0a498