### PR TITLE
Configure SpotBugs exclude filter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ subprojects {
     }
 
     tasks.withType<SpotBugsTask>().configureEach {
+        excludeFilter.set(rootProject.file("config/spotbugs/spotbugs-exclude.xml"))
         setIgnoreFailures(true)
     }
 

--- a/config/spotbugs/spotbugs-exclude.xml
+++ b/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Source name=".*[\\/]build[\\/]generated[\\/].*"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Summary
- add a SpotBugs exclude filter to ignore generated sources
- configure all SpotBugs tasks to use the exclude filter

## Testing
- `bash ./gradlew spotlessApply lintMarkdownFix`
- `bash ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b605a6fa48330aa62f5fc4f172536