### PR TITLE
Replace MockBean with MockitoBean in tests

### DIFF
--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AccountControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AccountControllerTest.java
@@ -12,8 +12,8 @@ import net.firedevops.firemud.service.AccountService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(AccountController.class)
@@ -22,7 +22,7 @@ class AccountControllerTest {
   @Autowired private MockMvc mockMvc;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @MockBean private AccountService accountService;
+  @MockitoBean private AccountService accountService;
 
   @Test
   void createAccountReturnsDto() throws Exception {

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -9,7 +9,7 @@ import net.firedevops.firemud.service.PingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PingController.class)
@@ -17,7 +17,7 @@ class PingControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockBean private PingService pingService;
+  @MockitoBean private PingService pingService;
 
   @Test
   void pingEndpointReturnsPong() throws Exception {


### PR DESCRIPTION
## Summary
- use new `@MockitoBean` annotation in account-service tests

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b60caae008330b9e5042261c60dc1