### PR TITLE
Add backlog and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: "Bug Report"
+about: "Report a problem with FireMUD"
+labels: bug
+assignees: ''
+---
+
+# Bug Report
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Run '...'
+3. See error
+
+## Expected Behavior
+
+What did you expect to happen?
+
+## Logs/Screenshots
+
+If applicable, add logs or screenshots to help explain your problem.
+
+## Environment
+
+- OS: <e.g., Ubuntu 22.04>
+- Java version: `java -version`
+- Docker version: `docker --version`
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: "Feature Request"
+about: "Suggest an idea or enhancement for FireMUD"
+labels: enhancement
+assignees: ''
+---
+
+# Feature Request
+
+## Summary
+
+Provide a clear description of the feature or change you would like to see.
+
+## Motivation
+
+Why should this be implemented? What problem does it solve?
+
+## Describe the Solution
+
+How do you imagine this feature working? Include examples or diagrams if helpful.
+
+## Additional Context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,21 @@
+---
+name: "Task"
+about: "Track a development task"
+labels: task
+assignees: ''
+---
+
+# Task
+
+## Description
+
+Briefly describe the work to be done.
+
+## Acceptance Criteria
+
+- [ ] Criteria 1
+- [ ] Criteria 2
+
+## Related Documents
+
+Link to relevant design docs or discussion threads.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ If you're setting up the project for the first time, follow these steps:
 1. Review prerequisites in [**Developer Setup**](DEVELOPER_SETUP.md) and install Java 17, Docker, Node.js, and other tools.
 2. Clone the repository and generate Gradle wrappers if needed with `./gradlew wrapper` (or the PowerShell script on Windows).
 3. Build all modules using `./gradlew build`.
-4. Start the local stack with `./gradlew devUp`.
-5. Explore the docs under `design/` to understand the architecture.
+4. Copy `.env.sample` to `.env` and adjust values if necessary.
+5. Start the local stack with `./gradlew devUp`.
+6. Explore the docs under `design/` to understand the architecture.
 
 Once your environment is running you can create a feature branch and submit a PR as described below.
 
@@ -61,5 +62,12 @@ Hooks automatically format code and lint Markdown before each commit.
 6. Open a pull request against the `main` branch of this repository.
 7. Fill out the PR template, describing your changes and referencing any related issues.
 8. Participate in the review process by addressing feedback promptly.
+
+## Code Review Expectations
+
+- Run `./gradlew check` before pushing to ensure formatting and tests pass.
+- Reference related issue numbers in your PR description.
+- Link to relevant design documents when adding new features.
+- Keep commits focused and descriptive so reviewers can understand the intent.
 
 Following these guidelines helps keep the project consistent and makes the review process smoother. We appreciate your contributions!

--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -12,6 +12,7 @@ This directory contains core documentation for the shared infrastructure that po
 | [System Architecture Diagram](../system-architecture-diagram.md) | Visual representation of component relationships and client flows. |
 | [System Context Diagram](../system-context-diagram.md) | Shows clients, DMZ components, internal services, and datastores. |
 | [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
+| [Environment & Secrets Management](./environment-and-secrets.md) | How services receive configuration values and handle sensitive data. |
 | [Gateway Architecture](./gateway-architecture.md)       | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
 | [Protocol Bridging](./protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
 | [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md) | Conventions for service APIs. |

--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -1,0 +1,37 @@
+# 🔐 Environment Variables & Secrets Management
+
+This document explains how configuration values and sensitive secrets are supplied to FireMUD services in both development and production.
+
+---
+
+## 🧪 Local Development
+
+- Environment variables are loaded from a `.env` file when running `./gradlew devUp`.
+- The sample file `.env.sample` contains default credentials for PostgreSQL and Redis.
+- Docker Compose passes these variables to each container so Spring Boot can connect to the databases.
+- Secrets such as JWT signing keys are not required in development; random keys are generated on startup.
+
+## ☁️ Production
+
+- Kubernetes `ConfigMap` objects store non‑secret configuration values like host names or feature flags.
+- Sensitive values (database passwords, JWT keys, TLS certificates) are stored in Kubernetes `Secret` objects.
+- The manifests in `k8s/base/` demonstrate loading these via `envFrom` so that services receive the same variables as in development.
+- Secrets are provisioned by **cert-manager** and rotated automatically.
+
+## 🔄 Variable Prefixes
+
+Shared libraries support overriding default settings with environment variables using the `FIREMUD_` prefix. For example:
+
+```bash
+FIREMUD_POSTGRES_HOST=postgres
+FIREMUD_POSTGRES_PORT=5432
+FIREMUD_REDIS_HOST=redis
+FIREMUD_REDIS_PORT=6379
+```
+
+Each service merges these variables with its own `application.yml` profile.
+
+## 📚 Related Docs
+
+- [Deployment Environments](./deployment-environments.md)
+- [System Architecture: Security](../system-architecture-security.md)

--- a/design/project-management/README.md
+++ b/design/project-management/README.md
@@ -7,5 +7,6 @@ Key files include:
 - [**ai-rules-global.md**](./ai-rules-global.md) and [**ai-rules-local.md**](./ai-rules-local.md) – Coding and documentation guidelines.
 - [**core-requirements.md**](./core-requirements.md) – High-level feature requirements.
 - [**task-list.md**](./task-list.md) – Active and planned development tasks.
+- [**backlog.md**](./backlog.md) – Summary of outstanding tasks and known issues.
 - [**design-assumptions.md**](./design-assumptions.md) – Supporting materials and research notes.
 - [**issues-working.md**](./issues-working.md) – In-progress architecture decisions and open questions.

--- a/design/project-management/backlog.md
+++ b/design/project-management/backlog.md
@@ -1,0 +1,13 @@
+# 📌 Backlog
+
+This document lists outstanding tasks and known issues that have not yet been scheduled. Use GitHub Issues for active tracking, but keep a high‑level summary here so newcomers understand current priorities.
+
+## 🚧 Open Tasks
+
+- Integrate pre-commit hooks for Checkstyle and SpotBugs
+- Establish base integration test setup using Testcontainers
+- Summarize controller routes in service design docs
+
+## 🐞 Known Issues
+
+- None at this time

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -37,9 +37,9 @@ This checklist is structured to **build foundational features first**, followed 
   - [x] Expand `CONTRIBUTING.md` with onboarding instructions
   - [x] Populate `FAQ.md` with common questions
   - [x] Add service-level design README links to central architecture docs
-  - [ ] Create issue template and maintain backlog for tasks and bugs
-  - [ ] Provide contributor guide with local setup commands and code review expectations
-  - [ ] Document environment variables and secrets management strategy
+  - [x] Create issue template and maintain backlog for tasks and bugs
+  - [x] Provide contributor guide with local setup commands and code review expectations
+  - [x] Document environment variables and secrets management strategy
 - [x] Expand `docker-compose.yml` to include all services
 - [x] Create baseline Kubernetes manifests or Helm charts for deployment
   - [x] Add Deployment and Service YAML manifests for each microservice


### PR DESCRIPTION
## Summary
- add issue templates for bugs, tasks, and features
- document environment variables and secrets handling
- add backlog doc and link it from PM README
- update CONTRIBUTING with local setup and review notes
- link new doc from infrastructure README
- mark checklist items in task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869f430b8d883309e8107e542a81e95