### PR TITLE
Implement proto publishing

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -126,7 +126,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
   - [x] Implement configuration management (centralized properties, environment handling)
   - [x] Include Lombok and MapStruct dependencies for annotation-based code generation
   - [x] Publish common package to internal repository (Maven/Gradle)
-  - [ ] Publish **firemud-protos** artifact with shared gRPC definitions
+  - [x] Publish **firemud-protos** artifact with shared gRPC definitions
   - [x] Add `common-library` README with usage examples
   - [ ] Extend **firemud-common** with saga orchestration support
     - [ ] Define `saga` schema tables for step tracking and state

--- a/protos/README.md
+++ b/protos/README.md
@@ -1,0 +1,7 @@
+# FireMUD Proto Definitions
+
+This module contains all gRPC and protocol buffer definitions shared across the FireMUD services.
+The Gradle build publishes a `firemud-protos` artifact so that other projects can depend on a single
+package rather than copying proto files.
+
+Run `./gradlew :firemud-protos:publish` to deploy the artifact to the GitHub Packages registry.

--- a/protos/build.gradle.kts
+++ b/protos/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+tasks.register<Jar>("sourcesJar") {
+    from(".") { include("**/*.proto") }
+    archiveClassifier.set("sources")
+}
+
+artifacts {
+    add("archives", tasks.named("sourcesJar"))
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            artifactId = "firemud-protos"
+        }
+    }
+    repositories {
+        maven {
+            name = "github"
+            url = uri("https://maven.pkg.github.com/firedevops/firemud")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/protos/settings.gradle.kts
+++ b/protos/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "firemud-protos"


### PR DESCRIPTION
## Summary
- create a standalone Gradle project in `protos/` to publish shared definitions
- update task list marking proto artifact as completed

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e31b0fc788330a718bad293403a0d