### PR TITLE
Fix buf setup rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v1
         with:
           version: '1.30.0'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🛠️ Fetch Base Commit for Buf Breaking
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- use `${{ secrets.GITHUB_TOKEN }}` when running buf-setup-action

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686eef31fd98833081195eac1572764c