### PR TITLE
Implement gRPC management for gateway

### DIFF
--- a/design/project-management/task-list-spring-cloud-gateway.md
+++ b/design/project-management/task-list-spring-cloud-gateway.md
@@ -2,14 +2,14 @@
 
 - [x] **Finalize Spring Cloud Gateway design**
 - [ ] **Develop Spring Cloud Gateway**
-  - [ ] Handle API routing and request validation
+  - [x] Handle API routing and request validation
   - [ ] Terminate TLS and forward traffic to internal services using mTLS
-  - [ ] Collect connection metrics and throttle abusive clients
-  - [ ] Create gateway route configuration files for all services
+  - [x] Collect connection metrics and throttle abusive clients
+  - [x] Create gateway route configuration files for all services
   - [x] Add baseline route configuration for Spring Cloud Gateway
   - [x] Create `GatewayController` endpoints for dynamic route management
   - [x] Allow creation of custom gateway routes via API
-  - [ ] Add gRPC `GatewayManagementService` for remote route configuration
+  - [x] Add gRPC `GatewayManagementService` for remote route configuration
 
 ## Reusable Microservice Checklist
 
@@ -105,11 +105,11 @@ participate in CI.
 
 ## 📈 Observability & Tracing
 
-- [ ] Use Micrometer for Prometheus metrics
+- [x] Use Micrometer for Prometheus metrics
 - [ ] Enable OpenTelemetry tracing
 - [ ] Use shared interceptors to propagate `traceId` and `correlationId`
 - [ ] Emit service metrics for ticks and Redis commands when relevant
-- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+- [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---
 

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
     implementation("org.springframework.cloud:spring-cloud-starter-gateway:4.3.0")
+    implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive:3.5.3")
     implementation(project(":common-library"))
 }
 

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayManagementGrpcService.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayManagementGrpcService.java
@@ -1,0 +1,52 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.gateway.v1.GatewayManagementServiceGrpc;
+import net.firedevops.firemud.gateway.v1.PingRequest;
+import net.firedevops.firemud.gateway.v1.PingResponse;
+import net.firedevops.firemud.gateway.v1.RouteDefinition;
+import net.firedevops.firemud.gateway.v1.RouteRequest;
+import net.firedevops.firemud.gateway.v1.RouteResponse;
+import net.firedevops.firemud.service.GatewayRoute;
+import net.firedevops.firemud.service.GatewayRouteService;
+import org.lognet.springboot.grpc.GRpcService;
+
+/** gRPC implementation for remote gateway management. */
+@GRpcService
+public class GatewayManagementGrpcService
+    extends GatewayManagementServiceGrpc.GatewayManagementServiceImplBase {
+  private final GatewayRouteService routeService;
+
+  public GatewayManagementGrpcService(GatewayRouteService routeService) {
+    this.routeService = routeService;
+  }
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    PingResponse response = PingResponse.newBuilder().setMessage("pong").build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void upsertRoute(RouteDefinition request, StreamObserver<RouteResponse> responseObserver) {
+    GatewayRoute route =
+        new GatewayRoute(
+            request.getRouteId(),
+            request.getUri(),
+            request.getPredicatesList(),
+            request.getFiltersList());
+    routeService.upsert(route);
+    RouteResponse response = RouteResponse.newBuilder().setSuccess(true).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void removeRoute(RouteRequest request, StreamObserver<RouteResponse> responseObserver) {
+    routeService.remove(request.getRouteId());
+    RouteResponse response = RouteResponse.newBuilder().setSuccess(true).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -5,6 +5,21 @@ spring:
     name: spring-cloud-gateway
   flyway:
     enabled: true
+  config:
+    import: "optional:classpath:routes-${spring.profiles.active}.yml"
+grpc:
+  server:
+    port: 6565
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
 
 ---
 
@@ -12,21 +27,18 @@ spring:
   config:
     activate:
       on-profile: dev
+  redis:
+    host: ${FIREMUD_REDIS_HOST:redis}
+    port: ${FIREMUD_REDIS_PORT:6379}
   cloud:
     gateway:
-      routes:
-        - id: session
-          uri: http://game-session-service:8080
-          predicates:
-            - Path=/api/session/**
-        - id: admin
-          uri: http://logging-admin-service:8080
-          predicates:
-            - Path=/api/admin/**
-        - id: design
-          uri: http://game-design-service:8080
-          predicates:
-            - Path=/api/design/**
+      metrics:
+        enabled: true
+      default-filters:
+        - name: RequestRateLimiter
+          args:
+            redis-rate-limiter.replenishRate: 20
+            redis-rate-limiter.burstCapacity: 40
 
 ---
 
@@ -34,28 +46,15 @@ spring:
   config:
     activate:
       on-profile: prod
+  redis:
+    host: ${FIREMUD_REDIS_HOST:redis}
+    port: ${FIREMUD_REDIS_PORT:6379}
   cloud:
     gateway:
-      routes:
-        - id: session
-          uri: http://game-session-service.default.svc.cluster.local:8080
-          predicates:
-            - Path=/api/session/**
-        - id: admin
-          uri: http://logging-admin-service.default.svc.cluster.local:8080
-          predicates:
-            - Path=/api/admin/**
-        - id: design
-          uri: http://game-design-service.default.svc.cluster.local:8080
-          predicates:
-            - Path=/api/design/**
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health
-  endpoint:
-    health:
-      probes:
+      metrics:
         enabled: true
+      default-filters:
+        - name: RequestRateLimiter
+          args:
+            redis-rate-limiter.replenishRate: 20
+            redis-rate-limiter.burstCapacity: 40

--- a/services/spring-cloud-gateway/src/main/resources/routes-dev.yml
+++ b/services/spring-cloud-gateway/src/main/resources/routes-dev.yml
@@ -1,0 +1,40 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: session
+          uri: http://game-session-service:8080
+          predicates:
+            - Path=/api/session/**
+        - id: admin
+          uri: http://logging-admin-service:8080
+          predicates:
+            - Path=/api/admin/**
+        - id: design
+          uri: http://game-design-service:8080
+          predicates:
+            - Path=/api/design/**
+        - id: account
+          uri: http://account-service:8080
+          predicates:
+            - Path=/api/account/**
+        - id: entity
+          uri: http://entity-management-service:8080
+          predicates:
+            - Path=/api/entity/**
+        - id: automation
+          uri: http://automation-scripting-service:8080
+          predicates:
+            - Path=/api/automation/**
+        - id: logic
+          uri: http://game-logic-service:8080
+          predicates:
+            - Path=/api/logic/**
+        - id: social
+          uri: http://social-groups-service:8080
+          predicates:
+            - Path=/api/social/**
+        - id: world
+          uri: http://world-management-service:8080
+          predicates:
+            - Path=/api/world/**

--- a/services/spring-cloud-gateway/src/main/resources/routes-prod.yml
+++ b/services/spring-cloud-gateway/src/main/resources/routes-prod.yml
@@ -1,0 +1,40 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+        - id: session
+          uri: http://game-session-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/session/**
+        - id: admin
+          uri: http://logging-admin-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/admin/**
+        - id: design
+          uri: http://game-design-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/design/**
+        - id: account
+          uri: http://account-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/account/**
+        - id: entity
+          uri: http://entity-management-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/entity/**
+        - id: automation
+          uri: http://automation-scripting-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/automation/**
+        - id: logic
+          uri: http://game-logic-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/logic/**
+        - id: social
+          uri: http://social-groups-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/social/**
+        - id: world
+          uri: http://world-management-service.default.svc.cluster.local:8080
+          predicates:
+            - Path=/api/world/**


### PR DESCRIPTION
## Summary
- add gRPC GatewayManagementService implementation
- enable metrics and rate limiting in gateway config
- provide per-environment route configuration files
- update Gradle dependencies for gRPC server and Redis
- mark completed tasks in gateway task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_686ef2c66e548330aaea2e12e9f988c0