### PR TITLE
Switch to Jwt parserBuilder

### DIFF
--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -15,9 +15,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-jdbc:3.5.3")
     implementation("io.micrometer:micrometer-core:1.15.1")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
     api("org.springframework.boot:spring-boot-starter-web:3.5.3")
     api("org.springframework.boot:spring-boot-starter-validation:3.5.3")

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
@@ -30,6 +30,9 @@ public class JwtUtil {
   }
 
   public Jws<Claims> parseToken(String token) {
-    return Jwts.parser().setSigningKey(Keys.hmacShaKeyFor(key)).build().parseClaimsJws(token);
+    return Jwts.parserBuilder()
+        .setSigningKey(Keys.hmacShaKeyFor(key))
+        .build()
+        .parseClaimsJws(token);
   }
 }

--- a/services/common-library/src/test/java/unit/net/firedevops/firemud/common/security/JwtUtilTest.java
+++ b/services/common-library/src/test/java/unit/net/firedevops/firemud/common/security/JwtUtilTest.java
@@ -1,0 +1,21 @@
+package net.firedevops.firemud.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class JwtUtilTest {
+  @Test
+  void generateAndParseTokenReturnsClaims() {
+    JwtUtil util = new JwtUtil("mysecretkey123456789012345678901", 3600000L);
+    String token = util.generateToken("demo", Map.of("role", "admin"));
+
+    Jws<Claims> parsed = util.parseToken(token);
+
+    assertEquals("demo", parsed.getBody().getSubject());
+    assertEquals("admin", parsed.getBody().get("role"));
+  }
+}


### PR DESCRIPTION
## Summary
- use `Jwts.parserBuilder()` for verifying JWT tokens
- downgrade jjwt libraries to 0.11.5 to support parserBuilder
- add JwtUtil unit test verifying token generation and parsing

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b60a0af9883308e5181d5f1d349d0