### PR TITLE
Add game template docs and APIs

### DIFF
--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -37,7 +37,7 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Scripting and event workflow creation.
 - Visual editor for building scripts in the same component-based DSL used by the
   Automation & Scripting Service.
-- Game templates with predefined rulesets and administrators.
+- [Game templates](game-templates.md) with predefined rulesets and administrators.
 - Version and patch note management for published games.
 - Import/export of design assets for sharing between game worlds.
 

--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -1,7 +1,7 @@
 # Game Design Service Task List
 
 - [ ] **Expand Game Design Service**
-  - [ ] Provide game templates and configuration tools
+  - [x] Provide game templates and configuration tools
   - [x] Enable publishing of game versions
   - [ ] Use saga orchestrator for game publishing workflow
   - [x] Ensure domain services copy data by `version_id` and never query the design database at runtime

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -1,6 +1,8 @@
 # Game Design Service
 
-Refer to [design/README.md](design/README.md) for architecture details.
+Refer to [design/README.md](design/README.md) for architecture details. A new
+document describing game templates and configuration tools is available at
+[design/game-templates.md](design/game-templates.md).
 
 - **Proto definitions**: [../../protos/game-design/v1](../../protos/game-design/v1)
 

--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -4,6 +4,9 @@ The design for this service is located here:
 
 [📄 Central Architecture: Game Design Service Design](../../../design/architecture/microservices/game-design-service/README.md)
 
+Additional details on template management can be found in
+[game-templates.md](game-templates.md).
+
 This stub exists to make the design easy to find from the service source tree.
 
 ## REST & gRPC Endpoints

