### PR TITLE
Update TCP proxy design docs

### DIFF
--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -45,13 +45,14 @@ Bridges legacy Telnet clients into the platform by converting raw TCP traffic in
 
 ### Service Interactions
 
-The proxy does not expose its own public gRPC API. Instead it performs two
-internal operations when communicating with other microservices:
+The proxy does not expose a public client API. Instead it defines two gRPC
+events used internally when communicating with other microservices:
 
 - **NotifyDisconnect** – informs the Game Session Service when a Telnet client
     drops so the session may be suspended.
 - **PushBufferedInput** – forwards any queued commands after a reconnect
     event.
+These messages live in [`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
 
 ### Telnet Command Handling
 

--- a/design/project-management/task-list-tcp-proxy-service.md
+++ b/design/project-management/task-list-tcp-proxy-service.md
@@ -1,7 +1,7 @@
 # TCP Proxy Service Task List
 
 - [ ] **Implement dedicated TCP Proxy Service bridging Telnet clients to the Gateway**
-- [ ] **Define Telnet bridge gRPC APIs for TCP Proxy Service**
+- [x] **Define Telnet bridge gRPC APIs for TCP Proxy Service**
 - [ ] **Develop TCP Proxy Service**
   - [ ] Implement Telnet networking and WebSocket bridging
   - [ ] Buffer Telnet input and discard on disconnect to support reconnection
@@ -35,8 +35,8 @@ participate in CI.
 
 - [x] Define gRPC service stubs with explicit `Request`/`Response` messages
 - [x] Version proto files under `protos/{service}/v1` with `package {service}.v1`
-- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
-- [ ] Generate gRPC stubs via Gradle and include them in the source set
+- [x] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
 - [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
@@ -115,9 +115,9 @@ participate in CI.
 ## 📖 Documentation
 
 - [x] Create `design/README.md` summarizing APIs and sample requests
-- [ ] Document proto contracts and any Redis keys in the service README
-- [ ] Document required environment variables and configuration
-- [ ] Note `tenantId` handling and cross-service dependencies
+- [x] Document proto contracts and any Redis keys in the service README
+- [x] Document required environment variables and configuration
+- [x] Note `tenantId` handling and cross-service dependencies
 - [x] Add a design document under `design/architecture/microservices/<service>/README.md`
 
 ---

--- a/protos/tcp-proxy/v1/README.md
+++ b/protos/tcp-proxy/v1/README.md
@@ -1,7 +1,9 @@
 # Tcp-proxy Service Proto (v1)
 
-This directory contains version 1 protocol buffer definitions for the tcp proxy service.
-They describe the gRPC API exposed by the service.
+This directory contains version 1 protocol buffer definitions for the TCP Proxy
+Service. They describe the internal gRPC events used by the service to notify
+the Game Session Service about client disconnects and to push buffered input
+after reconnects.
 
 Generate Java stubs with `./gradlew generateProto` from the repository root.
 For details see the [design docs](../../../design/architecture/microservices/tcp-proxy-service/README.md).

--- a/protos/tcp-proxy/v1/tcp_proxy_service.proto
+++ b/protos/tcp-proxy/v1/tcp_proxy_service.proto
@@ -5,12 +5,35 @@ package tcp_proxy.v1;
 option java_package = "net.firedevops.firemud.tcpproxy.v1";
 option java_multiple_files = true;
 
+import "shared/v1/errors.proto";
+
 service TcpProxyService {
   rpc Ping(PingRequest) returns (PingResponse);
+  rpc NotifyDisconnect(NotifyDisconnectRequest) returns (NotifyDisconnectResponse);
+  rpc PushBufferedInput(PushBufferedInputRequest) returns (PushBufferedInputResponse);
 }
 
 message PingRequest {}
 
 message PingResponse {
   string message = 1;
+}
+
+message NotifyDisconnectRequest {
+  string session_id = 1;
+  string tenant_id = 2;
+}
+
+message NotifyDisconnectResponse {
+  shared.v1.ErrorDetail error = 1;
+}
+
+message PushBufferedInputRequest {
+  string session_id = 1;
+  repeated string commands = 2;
+  string tenant_id = 3;
+}
+
+message PushBufferedInputResponse {
+  shared.v1.ErrorDetail error = 1;
 }

--- a/services/tcp-proxy-service/README.md
+++ b/services/tcp-proxy-service/README.md
@@ -3,6 +3,8 @@
 Refer to [design/README.md](design/README.md) for architecture details.
 
 - **Proto definitions**: [../../protos/tcp-proxy/v1](../../protos/tcp-proxy/v1)
+  include events used to notify the Game Session Service when clients disconnect
+  and to push buffered commands after a reconnect.
 
 ## Running Locally
 
@@ -15,3 +17,23 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Configuration
+
+Environment variables used by the service:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TCP_PROXY_PORT` | Port to accept Telnet connections | `2323` |
+| `GATEWAY_WS_URL` | WebSocket endpoint for the Spring Cloud Gateway | `ws://spring-cloud-gateway:8080/ws` |
+
+The proxy tags each connection with the player's `tenantId` during login so the
+gateway can route commands to the correct game instance. See the
+[Multi-Tenancy design](../../design/architecture/system-architecture-multi-tenancy.md)
+for details.
+
+### Dependencies
+
+- **Spring Cloud Gateway** – receives proxied WebSocket traffic.
+- **Game Session Service** – sessions are resumed via the `NotifyDisconnect` and
+  `PushBufferedInput` events defined in the proto contracts.

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -1,9 +1,11 @@
+import com.google.protobuf.gradle.*
 import com.github.spotbugs.snom.SpotBugsTask
 
 plugins {
     // Apply the Spring Boot plugin so `bootBuildImage` is available for Docker builds
     id("org.springframework.boot") version "3.5.3"
     id("org.flywaydb.flyway") version "11.10.1"
+    id("com.google.protobuf")
 }
 
 dependencies {
@@ -16,6 +18,35 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
     implementation(project(":common-library"))
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:4.31.1"
+    }
+    plugins {
+        id("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.73.0"
+        }
+    }
+    generateProtoTasks {
+        ofSourceSet("main").forEach {
+            it.plugins {
+                id("grpc")
+            }
+        }
+    }
+}
+
+sourceSets["main"].java.srcDirs(
+    "build/generated/source/proto/main/java",
+    "build/generated/source/proto/main/grpc"
+)
+
+sourceSets {
+    main {
+        proto.srcDir("../../protos")
+    }
 }
 
 tasks.named<SpotBugsTask>("spotbugsMain") {

--- a/services/tcp-proxy-service/design/README.md
+++ b/services/tcp-proxy-service/design/README.md
@@ -18,7 +18,11 @@ curl http://localhost:8080/ping
 
 ### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check.
+- `NotifyDisconnect(NotifyDisconnectRequest) returns (NotifyDisconnectResponse)` – informs the Game Session Service a Telnet client disconnected.
+- `PushBufferedInput(PushBufferedInputRequest) returns (PushBufferedInputResponse)` – delivers queued commands after a reconnect.
+
+All RPC definitions live in [`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
 
 ```bash
 grpcurl -plaintext localhost:6565 tcp_proxy.v1.TcpProxyService/Ping


### PR DESCRIPTION
## Summary
- document new TcpProxyService gRPC events and env variables
- add proto messages for NotifyDisconnect and PushBufferedInput
- configure protobuf generation in tcp-proxy build
- update tcp proxy service design and task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`
- `./dev-tools/generate-grpc-docs.sh` *(fails: protoc-gen-doc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef2cc8a508330b1a913c26dbb86ac