### PR TITLE
Add frontend tasks and API explorer docs

### DIFF
--- a/design/project-management/backlog.md
+++ b/design/project-management/backlog.md
@@ -10,6 +10,9 @@ This document lists outstanding tasks and known issues that have not yet been sc
 - Create cross-service integration example scripts demonstrating account creation and game session startup
 - Seed data for local development with sample worlds and characters
 - Generate OpenAPI specs and host Swagger UI in CI
+- Provide interactive API explorer for manual testing
+- Set up ESLint and Prettier with pre-commit hooks for the React codebase
+- Add accessibility checks (Axe or Lighthouse) to the CI workflow
 
 ## 🐞 Known Issues
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -262,6 +262,13 @@ This checklist is structured to **build foundational features first**, followed 
     - [ ] Link to corresponding proto files
       - [ ] Generate OpenAPI specs and publish Swagger UI
       - [ ] Publish API documentation automatically in the CI pipeline
+      - [ ] Provide interactive API explorer for manual testing
+### Web Frontend
+- [ ] Scaffold React-based MUD client with Vite and Material-UI
+- [ ] Build web-based game editor for game creators
+- [ ] Configure ESLint and Prettier for consistent formatting
+- [ ] Add pre-commit hooks for frontend linting
+- [ ] Add accessibility checks (Axe or Lighthouse) to CI
 
 ---
 


### PR DESCRIPTION
## Summary
- update task-list with React frontend tasks
- note interactive API explorer
- update backlog accordingly

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test` *(fails: PingControllerTest > pingEndpointReturnsPong())*

------
https://chatgpt.com/codex/tasks/task_e_686a04d1b11c8330bbed552e6d9ffcc7