### PR TITLE
Implement stats and NPC respawn features

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -37,6 +37,7 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Character and NPC management.
 - Item storage and inventory handling.
 - Experience and level tracking.
+- NPC respawn scheduling with configurable delays.
 - Character creation templates pulled from the Game Design Service.
 - Supports instance-based spaces so characters can enter private dungeons or
   personalized housing without affecting the main world state.
@@ -48,6 +49,7 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Many-to-many tables define inventory and equipment relationships.
 - `instance_member` table tracks which characters are present in optional
   instance-based spaces.
+- Entity graphs cache inventory relationships for fast lookups.
 
 ### gRPC APIs
 
@@ -106,7 +108,6 @@ proto files, run `./gradlew generateProto` to update generated sources.
 
 ## Future Enhancements
 
-- Entity graph caching for faster lookups.
 - Support for complex crafting recipes.
 - Cross-game account linking to share a single profile across multiple games (see
   [Multi-Tenancy](../system-architecture-multi-tenancy.md)).

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/CharacterDto.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/CharacterDto.java
@@ -8,4 +8,11 @@ public record CharacterDto(
     @NotNull Long tenantId,
     @NotNull Long accountId,
     @NotNull @Size(max = 100) String name,
-    int level) {}
+    int level,
+    int experience,
+    int strength,
+    int agility,
+    int intelligence,
+    int stamina,
+    int health,
+    int mana) {}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/NpcDto.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/NpcDto.java
@@ -4,4 +4,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record NpcDto(
-    Long id, @NotNull Long tenantId, @NotNull @Size(max = 100) String name, String behavior) {}
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull @Size(max = 100) String name,
+    String behavior,
+    int respawnDelaySeconds,
+    Long lastDefeatedAtEpochMs) {}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Character.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Character.java
@@ -1,11 +1,22 @@
 package net.firedevops.firemud.entity;
 
 import jakarta.persistence.*;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Data;
 
 @Data
 @Entity
 @Table(name = "characters")
