### PR TITLE
Fix protobuf compile issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ subprojects {
         implementation("io.grpc:grpc-stub:1.73.0")
         implementation("io.grpc:grpc-protobuf:1.73.0")
         implementation("io.grpc:grpc-netty-shaded:1.73.0")
-        implementation("com.google.protobuf:protobuf-java:3.25.3")
+        implementation("com.google.protobuf:protobuf-java:4.31.1")
         implementation("javax.annotation:javax.annotation-api:1.3.2")
     }
 


### PR DESCRIPTION
## Summary
- update protobuf runtime to 4.31.1 so the Generated annotation exists

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test` *(fails: PingControllerTest > pingEndpointReturnsPong())*

------
https://chatgpt.com/codex/tasks/task_e_686a02228b608330a6d3d10c37e6cbb1