### PR TITLE
Add donation links and funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: benhook1013
+patreon: firemud
+custom: ["https://paypal.me/firedevops"]

--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ Your support can make a significant difference in the development and success of
 
 - **Contribute**: See the [Getting Started and Contributing](#getting-started-and-contributing) section for ways to contribute code, documentation, or ideas.
 - **Spread the Word**: Share the project with friends, colleagues, and on social media platforms to help us reach a wider audience.
-- **Financial Contributions**: See the [Community & Funding tasks](design/project-management/task-list.md#🛠-phase-11-community--funding) for planned donation options. Upcoming support channels include:
-  - **Sponsor on PayPal** *(planned)*
-  - **Sponsor on GitHub** *(planned)*
-  - **Patreon** *(planned)*
+- **Financial Contributions**: Help fund ongoing development:
+  - [Donate via PayPal](https://paypal.me/firedevops)
+  - [Sponsor on GitHub](https://github.com/sponsors/benhook1013)
+  - [Support us on Patreon](https://patreon.com/firemud)
 
   *Note: Financial contributions will be used to cover development costs, hosting, and other expenses related to the project.*
 

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -301,11 +301,11 @@ The standard microservice checklist is now copied into each service task list.
 
 ## 🛠️ Phase 4: Community & Funding
 
-- [ ] Set up financial contribution options
-  - [ ] Add PayPal donation link
-  - [ ] Add Patreon donation link
-  - [ ] Configure GitHub Sponsors profile
-- [ ] Create Patreon page
+- [x] Set up financial contribution options
+  - [x] Add PayPal donation link
+  - [x] Add Patreon donation link
+  - [x] Configure GitHub Sponsors profile
+- [x] Create Patreon page
 
 ---
 


### PR DESCRIPTION
## Summary
- add FUNDING.yml with GitHub Sponsors, Patreon, and PayPal
- update README with direct donation links
- mark funding tasks as completed in the master task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e10c1d60883308c7124536bf601e1