### PR TITLE
Fix axe CLI file path

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "format": "prettier --check \"src/**/*.{ts,tsx}\"",
     "format:fix": "prettier --write \"src/**/*.{ts,tsx}\"",
-    "accessibility": "npm run build && npx axe file:./dist/index.html --exit"
+    "accessibility": "npm run build && npx axe dist/index.html --exit"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
## Summary
- point accessibility tests at dist/index.html without `file:` prefix

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f51dc41608330b940ea7547e559c2