### PR TITLE
Document env vars and use shared error proto

### DIFF
--- a/protos/game-design/v1/game_design_service.proto
+++ b/protos/game-design/v1/game_design_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package gamedesign.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.gamedesign.v1";
 option java_multiple_files = true;
 
@@ -20,6 +22,7 @@ message SaveRevisionRequest {
 
 message SaveRevisionResponse {
   int64 revision_id = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message PublishVersionRequest {
@@ -29,6 +32,7 @@ message PublishVersionRequest {
 
 message PublishVersionResponse {
   int64 version_id = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message ListVersionsRequest {
@@ -37,6 +41,7 @@ message ListVersionsRequest {
 
 message ListVersionsResponse {
   repeated Version versions = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message Version {
@@ -49,4 +54,5 @@ message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -15,3 +15,18 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Environment Variables
+
+The service reads configuration from standard Spring Boot variables. Typical
+settings when running locally are:
+
+| Variable | Purpose |
+| --- | --- |
+| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL |
+| `SPRING_DATASOURCE_USERNAME` | Database user |
+| `SPRING_DATASOURCE_PASSWORD` | Database password |
+| `SPRING_PROFILES_ACTIVE` | Spring profile (`dev` or `prod`) |
+
+See the [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+document for details on how these values are supplied in different environments.

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -46,7 +46,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/game-design")
+        proto.srcDir("../../protos")
     }
 }
 


### PR DESCRIPTION
## Summary
- reuse `ErrorDetail` from `shared` protos in the Game Design service API
- document required environment variables for Game Design Service
- include shared proto directory in Gradle config

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686ef2a588108330acde922fd8452b08