### PR TITLE
Implement feature flag toggles

### DIFF
--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -4,7 +4,7 @@
   - [x] Collect logs from all services and provide search dashboards
   - [x] Allow players to report others for abuse/violations
   - [x] Store logs for admin moderation and auditing
-  - [ ] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
+  - [x] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
     - [x] Provide analytics dashboards for operators
     - [x] Define moderation policies including profanity filters
   - [ ] Integrate Alertmanager for automated alerts

--- a/protos/logging-admin/v1/logging_admin_service.proto
+++ b/protos/logging-admin/v1/logging_admin_service.proto
@@ -9,6 +9,7 @@ service LoggingAdminService {
   rpc Ping(PingRequest) returns (PingResponse);
   rpc QueryLogs(QueryLogsRequest) returns (QueryLogsResponse);
   rpc ApplyModerationAction(ApplyModerationActionRequest) returns (ApplyModerationActionResponse);
+  rpc ToggleFeatureFlag(ToggleFeatureFlagRequest) returns (ToggleFeatureFlagResponse);
 }
 
 message PingRequest {}
@@ -34,5 +35,15 @@ message ApplyModerationActionRequest {
 }
 
 message ApplyModerationActionResponse {
+  bool success = 1;
+}
+
+message ToggleFeatureFlagRequest {
+  string tenant_id = 1;
+  string name = 2;
+  bool enabled = 3;
+}
+
+message ToggleFeatureFlagResponse {
   bool success = 1;
 }

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -40,3 +40,13 @@ and chat logs from the
 [Social & Groups Service](../../design/architecture/microservices/social-groups-service/README.md).
 Game Session metrics are streamed from the
 [Game Session Service](../../design/architecture/microservices/game-session-service/README.md).
+
+## Feature Flags
+
+Toggle runtime flags via REST:
+
+```bash
+curl -X POST http://localhost:8080/feature-flags/toggle \
+  -H "Content-Type: application/json" \
+  -d '{"tenantId":1,"name":"double_xp","enabled":true}'
+```

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.5.3")
+    implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
     implementation(project(":common-library"))
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }

--- a/services/logging-admin-service/design/README.md
+++ b/services/logging-admin-service/design/README.md
@@ -23,7 +23,10 @@ curl http://localhost:8080/ping
 - `QueryLogs(QueryLogsRequest) returns (QueryLogsResponse)` – searches collected logs.
 - `ApplyModerationAction(ApplyModerationActionRequest) returns (ApplyModerationActionResponse)` – records a moderation event.
 - `CreateReport(CreateReportRequest) returns (CreateReportResponse)` – ingest a player report.
+- `ToggleFeatureFlag(ToggleFeatureFlagRequest) returns (ToggleFeatureFlagResponse)` – enable or disable a feature flag.
 
 ```bash
 grpcurl -plaintext localhost:6565 logging_admin.v1.LoggingAdminService/Ping
 ```
