### PR TITLE
Fix buf breaking base branch issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,15 @@ jobs:
         with:
           version: '1.30.0'
 
-      - name: 🛠️ Fetch Base Branch for Buf Breaking
+      - name: 🛠️ Fetch Base Commit for Buf Breaking
         if: github.event_name == 'pull_request'
         run: |
-          git fetch origin +refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+          git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
 
       - name: ⚠️ Buf Breaking
         if: github.event_name == 'pull_request'
         run: |
-          buf breaking --against origin/${{ github.event.pull_request.base.ref }}
+          buf breaking --against ${{ github.event.pull_request.base.sha }}
 
       - name: ⚙️ Generate Protobufs
         run: buf generate


### PR DESCRIPTION
## Summary
- make buf breaking use the base commit SHA
- fetch the base commit to ensure the reference exists

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e44583c0883308c15d7be8b603869