### PR TITLE
Switch to markdownlint-cli2 config

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,13 +1,14 @@
 {
-  "default": true,
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD026": false
+  },
   "ignores": [
     "**/node_modules/**",
     "**/.gradle/**",
     "**/build/**",
     "**/.git/**"
   ],
-  "gitignore": true,
-
-  "MD013": false,
-  "MD026": false
+  "gitignore": true
 }

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -64,7 +64,7 @@ To manually fix correctable issues, run:
 ./gradlew lintMarkdownFix
 ```
 
-Linting rules are defined in `.markdownlint.json` at the project root. Auto-fixing is not part of the `check` phase so that CI runs remain non-destructive.
+Linting rules are defined in `.markdownlint-cli2.jsonc` at the project root. Auto-fixing is not part of the `check` phase so that CI runs remain non-destructive.
 
 ## Lombok and MapStruct
 

--- a/design/architecture/repository-structure.md
+++ b/design/architecture/repository-structure.md
@@ -2,7 +2,7 @@
 
 This repository uses a hierarchical Gradle layout. All microservices and the shared `common-library` now live under a top-level `services/` folder to keep the root tidy.
 
-```
+```text
 root
 ├── services/
 │   ├── common-library

--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -8,7 +8,7 @@ This document describes the structure and tooling for FireMUD's browser-based us
 
 FireMUD uses React components with a **feature-first** organization. Each feature folder contains its own components, tests, and styling:
 
-```
+```text
 frontend/
   src/
     features/

--- a/k8s/base/README.md
+++ b/k8s/base/README.md
@@ -36,7 +36,7 @@ All Spring Boot services expect PostgreSQL and Redis connection details via
 environment variables. A `firemud-config` `ConfigMap` and `firemud-secret`
 `Secret` are provided to supply these values:
 
-```
+```bash
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=firemud


### PR DESCRIPTION
## Summary
- use `.markdownlint-cli2.jsonc` for configuration
- update docs that mention the config
- add fenced code block languages where markdownlint flagged issues

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b8008c3d083308bff25c65f59911e