### PR TITLE
Ignore generated proto classes for SpotBugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.github.gradle.node.npm.task.NpxTask
 import com.github.spotbugs.snom.SpotBugsTask
+import java.io.File
 
 plugins {
     java
@@ -60,6 +61,10 @@ subprojects {
     tasks.withType<SpotBugsTask>().configureEach {
         excludeFilter.set(rootProject.file("config/spotbugs/spotbugs-exclude.xml"))
         setIgnoreFailures(true)
+        // Exclude generated sources such as Protobuf classes from analysis
+        val generatedDir = "${File.separator}generated${File.separator}"
+        classDirs.setFrom(classDirs.files.filterNot { it.path.contains(generatedDir) })
+        sourceDirs.setFrom(sourceDirs.files.filterNot { it.path.contains(generatedDir) })
     }
 
     tasks.test {


### PR DESCRIPTION
## Summary
- update SpotBugs task configuration so generated sources aren't analyzed

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686b654719008330a32cbc55a5fe0537