### PR TITLE
Update world management docs and proto

### DIFF
--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -37,7 +37,7 @@ participate in CI.
 
 - [x] Define gRPC service stubs with explicit `Request`/`Response` messages
 - [x] Version proto files under `protos/{service}/v1` with `package {service}.v1`
-- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [x] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
@@ -118,8 +118,8 @@ participate in CI.
 
 - [x] Create `design/README.md` summarizing APIs and sample requests
 - [x] Document proto contracts and any Redis keys in the service README
-- [ ] Document required environment variables and configuration
-- [ ] Note `tenantId` handling and cross-service dependencies
+- [x] Document required environment variables and configuration
+- [x] Note `tenantId` handling and cross-service dependencies
 - [x] Add a design document under `design/architecture/microservices/<service>/README.md`
 
 ---

--- a/protos/world-management/v1/world_management_service.proto
+++ b/protos/world-management/v1/world_management_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package world_management.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.worldmanagement.v1";
 option java_multiple_files = true;
 
@@ -18,6 +20,7 @@ message GetRoomRequest {
 
 message GetRoomResponse {
   string room_json = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message UpdateWorldStateRequest {
@@ -26,10 +29,12 @@ message UpdateWorldStateRequest {
 
 message UpdateWorldStateResponse {
   bool success = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/world-management-service/README.md
+++ b/services/world-management-service/README.md
@@ -15,3 +15,29 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Environment Variables
+
+The service relies on standard Spring Boot properties for PostgreSQL and Redis
+connections. Typical variables in development are:
+
+| Variable | Purpose |
+| --- | --- |
+| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL |
+| `SPRING_DATASOURCE_USERNAME` | Database user |
+| `SPRING_DATASOURCE_PASSWORD` | Database password |
+| `SPRING_REDIS_HOST` | Redis hostname |
+| `SPRING_REDIS_PORT` | Redis port |
+
+Configuration values can also be set through profiles in `application.yml`.
+
+## Tenant Handling and Dependencies
+
+All world tables include a `tenantId` column to keep game data isolated.
+Requests to this service must provide the tenant identifier, and downstream
+calls include it when communicating with other services. The World Management
+Service depends on:
+
+- **Game Design Service** for procedural generation rules and versioned map data.
+- **Game Session Service** to deliver room information and world event updates.
+- **Automation & Scripting Service** to react to scheduled world changes.

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -46,7 +46,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/world-management")
+        proto.srcDir("../../protos")
     }
 }
 


### PR DESCRIPTION
## Summary
- document environment variables and dependencies for World Management Service
- import shared ErrorDetail in world-management proto
- update Gradle proto source directory
- mark completed tasks in service task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686ef2d67d94833088372965382900dc