### PR TITLE
Fix Trivy step execution in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
         uses: aquasecurity/setup-trivy@v0.2.1
 
       - name: 🔍 Run Trivy and Save Report
+        if: always()
         continue-on-error: false
         run: |
           echo "::group::Run Trivy"
@@ -121,6 +122,7 @@ jobs:
           echo "::endgroup::"
 
       - name: 📤 Upload Trivy Report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: trivy-report-${{ github.sha }}
@@ -132,7 +134,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('trivy-report.txt', 'utf8');
+            const path = 'trivy-report.txt';
+            const report = fs.existsSync(path)
+              ? fs.readFileSync(path, 'utf8')
+              : 'Trivy report not available.';
 
             const hasVulnerabilities =
               /Total:\s+[1-9]/.test(report) || /CRITICAL|HIGH/.test(report);


### PR DESCRIPTION
## Summary
- ensure Trivy scan runs regardless of earlier failures
- always upload trivy report
- skip PR comment error if no report exists

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a0921dfd8833097bb34f1539bfca6