### PR TITLE
Update Game Session Service docs and proto

### DIFF
--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -74,6 +74,12 @@ Orchestrates live game sessions, including tick execution, player input validati
 
 ## Operational Notes
 
+Environment variables supply PostgreSQL and Redis connection details. The
+common library's `DatabaseAutoConfiguration` reads values from
+`FIREMUD_POSTGRES_*` and `FIREMUD_REDIS_*` as described in the
+[Deployment Environments](../../infrastructure/deployment-environments.md)
+document.
+
 - Deployed in Kubernetes with multiple replicas; Redis provides the shared state needed for sticky sessions.
 - Exposes `/actuator/health` for readiness and liveness probes used by the cluster.
 - Metrics and traces flow to Prometheus and OpenTelemetry, and logs are shipped via Fluent Bit to Elasticsearch.

--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package game_session.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.gamesession.v1";
 option java_multiple_files = true;
 
@@ -19,6 +21,7 @@ message StartSessionRequest {
 
 message StartSessionResponse {
   string session_id = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message EnqueueCommandRequest {
@@ -28,6 +31,7 @@ message EnqueueCommandRequest {
 
 message EnqueueCommandResponse {
   bool accepted = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message QueryStateRequest {
@@ -36,10 +40,12 @@ message QueryStateRequest {
 
 message QueryStateResponse {
   string state_json = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -4,6 +4,29 @@ Refer to [design/README.md](design/README.md) for architecture details.
 
 - **Proto definitions**: [../../protos/game-session/v1](../../protos/game-session/v1)
 
+## Configuration
+
+The service relies on `DatabaseAutoConfiguration` and `RedisProperties` from the
+common library. Connection details are supplied via environment variables as
+described in the [Deployment Environments](../../design/architecture/infrastructure/deployment-environments.md)
+doc. Most setups can use the defaults from `.env.sample`:
+
+```bash
+FIREMUD_POSTGRES_HOST=postgres
+FIREMUD_POSTGRES_PORT=5432
+FIREMUD_POSTGRES_USER=firemud
+FIREMUD_POSTGRES_PASSWORD=firemud
+FIREMUD_POSTGRES_DB=firemud
+FIREMUD_REDIS_HOST=redis
+FIREMUD_REDIS_PORT=6379
+```
+
+Each request includes a `tenantId` that identifies the game instance. Database
+rows and Redis keys are prefixed with this value to keep game data isolated as
+outlined in the [Multi-Tenancy](../../design/architecture/system-architecture-multi-tenancy.md)
+document. The service coordinates with the Game Logic, Entity Management and
+World Management services over gRPC.
+
 ## Running Locally
 
 ```bash

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -46,7 +46,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/game-session")
+        proto.srcDir("../../protos")
     }
 }
 

--- a/services/game-session-service/design/README.md
+++ b/services/game-session-service/design/README.md
@@ -6,6 +6,17 @@ The design for this service is located here:
 
 This stub exists to make the design easy to find from the service source tree.
 
+## Configuration
+
+Environment variables configure the PostgreSQL and Redis connections via
+`DatabaseAutoConfiguration` and `RedisProperties`. Refer to the
+[Deployment Environments](../../../design/architecture/infrastructure/deployment-environments.md)
+document for details. The `.env.sample` file contains example values.
+
+The service enforces multi-tenant isolation. All tables include a `tenant_id`
+column and Redis keys are prefixed with this value as outlined in the
+[Multi-Tenancy design](../../../design/architecture/system-architecture-multi-tenancy.md).
+
 ## REST & gRPC Endpoints
 
 ### REST


### PR DESCRIPTION
## Summary
- document environment variables in the Game Session Service README and design stub
- explain tenant ID isolation and dependencies
- reference environment variables in the central design doc
- add ErrorDetail usage in Game Session proto
- include shared proto directory in Gradle build

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686ef2b0ad508330989e5dcb25156811