### PR TITLE
Add friend management skeleton

### DIFF
--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.service.FriendService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/friends")
+public class FriendController {
+  private final FriendService friendService;
+
+  public FriendController(FriendService friendService) {
+    this.friendService = friendService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<FriendLinkDto>> addFriend(
+      @Valid @RequestBody AddFriendRequest request) {
+    FriendLinkDto dto = friendService.addFriend(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddFriendRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddFriendRequest.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AddFriendRequest(
+    @NotNull Long tenantId, @NotNull Long accountId, @NotNull Long friendAccountId) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/FriendLinkDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/FriendLinkDto.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record FriendLinkDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull Long accountId,
+    @NotNull Long friendAccountId,
+    String status,
+    Instant createdAt) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/FriendLinkMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/FriendLinkMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.entity.FriendLink;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FriendLinkMapper {
+  FriendLinkDto toDto(FriendLink entity);
+
+  FriendLink toEntity(FriendLinkDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/FriendService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/FriendService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.FriendLinkDto;
+
+public interface FriendService {
+  FriendLinkDto addFriend(AddFriendRequest request);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
@@ -1,0 +1,36 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.entity.FriendLink;
+import net.firedevops.firemud.mapper.FriendLinkMapper;
+import net.firedevops.firemud.repository.FriendLinkRepository;
+import net.firedevops.firemud.service.FriendService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FriendServiceImpl implements FriendService {
+  private static final Logger logger = LoggingUtil.getLogger(FriendServiceImpl.class);
+
+  private final FriendLinkRepository friendLinkRepository;
+  private final FriendLinkMapper friendLinkMapper;
+
+  @Override
+  @Transactional
+  public FriendLinkDto addFriend(AddFriendRequest request) {
+    logger.info("Adding friend {} -> {}", request.accountId(), request.friendAccountId());
+    FriendLink link = new FriendLink();
+    link.setTenantId(request.tenantId());
+    link.setAccountId(request.accountId());
+    link.setFriendAccountId(request.friendAccountId());
+    link.setStatus("active");
+    link.setCreatedAt(Instant.now());
+    return friendLinkMapper.toDto(friendLinkRepository.save(link));
+  }
+}

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/FriendControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/FriendControllerTest.java
@@ -1,0 +1,42 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.service.FriendService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FriendController.class)
+class FriendControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockitoBean private FriendService friendService;
+
+  @Test
+  void addFriendReturnsDto() throws Exception {
+    AddFriendRequest request = new AddFriendRequest(1L, 2L, 3L);
+    FriendLinkDto response = new FriendLinkDto(1L, 1L, 2L, 3L, "active", null);
+    when(friendService.addFriend(request)).thenReturn(response);
+
+    mockMvc
+        .perform(
+            post("/friends")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data.accountId").value(2L));
+  }
+}

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/FriendServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/FriendServiceImplTest.java
@@ -1,0 +1,45 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.entity.FriendLink;
+import net.firedevops.firemud.mapper.FriendLinkMapper;
+import net.firedevops.firemud.repository.FriendLinkRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mockito;
+
+class FriendServiceImplTest {
+  private FriendLinkRepository repository;
+  private FriendServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    repository = Mockito.mock(FriendLinkRepository.class);
+    FriendLinkMapper mapper = Mappers.getMapper(FriendLinkMapper.class);
+    service = new FriendServiceImpl(repository, mapper);
+  }
+
+  @Test
+  void addFriendReturnsDto() {
+    AddFriendRequest request = new AddFriendRequest(1L, 2L, 3L);
+    FriendLink saved = new FriendLink();
+    saved.setId(1L);
+    saved.setTenantId(1L);
+    saved.setAccountId(2L);
+    saved.setFriendAccountId(3L);
+    saved.setStatus("active");
+    saved.setCreatedAt(Instant.now());
+    when(repository.save(any(FriendLink.class))).thenReturn(saved);
+
+    FriendLinkDto result = service.addFriend(request);
+    assertEquals(2L, result.accountId());
+    assertEquals(3L, result.friendAccountId());
+  }
+}


### PR DESCRIPTION
## Summary
- add DTOs for friend requests
- implement `FriendService` with a basic add-friend operation
- expose `/friends` REST endpoint
- add MapStruct mapper and unit tests

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f407c377c83308943e83296a58610