### PR TITLE
Append common checklist to service task lists

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -33,3 +33,117 @@
   - Implement premium hosting tiers & features for game creators
   - Implement platform-controlled ad system (for free-to-play games)
   - Implement revenue-sharing system for game creators
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -16,3 +16,117 @@
   - Provide web UI for script creation and testing
   - Add advanced AI modules for complex behaviors
   - Enforce fairness quotas and per-script resource limits
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-entity-management-service.md
+++ b/design/project-management/task-list-entity-management-service.md
@@ -10,3 +10,117 @@
   - Implement cross-game account linking (allow single account across multiple hosted games)
   - Implement entity graph caching for fast lookups
   - Support complex crafting recipes
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -32,3 +32,117 @@
   - [ ] Copy published data to domain services using the `version_id`
   - [ ] Activate versions and runtime flags via the Game Session Service
   - [ ] Expose admin APIs for runtime flag toggles through the Logging & Admin Service
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -9,3 +9,117 @@
   - Implement action aliases system (custom command mappings)
   - Add scripting hooks for custom actions
   - Optimize performance for large-scale battles
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-game-session-service.md
+++ b/design/project-management/task-list-game-session-service.md
@@ -14,3 +14,117 @@
   - Plan for cross-region sharding and session handoff
   - Implement `game_manifest` table for version coordination
   - Emit gameplay analytics for operators
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -15,3 +15,117 @@
   - Integrate saga metrics and timeout recovery
   - Use saga orchestrator for multi-service admin operations (bans, content revocation)
   - Build role-based admin UI
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -11,3 +11,117 @@
   - Provide rich moderation tools for chat
   - Add optional voice chat integration
   - Use saga orchestrator for guild creation workflow
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-spring-cloud-gateway.md
+++ b/design/project-management/task-list-spring-cloud-gateway.md
@@ -11,3 +11,117 @@
   - Create `GatewayController` endpoints for dynamic route management
     - Allow creation of custom gateway routes via API
   - Add gRPC `GatewayManagementService` for remote route configuration
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-tcp-proxy-service.md
+++ b/design/project-management/task-list-tcp-proxy-service.md
@@ -10,3 +10,117 @@
   - Enforce Telnet command whitelist and input sanitization
   - Implement connection throttling and rate limits
   - Support TLS termination for secure Telnet clients
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*

--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -12,3 +12,117 @@
   - Use saga orchestrator for world creation workflow
   - Provide tools to fine-tune procedural generation rules
   - Support multi-server world shards
+
+## Reusable Microservice Checklist
+
+These tasks apply to every FireMUD service unless noted otherwise. Gateway and
+TCP Proxy skip the gRPC and database items but still expose health checks and
+participate in CI.
+
+---
+
+## 📦 Project Setup & CI
+
+- [ ] Register the module in `settings.gradle.kts` and apply the `java` plugin
+- [ ] Add a minimal Spring Boot application with `PingController` and gRPC `PingService` *(not needed for Gateway or TCP Proxy)*
+- [ ] Provide a `Dockerfile` and Gradle task to build the image
+- [ ] Create `README.md` with local setup instructions and design links
+- [ ] Add the service to the GitHub Actions build matrix and Buf lint step
+- [ ] Include the service in the Docker image workflow (`buildDockerImages`)
+- [ ] Define Kubernetes `Deployment` and `Service` manifests
+- [ ] Expose `/actuator/health` for readiness and liveness probes
+
+---
+
+## 🧱 API Definition
+
+- [ ] Define gRPC service stubs with explicit `Request`/`Response` messages
+- [ ] Version proto files under `protos/{service}/v1` with `package {service}.v1`
+- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [ ] Add the proto directory to `buf.yaml` for lint and breaking change checks
+- [ ] Provide contract smoke tests using `grpcurl`
+- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+
+---
+
+## 🔒 Authentication & Authorization
+
+- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [ ] Gameplay services rely on the Game Session Service for session validation
+
+---
+
+## 🔁 Inter-Service Communication
+
+- [ ] Use `firemud-common` protobuf types for shared messages
+- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [ ] Register with service discovery via helpers in `firemud-common`
+- [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
+- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+
+---
+
+## 📚 Shared Library Integration
+
+- [ ] Depend on `firemud-common` via Gradle
+- [ ] Apply logging, tracing, and security interceptors from the library
+- [ ] Use provided autoconfiguration classes to reduce boilerplate
+- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+
+---
+
+## 🔄 Saga Participation *(if used)*
+
+- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [ ] Emit metrics and correlation IDs for compensation and retries
+- [ ] Document saga participation in `design/README.md`
+
+---
+
+## 🔑 Redis Integration *(if used)*
+
+- [ ] Use Redis for transient gameplay state only
+- [ ] Access Redis through helpers in `firemud-common`
+- [ ] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
+- [ ] Validate shard-local key usage and avoid per-service caching
+- [ ] Emit metrics for Redis connectivity and commands
+- [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
+- [ ] Prefix all keys with `tenantId` to isolate game data
+
+---
+
+## 🧪 Testing & Quality Gates
+
+- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [ ] Use Spring Boot Test and Testcontainers for integration tests
+- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [ ] Seed minimal test data for local workflows
+- [ ] Run `./gradlew check` in CI to execute all tests
+- [ ] *(When workflows span services)* add cross-service integration tests
+
+---
+
+## 📈 Observability & Tracing
+
+- [ ] Use Micrometer for Prometheus metrics
+- [ ] Enable OpenTelemetry tracing
+- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+
+---
+
+## 📖 Documentation
+
+- [ ] Create `design/README.md` summarizing APIs and sample requests
+- [ ] Document proto contracts and any Redis keys in the service README
+- [ ] Document required environment variables and configuration
+- [ ] Note `tenantId` handling and cross-service dependencies
+- [ ] Add a design document under `design/architecture/microservices/<service>/README.md`
+
+---
+
+*Game-specific services may define additional commands or entity behavior but follow the same deployment conventions.*


### PR DESCRIPTION
## Summary
- add `Reusable Microservice Checklist` section to each service-specific task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686cf6565d048330b923c3bcf6224ecc