### PR TITLE
Align protobuf tooling across services

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ subprojects {
         implementation("io.grpc:grpc-stub:1.73.0")
         implementation("io.grpc:grpc-protobuf:1.73.0")
         implementation("io.grpc:grpc-netty-shaded:1.73.0")
-        implementation("com.google.protobuf:protobuf-java:3.25.3")
+        implementation("com.google.protobuf:protobuf-java:4.31.1")
         implementation("javax.annotation:javax.annotation-api:1.3.2")
     }
 

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -1,13 +1,8 @@
 import com.google.protobuf.gradle.*
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -26,7 +21,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:4.31.1"
     }
     plugins {
         id("grpc") {

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
     id("org.springframework.boot") version "3.5.3" apply false
 }
 
-repositories {
-    mavenCentral()
-}
 
 dependencies {
     implementation("org.mapstruct:mapstruct:1.5.5.Final")

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -23,7 +18,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:4.31.1"
     }
     plugins {
         id("grpc") {

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {
@@ -25,7 +20,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.25.3"
+        artifact = "com.google.protobuf:protoc:4.31.1"
     }
     plugins {
         id("grpc") {

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -1,11 +1,6 @@
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3" apply false
     id("org.flywaydb.flyway") version "11.10.1"
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -1,14 +1,9 @@
 import com.google.protobuf.gradle.*
 
 plugins {
-    java
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
     id("com.google.protobuf")
-}
-
-repositories {
-    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- remove redundant repository blocks
- stop declaring `java` plugin in submodules
- unify protoc compiler to 4.31.1
- update protobuf runtime to 4.31.1

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test` *(fails: PingControllerTest > pingEndpointReturnsPong())*

------
https://chatgpt.com/codex/tasks/task_e_686a0419b21483309be097df3a48d05f