### PR TITLE
docs: update automation scripting README

### DIFF
--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -122,8 +122,8 @@ participate in CI.
 
 - [x] Create `design/README.md` summarizing APIs and sample requests
 - [x] Document proto contracts and any Redis keys in the service README
-- [ ] Document required environment variables and configuration
-- [ ] Note `tenantId` handling and cross-service dependencies
+- [x] Document required environment variables and configuration
+- [x] Note `tenantId` handling and cross-service dependencies
 - [x] Add a design document under `design/architecture/microservices/<service>/README.md`
 
 ---

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -15,3 +15,35 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Environment Variables
+
+The service relies on standard Spring Boot properties for database and Redis
+connections. Typical variables include:
+
+| Variable | Purpose |
+| --- | --- |
+| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL |
+| `SPRING_DATASOURCE_USERNAME` | Database user |
+| `SPRING_DATASOURCE_PASSWORD` | Database password |
+| `SPRING_REDIS_HOST` | Redis hostname |
+| `SPRING_REDIS_PORT` | Redis port |
+
+Values can also be specified in `application.yml` profiles for different
+environments.
+
+## Redis Key Pattern
+
+Automation events are stored in Redis using the following format:
+
+```text
+automation_queue:{tenantId}:{entityId}
+```
+
+These ephemeral keys queue triggered events until a script runs.
+
+## Tenant Handling and Dependencies
+
+Each script row includes a `tenantId` column to keep data isolated between
+games. The service receives events from the Game Session Service and sends
+commands to the Game Logic Service for rule evaluation.


### PR DESCRIPTION
## Summary
- document environment variables and tenant handling for automation service
- check off related tasks in the automation task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686ef296df108330b3801c2cdc733eb6