### PR TITLE
Add ERD generation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,3 +294,25 @@ jobs:
               });
             }
 
+
+  generate-erd:
+    name: Generate ERD Diagrams
+    runs-on: ubuntu-latest
+    needs: trivy-scan
+    steps:
+      - name: ⬇️ Checkout Code
+        uses: actions/checkout@v3
+
+      - name: ⚙️ Set Up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: 🖼️ Generate ERD diagrams
+        run: ./dev-tools/generate-erd.sh
+
+      - name: 📤 Upload ERD artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: erd-diagrams-${{ github.sha }}
+          path: design/erd

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 # Terraform
 **/.terraform/
 *.tfstate
+design/erd/

--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -27,6 +27,10 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 
 Migrations are therefore applied consistently in every environment without manual steps.
 
+### ERD Diagrams
+
+CI runs `dev-tools/generate-erd.sh` after tests complete to create database diagrams. The script concatenates each service's migrations, converts them to DBML via `@dbml/cli`, and uploads the output as build artifacts.
+
 ---
 
 ## 📚 Related Documentation

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -210,7 +210,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
     - [x] Include generated sources in build and CI
     - [x] OpenAPI consistency
     - [x] Static analysis
-  - [ ] Generate ERD diagrams and baseline Flyway scripts for each service in CI
+  - [x] Generate ERD diagrams and baseline Flyway scripts for each service in CI
   - [x] Add pre-commit hooks for:
     - [x] Spotless
     - [x] Checkstyle

--- a/dev-tools/generate-erd.sh
+++ b/dev-tools/generate-erd.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Generate ERD diagrams and baseline migration scripts
+set -euo pipefail
+
+OUT_DIR="design/erd"
+mkdir -p "$OUT_DIR"
+
+for service in services/*-service; do
+  MIG_DIR="$service/src/main/resources/db/migration"
+  if [ -d "$MIG_DIR" ]; then
+    NAME=$(basename "$service")
+    BASELINE="$OUT_DIR/${NAME}-baseline.sql"
+    DBML_OUT="$OUT_DIR/${NAME}.dbml"
+    cat "$MIG_DIR"/*.sql > "$BASELINE"
+    npx -y -p @dbml/cli sql2dbml --postgres "$BASELINE" --out-file "$DBML_OUT"
+  fi
+done
+
+echo "ERD diagrams written to $OUT_DIR"


### PR DESCRIPTION
## Summary
- generate ERD diagrams from Flyway migrations
- upload diagrams in CI
- document new ERD generation step
- ignore generated diagrams
- mark CI task complete in task-list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e478cda108330b32e739ef5f0a503