### PR TITLE
Implement account authentication gRPC service

### DIFF
--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.5.3")
     implementation(project(":common-library"))
     implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
+    implementation("io.micrometer:micrometer-core:1.15.1")
+    implementation("io.opentelemetry:opentelemetry-api:1.38.0")
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/AccountServiceApplication.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/AccountServiceApplication.java
@@ -1,9 +1,14 @@
 package net.firedevops.firemud;
 
+import net.firedevops.firemud.common.config.CommonAutoConfiguration;
+import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
+import net.firedevops.firemud.config.AuthConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, AuthConfig.class})
 public class AccountServiceApplication {
   public static void main(String[] args) {
     SpringApplication.run(AccountServiceApplication.class, args);

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,0 +1,15 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+public class AuthConfig {
+  @Bean
+  public JwtUtil jwtUtil(AuthProperties props) {
+    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "firemud.auth")
+public class AuthProperties {
+  private String jwtSecret;
+  private long jwtExpirationMs;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -1,0 +1,31 @@
+package net.firedevops.firemud.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+import net.firedevops.firemud.common.grpc.LoggingInterceptor;
+import net.firedevops.firemud.common.grpc.MetricsInterceptor;
+import net.firedevops.firemud.common.grpc.TracingInterceptor;
+import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcConfig {
+  @Bean
+  @GRpcGlobalInterceptor
+  public LoggingInterceptor loggingInterceptor() {
+    return new LoggingInterceptor();
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public MetricsInterceptor metricsInterceptor(MeterRegistry registry) {
+    return new MetricsInterceptor(registry);
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public TracingInterceptor tracingInterceptor(Tracer tracer) {
+    return new TracingInterceptor(tracer);
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/AccountRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/AccountRepository.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.repository;
 
+import java.util.Optional;
 import net.firedevops.firemud.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AccountRepository extends JpaRepository<Account, Long> {}
+public interface AccountRepository extends JpaRepository<Account, Long> {
+  Optional<Account> findByTenantIdAndUsername(Long tenantId, String username);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
@@ -5,4 +5,6 @@ import net.firedevops.firemud.dto.CreateAccountRequest;
 
 public interface AccountService {
   AccountDto createAccount(CreateAccountRequest request);
+
+  String authenticate(Long tenantId, String username, String password);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -1,0 +1,65 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.account.v1.AccountServiceGrpc;
+import net.firedevops.firemud.account.v1.AuthenticateRequest;
+import net.firedevops.firemud.account.v1.AuthenticateResponse;
+import net.firedevops.firemud.account.v1.CreateAccountRequest;
+import net.firedevops.firemud.account.v1.CreateAccountResponse;
+import net.firedevops.firemud.account.v1.PingRequest;
+import net.firedevops.firemud.account.v1.PingResponse;
+import net.firedevops.firemud.service.AccountService;
+import net.firedevops.firemud.service.PingService;
+import org.lognet.springboot.grpc.GRpcService;
+
+@GRpcService
+public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBase {
+  private final PingService pingService;
+  private final AccountService accountService;
+
+  public AccountGrpcService(PingService pingService, AccountService accountService) {
+    this.pingService = pingService;
+    this.accountService = accountService;
+  }
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    String msg = pingService.ping();
+    PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void createAccount(
+      CreateAccountRequest request, StreamObserver<CreateAccountResponse> responseObserver) {
+    net.firedevops.firemud.dto.CreateAccountRequest dto =
+        new net.firedevops.firemud.dto.CreateAccountRequest(
+            Long.valueOf(request.getTenantId()),
+            request.getUsername(),
+            request.getEmail(),
+            request.getPassword());
+    var account = accountService.createAccount(dto);
+    CreateAccountResponse response =
+        CreateAccountResponse.newBuilder().setAccountId(account.id().toString()).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void authenticate(
+      AuthenticateRequest request, StreamObserver<AuthenticateResponse> responseObserver) {
+    try {
+      String token =
+          accountService.authenticate(
+              Long.valueOf(request.getTenantId()), request.getUsername(), request.getPassword());
+      AuthenticateResponse response = AuthenticateResponse.newBuilder().setAuthToken(token).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      responseObserver.onError(
+          Status.UNAUTHENTICATED.withDescription(ex.getMessage()).asRuntimeException());
+    }
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -3,7 +3,10 @@ package net.firedevops.firemud.service.impl;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.Optional;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.entity.Account;
@@ -20,10 +23,13 @@ public class AccountServiceImpl implements AccountService {
 
   private final AccountRepository accountRepository;
   private final AccountMapper accountMapper;
+  private final JwtUtil jwtUtil;
 
-  public AccountServiceImpl(AccountRepository accountRepository, AccountMapper accountMapper) {
+  public AccountServiceImpl(
+      AccountRepository accountRepository, AccountMapper accountMapper, JwtUtil jwtUtil) {
     this.accountRepository = accountRepository;
     this.accountMapper = accountMapper;
+    this.jwtUtil = jwtUtil;
   }
 
   @Override
@@ -37,6 +43,19 @@ public class AccountServiceImpl implements AccountService {
     account.setPasswordHash(hashPassword(request.password()));
     account = accountRepository.save(account);
     return accountMapper.toDto(account);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public String authenticate(Long tenantId, String username, String password) {
+    Optional<Account> accountOpt = accountRepository.findByTenantIdAndUsername(tenantId, username);
+    Account account =
+        accountOpt.orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+    String hash = hashPassword(password);
+    if (!hash.equals(account.getPasswordHash())) {
+      throw new IllegalArgumentException("Invalid credentials");
+    }
+    return jwtUtil.generateToken(account.getId().toString(), Map.of("accountId", account.getId()));
   }
 
   private String hashPassword(String password) {

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -9,6 +9,11 @@ grpc:
   server:
     port: 6565
 
+firemud:
+  auth:
+    jwt-secret: changeit-changeit-changeit-changeit
+    jwt-expiration-ms: 3600000
+
 management:
   endpoints:
     web:

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -1,0 +1,80 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.dto.AccountDto;
+import net.firedevops.firemud.dto.CreateAccountRequest;
+import net.firedevops.firemud.entity.Account;
+import net.firedevops.firemud.mapper.AccountMapper;
+import net.firedevops.firemud.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class AccountServiceImplTest {
+  @Mock private AccountRepository accountRepository;
+
+  private AccountServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+    AccountMapper mapper = Mappers.getMapper(AccountMapper.class);
+    JwtUtil jwtUtil = new JwtUtil("mysecretkey123456789012345678901", 3600000L);
+    service = new AccountServiceImpl(accountRepository, mapper, jwtUtil);
+  }
+
+  @Test
+  void createAccountPersistsEntity() {
+    CreateAccountRequest request =
+        new CreateAccountRequest(1L, "demo", "demo@example.com", "password");
+    Account saved = new Account();
+    saved.setId(1L);
+    when(accountRepository.save(org.mockito.ArgumentMatchers.any(Account.class))).thenReturn(saved);
+
+    AccountDto dto = service.createAccount(request);
+
+    assertEquals(1L, dto.id());
+  }
+
+  @Test
+  void authenticateReturnsTokenWhenPasswordMatches() {
+    Account account = new Account();
+    account.setId(1L);
+    account.setTenantId(1L);
+    account.setUsername("demo");
+    account.setPasswordHash(hash("password"));
+    when(accountRepository.findByTenantIdAndUsername(1L, "demo")).thenReturn(Optional.of(account));
+
+    String token = service.authenticate(1L, "demo", "password");
+
+    assertNotNull(token);
+  }
+
+  @Test
+  void authenticateThrowsWhenInvalid() {
+    when(accountRepository.findByTenantIdAndUsername(1L, "demo")).thenReturn(Optional.empty());
+    assertThrows(IllegalArgumentException.class, () -> service.authenticate(1L, "demo", "bad"));
+  }
+
+  private static String hash(String password) {
+    try {
+      java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+      byte[] hash = md.digest(password.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder();
+      for (byte b : hash) {
+        sb.append(String.format("%02x", b));
+      }
+      return sb.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JWT auth configuration
- implement `AccountService.authenticate`
- expose account gRPC service and global interceptors
- wire up common auto-configuration
- test account service logic

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f4e413d508330a7caa8ed07eb638a