### PR TITLE
Speed up CI with caching and parallel scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,23 +42,18 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: 💾 Cache Gradle Dependencies
+      - name: 💾 Cache Node Modules
         uses: actions/cache@v3
         with:
           path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: gradle-${{ runner.os }}-
+            ~/.npm
+            node_modules
+          key: node-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: node-${{ runner.os }}-
 
-      - name: 💾 Cache Trivy DB
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/trivy
-          key: trivy-db-${{ runner.os }}-${{ hashFiles('**/build.gradle*', '**/package-lock.json') }}
-          restore-keys: trivy-db-${{ runner.os }}-
-      - name: 🔓 Make Gradle Wrapper Executable
-        run: chmod +x ./gradlew
+      - name: ⚙️ Set Up Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: 🎨 Apply Spotless Formatting
         run: |
           echo "::group::Run Spotless"
@@ -117,69 +112,6 @@ jobs:
           name: test-logs-${{ github.sha }}
           path: build/reports/tests/test/
 
-      - name: 🛡️ Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.1
-
-      - name: 🔍 Run Trivy and Save Report
-        if: always()
-        continue-on-error: false
-        run: |
-          echo "::group::Run Trivy"
-          trivy fs --config .trivy.yaml . | tee trivy-report.txt
-          echo "::endgroup::"
-
-      - name: 📤 Upload Trivy Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: trivy-report-${{ github.sha }}
-          path: trivy-report.txt
-
-      - name: 💬 Upload Trivy Report as PR Comment
-        if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require('fs');
-            const path = 'trivy-report.txt';
-            const report = fs.existsSync(path)
-              ? fs.readFileSync(path, 'utf8')
-              : 'Trivy report not available.';
-
-            const hasVulnerabilities =
-              /Total:\s+[1-9]/.test(report) || /CRITICAL|HIGH/.test(report);
-
-            const summary = hasVulnerabilities
-              ? "❌ Critical/High vulnerabilities detected"
-              : "✅ No critical/high vulnerabilities found";
-
-            const body = `### 🔍 Trivy Security Scan Report\n**${summary}**\n\n\`\`\`\n${report}\n\`\`\``;
-
-            core.summary.addHeading("🔍 Trivy Security Scan");
-            core.summary.addRaw(summary).write();
-
-            const { data: comments } = await github.rest.issues.listComments({
-              ...context.repo,
-              issue_number: context.issue.number
-            });
-
-            const existing = comments.find(comment =>
-              comment.body.startsWith('### 🔍 Trivy Security Scan Report')
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: existing.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                ...context.repo,
-                issue_number: context.issue.number,
-                body
-              });
-            }
 
       - name: 💬 Upload Build Summary Comment
         if: github.event_name == 'pull_request' && always()
@@ -224,3 +156,78 @@ jobs:
                 body
               });
             }
+
+  trivy-scan:
+    name: Trivy Security Scan
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - name: ⬇️ Checkout Code
+        uses: actions/checkout@v3
+      - name: 💾 Cache Trivy DB
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ runner.os }}-${{ hashFiles('**/build.gradle*', '**/package-lock.json') }}
+          restore-keys: trivy-db-${{ runner.os }}-
+      - name: 🛡️ Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.1
+      - name: 🔍 Run Trivy and Save Report
+        if: always()
+        continue-on-error: false
+        run: |
+          echo "::group::Run Trivy"
+          trivy fs --config .trivy.yaml . | tee trivy-report.txt
+          echo "::endgroup::"
+      - name: 📤 Upload Trivy Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report-${{ github.sha }}
+          path: trivy-report.txt
+      - name: 💬 Upload Trivy Report as PR Comment
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'trivy-report.txt';
+            const report = fs.existsSync(path)
+              ? fs.readFileSync(path, 'utf8')
+              : 'Trivy report not available.';
+
+            const hasVulnerabilities =
+              /Total:\s+[1-9]/.test(report) || /CRITICAL|HIGH/.test(report);
+
+            const summary = hasVulnerabilities
+              ? "❌ Critical/High vulnerabilities detected"
+              : "✅ No critical/high vulnerabilities found";
+
+            const body = `### 🔍 Trivy Security Scan Report\n**${summary}**\n\n\`\`\n${report}\n\`\``;
+
+            core.summary.addHeading("🔍 Trivy Security Scan");
+            core.summary.addRaw(summary).write();
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+
+            const existing = comments.find(comment =>
+              comment.body.startsWith('### 🔍 Trivy Security Scan Report')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,8 @@ plugins {
 
 node {
     version.set("20.11.0")
-    download.set(true)
+    // Don't download Node in CI; use the version provided by the environment
+    download.set(System.getenv("CI") == null)
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
+org.gradle.daemon=true


### PR DESCRIPTION
## Summary
- enable Gradle config cache, parallel and daemon mode
- don't download Node in CI
- cache `node_modules` and set up Gradle via official build action
- move Trivy steps into a dedicated job

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b66d94ef483309328199c73cd8e0e