### PR TITLE
Refine SpotBugs class scanning

### DIFF
--- a/design/architecture/repository-structure.md
+++ b/design/architecture/repository-structure.md
@@ -2,7 +2,7 @@
 
 This repository uses a hierarchical Gradle layout. All microservices and the shared `common-library` now live under a top-level `services/` folder to keep the root tidy.
 
-```
+```text
 root
 ├── services/
 │   ├── common-library

--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -8,7 +8,7 @@ This document describes the structure and tooling for FireMUD's browser-based us
 
 FireMUD uses React components with a **feature-first** organization. Each feature folder contains its own components, tests, and styling:
 
-```
+```text
 frontend/
   src/
     features/

--- a/k8s/base/README.md
+++ b/k8s/base/README.md
@@ -36,7 +36,7 @@ All Spring Boot services expect PostgreSQL and Redis connection details via
 environment variables. A `firemud-config` `ConfigMap` and `firemud-secret`
 `Secret` are provided to supply these values:
 
-```
+```bash
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=firemud

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -51,20 +51,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -52,21 +52,18 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}
 

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -28,20 +28,17 @@ dependencies {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -52,20 +52,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -52,20 +52,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -49,21 +49,18 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}
 

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -52,20 +52,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -52,20 +52,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -52,20 +52,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -51,21 +51,18 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}
 

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -17,20 +17,17 @@ dependencies {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -52,20 +52,17 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    classes = fileTree("$buildDir/classes/java/main") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    classes = fileTree("$buildDir/classes/java/test") {
+    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
         exclude("**/proto/**")
         exclude("**/*OuterClass.class")
-    }
+    })
 }
 
-tasks.named("spotbugsTest") {
-    dependsOn(tasks.named("compileTestJava"))
-}


### PR DESCRIPTION
## Summary
- tweak SpotBugs configuration to use `setFrom` on the configurable file collection
- keep proto and `OuterClass` exclusions
- fix missing fenced code block languages in docs

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b8179c43083309e1e3a596d836dae