### PR TITLE
Implement game session lifecycle APIs

### DIFF
--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -10,6 +10,8 @@ option java_multiple_files = true;
 service GameSessionService {
   rpc Ping(PingRequest) returns (PingResponse);
   rpc StartSession(StartSessionRequest) returns (StartSessionResponse);
+  rpc StopSession(StopSessionRequest) returns (StopSessionResponse);
+  rpc RestartSession(RestartSessionRequest) returns (RestartSessionResponse);
   rpc EnqueueCommand(EnqueueCommandRequest) returns (EnqueueCommandResponse);
   rpc QueryState(QueryStateRequest) returns (QueryStateResponse);
 }
@@ -21,6 +23,24 @@ message StartSessionRequest {
 
 message StartSessionResponse {
   string session_id = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message StopSessionRequest {
+  string session_id = 1;
+}
+
+message StopSessionResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message RestartSessionRequest {
+  string session_id = 1;
+}
+
+message RestartSessionResponse {
+  bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }
 

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -4,6 +4,13 @@ Refer to [design/README.md](design/README.md) for architecture details.
 
 - **Proto definitions**: [../../protos/game-session/v1](../../protos/game-session/v1)
 
+New lifecycle endpoints manage running sessions:
+
+```bash
+POST /sessions/{id}/stop    # stop a running session
+POST /sessions/{id}/restart # restart a stopped session
+```
+
 ## Configuration
 
 The service relies on `DatabaseAutoConfiguration` and `RedisProperties` from the

--- a/services/game-session-service/design/README.md
+++ b/services/game-session-service/design/README.md
@@ -23,6 +23,8 @@ column and Redis keys are prefixed with this value as outlined in the
 
 - `GET /ping` – basic health check returning `"pong"`.
 - `POST /sessions` – create a new game session from a published version.
+- `POST /sessions/{id}/stop` – stop a running session.
+- `POST /sessions/{id}/restart` – restart a stopped session.
 
 ```bash
 curl http://localhost:8080/ping

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/controller/GameInstanceController.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/controller/GameInstanceController.java
@@ -6,6 +6,7 @@ import net.firedevops.firemud.dto.GameInstanceDto;
 import net.firedevops.firemud.dto.StartSessionRequest;
 import net.firedevops.firemud.service.GameInstanceService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +26,18 @@ public class GameInstanceController {
   public ResponseEntity<ApiResponse<GameInstanceDto>> startSession(
       @Valid @RequestBody StartSessionRequest request) {
     GameInstanceDto dto = gameInstanceService.startSession(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @PostMapping("/{sessionId}/stop")
+  public ResponseEntity<ApiResponse<GameInstanceDto>> stopSession(@PathVariable long sessionId) {
+    GameInstanceDto dto = gameInstanceService.stopSession(sessionId);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @PostMapping("/{sessionId}/restart")
+  public ResponseEntity<ApiResponse<GameInstanceDto>> restartSession(@PathVariable long sessionId) {
+    GameInstanceDto dto = gameInstanceService.restartSession(sessionId);
     return ResponseEntity.ok(ApiResponse.success(dto));
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/GameManifestDto.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/GameManifestDto.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record GameManifestDto(
+    Long id, @NotNull @Size(max = 100) String versionId, @Size(max = 500) String description) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/entity/GameManifest.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/entity/GameManifest.java
@@ -1,0 +1,19 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "game_manifest")
+public class GameManifest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String versionId;
+
+  @Column(length = 500)
+  private String description;
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/mapper/GameManifestMapper.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/mapper/GameManifestMapper.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GameManifestDto;
+import net.firedevops.firemud.entity.GameManifest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface GameManifestMapper {
+  GameManifestDto toDto(GameManifest entity);
+
+  GameManifest toEntity(GameManifestDto dto);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/repository/GameInstanceRepository.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/repository/GameInstanceRepository.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.repository;
 
+import java.util.Optional;
 import net.firedevops.firemud.entity.GameInstance;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GameInstanceRepository extends JpaRepository<GameInstance, Long> {}
+public interface GameInstanceRepository extends JpaRepository<GameInstance, Long> {
+  Optional<GameInstance> findFirstByOwnerAccountIdAndStatus(Long ownerAccountId, String status);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/repository/GameManifestRepository.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/repository/GameManifestRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.GameManifest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameManifestRepository extends JpaRepository<GameManifest, Long> {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/GameInstanceService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/GameInstanceService.java
@@ -6,4 +6,8 @@ import net.firedevops.firemud.dto.StartSessionRequest;
 /** Service handling game instance lifecycle operations. */
 public interface GameInstanceService {
   GameInstanceDto startSession(StartSessionRequest request);
+
+  GameInstanceDto stopSession(long sessionId);
+
+  GameInstanceDto restartSession(long sessionId);
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/GameManifestService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/GameManifestService.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.GameManifestDto;
+
+public interface GameManifestService {
+  GameManifestDto createManifest(GameManifestDto dto);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -29,6 +29,17 @@ public class GameInstanceServiceImpl implements GameInstanceService {
   public GameInstanceDto startSession(StartSessionRequest request) {
     logger.info(
         "Starting game session for tenant {} version {}", request.tenantId(), request.versionId());
+    repository
+        .findFirstByOwnerAccountIdAndStatus(request.ownerAccountId(), "RUNNING")
+        .ifPresent(
+            existing -> {
+              logger.info(
+                  "Stopping existing session {} for owner {}",
+                  existing.getId(),
+                  existing.getOwnerAccountId());
+              existing.setStatus("STOPPED");
+              repository.save(existing);
+            });
     GameInstance instance = new GameInstance();
     instance.setTenantId(request.tenantId());
     instance.setVersionId(request.versionId());
@@ -36,5 +47,27 @@ public class GameInstanceServiceImpl implements GameInstanceService {
     instance.setStatus("RUNNING");
     instance = repository.save(instance);
     return mapper.toDto(instance);
+  }
+
+  @Override
+  @Transactional
+  public GameInstanceDto stopSession(long sessionId) {
+    GameInstance instance =
+        repository
+            .findById(sessionId)
+            .orElseThrow(() -> new IllegalArgumentException("Session not found"));
+    instance.setStatus("STOPPED");
+    return mapper.toDto(repository.save(instance));
+  }
+
+  @Override
+  @Transactional
+  public GameInstanceDto restartSession(long sessionId) {
+    GameInstance instance =
+        repository
+            .findById(sessionId)
+            .orElseThrow(() -> new IllegalArgumentException("Session not found"));
+    instance.setStatus("RUNNING");
+    return mapper.toDto(repository.save(instance));
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameManifestServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameManifestServiceImpl.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.service.impl;
+
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.GameManifestDto;
+import net.firedevops.firemud.entity.GameManifest;
+import net.firedevops.firemud.mapper.GameManifestMapper;
+import net.firedevops.firemud.repository.GameManifestRepository;
+import net.firedevops.firemud.service.GameManifestService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GameManifestServiceImpl implements GameManifestService {
+  private static final Logger logger = LoggingUtil.getLogger(GameManifestServiceImpl.class);
+  private final GameManifestRepository repository;
+  private final GameManifestMapper mapper;
+
+  public GameManifestServiceImpl(GameManifestRepository repository, GameManifestMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  @Override
+  @Transactional
+  public GameManifestDto createManifest(GameManifestDto dto) {
+    logger.info("Creating game manifest for version {}", dto.versionId());
+    GameManifest entity = mapper.toEntity(dto);
+    entity = repository.save(entity);
+    return mapper.toDto(entity);
+  }
+}

--- a/services/game-session-service/src/main/resources/db/migration/V1__init.sql
+++ b/services/game-session-service/src/main/resources/db/migration/V1__init.sql
@@ -1,4 +1,4 @@
-CREATE TABLE game_session (
+CREATE TABLE game_instances (
     id BIGSERIAL PRIMARY KEY,
     version_id BIGINT NOT NULL,
     owner_account_id BIGINT NOT NULL,

--- a/services/game-session-service/src/main/resources/db/migration/V2__create_game_manifest.sql
+++ b/services/game-session-service/src/main/resources/db/migration/V2__create_game_manifest.sql
@@ -1,0 +1,6 @@
+CREATE TABLE game_manifest (
+    id BIGSERIAL PRIMARY KEY,
+    version_id VARCHAR(100) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/services/game-session-service/src/main/resources/openapi.yaml
+++ b/services/game-session-service/src/main/resources/openapi.yaml
@@ -82,3 +82,43 @@ paths:
                     $ref: '#/components/schemas/GameInstanceDto'
         '400':
           description: Invalid request
+  /sessions/{sessionId}/stop:
+    post:
+      summary: Stop a running session
+      operationId: stopSession
+      parameters:
+        - in: path
+          name: sessionId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Stopped session
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GameInstanceDto'
+  /sessions/{sessionId}/restart:
+    post:
+      summary: Restart a stopped session
+      operationId: restartSession
+      parameters:
+        - in: path
+          name: sessionId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Restarted session
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GameInstanceDto'

--- a/services/game-session-service/src/test/java/integration/net/firedevops/firemud/controller/GameInstanceControllerTest.java
+++ b/services/game-session-service/src/test/java/integration/net/firedevops/firemud/controller/GameInstanceControllerTest.java
@@ -39,4 +39,24 @@ class GameInstanceControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.id").value(1));
   }
+
+  @Test
+  void stopSessionReturnsDto() throws Exception {
+    GameInstanceDto dto = new GameInstanceDto(1L, 1L, "v1", 1L, "STOPPED");
+    org.mockito.Mockito.when(gameInstanceService.stopSession(1L)).thenReturn(dto);
+    mockMvc
+        .perform(post("/sessions/1/stop"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.status").value("STOPPED"));
+  }
+
+  @Test
+  void restartSessionReturnsDto() throws Exception {
+    GameInstanceDto dto = new GameInstanceDto(1L, 1L, "v1", 1L, "RUNNING");
+    org.mockito.Mockito.when(gameInstanceService.restartSession(1L)).thenReturn(dto);
+    mockMvc
+        .perform(post("/sessions/1/restart"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.status").value("RUNNING"));
+  }
 }


### PR DESCRIPTION
## Summary
- implement stop/restart session endpoints and service methods
- ensure single-session enforcement when starting a game
- add GameManifest entity and migration for version coordination
- document new APIs
- update proto definitions

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f4ecc4ea48330a7bee99addaf0d52