### PR TITLE
Implement start session endpoint

### DIFF
--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -21,6 +21,18 @@ FIREMUD_REDIS_HOST=redis
 FIREMUD_REDIS_PORT=6379
 ```
 
+Typical environment variables are summarized below:
+
+| Variable | Purpose |
+| --- | --- |
+| `FIREMUD_POSTGRES_HOST` | PostgreSQL hostname |
+| `FIREMUD_POSTGRES_PORT` | PostgreSQL port |
+| `FIREMUD_POSTGRES_USER` | Database user |
+| `FIREMUD_POSTGRES_PASSWORD` | Database password |
+| `FIREMUD_POSTGRES_DB` | Database name |
+| `FIREMUD_REDIS_HOST` | Redis hostname |
+| `FIREMUD_REDIS_PORT` | Redis port |
+
 Each request includes a `tenantId` that identifies the game instance. Database
 rows and Redis keys are prefixed with this value to keep game data isolated as
 outlined in the [Multi-Tenancy](../../design/architecture/system-architecture-multi-tenancy.md)
@@ -38,3 +50,11 @@ To run the entire stack:
 ```bash
 ./gradlew devUp
 ```
+
+## Tenant Handling and Dependencies
+
+Every session row contains a `tenantId` column, and all Redis keys include this
+prefix. This isolates game data for each hosted title. The service communicates
+with the Game Logic, Entity Management, and World Management services over gRPC
+to coordinate ticks and world state. Lifecycle events are also sent to the
+Logging & Admin Service for auditing.

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/controller/GameInstanceController.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/controller/GameInstanceController.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.GameInstanceDto;
+import net.firedevops.firemud.dto.StartSessionRequest;
+import net.firedevops.firemud.service.GameInstanceService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** REST endpoints for managing game instances. */
+@RestController
+@RequestMapping("/sessions")
+public class GameInstanceController {
+  private final GameInstanceService gameInstanceService;
+
+  public GameInstanceController(GameInstanceService gameInstanceService) {
+    this.gameInstanceService = gameInstanceService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<GameInstanceDto>> startSession(
+      @Valid @RequestBody StartSessionRequest request) {
+    GameInstanceDto dto = gameInstanceService.startSession(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/StartSessionRequest.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/StartSessionRequest.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/** Request payload for starting a new game session. */
+public record StartSessionRequest(
+    @NotNull Long tenantId,
+    @NotNull @Size(max = 100) String versionId,
+    @NotNull Long ownerAccountId) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/GameInstanceService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/GameInstanceService.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.GameInstanceDto;
+import net.firedevops.firemud.dto.StartSessionRequest;
+
+/** Service handling game instance lifecycle operations. */
+public interface GameInstanceService {
+  GameInstanceDto startSession(StartSessionRequest request);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.service.impl;
+
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.GameInstanceDto;
+import net.firedevops.firemud.dto.StartSessionRequest;
+import net.firedevops.firemud.entity.GameInstance;
+import net.firedevops.firemud.mapper.GameInstanceMapper;
+import net.firedevops.firemud.repository.GameInstanceRepository;
+import net.firedevops.firemud.service.GameInstanceService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Default implementation of {@link GameInstanceService}. */
+@Service
+public class GameInstanceServiceImpl implements GameInstanceService {
+  private static final Logger logger = LoggingUtil.getLogger(GameInstanceServiceImpl.class);
+
+  private final GameInstanceRepository repository;
+  private final GameInstanceMapper mapper;
+
+  public GameInstanceServiceImpl(GameInstanceRepository repository, GameInstanceMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  @Override
+  @Transactional
+  public GameInstanceDto startSession(StartSessionRequest request) {
+    logger.info(
+        "Starting game session for tenant {} version {}", request.tenantId(), request.versionId());
+    GameInstance instance = new GameInstance();
+    instance.setTenantId(request.tenantId());
+    instance.setVersionId(request.versionId());
+    instance.setOwnerAccountId(request.ownerAccountId());
+    instance.setStatus("RUNNING");
+    instance = repository.save(instance);
+    return mapper.toDto(instance);
+  }
+}

--- a/services/game-session-service/src/main/resources/openapi.yaml
+++ b/services/game-session-service/src/main/resources/openapi.yaml
@@ -15,6 +15,33 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  schemas:
+    StartSessionRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        versionId:
+          type: string
+        ownerAccountId:
+          type: integer
+      required:
+        - tenantId
+        - versionId
+        - ownerAccountId
+    GameInstanceDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        versionId:
+          type: string
+        ownerAccountId:
+          type: integer
+        status:
+          type: string
 paths:
   /ping:
     get:
@@ -31,5 +58,27 @@ paths:
                   data:
                     type: string
                     example: pong
+        '400':
+          description: Invalid request
+  /sessions:
+    post:
+      summary: Start a new game session
+      operationId: startSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartSessionRequest'
+      responses:
+        '200':
+          description: Game instance details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GameInstanceDto'
         '400':
           description: Invalid request

--- a/services/game-session-service/src/test/java/integration/net/firedevops/firemud/controller/GameInstanceControllerTest.java
+++ b/services/game-session-service/src/test/java/integration/net/firedevops/firemud/controller/GameInstanceControllerTest.java
@@ -1,0 +1,42 @@
+package net.firedevops.firemud.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.dto.GameInstanceDto;
+import net.firedevops.firemud.dto.StartSessionRequest;
+import net.firedevops.firemud.service.GameInstanceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GameInstanceController.class)
+@AutoConfigureMockMvc
+class GameInstanceControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockBean private GameInstanceService gameInstanceService;
+
+  @Test
+  void startSessionReturnsDto() throws Exception {
+    GameInstanceDto dto = new GameInstanceDto(1L, 1L, "v1", 1L, "RUNNING");
+    org.mockito.Mockito.when(gameInstanceService.startSession(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(dto);
+    StartSessionRequest request = new StartSessionRequest(1L, "v1", 1L);
+    mockMvc
+        .perform(
+            post("/sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.id").value(1));
+  }
+}


### PR DESCRIPTION
## Summary
- document environment variables and dependencies
- add startSession REST endpoint for Game Session Service
- update OpenAPI spec
- add integration test

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f411478f48330b1f56e3829583377