### PR TITLE
Fix Buf breaking reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: ⚠️ Buf Breaking
         if: github.event_name == 'pull_request'
         run: |
-          buf breaking --against ".git#commit=${{ github.event.pull_request.base.sha }}"
+          buf breaking --against ".git#ref=${{ github.event.pull_request.base.sha }}"
 
       - name: ⚙️ Generate Protobufs
         run: buf generate


### PR DESCRIPTION
## Summary
- update CI workflow to use `git#ref` when running Buf breaking

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e4a8ddc348330a9172135415b26b6