### PR TITLE
Update game logic docs and proto

### DIFF
--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -57,6 +57,7 @@ This service is largely stateless. It relies on:
 
 - `Ping` – basic connectivity check.
 - `ExecuteCommand` – evaluates a parsed command and returns the outcome.
+- All responses include a `shared.v1.ErrorDetail` field for standardized error handling.
 
 ## Dependencies
 
@@ -79,7 +80,22 @@ details on shared infrastructure components.
 - Prometheus collects command execution metrics while Fluent Bit forwards logs
   to Elasticsearch with trace context from OpenTelemetry.
 - For environment-specific configuration see
+
   [Deployment Environments](../../infrastructure/deployment-environments.md).
+
+## Environment Variables
+
+The service uses the standard configuration outlined in
+[Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
+Key variables include:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `SPRING_PROFILES_ACTIVE` | Spring profile (`dev` or `prod`) | `dev` |
+| `FIREMUD_POSTGRES_HOST` | PostgreSQL host | `postgres` |
+| `FIREMUD_POSTGRES_PORT` | PostgreSQL port | `5432` |
+| `FIREMUD_REDIS_HOST` | Redis host | `redis` |
+| `FIREMUD_REDIS_PORT` | Redis port | `6379` |
 
 ## Proto Files
 

--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -34,7 +34,7 @@ participate in CI.
 
 - [x] Define gRPC service stubs with explicit `Request`/`Response` messages
 - [x] Version proto files under `protos/{service}/v1` with `package {service}.v1`
-- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [x] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
@@ -115,7 +115,7 @@ participate in CI.
 
 - [x] Create `design/README.md` summarizing APIs and sample requests
 - [x] Document proto contracts and any Redis keys in the service README
-- [ ] Document required environment variables and configuration
+- [x] Document required environment variables and configuration
 - [x] Note `tenantId` handling and cross-service dependencies
 - [x] Add a design document under `design/architecture/microservices/<service>/README.md`
 

--- a/protos/game-logic/v1/README.md
+++ b/protos/game-logic/v1/README.md
@@ -3,5 +3,8 @@
 This directory contains version 1 protocol buffer definitions for the game logic service.
 They describe the gRPC API exposed by the service.
 
+These messages reuse common types like `ErrorDetail` from
+[`protos/shared/v1`](../../shared/v1/errors.proto) for consistent error handling.
+
 Generate Java stubs with `./gradlew generateProto` from the repository root.
 For details see the [design docs](../../../design/architecture/microservices/game-logic-service/README.md).

--- a/protos/game-logic/v1/game_logic_service.proto
+++ b/protos/game-logic/v1/game_logic_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package game_logic.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.gamelogic.v1";
 option java_multiple_files = true;
 
@@ -14,6 +16,7 @@ message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }
 
 message ExecuteCommandRequest {
@@ -24,4 +27,5 @@ message ExecuteCommandRequest {
 
 message ExecuteCommandResponse {
   string result = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -21,3 +21,19 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Environment Variables
+
+This service relies on the standard `FIREMUD_` prefixed variables for
+PostgreSQL and Redis configuration. Common settings in development are:
+
+| Variable | Purpose |
+| --- | --- |
+| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL |
+| `SPRING_DATASOURCE_USERNAME` | Database user |
+| `SPRING_DATASOURCE_PASSWORD` | Database password |
+| `SPRING_REDIS_HOST` | Redis hostname |
+| `SPRING_REDIS_PORT` | Redis port |
+
+See the [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+doc for defaults and profile-based configuration.

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -43,7 +43,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/game-logic")
+        proto.srcDir("../../protos")
     }
 }
 


### PR DESCRIPTION
## Summary
- document environment variables for game-logic service
- reuse `ErrorDetail` shared protobuf type
- note ErrorDetail usage in design docs
- update proto source path
- mark completed tasks in task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686f41292df0833093f77f8e4bb0aa35