### PR TITLE
Fix axe CLI path

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "format": "prettier --check \"src/**/*.{ts,tsx}\"",
     "format:fix": "prettier --write \"src/**/*.{ts,tsx}\"",
-    "accessibility": "npm run build && npx axe file:dist/index.html --exit"
+    "accessibility": "npm run build && npx axe file:./dist/index.html --exit"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
## Summary
- correct the accessibility script path for `@axe-core/cli`

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f4d4177248330b3295ee95c9fa3a1