### PR TITLE
Fix CI build by enabling bootBuildImage

### DIFF
--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -1,7 +1,8 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id("org.springframework.boot") version "3.5.3" apply false
+    // Apply the Spring Boot plugin so `bootBuildImage` is available for Docker builds
+    id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
 }
 


### PR DESCRIPTION
## Summary
- apply Spring Boot plugin in tcp-proxy-service so `bootBuildImage` exists

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e4269c1d083308eb78d1a8a8f0189