+
+- `POST /feature-flags/toggle` – enable or disable runtime flags.

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/FeatureFlagController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/FeatureFlagController.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.service.FeatureFlagService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/feature-flags")
+public class FeatureFlagController {
+  private final FeatureFlagService service;
+
+  public FeatureFlagController(FeatureFlagService service) {
+    this.service = service;
+  }
+
+  @PostMapping("/toggle")
+  public ResponseEntity<ApiResponse<FeatureFlagDto>> toggle(
+      @Valid @RequestBody ToggleFeatureFlagRequest request) {
+    FeatureFlagDto dto = service.toggleFlag(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/FeatureFlagDto.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/FeatureFlagDto.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record FeatureFlagDto(
+    Long id, @NotNull Long tenantId, @NotBlank @Size(max = 100) String name, boolean enabled) {}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/ToggleFeatureFlagRequest.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/ToggleFeatureFlagRequest.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ToggleFeatureFlagRequest(
+    @NotNull Long tenantId, @NotBlank @Size(max = 100) String name, boolean enabled) {}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/entity/FeatureFlag.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/entity/FeatureFlag.java
@@ -1,0 +1,22 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "feature_flag")
+public class FeatureFlag {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Column(nullable = false)
+  private boolean enabled;
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/mapper/FeatureFlagMapper.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/mapper/FeatureFlagMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.entity.FeatureFlag;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FeatureFlagMapper {
+  FeatureFlagDto toDto(FeatureFlag entity);
+
+  FeatureFlag toEntity(FeatureFlagDto dto);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/FeatureFlagRepository.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/FeatureFlagRepository.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.repository;
+
+import java.util.Optional;
+import net.firedevops.firemud.entity.FeatureFlag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeatureFlagRepository extends JpaRepository<FeatureFlag, Long> {
+  Optional<FeatureFlag> findByTenantIdAndName(Long tenantId, String name);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/FeatureFlagService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/FeatureFlagService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+
+public interface FeatureFlagService {
+  FeatureFlagDto toggleFlag(ToggleFeatureFlagRequest request);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.Optional;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.entity.FeatureFlag;
+import net.firedevops.firemud.mapper.FeatureFlagMapper;
+import net.firedevops.firemud.repository.FeatureFlagRepository;
+import net.firedevops.firemud.service.FeatureFlagService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class FeatureFlagServiceImpl implements FeatureFlagService {
+  private static final Logger logger = LoggingUtil.getLogger(FeatureFlagServiceImpl.class);
+
+  private final FeatureFlagRepository repository;
+  private final FeatureFlagMapper mapper;
+
+  public FeatureFlagServiceImpl(FeatureFlagRepository repository, FeatureFlagMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  @Override
+  @Transactional
+  public FeatureFlagDto toggleFlag(ToggleFeatureFlagRequest request) {
+    logger.info("Toggling feature flag {} for tenant {}", request.name(), request.tenantId());
+    Optional<FeatureFlag> existing =
+        repository.findByTenantIdAndName(request.tenantId(), request.name());
+    FeatureFlag flag = existing.orElseGet(FeatureFlag::new);
+    flag.setTenantId(request.tenantId());
+    flag.setName(request.name());
+    flag.setEnabled(request.enabled());
+    flag = repository.save(flag);
+    return mapper.toDto(flag);
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.loggingadmin.v1.LoggingAdminServiceGrpc;
+import net.firedevops.firemud.loggingadmin.v1.PingRequest;
+import net.firedevops.firemud.loggingadmin.v1.PingResponse;
+import net.firedevops.firemud.loggingadmin.v1.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.loggingadmin.v1.ToggleFeatureFlagResponse;
+import net.firedevops.firemud.service.FeatureFlagService;
+import org.lognet.springboot.grpc.GRpcService;
+
+@GRpcService
+public class LoggingAdminGrpcService extends LoggingAdminServiceGrpc.LoggingAdminServiceImplBase {
+
+  private final FeatureFlagService featureFlagService;
+
+  public LoggingAdminGrpcService(FeatureFlagService featureFlagService) {
+    this.featureFlagService = featureFlagService;
+  }
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    PingResponse response = PingResponse.newBuilder().setMessage("pong").build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void toggleFeatureFlag(
+      ToggleFeatureFlagRequest request,
+      StreamObserver<ToggleFeatureFlagResponse> responseObserver) {
+    featureFlagService.toggleFlag(
+        new net.firedevops.firemud.dto.ToggleFeatureFlagRequest(
+            Long.valueOf(request.getTenantId()), request.getName(), request.getEnabled()));
+    ToggleFeatureFlagResponse response =
+        ToggleFeatureFlagResponse.newBuilder().setSuccess(true).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}

--- a/services/logging-admin-service/src/main/resources/db/migration/V4__add_tenant_id_to_feature_flag.sql
+++ b/services/logging-admin-service/src/main/resources/db/migration/V4__add_tenant_id_to_feature_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feature_flag ADD COLUMN tenant_id BIGINT NOT NULL;

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/FeatureFlagControllerTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/FeatureFlagControllerTest.java
@@ -1,0 +1,42 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.service.FeatureFlagService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FeatureFlagController.class)
+class FeatureFlagControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockitoBean private FeatureFlagService service;
+
+  @Test
+  void toggleReturnsDto() throws Exception {
+    ToggleFeatureFlagRequest request = new ToggleFeatureFlagRequest(1L, "demo", true);
+    FeatureFlagDto dto = new FeatureFlagDto(1L, 1L, "demo", true);
+    when(service.toggleFlag(request)).thenReturn(dto);
+
+    mockMvc
+        .perform(
+            post("/feature-flags/toggle")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data.enabled").value(true));
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/FeatureFlagServiceImplTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/FeatureFlagServiceImplTest.java
@@ -1,0 +1,45 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.entity.FeatureFlag;
+import net.firedevops.firemud.mapper.FeatureFlagMapper;
+import net.firedevops.firemud.repository.FeatureFlagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class FeatureFlagServiceImplTest {
+  @Mock FeatureFlagRepository repository;
+  @Mock FeatureFlagMapper mapper;
+
+  @InjectMocks FeatureFlagServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void toggleCreatesNewFlag() {
+    ToggleFeatureFlagRequest request = new ToggleFeatureFlagRequest(1L, "demo", true);
+    FeatureFlag saved = new FeatureFlag();
+    when(repository.findByTenantIdAndName(1L, "demo")).thenReturn(Optional.empty());
+    when(repository.save(any())).thenReturn(saved);
+    FeatureFlagDto dto = new FeatureFlagDto(null, 1L, "demo", true);
+    when(mapper.toDto(saved)).thenReturn(dto);
+
+    FeatureFlagDto result = service.toggleFlag(request);
+
+    assertEquals(dto, result);
+    verify(repository).save(any(FeatureFlag.class));
+  }
+}


### PR DESCRIPTION
## Summary
- add feature flag JPA entity and service implementation
- expose `/feature-flags/toggle` REST endpoint and gRPC method
- document new API in design docs and service README
- update task list for Logging and Admin Service
- add Flyway migration and unit tests

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew :logging-admin-service:generateProto`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f409256ec8330b1451e72ff1aaf77