### PR TITLE
Remove summary doc; update backlog tasks

### DIFF
--- a/design/project-management/backlog.md
+++ b/design/project-management/backlog.md
@@ -7,6 +7,9 @@ This document lists outstanding tasks and known issues that have not yet been sc
 - Integrate pre-commit hooks for Checkstyle and SpotBugs
 - Establish base integration test setup using Testcontainers
 - Summarize controller routes in service design docs
+- Create cross-service integration example scripts demonstrating account creation and game session startup
+- Seed data for local development with sample worlds and characters
+- Generate OpenAPI specs and host Swagger UI in CI
 
 ## 🐞 Known Issues
 


### PR DESCRIPTION
## Summary
- remove unused task-summary document and reference
- add seed data and OpenAPI tasks to the backlog

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6869fcc67a88833089323eb14c4e12af