### PR TITLE
Comment out unused frontend dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@ updates:
       time: "04:00"
       timezone: "Pacific/Auckland"
 
-  - package-ecosystem: "npm"
-    directory: "/frontend"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "04:00"
-      timezone: "Pacific/Auckland"
+  # - package-ecosystem: "npm"
+  #   directory: "/frontend"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "sunday"
+  #     time: "04:00"
+  #     timezone: "Pacific/Auckland"


### PR DESCRIPTION
## Summary
- comment out the npm `/frontend` entry in `.github/dependabot.yml` while the frontend code is not yet present

## Testing
- `sh gradlew spotlessApply lintMarkdownFix`
- `sh gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686a428024a083308d656532da229ca0