### PR TITLE
Update common task list

### DIFF
--- a/design/project-management/task-list-common.md
+++ b/design/project-management/task-list-common.md
@@ -28,11 +28,9 @@ These tasks apply to every service module. Gateway and TCP Proxy implement only 
 - [ ] Define and implement gRPC service stubs with explicit `Request`/`Response` messages
 - [ ] Version all `.proto` files (`package service.v1`) and place under `protos/{service}/v1`
 - [ ] Use shared types (e.g., `ErrorDetail`, `EntityId`) from `protos/shared/`
-- [ ] Lint `.proto` files with `buf` and enforce schema compatibility and versioning in CI
 - [ ] Validate requests and map gRPC errors to appropriate status codes
 - [ ] Add structured error responses using `shared/ErrorDetail.proto`
 - [ ] Add contract smoke tests for gRPC (`grpcurl`) and REST (`curl`)
-- [ ] Generate gRPC stubs via Gradle and include in CI pipeline
 - [ ] Enforce `tenantId` validation for create endpoints
 
 ---

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -153,8 +153,9 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [ ] Automate Docker image builds and registry pushes
 - [ ] Add CI steps for:
   - Protobuf generation and schema checking
-  - Proto linting and compatibility (`buf`)
+  - Lint `.proto` files with `buf` and enforce schema versioning
   - Include `buf breaking` tests in CI for backward compatibility
+  - Generate gRPC stubs for each service via Gradle plugin
   - Integrate proto generation and schema validation into CI workflow
     - Include generated sources in build and CI
     - OpenAPI consistency


### PR DESCRIPTION
## Summary
- trim global items from `task-list-common.md`
- include proto linting and gRPC stub generation steps in main task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686b9755ed7c8330a735b838dadfe01a