--- a/services/game-design-service/design/game-templates.md
+++ b/services/game-design-service/design/game-templates.md
@@ -1,0 +1,37 @@
+# Game Templates and Configuration Tools
+
+This document expands on how the Game Design Service provides reusable templates
+for new games. Templates bundle world data, scripts and default settings so that
+creators can quickly spin up new projects without starting from scratch.
+
+## Template Contents
+
+- **World Layout** – predefined regions and rooms loaded from the World
+  Management Service.
+- **Starter Items and NPCs** – basic entity definitions for a new game.
+- **Default Rulesets** – gameplay rules and runtime flags stored with the
+  template.
+- **Admin Accounts** – initial administrators configured at template creation.
+
+Templates are versioned like any other design asset. Publishing a version copies
+these templates to the domain services using the `version_id` workflow described
+in [Versioning & Runtime Configuration](../../../design/architecture/system-architecture-versioning-runtime.md).
+
+## Creating Templates
+
+Creators submit a `GameTemplateDto` via the REST API:
+
+```bash
+curl -X POST http://localhost:8080/templates \
+     -H 'Content-Type: application/json' \
+     -d '{"tenantId":1,"name":"Default","config":"{}"}'
+```
+
+The service validates the payload and stores it in the `game_templates` table.
+Templates can then be listed per `tenantId` to help bootstrap new games.
+
+## Related Design
+
+- [Game Design Service Architecture](../../../design/architecture/microservices/game-design-service/README.md)
+- [Multi-Tenancy](../../../design/architecture/system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../../design/architecture/service-responsibility-matrix.md)

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/controller/GameTemplateController.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/controller/GameTemplateController.java
@@ -1,0 +1,35 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.GameTemplateDto;
+import net.firedevops.firemud.service.GameTemplateService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/templates")
+@RequiredArgsConstructor
+public class GameTemplateController {
+  private final GameTemplateService templateService;
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<GameTemplateDto>> create(
+      @Valid @RequestBody GameTemplateDto dto) {
+    GameTemplateDto created = templateService.createTemplate(dto);
+    return ResponseEntity.ok(ApiResponse.success(created));
+  }
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<GameTemplateDto>>> list(@RequestParam Long tenantId) {
+    List<GameTemplateDto> templates = templateService.listTemplates(tenantId);
+    return ResponseEntity.ok(ApiResponse.success(templates));
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameTemplateDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameTemplateDto.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record GameTemplateDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull @Size(max = 100) String name,
+    String description,
+    @NotNull String config,
+    LocalDateTime createdAt) {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/GameTemplate.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/GameTemplate.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "game_templates")
+public class GameTemplate {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Column(length = 255)
+  private String description;
+
+  @Lob
+  @Column(nullable = false)
+  private String config;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/GameTemplateMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/GameTemplateMapper.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GameTemplateDto;
+import net.firedevops.firemud.entity.GameTemplate;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface GameTemplateMapper {
+  GameTemplateDto toDto(GameTemplate entity);
+
+  GameTemplate toEntity(GameTemplateDto dto);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameTemplateRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameTemplateRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.GameTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameTemplateRepository extends JpaRepository<GameTemplate, Long> {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/GameTemplateService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/GameTemplateService.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.service;
+
+import java.util.List;
+import net.firedevops.firemud.dto.GameTemplateDto;
+
+public interface GameTemplateService {
+  GameTemplateDto createTemplate(GameTemplateDto dto);
+
+  List<GameTemplateDto> listTemplates(Long tenantId);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameTemplateServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameTemplateServiceImpl.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.GameTemplateDto;
+import net.firedevops.firemud.entity.GameTemplate;
+import net.firedevops.firemud.mapper.GameTemplateMapper;
+import net.firedevops.firemud.repository.GameTemplateRepository;
+import net.firedevops.firemud.service.GameTemplateService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GameTemplateServiceImpl implements GameTemplateService {
+  private static final Logger logger = LoggingUtil.getLogger(GameTemplateServiceImpl.class);
+
+  private final GameTemplateRepository repository;
+  private final GameTemplateMapper mapper;
+
+  @Override
+  @Transactional
+  public GameTemplateDto createTemplate(GameTemplateDto dto) {
+    logger.info("Creating game template {}", dto.name());
+    GameTemplate entity = mapper.toEntity(dto);
+    entity = repository.save(entity);
+    return mapper.toDto(entity);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<GameTemplateDto> listTemplates(Long tenantId) {
+    return repository.findAll().stream()
+        .filter(t -> t.getTenantId().equals(tenantId))
+        .map(mapper::toDto)
+        .toList();
+  }
+}

--- a/services/game-design-service/src/main/resources/db/migration/V2__game_templates.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V2__game_templates.sql
@@ -1,0 +1,10 @@
+CREATE TABLE game_templates (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(255),
+    config JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE game_templates ADD CONSTRAINT game_templates_unique_name UNIQUE (tenant_id, name);

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
@@ -1,0 +1,42 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import net.firedevops.firemud.dto.GameTemplateDto;
+import net.firedevops.firemud.entity.GameTemplate;
+import net.firedevops.firemud.mapper.GameTemplateMapper;
+import net.firedevops.firemud.repository.GameTemplateRepository;
+import org.junit.jupiter.api.Test;
+
+class GameTemplateServiceImplTest {
+  @Test
+  void createTemplateSavesEntity() {
+    GameTemplateRepository repo = mock(GameTemplateRepository.class);
+    GameTemplateMapper mapper = mock(GameTemplateMapper.class);
+    GameTemplateServiceImpl service = new GameTemplateServiceImpl(repo, mapper);
+    GameTemplateDto dto = new GameTemplateDto(null, 1L, "test", null, "{}", null);
+    GameTemplate entity = new GameTemplate();
+    when(mapper.toEntity(dto)).thenReturn(entity);
+    when(repo.save(entity)).thenReturn(entity);
+    when(mapper.toDto(entity)).thenReturn(new GameTemplateDto(1L, 1L, "test", null, "{}", null));
+    GameTemplateDto result = service.createTemplate(dto);
+    assertEquals(1L, result.id());
+  }
+
+  @Test
+  void listTemplatesFiltersByTenantId() {
+    GameTemplateRepository repo = mock(GameTemplateRepository.class);
+    GameTemplateMapper mapper = mock(GameTemplateMapper.class);
+    GameTemplateServiceImpl service = new GameTemplateServiceImpl(repo, mapper);
+    GameTemplate template = new GameTemplate();
+    template.setId(1L);
+    template.setTenantId(1L);
+    when(repo.findAll()).thenReturn(List.of(template));
+    when(mapper.toDto(template)).thenReturn(new GameTemplateDto(1L, 1L, "name", null, "{}", null));
+    List<GameTemplateDto> result = service.listTemplates(1L);
+    assertEquals(1, result.size());
+  }
+}


### PR DESCRIPTION
## Summary
- document how to use game templates in Game Design Service
- expose simple CRUD for templates
- track template creation with JPA and MapStruct
- update design doc links and task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f4e5ca2e88330b12f3ffa59c06cdf