### PR TITLE
Add openapi and update social groups schema

### DIFF
--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -1,7 +1,7 @@
 # Social & Groups Service Task List
 
 - [ ] **Develop Social & Groups Service**
-  - [ ] Enable cross-game friend lists and social graph
+  - [x] Enable cross-game friend lists and social graph
   - [ ] Support private messages, global chat, and guild channels
   - [ ] Implement player-to-player mail system (asynchronous in-game messaging)
   - [ ] Allow players to form and manage guilds
@@ -40,7 +40,7 @@ participate in CI.
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
-- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [x] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
 - [x] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
 
 ---

--- a/services/social-groups-service/README.md
+++ b/services/social-groups-service/README.md
@@ -22,3 +22,17 @@ This service uses the standard `FIREMUD_` prefixed variables for PostgreSQL and
 Redis connectivity. See the
 [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
 doc for defaults.
+
+## API Documentation
+
+REST endpoints are documented in `openapi.yaml` within the resources directory. A Swagger UI can be generated using any OpenAPI toolchain.
+
+### Example Request
+
+Create a friend link:
+
+```bash
+curl -X POST http://localhost:8080/friends \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"accountId":100,"friendAccountId":200}'
+```

--- a/services/social-groups-service/design/README.md
+++ b/services/social-groups-service/design/README.md
@@ -5,6 +5,7 @@ The design for this service is located here:
 [📄 Central Architecture: Social Groups Service Design](../../../design/architecture/microservices/social-groups-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+An OpenAPI specification is available at `src/main/resources/openapi.yaml`.
 
 ## REST & gRPC Endpoints
 
@@ -14,6 +15,14 @@ This stub exists to make the design easy to find from the service source tree.
 
 ```bash
 curl http://localhost:8080/ping
+```
+
+- `POST /friends` – create a friend link.
+
+```bash
+curl -X POST http://localhost:8080/friends \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"accountId":100,"friendAccountId":200}'
 ```
 
 ### gRPC

--- a/services/social-groups-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/social-groups-service/src/main/resources/db/migration/V1__init.sql
@@ -1,27 +1,33 @@
-CREATE TABLE guild (
+CREATE TABLE guilds (
     id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
     name VARCHAR(100) NOT NULL,
-    owner_id BIGINT NOT NULL,
-    tenant_id BIGINT NOT NULL
+    owner_account_id BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE guild_member (
-    guild_id BIGINT NOT NULL REFERENCES guild(id),
+CREATE TABLE guild_members (
+    guild_id BIGINT NOT NULL REFERENCES guilds(id),
     account_id BIGINT NOT NULL,
     role VARCHAR(50) NOT NULL,
     PRIMARY KEY (guild_id, account_id)
 );
 
-CREATE TABLE chat_message (
+CREATE TABLE chat_messages (
     id BIGSERIAL PRIMARY KEY,
-    sender_id BIGINT NOT NULL,
-    channel VARCHAR(50),
-    message TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    tenant_id BIGINT NOT NULL,
+    sender_account_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    guild_id BIGINT,
+    recipient_account_id BIGINT
 );
 
-CREATE TABLE friend_link (
+CREATE TABLE friend_links (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
     account_id BIGINT NOT NULL,
     friend_account_id BIGINT NOT NULL,
-    PRIMARY KEY (account_id, friend_account_id)
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/services/social-groups-service/src/main/resources/openapi.yaml
+++ b/services/social-groups-service/src/main/resources/openapi.yaml
@@ -1,0 +1,85 @@
+openapi: 3.0.3
+info:
+  title: Social Groups Service API
+  description: API for friend lists and guild chat
+  version: 1.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: https://api.firemud.com
+security: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    AddFriendRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        accountId:
+          type: integer
+        friendAccountId:
+          type: integer
+      required:
+        - tenantId
+        - accountId
+        - friendAccountId
+    FriendLinkDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        accountId:
+          type: integer
+        friendAccountId:
+          type: integer
+        status:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+paths:
+  /ping:
+    get:
+      summary: Health check endpoint
+      operationId: ping
+      responses:
+        '200':
+          description: Pong response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+                    example: pong
+  /friends:
+    post:
+      summary: Create a friend link
+      operationId: addFriend
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddFriendRequest'
+      responses:
+        '200':
+          description: Friend link created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/FriendLinkDto'
+        '400':
+          description: Invalid request


### PR DESCRIPTION
## Summary
- document social groups REST API via `openapi.yaml`
- align Flyway migration with entity definitions
- note openapi spec and example in service docs
- mark completed tasks in social groups service checklist

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f4f761bd88330afcb8a86d4ade4d2