### PR TITLE
Fix Buf breaking SHA reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: ⚠️ Buf Breaking
         if: github.event_name == 'pull_request'
         run: |
-          buf breaking --against ${{ github.event.pull_request.base.sha }}
+          buf breaking --against ".git#commit=${{ github.event.pull_request.base.sha }}"
 
       - name: ⚙️ Generate Protobufs
         run: buf generate


### PR DESCRIPTION
## Summary
- fix CI job for Buf breaking changes by using `.git#commit` syntax

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e485f795883308b76134405709b14