### PR TITLE
Fix YAML indent in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
                 issue_number: context.issue.number,
                 body
             });
-          }
+            }
 
   generate-erd:
     name: Generate ERD Diagrams


### PR DESCRIPTION
## Summary
- fix indentation in `.github/workflows/ci.yml` to correct YAML syntax

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686e4dc611a88330be6e488c7977fc0f