### PR TITLE
Implement inventory support and docs

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -108,3 +108,5 @@ proto files, run `./gradlew generateProto` to update generated sources.
 
 - Entity graph caching for faster lookups.
 - Support for complex crafting recipes.
+- Cross-game account linking to share a single profile across multiple games (see
+  [Multi-Tenancy](../system-architecture-multi-tenancy.md)).

--- a/protos/entity-management/v1/entity_management_service.proto
+++ b/protos/entity-management/v1/entity_management_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package entity_management.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.entitymanagement.v1";
 option java_multiple_files = true;
 
@@ -20,6 +22,7 @@ message CreateCharacterRequest {
 
 message CreateCharacterResponse {
   string character_id = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message UpdateEntityRequest {
@@ -28,6 +31,7 @@ message UpdateEntityRequest {
 
 message UpdateEntityResponse {
   bool success = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message QueryInventoryRequest {
@@ -36,10 +40,12 @@ message QueryInventoryRequest {
 
 message QueryInventoryResponse {
   repeated string item_ids = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -15,3 +15,30 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Environment Variables
+
+The service reads database and Redis settings from the common
+`DatabaseAutoConfiguration` and `RedisProperties` classes. Override defaults
+using the following variables:
+
+- `FIREMUD_POSTGRES_HOST`
+- `FIREMUD_POSTGRES_PORT`
+- `FIREMUD_POSTGRES_DATABASE`
+- `FIREMUD_POSTGRES_USERNAME`
+- `FIREMUD_POSTGRES_PASSWORD`
+- `FIREMUD_REDIS_HOST`
+- `FIREMUD_REDIS_PORT`
+
+## Cross-Service Dependencies
+
+Entity data is scoped by `tenantId` as described in the
+[Multi-Tenancy design](../../design/architecture/system-architecture-multi-tenancy.md).
+The service relies on the **Game Design Service** for character templates and
+item definitions and coordinates runtime persistence with the
+**Game Session Service**.
+
+## Proto Contracts
+
+See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)
+for RPC definitions. Responses return `shared.v1.ErrorDetail` on failure.

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -46,7 +46,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/entity-management")
+        proto.srcDir("../../protos")
     }
 }
 

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/InventoryEntryDto.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/InventoryEntryDto.java
@@ -1,0 +1,5 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record InventoryEntryDto(@NotNull Long characterId, @NotNull Long itemId, int quantity) {}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/InventoryEntry.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/InventoryEntry.java
@@ -1,0 +1,22 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "inventory")
+public class InventoryEntry {
+  @EmbeddedId private InventoryKey id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("characterId")
+  private Character character;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("itemId")
+  private Item item;
+
+  @Column(nullable = false)
+  private int quantity;
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/InventoryKey.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/InventoryKey.java
@@ -1,0 +1,16 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+@Embeddable
+public class InventoryKey implements Serializable {
+  @Column(name = "character_id")
+  private Long characterId;
+
+  @Column(name = "item_id")
+  private Long itemId;
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/InventoryEntryMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/InventoryEntryMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.InventoryEntryDto;
+import net.firedevops.firemud.entity.InventoryEntry;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface InventoryEntryMapper {
+  @Mapping(target = "characterId", source = "character.id")
+  @Mapping(target = "itemId", source = "item.id")
+  InventoryEntryDto toDto(InventoryEntry entity);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/InventoryEntryRepository.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/InventoryEntryRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.InventoryEntry;
+import net.firedevops.firemud.entity.InventoryKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InventoryEntryRepository extends JpaRepository<InventoryEntry, InventoryKey> {}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/InventoryService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/InventoryService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import java.util.List;
+import net.firedevops.firemud.dto.InventoryEntryDto;
+
+public interface InventoryService {
+  List<InventoryEntryDto> listInventory(Long characterId);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/InventoryServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/InventoryServiceImpl.java
@@ -1,0 +1,24 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.dto.InventoryEntryDto;
+import net.firedevops.firemud.mapper.InventoryEntryMapper;
+import net.firedevops.firemud.repository.InventoryEntryRepository;
+import net.firedevops.firemud.service.InventoryService;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryServiceImpl implements InventoryService {
+  private final InventoryEntryRepository repository;
+  private final InventoryEntryMapper mapper;
+
+  @Override
+  public List<InventoryEntryDto> listInventory(Long characterId) {
+    return repository.findAll().stream()
+        .filter(e -> e.getId().getCharacterId().equals(characterId))
+        .map(mapper::toDto)
+        .toList();
+  }
+}

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/InventoryServiceImplTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/InventoryServiceImplTest.java
@@ -1,0 +1,36 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import net.firedevops.firemud.dto.InventoryEntryDto;
+import net.firedevops.firemud.entity.InventoryEntry;
+import net.firedevops.firemud.entity.InventoryKey;
+import net.firedevops.firemud.mapper.InventoryEntryMapper;
+import net.firedevops.firemud.repository.InventoryEntryRepository;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mockito;
+
+class InventoryServiceImplTest {
+  @Test
+  void listInventoryReturnsMappedDtos() {
+    InventoryEntryRepository repo = Mockito.mock(InventoryEntryRepository.class);
+    InventoryEntryMapper mapper = Mappers.getMapper(InventoryEntryMapper.class);
+    InventoryServiceImpl service = new InventoryServiceImpl(repo, mapper);
+
+    InventoryEntry entry = new InventoryEntry();
+    InventoryKey key = new InventoryKey();
+    key.setCharacterId(1L);
+    key.setItemId(2L);
+    entry.setId(key);
+    entry.setQuantity(3);
+
+    when(repo.findAll()).thenReturn(List.of(entry));
+
+    List<InventoryEntryDto> result = service.listInventory(1L);
+    assertEquals(1, result.size());
+    assertEquals(3, result.get(0).quantity());
+  }
+}


### PR DESCRIPTION
## Summary
- add ErrorDetail to entity-management proto
- update build to include shared protos
- implement inventory entry JPA entity and service
- document env vars, dependencies, and proto responses
- document future enhancement for cross-game account linking

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686ef29f87cc833081e116f4e74a44cd