### PR TITLE
Remove redundant jacoco step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,6 @@ jobs:
           echo "::group::Run Tests"
           ./gradlew check
           echo "::endgroup::"
-
-      - name: 📊 Generate Code Coverage
-        run: |
-          echo "::group::Generate Coverage"
-          ./gradlew jacocoTestReport
-          echo "::endgroup::"
-
       - name: 📈 Parse Coverage %
         id: coverage
         run: |


### PR DESCRIPTION
## Summary
- remove the jacocoTestReport job step in CI workflow

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b70261ea88330af5b076d4b3c85a2