### PR TITLE
Fix Docs workflow paths

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Publish Documentation
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - name: Build documentation
+        run: |
+          mkdir -p public/design
+          cp -r design/* public/design/
+          cp README.md public/index.md
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -66,7 +66,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
   - [x] Add `.editorconfig` for consistent indentation and whitespace rules
   - [x] Enable Gradle configuration cache and parallel builds
   - [x] Add GitHub workflow to build Docker images
-  - [ ] Add GitHub workflow to publish documentation to GitHub Pages
+  - [x] Add GitHub workflow to publish documentation to GitHub Pages
 
 - [x] **Miscellaneous**
   - [x] Write initial design for each microservice


### PR DESCRIPTION
## Summary
- fix doc workflow to preserve `design/` path for pages

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686cfc81fcc483309a3bce7e6a95d469