### PR TITLE
Add firemud-protos module

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -126,7 +126,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
   - [x] Implement configuration management (centralized properties, environment handling)
   - [x] Include Lombok and MapStruct dependencies for annotation-based code generation
   - [x] Publish common package to internal repository (Maven/Gradle)
-  - [ ] Publish **firemud-protos** artifact with shared gRPC definitions
+  - [x] Publish **firemud-protos** artifact with shared gRPC definitions
   - [x] Add `common-library` README with usage examples
   - [ ] Extend **firemud-common** with saga orchestration support
     - [ ] Define `saga` schema tables for step tracking and state

--- a/services/firemud-protos/README.md
+++ b/services/firemud-protos/README.md
@@ -1,0 +1,13 @@
+# FireMUD Protos
+
+This module packages all protobuf definitions under the top-level `protos/` directory. Use it when other projects need the raw `.proto` files without cloning the entire repository.
+
+## Publishing
+
+Artifacts are published as `firemud-protos` to the GitHub Packages registry:
+
+```bash
+./gradlew :firemud-protos:publish -Pgpr.user=<username> -Pgpr.key=<token>
+```
+
+The resulting JAR contains only `.proto` resources. Generated sources are not included so consuming projects can apply their own code generation steps.

--- a/services/firemud-protos/build.gradle.kts
+++ b/services/firemud-protos/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    `java`
+    `maven-publish`
+}
+
+java {
+    // no compiled classes; just package proto files
+    sourceSets["main"].java.srcDirs()
+    withSourcesJar()
+}
+
+// Include proto files as resources
+sourceSets["main"].resources.srcDir("${rootProject.projectDir}/protos")
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "firemud-protos"
+        }
+    }
+    repositories {
+        maven {
+            name = "github"
+            url = uri("https://maven.pkg.github.com/firedevops/firemud")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,9 @@ rootProject.name = "firemud"
 include("common-library")
 project(":common-library").projectDir = File("services/common-library")
 
+include("firemud-protos")
+project(":firemud-protos").projectDir = File("services/firemud-protos")
+
 include("account-service")
 project(":account-service").projectDir = File("services/account-service")
 


### PR DESCRIPTION
## Summary
- provide a `firemud-protos` Gradle module to package all `.proto` files
- document how to publish this artifact
- reference the module in `settings.gradle.kts`
- mark the related task as complete

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e31b0fc788330a718bad293403a0d