### PR TITLE
Refine CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,6 @@ jobs:
           path: ~/.cache/trivy
           key: trivy-db-${{ runner.os }}-${{ hashFiles('**/build.gradle*', '**/package-lock.json') }}
           restore-keys: trivy-db-${{ runner.os }}-
-
-      - name: ⚙️ Generate Gradle Wrapper
-        run: gradle wrapper --gradle-version 8.5 --distribution-type bin
-
       - name: 🎨 Apply Spotless Formatting
         run: |
           echo "::group::Run Spotless"

--- a/.github/workflows/weekly-security-scan.yml
+++ b/.github/workflows/weekly-security-scan.yml
@@ -7,10 +7,24 @@ on:
 jobs:
   trivy-scan:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - account-service
+          - automation-scripting-service
+          - entity-management-service
+          - game-design-service
+          - game-logic-service
+          - game-session-service
+          - logging-admin-service
+          - social-groups-service
+          - spring-cloud-gateway
+          - tcp-proxy-service
+          - world-management-service
     steps:
       - uses: actions/checkout@v3
       - name: Trivy container and dependency scan
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ghcr.io/my-org/my-service:latest
+          image-ref: ghcr.io/firemud/${{ matrix.service }}:latest
           exit-code: '1'


### PR DESCRIPTION
## Summary
- replace placeholder image in weekly security scan with actual GHCR repo images
- drop gradle wrapper generation step from CI workflow

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869fa6d893c8330a8abf742ec49be5c