### PR TITLE
Implement gRPC service and tracing for Game Logic

### DIFF
--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -64,9 +64,9 @@ participate in CI.
 ## 📚 Shared Library Integration
 
 - [x] Depend on `firemud-common` via Gradle
-- [ ] Apply logging, tracing, and security interceptors from the library
-- [ ] Use provided autoconfiguration classes to reduce boilerplate
-- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+- [x] Apply logging, tracing, and security interceptors from the library
+- [x] Use provided autoconfiguration classes to reduce boilerplate
+- [x] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
 
 ---
 
@@ -103,11 +103,11 @@ participate in CI.
 
 ## 📈 Observability & Tracing
 
-- [ ] Use Micrometer for Prometheus metrics
-- [ ] Enable OpenTelemetry tracing
-- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [x] Use Micrometer for Prometheus metrics
+- [x] Enable OpenTelemetry tracing
+- [x] Use shared interceptors to propagate `traceId` and `correlationId`
 - [ ] Emit service metrics for ticks and Redis commands when relevant
-- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+- [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---
 

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -15,6 +15,11 @@ dependencies {
     implementation("org.mapstruct:mapstruct:1.6.3")
     implementation("org.springframework.boot:spring-boot-starter:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
+    implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
+    implementation("io.opentelemetry:opentelemetry-api:1.38.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
+    implementation("io.micrometer:micrometer-registry-prometheus:1.15.1")
     implementation(project(":common-library"))
 }
 

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/config/GrpcServerConfig.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/config/GrpcServerConfig.java
@@ -1,0 +1,33 @@
+package net.firedevops.firemud.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+import net.firedevops.firemud.common.grpc.LoggingInterceptor;
+import net.firedevops.firemud.common.grpc.MetricsInterceptor;
+import net.firedevops.firemud.common.grpc.TracingInterceptor;
+import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Registers gRPC interceptors for logging, metrics, and tracing. */
+@Configuration
+public class GrpcServerConfig {
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public LoggingInterceptor loggingInterceptor() {
+    return new LoggingInterceptor();
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public MetricsInterceptor metricsInterceptor(MeterRegistry meterRegistry) {
+    return new MetricsInterceptor(meterRegistry);
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public TracingInterceptor tracingInterceptor(Tracer tracer) {
+    return new TracingInterceptor(tracer);
+  }
+}

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/config/TracingConfig.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/config/TracingConfig.java
@@ -1,0 +1,43 @@
+package net.firedevops.firemud.config;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Basic OpenTelemetry configuration exporting spans to the OTLP collector. */
+@Configuration
+public class TracingConfig {
+
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
+
+  @Bean
+  public OpenTelemetry openTelemetry() {
+    OtlpGrpcSpanExporter exporter =
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
+
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(BatchSpanProcessor.builder(exporter).build())
+            .setResource(
+                Resource.create(
+                    Attributes.of(AttributeKey.stringKey("service.name"), "game-logic-service")))
+            .build();
+
+    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+  }
+
+  @Bean
+  public Tracer tracer(OpenTelemetry openTelemetry) {
+    return openTelemetry.getTracer("game-logic-service");
+  }
+}

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
@@ -1,0 +1,39 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.gamelogic.v1.ExecuteCommandRequest;
+import net.firedevops.firemud.gamelogic.v1.ExecuteCommandResponse;
+import net.firedevops.firemud.gamelogic.v1.GameLogicServiceGrpc;
+import net.firedevops.firemud.gamelogic.v1.PingRequest;
+import net.firedevops.firemud.gamelogic.v1.PingResponse;
+import net.firedevops.firemud.logic.service.CommandService;
+import net.firedevops.firemud.service.PingService;
+import org.lognet.springboot.grpc.GRpcService;
+
+/** gRPC endpoints for the Game Logic Service. */
+@GRpcService
+public class GameLogicGrpcService extends GameLogicServiceGrpc.GameLogicServiceImplBase {
+  private final PingService pingService;
+  private final CommandService commandService;
+
+  public GameLogicGrpcService(PingService pingService, CommandService commandService) {
+    this.pingService = pingService;
+    this.commandService = commandService;
+  }
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    PingResponse response = PingResponse.newBuilder().setMessage(pingService.ping()).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void executeCommand(
+      ExecuteCommandRequest request, StreamObserver<ExecuteCommandResponse> responseObserver) {
+    String result = commandService.handleCommand(request.getCommand());
+    ExecuteCommandResponse response = ExecuteCommandResponse.newBuilder().setResult(result).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
@@ -1,0 +1,48 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.gamelogic.v1.PingRequest;
+import net.firedevops.firemud.gamelogic.v1.PingResponse;
+import net.firedevops.firemud.logic.command.DefaultCommandParser;
+import net.firedevops.firemud.logic.command.SimpleCommandProcessor;
+import net.firedevops.firemud.logic.event.EventDispatcher;
+import net.firedevops.firemud.logic.script.NoOpScriptingHook;
+import net.firedevops.firemud.logic.service.CommandServiceImpl;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.service.impl.PingServiceImpl;
+import org.junit.jupiter.api.Test;
+
+class GameLogicGrpcServiceTest {
+  @Test
+  void pingEndpointReturnsPong() {
+    PingService pingService = new PingServiceImpl();
+    var dispatcher = new EventDispatcher();
+    var processor = new SimpleCommandProcessor(dispatcher, new NoOpScriptingHook());
+    var commandService = new CommandServiceImpl(new DefaultCommandParser(), processor);
+    GameLogicGrpcService service = new GameLogicGrpcService(pingService, commandService);
+
+    AtomicReference<PingResponse> holder = new AtomicReference<>();
+    service.ping(
+        PingRequest.newBuilder().build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            holder.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            fail(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("pong", holder.get().getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GameLogicGrpcService` and associated unit test
- register gRPC interceptors for logging, metrics, and tracing
- configure OpenTelemetry tracing
- expose Prometheus metrics and update build
- mark completed tasks in Game Logic service checklist

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f4e9071588330b59c0d835f0a5e6c