### PR TITLE
Move global tasks out of common list

### DIFF
--- a/design/project-management/task-list-common.md
+++ b/design/project-management/task-list-common.md
@@ -13,11 +13,7 @@ These tasks apply to every service module. Gateway and TCP Proxy implement only 
 - [ ] Add minimal `README.md` with local setup instructions and design links
 - [ ] Define Kubernetes `Deployment` and `Service` manifests
 - [ ] Add Kubernetes readiness and liveness probes
-- [ ] Prepare Helm charts for each service
-- [ ] Verify service startup via `./gradlew devUp` and confirm `Started` logs
 - [ ] Expose `/actuator/health` endpoint with Spring Boot Actuator
-- [ ] Create baseline Kubernetes manifests or Helm charts for deployment
-  - [ ] Create Kubernetes `NetworkPolicy` manifests to restrict service communication
 
 ---
 
@@ -38,7 +34,6 @@ These tasks apply to every service module. Gateway and TCP Proxy implement only 
 - [ ] Add contract smoke tests for gRPC (`grpcurl`) and REST (`curl`)
 - [ ] Generate gRPC stubs via Gradle and include in CI pipeline
 - [ ] Enforce `tenantId` validation for create endpoints
-- [ ] Generate ERD diagrams and baseline Flyway scripts for each service (automated in CI)
 
 ---
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -112,6 +112,8 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [ ] Write sample Terraform code to:
   - [ ] Define `firemud` namespace and basic RBAC
   - [ ] Optionally configure local Redis or Helm releases
+  - [ ] Prepare Helm charts and baseline Kubernetes manifests for each service
+    - [ ] Include `Deployment`, `Service`, and `NetworkPolicy` manifests
 - [ ] Add example `values.yaml` files for local and dev environments
 - [ ] Support Helm-based config overrides for:
   - [ ] Redis connection info
@@ -146,6 +148,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 ### CI/CD & Developer Automation
 
 - [ ] Create Gradle `devUp` task to build all services and start Docker Compose with sample data
+- [ ] Verify each service starts via `./gradlew devUp` and shows `Started` logs
 - [ ] Provision ephemeral preview environments for pull requests
 - [ ] Automate Docker image builds and registry pushes
 - [ ] Add CI steps for:
@@ -153,10 +156,11 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
   - Proto linting and compatibility (`buf`)
   - Include `buf breaking` tests in CI for backward compatibility
   - Integrate proto generation and schema validation into CI workflow
-  - Include generated sources in build and CI
-  - OpenAPI consistency
-  - Static analysis
-- [ ] Add pre-commit hooks for:
+    - Include generated sources in build and CI
+    - OpenAPI consistency
+    - Static analysis
+  - [ ] Generate ERD diagrams and baseline Flyway scripts for each service in CI
+  - [ ] Add pre-commit hooks for:
   - Spotless
   - Checkstyle
   - markdownlint


### PR DESCRIPTION
## Summary
- trim items in `task-list-common.md` that are not per‑service
- move infrastructure and CI details back to the main `task-list.md`

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b924de9c48330ac8c2ba00581034a