### PR TITLE
Shift kickoff tasks under common microservice section

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -113,11 +113,6 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [x] **Choose technology stack (Spring Boot, PostgreSQL, Redis, WebSockets, Kubernetes, etc.)**
 - [x] **Set up Docker and Kubernetes for containerized deployment**
 - [x] **Set up centralized logging & monitoring (Fluent Bit, Elasticsearch, Kibana, Grafana, Prometheus, OpenTelemetry, Alertmanager)**
-
-#### Coding Kickoff Checklist
-  - [ ] Provision ephemeral preview environments for pull requests
-  - [ ] Finalize API schemas from concrete gameplay flows
-  - [ ] Create Gradle `devUp` task to build all services and start Docker Compose with sample data
 ### Web Frontend
 - [ ] Scaffold React-based MUD client with Vite and Material-UI
 - [ ] Build web-based game editor for game creators
@@ -165,6 +160,7 @@ _Applies to:_
 ---
 
 #### 🧱 Domain Modeling & API Exposure
+- [ ] Finalize API schemas from concrete gameplay flows
 - [ ] Define JPA entities and repositories using Spring Data for core domain objects
 - [ ] Implement initial JPA entities and repositories
 - [ ] Configure Flyway migrations for each service's initial schema
@@ -267,6 +263,8 @@ _Applies to:_
 ---
 
 #### 🚀 CI/CD & Developer Automation
+- [ ] Create Gradle `devUp` task to build all services and start Docker Compose with sample data
+- [ ] Provision ephemeral preview environments for pull requests
 - [ ] Automate Docker image builds and registry pushes
 - [ ] Add CI steps for:
   - Protobuf generation and schema checking


### PR DESCRIPTION
## Summary
- prune `Coding Kickoff` section
- move kickoff steps to common list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check` *(fails: entity-management-service spotbugs task configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686b6f10e6888330b4fe36075d0b54e6