### PR TITLE
Add static analysis hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,13 @@ repos:
         entry: ./gradlew lintMarkdown
         language: system
         pass_filenames: false
+      - id: checkstyle
+        name: Checkstyle
+        entry: ./gradlew checkstyleMain
+        language: system
+        pass_filenames: false
+      - id: spotbugs
+        name: SpotBugs
+        entry: ./gradlew spotbugsMain
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ Once your environment is running you can create a feature branch and submit a PR
 
 ## Pre-commit Hooks
 
-The repository includes a `.pre-commit-config.yaml` that runs Spotless and
-markdownlint. Install the pre-commit tool and set up the hooks
+The repository includes a `.pre-commit-config.yaml` that runs Spotless,
+markdownlint, Checkstyle, and SpotBugs. Install the pre-commit tool and set up the hooks
 with:
 
 ```bash
@@ -42,7 +42,7 @@ pip install pre-commit
 pre-commit install
 ```
 
-Hooks automatically format code and lint Markdown before each commit.
+Hooks automatically format code, lint Markdown, and run static analysis before each commit.
 
 ## Testing Requirements
 

--- a/config/git-hooks/pre-commit
+++ b/config/git-hooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-./gradlew spotlessApply lintMarkdownFix
+./gradlew spotlessApply lintMarkdownFix checkstyleMain spotbugsMain

--- a/design/project-management/backlog.md
+++ b/design/project-management/backlog.md
@@ -4,7 +4,7 @@ This document lists outstanding tasks and known issues that have not yet been sc
 
 ## 🚧 Open Tasks
 
-- Integrate pre-commit hooks for Checkstyle and SpotBugs
+- ~~Integrate pre-commit hooks for Checkstyle and SpotBugs~~ (done)
 - Establish base integration test setup using Testcontainers
 - Summarize controller routes in service design docs
 - Create cross-service integration example scripts demonstrating account creation and game session startup

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -211,7 +211,7 @@ This checklist is structured to **build foundational features first**, followed 
   - [ ] Provision ephemeral preview environments for pull requests
   - [x] Integrate `markdownlint` in CI build
   - [x] Add pre-commit hooks for Spotless and markdownlint
-  - [ ] Add pre-commit hooks for static analysis tools (Checkstyle, SpotBugs)
+  - [x] Add pre-commit hooks for static analysis tools (Checkstyle, SpotBugs)
   - [x] Configure static analysis tools
     - [x] Add Checkstyle rules for code style enforcement
     - [x] Integrate SpotBugs for static bug detection


### PR DESCRIPTION
## Summary
- run Checkstyle and SpotBugs via pre‑commit hook
- document new hooks
- mark backlog and task list item complete

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test` *(fails: cannot find symbol com.google.protobuf.Generated)*

------
https://chatgpt.com/codex/tasks/task_e_686a05aaead48330b4acc0567ec11ad8