### PR TITLE
Fix missing bootBuildImage task

### DIFF
--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
-    id("org.springframework.boot") version "3.5.3" apply false
+    id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
 }
 
@@ -12,6 +12,8 @@ dependencies {
     compileOnly("org.projectlombok:lombok:1.18.38")
     implementation("org.flywaydb:flyway-core:11.10.1")
     implementation("org.mapstruct:mapstruct:1.6.3")
+    implementation("org.springframework.boot:spring-boot-starter:3.5.3")
+    implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
     implementation(project(":common-library"))
 }
 


### PR DESCRIPTION
## Summary
- enable the Spring Boot plugin for `tcp-proxy-service`
- add Spring Boot starter dependencies so the module can build its image

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew :tcp-proxy-service:check`
- `./gradlew buildDockerImages --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_686e4269c1d083308eb78d1a8a8f0189