### PR TITLE
Update automation service proto and tests

### DIFF
--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -41,7 +41,7 @@ participate in CI.
 
 - [x] Define gRPC service stubs with explicit `Request`/`Response` messages
 - [x] Version proto files under `protos/{service}/v1` with `package {service}.v1`
-- [ ] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
+- [x] Reuse shared types (e.g., `ErrorDetail`) from `protos/shared/`
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
@@ -99,7 +99,7 @@ participate in CI.
 
 ## 🧪 Testing & Quality Gates
 
-- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [ ] Use Spring Boot Test and Testcontainers for integration tests
 - [ ] Validate contracts with smoke tests (gRPC and REST)
 - [ ] Seed minimal test data for local workflows

--- a/protos/automation-scripting/v1/README.md
+++ b/protos/automation-scripting/v1/README.md
@@ -5,3 +5,6 @@ They describe the gRPC API exposed by the service.
 
 Generate Java stubs with `./gradlew generateProto` from the repository root.
 For details see the [design docs](../../../design/architecture/microservices/automation-scripting-service/README.md).
+
+The `PingResponse` message reuses the shared `ErrorDetail` type from
+`protos/shared/v1/errors.proto`.

--- a/protos/automation-scripting/v1/automation_scripting_service.proto
+++ b/protos/automation-scripting/v1/automation_scripting_service.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package automation_scripting.v1;
 
+import "shared/v1/errors.proto";
+
 option java_package = "net.firedevops.firemud.automationscripting.v1";
 option java_multiple_files = true;
 
@@ -13,4 +15,5 @@ message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
 }

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -2,7 +2,7 @@
 
 Refer to [design/README.md](design/README.md) for architecture details.
 
-- **Proto definitions**: [../../protos/automation-scripting/v1](../../protos/automation-scripting/v1)
+- **Proto definitions**: [../../protos/automation-scripting/v1](../../protos/automation-scripting/v1) (uses shared `ErrorDetail`)
 
 ## Running Locally
 

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -46,7 +46,7 @@ sourceSets["main"].java.srcDirs(
 
 sourceSets {
     main {
-        proto.srcDir("../../protos/automation-scripting")
+        proto.srcDir("../../protos")
     }
 }
 

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PingController.class)
+class PingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PingService pingService;
+
+  @Test
+  void pingEndpointReturnsPong() throws Exception {
+    when(pingService.ping()).thenReturn("pong");
+
+    mockMvc
+        .perform(get("/ping"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data").value("pong"));
+  }
+}


### PR DESCRIPTION
## Summary
- reuse shared ErrorDetail type in automation scripting proto
- document ErrorDetail usage in proto README and service README
- update automation scripting service Gradle config to include shared protos
- add PingControllerTest
- check off completed tasks in automation service task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_686f417fe32c83309335480d0916e1ba