### PR TITLE
Update social groups docs and proto

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -64,6 +64,14 @@ Provides chat, guild, and social networking features across games. Enables playe
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
+### TenantId Handling & Cross-Service Dependencies
+
+All data models include a `tenantId` column so chat history and guild
+information remain isolated per game. Redis keys use the same prefix. The service
+validates this context on every request and forwards the identifier to other
+services, such as the Logging & Admin Service, to maintain isolation across the
+platform.
+
 > See [**Gateway Architecture**](../../infrastructure/gateway-architecture.md),
 [**Deployment Environments**](../../infrastructure/deployment-environments.md),
 and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
@@ -78,6 +86,24 @@ details on shared infrastructure components.
 - Health is monitored via `/actuator/health`; see
   [Deployment Environments](../../infrastructure/deployment-environments.md) for
   differences between local Docker Compose and production.
+
+## Environment Variables
+
+The service uses the shared configuration conventions defined in
+[Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
+Important variables include:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `SPRING_PROFILES_ACTIVE` | Spring profile (`dev` or `prod`) | `dev` |
+| `FIREMUD_POSTGRES_HOST` | PostgreSQL host | `postgres` |
+| `FIREMUD_POSTGRES_PORT` | PostgreSQL port | `5432` |
+| `FIREMUD_REDIS_HOST` | Redis host | `redis` |
+| `FIREMUD_REDIS_PORT` | Redis port | `6379` |
+
+See `DatabaseAutoConfiguration` in the
+[Shared Libraries](../system-architecture-shared-libraries.md) for how these
+variables are consumed.
 
 ## Proto Files
 

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -36,7 +36,7 @@ participate in CI.
 
 - [x] Define gRPC service stubs with explicit `Request`/`Response` messages
 - [x] Version proto files under `protos/{service}/v1` with `package {service}.v1`
-- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [x] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
@@ -117,8 +117,8 @@ participate in CI.
 
 - [x] Create `design/README.md` summarizing APIs and sample requests
 - [x] Document proto contracts and any Redis keys in the service README
-- [ ] Document required environment variables and configuration
-- [ ] Note `tenantId` handling and cross-service dependencies
+- [x] Document required environment variables and configuration
+- [x] Note `tenantId` handling and cross-service dependencies
 - [x] Add a design document under `design/architecture/microservices/<service>/README.md`
 
 ---

--- a/protos/social-groups/v1/social_groups_service.proto
+++ b/protos/social-groups/v1/social_groups_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package social_groups.v1;
 
+import "shared/v1/errors.proto";
 option java_package = "net.firedevops.firemud.socialgroups.v1";
 option java_multiple_files = true;
 
@@ -16,6 +17,7 @@ message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message SendMessageRequest {
@@ -27,6 +29,7 @@ message SendMessageRequest {
 
 message SendMessageResponse {
   bool success = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message CreateGuildRequest {
@@ -37,6 +40,7 @@ message CreateGuildRequest {
 
 message CreateGuildResponse {
   string guild_id = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message AddFriendRequest {
@@ -47,4 +51,5 @@ message AddFriendRequest {
 
 message AddFriendResponse {
   bool success = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/social-groups-service/README.md
+++ b/services/social-groups-service/README.md
@@ -15,3 +15,10 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Environment Variables
+
+This service uses the standard `FIREMUD_` prefixed variables for PostgreSQL and
+Redis connectivity. See the
+[Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+doc for defaults.

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -46,7 +46,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/social-groups")
+        proto.srcDir("../../protos")
     }
 }
 


### PR DESCRIPTION
## Summary
- add `ErrorDetail` usage to social-groups proto
- document environment variables and tenantId usage
- include shared protos in the service build
- update service README with environment info
- check off completed items in service task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686ef2bd5da08330a1069039ba7da7bd