### PR TITLE
Fix SpotBugs class setting for Gradle 8

### DIFF
--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -51,15 +51,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+        )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+        )
 }
 

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -52,16 +52,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -28,15 +28,19 @@ dependencies {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -52,15 +52,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -52,15 +52,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -49,16 +49,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -52,15 +52,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -52,15 +52,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -52,15 +52,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -51,16 +51,20 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -17,15 +17,19 @@ dependencies {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -52,15 +52,19 @@ sourceSets {
 
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/main") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/main") {
+            exclude("**/proto/**")
+        }
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
-    (classes as org.gradle.api.file.ConfigurableFileCollection).setFrom(fileTree("$buildDir/classes/java/test") {
-        exclude("**/proto/**")
-    })
+    classes = files(
+        fileTree("$buildDir/classes/java/test") {
+            exclude("**/proto/**")
+        }
+    )
 }
 


### PR DESCRIPTION
## Summary
- avoid unsafe casts when setting classes for SpotBugs tasks
- assign `classes` using `files()` for main and test tasks

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b921fec24833084f410bf5975433b