### PR TITLE
Upgrade docs and Dockerfiles to Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java-version: [17]
+        java-version: [21]
         node-version: [20]
 
     steps:

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -23,7 +23,7 @@ Framework:
 
 Backend:
 
-- Java 17+
+- Java 21+
 - Spring Data JPA
 - Lombok
 - MapStruct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in improving the FireMUD Game Platform! This documen
 
 If you're setting up the project for the first time, follow these steps:
 
-1. Review prerequisites in [**Developer Setup**](DEVELOPER_SETUP.md) and install Java 17, Docker, Node.js, and other tools.
+1. Review prerequisites in [**Developer Setup**](DEVELOPER_SETUP.md) and install Java 21, Docker, Node.js, and other tools.
 2. Clone the repository and generate Gradle wrappers if needed with `./gradlew wrapper` (or the PowerShell script on Windows).
 3. Build all modules using `./gradlew build`.
 4. Copy `.env.sample` to `.env` and adjust values if necessary.
@@ -27,7 +27,7 @@ Once your environment is running you can create a feature branch and submit a PR
 - Follow the patterns described in the repository's `.windsurfrules` file for Java Spring projects.
 - Use four spaces for indentation and avoid trailing whitespace.
 - Favor immutable data structures, clear method names, and concise classes.
-- Backend code targets Java 17+ with Spring Boot 3.x; frontend code follows standard React/TypeScript conventions.
+- Backend code targets Java 21+ with Spring Boot 3.x; frontend code follows standard React/TypeScript conventions.
 - Document public methods and classes with brief Javadoc comments.
 - Install the git hook in `config/git-hooks/pre-commit` to automatically format and lint your commits.
 

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -6,7 +6,7 @@ This guide explains how to configure a local development environment for the Fir
 
 Install the following tools before building the services:
 
-- **Java 17+** – required for all Spring Boot microservices.
+- **Java 21+** – required for all Spring Boot microservices.
 - **Gradle** – used to build and test each service.
 - **Node.js** (latest LTS) – needed if you plan to build the React frontend.
 - **Docker** and **Docker Compose** – run the full stack locally.

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Format Code
         run: ./gradlew spotlessApply
       - name: Lint Markdown
@@ -48,7 +48,7 @@ jobs:
         run: ./gradlew check
 ```
 
-The example above checks out the repository, sets up Java 17, and runs a Gradle build. Each microservice can be built in a matrix strategy so jobs run in parallel.
+The example above checks out the repository, sets up Java 21, and runs a Gradle build. Each microservice can be built in a matrix strategy so jobs run in parallel.
 
 ---
 

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -23,7 +23,7 @@ Framework:
 
 Backend:
 
-- Java 17+
+- Java 21+
 - Spring Data JPA
 - Lombok
 - MapStruct

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -6,7 +6,7 @@ This document outlines high-level design and technology assumptions for the Fire
 
 ### Core Technologies
 
-- **Language**: Java 17+
+- **Language**: Java 21+
 - **Framework**: Spring Boot 3.x
 - **Architecture**: Microservices
 - **Boilerplate Reduction**: Lombok

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/automation-scripting-service/Dockerfile
+++ b/services/automation-scripting-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/entity-management-service/Dockerfile
+++ b/services/entity-management-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/game-design-service/Dockerfile
+++ b/services/game-design-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/game-logic-service/Dockerfile
+++ b/services/game-logic-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/game-session-service/Dockerfile
+++ b/services/game-session-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/logging-admin-service/Dockerfile
+++ b/services/logging-admin-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/social-groups-service/Dockerfile
+++ b/services/social-groups-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/spring-cloud-gateway/Dockerfile
+++ b/services/spring-cloud-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/tcp-proxy-service/Dockerfile
+++ b/services/tcp-proxy-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/services/world-management-service/Dockerfile
+++ b/services/world-management-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
## Summary
- update CI to use Java 21
- update docs referencing Java 17 to Java 21
- use Eclipse Temurin 21 images in all Dockerfiles

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686a3abc516c83309cd7693080fff0b1