### PR TITLE
Fix base Dockerfile image

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,5 +1,5 @@
 # Shared base image for FireMUD services
-FROM eclipse-temurin:21-jre-slim
+FROM eclipse-temurin:21-jre
 LABEL org.opencontainers.image.source="https://github.com/firedevops/FireMUD"
 RUN addgroup --system firemud && adduser --system --ingroup firemud firemud
 WORKDIR /app


### PR DESCRIPTION
## Summary
- fix build: use valid eclipse-temurin tag in `docker/base.Dockerfile`

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e44b5852c83309a326513b48137f6