### PR TITLE
Improve SpotBugs exclusions

### DIFF
--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -51,4 +51,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -52,5 +52,21 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }
 

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -28,4 +28,20 @@ dependencies {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -52,4 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -52,4 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -49,5 +49,21 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }
 

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -52,4 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -52,4 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -52,4 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -51,5 +51,21 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }
 

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -17,4 +17,20 @@ dependencies {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -52,4 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
+    classes = fileTree("$buildDir/classes/java/main") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named<SpotBugsTask>("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
+    classes = fileTree("$buildDir/classes/java/test") {
+        exclude("**/proto/**")
+        exclude("**/*OuterClass.class")
+    }
+}
+
+tasks.named("spotbugsTest") {
+    dependsOn(tasks.named("compileTestJava"))
 }


### PR DESCRIPTION
## Summary
- exclude generated classes under proto packages for all services
- keep spotbugsTest depending on compileTestJava
- remove versioned package exclusion since proto exclusion covers them

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b74b357148330887b8affd46fcc3a