### PR TITLE
Add weekly security scan item

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -219,6 +219,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [x] Post Trivy scan report as pull request comment
 - [x] Cache Trivy vulnerability database in CI for faster scans
 - [x] Schedule recurring security scans (including base image and dependency scans)
+- [x] Add `weekly-security-scan.yml` workflow to scan published images weekly
 - [x] Add GitHub workflow to generate release notes on tag push
 - [ ] Automate semantic version bumps
 - [ ] Integrate open source license scanning into CI


### PR DESCRIPTION
## Summary
- track the weekly security scan workflow in the main task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686cd20533988330b50e096c8226c382