### PR TITLE
Document secrets approach and new tasks

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -17,6 +17,9 @@ This document explains how configuration values and sensitive secrets are suppli
 - Sensitive values (database passwords, JWT keys, TLS certificates) are stored in Kubernetes `Secret` objects.
 - The manifests in `k8s/base/` demonstrate loading these via `envFrom` so that services receive the same variables as in development.
 - Secrets are provisioned by **cert-manager** and rotated automatically.
+- **Kubernetes Secrets** is the chosen mechanism for storing all sensitive
+  credentials. External secret stores like Vault are not planned at this
+  stage.
 
 ## 🔄 Variable Prefixes
 

--- a/design/architecture/system-architecture-security.md
+++ b/design/architecture/system-architecture-security.md
@@ -2,6 +2,10 @@
 
 This document outlines how FireMUD secures service communication, manages authentication keys, protects network traffic, and tracks abuse attempts. It complements the [Authentication & Authorization](./system-architecture-authentication.md) document by focusing on secret management, TLS usage, abuse resistance, and operational trust guarantees.
 
+Kubernetes Secrets has been selected as the platform's unified secret
+storage solution. This keeps credential management simple while working
+seamlessly with cert-manager for automatic rotation.
+
 ---
 
 ## 🔑 Token Issuance & Secret Storage

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -586,4 +586,15 @@ This checklist is structured to **build foundational features first**, followed 
 - [ ] Set up financial contribution options
   - [ ] Add PayPal donation link
   - [ ] Configure GitHub Sponsors profile
-  - [ ] Create Patreon page
+- [ ] Create Patreon page
+
+---
+
+## ➕ Additional Tasks
+
+- [ ] Integrate **Kubernetes Secrets** for storing all credentials across services
+  - External secret stores are not planned at this stage
+- [ ] Provide command-line tooling for local game and session management
+- [ ] Plan for **end-to-end UI testing** using Cypress or Playwright once the
+  web UI is stable
+- [ ] Evaluate localization and internationalization support for the React client


### PR DESCRIPTION
## Summary
- clarify that Kubernetes Secrets is the chosen secret store
- update security architecture with the decision
- list additional roadmap items for secrets, CLI, UI tests and i18n

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test` *(fails: PingControllerTest > pingEndpointReturnsPong())*

------
https://chatgpt.com/codex/tasks/task_e_686a08bd1da883309b360bb254e7ef69