### PR TITLE
Update FireMUD platform task list

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -50,8 +50,10 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
   - [x] Add `.windsurfrules` with AI coding guidelines
   - [x] Add `.trivy.yaml` for Trivy security scans
   - [x] Provide `.vscode` workspace settings
+  - [ ] Add `.editorconfig` for consistent indentation and whitespace rules
   - [x] Enable Gradle configuration cache and parallel builds
   - [x] Add GitHub workflow to build Docker images
+  - [ ] Add GitHub workflow to publish documentation to GitHub Pages
 
 - [x] **Miscellaneous**
   - [x] Write initial design for each microservice
@@ -132,6 +134,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
   - [ ] Define `firemud` namespace and basic RBAC
   - [ ] Optionally configure local Redis or Helm releases
   - [ ] Deploy Redis cluster with automatic failover and AOF persistence (see [Redis Architecture](../architecture/system-architecture-redis.md))
+  - [ ] Deploy PostgreSQL cluster with replication and persistent volumes
   - [ ] Install redis-exporter for Prometheus metrics
   - [ ] Prepare Helm charts and baseline Kubernetes manifests for each service
     - [ ] Include `Deployment`, `Service`, and `NetworkPolicy` manifests
@@ -151,6 +154,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [ ] Meta/control services validate JWTs; gameplay services trust Game Session Service and skip JWT checks
 - [ ] Rely on Game Session Service for gameplay session enforcement
 - [ ] Configure mutual TLS (mTLS) for gRPC between internal services
+- [ ] Install and configure `cert-manager` in the Kubernetes cluster
 - [ ] Manage certificates via Kubernetes `cert-manager`
 - [ ] Secure credentials using Kubernetes Secrets (external secret stores not planned yet)
 - [ ] Add integration test for mid-session role refresh via Game Session Service
@@ -211,6 +215,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [ ] Configure centralized log aggregation dashboards early
 - [ ] Deploy Prometheus, Grafana, and Alertmanager for metrics and alerts
 - [ ] Deploy OpenTelemetry Collector for distributed tracing
+- [ ] Deploy Jaeger or equivalent trace UI for visualizing spans
 - [ ] Generate gRPC API documentation with `protoc-gen-doc` and publish to project docs
 - [ ] Commit default Grafana and Kibana dashboard templates
 


### PR DESCRIPTION
## Summary
- extend repo setup tasks with editorconfig and docs publishing
- add PostgreSQL cluster setup
- document cert-manager installation
- deploy Jaeger for trace visualization

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686cc4d476748330bfb59661a1086c72