+@NamedEntityGraph(
+    name = "character.inventory",
+    attributeNodes = {
+      @NamedAttributeNode("inventoryEntries"),
+      @NamedAttributeNode("inventoryEntries.item")
+    })
 public class Character {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,4 +32,35 @@ public class Character {
   private String name;
 
   private int level;
+
+  @Column(nullable = false)
+  private int experience;
+
+  @Column(nullable = false)
+  private int strength;
+
+  @Column(nullable = false)
+  private int agility;
+
+  @Column(nullable = false)
+  private int intelligence;
+
+  @Column(nullable = false)
+  private int stamina;
+
+  @Column(nullable = false)
+  private int health;
+
+  @Column(nullable = false)
+  private int mana;
+
+  @OneToMany(
+      mappedBy = "character",
+      cascade = CascadeType.ALL,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY)
+  private Set<InventoryEntry> inventoryEntries = new HashSet<>();
+
+  @Column(name = "last_login_at")
+  private Instant lastLoginAt;
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Npc.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Npc.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.entity;
 
 import jakarta.persistence.*;
+import java.time.Instant;
 import lombok.Data;
 
 @Data
@@ -19,4 +20,10 @@ public class Npc {
 
   @Column(length = 100)
   private String behavior;
+
+  @Column(name = "respawn_delay", nullable = false)
+  private int respawnDelaySeconds = 60;
+
+  @Column(name = "last_defeated_at")
+  private Instant lastDefeatedAt;
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/NpcMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/NpcMapper.java
@@ -3,10 +3,19 @@ package net.firedevops.firemud.mapper;
 import net.firedevops.firemud.dto.NpcDto;
 import net.firedevops.firemud.entity.Npc;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface NpcMapper {
+  @Mapping(
+      target = "lastDefeatedAtEpochMs",
+      expression =
+          "java(entity.getLastDefeatedAt() == null ? null : entity.getLastDefeatedAt().toEpochMilli())")
   NpcDto toDto(Npc entity);
 
+  @Mapping(
+      target = "lastDefeatedAt",
+      expression =
+          "java(dto.lastDefeatedAtEpochMs() == null ? null : java.time.Instant.ofEpochMilli(dto.lastDefeatedAtEpochMs()))")
   Npc toEntity(NpcDto dto);
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/CharacterRepository.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/CharacterRepository.java
@@ -1,8 +1,14 @@
 package net.firedevops.firemud.repository;
 
+import java.util.Optional;
 import net.firedevops.firemud.entity.Character;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CharacterRepository extends JpaRepository<Character, Long> {}
+public interface CharacterRepository extends JpaRepository<Character, Long> {
+
+  @EntityGraph(attributePaths = {"inventoryEntries", "inventoryEntries.item"})
+  Optional<Character> findWithInventoryById(Long id);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/CharacterService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/CharacterService.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.CharacterDto;
+
+public interface CharacterService {
+  CharacterDto gainExperience(Long characterId, int amount);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/NpcService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/NpcService.java
@@ -1,0 +1,5 @@
+package net.firedevops.firemud.service;
+
+public interface NpcService {
+  boolean shouldRespawn(Long npcId);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/CharacterServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/CharacterServiceImpl.java
@@ -1,0 +1,33 @@
+package net.firedevops.firemud.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.dto.CharacterDto;
+import net.firedevops.firemud.entity.Character;
+import net.firedevops.firemud.mapper.CharacterMapper;
+import net.firedevops.firemud.repository.CharacterRepository;
+import net.firedevops.firemud.service.CharacterService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CharacterServiceImpl implements CharacterService {
+
+  private final CharacterRepository characterRepository;
+  private final CharacterMapper characterMapper;
+
+  private static final int EXP_PER_LEVEL = 1000;
+
+  @Override
+  @Transactional
+  public CharacterDto gainExperience(Long characterId, int amount) {
+    Character character = characterRepository.findById(characterId).orElseThrow();
+    character.setExperience(character.getExperience() + amount);
+    while (character.getExperience() >= character.getLevel() * EXP_PER_LEVEL) {
+      character.setExperience(character.getExperience() - character.getLevel() * EXP_PER_LEVEL);
+      character.setLevel(character.getLevel() + 1);
+    }
+    characterRepository.save(character);
+    return characterMapper.toDto(character);
+  }
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/NpcServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/NpcServiceImpl.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.entity.Npc;
+import net.firedevops.firemud.repository.NpcRepository;
+import net.firedevops.firemud.service.NpcService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NpcServiceImpl implements NpcService {
+
+  private final NpcRepository npcRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean shouldRespawn(Long npcId) {
+    Npc npc = npcRepository.findById(npcId).orElseThrow();
+    if (npc.getLastDefeatedAt() == null) {
+      return false;
+    }
+    return npc.getLastDefeatedAt()
+        .plusSeconds(npc.getRespawnDelaySeconds())
+        .isBefore(Instant.now());
+  }
+}

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/CharacterServiceImplTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/CharacterServiceImplTest.java
@@ -1,0 +1,45 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.firedevops.firemud.dto.CharacterDto;
+import net.firedevops.firemud.entity.Character;
+import net.firedevops.firemud.mapper.CharacterMapper;
+import net.firedevops.firemud.repository.CharacterRepository;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mockito;
+
+class CharacterServiceImplTest {
+
+  @Test
+  void gainExperienceLevelsUp() {
+    CharacterRepository repo = Mockito.mock(CharacterRepository.class);
+    CharacterMapper mapper = Mappers.getMapper(CharacterMapper.class);
+    CharacterServiceImpl service = new CharacterServiceImpl(repo, mapper);
+
+    Character character = new Character();
+    character.setId(1L);
+    character.setTenantId(1L);
+    character.setAccountId(1L);
+    character.setName("Test");
+    character.setLevel(1);
+    character.setExperience(0);
+    character.setStrength(1);
+    character.setAgility(1);
+    character.setIntelligence(1);
+    character.setStamina(1);
+    character.setHealth(10);
+    character.setMana(5);
+
+    when(repo.findById(1L)).thenReturn(Optional.of(character));
+    when(repo.save(any(Character.class))).thenAnswer(a -> a.getArgument(0));
+
+    CharacterDto dto = service.gainExperience(1L, 1000);
+    assertEquals(2, dto.level());
+    assertEquals(0, dto.experience());
+  }
+}

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/NpcServiceImplTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/NpcServiceImplTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import net.firedevops.firemud.entity.Npc;
+import net.firedevops.firemud.repository.NpcRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NpcServiceImplTest {
+
+  @Test
+  void shouldRespawnAfterDelay() {
+    NpcRepository repo = Mockito.mock(NpcRepository.class);
+    NpcServiceImpl service = new NpcServiceImpl(repo);
+
+    Npc npc = new Npc();
+    npc.setId(1L);
+    npc.setTenantId(1L);
+    npc.setName("Goblin");
+    npc.setBehavior("aggressive");
+    npc.setRespawnDelaySeconds(60);
+    npc.setLastDefeatedAt(Instant.now().minusSeconds(61));
+
+    when(repo.findById(1L)).thenReturn(Optional.of(npc));
+
+    assertTrue(service.shouldRespawn(1L));
+  }
+}


### PR DESCRIPTION
## Summary
- expand Entity Management Service domain model with character stats and NPC respawn data
- introduce services for character progression and NPC respawn checks
- support inventory entity graph fetching
- document new features
- add unit tests for character leveling and NPC respawn

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f524f00c08330813a8d7214be7889