### PR TITLE
Update automation scripting docs

### DIFF
--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -71,9 +71,9 @@ participate in CI.
 ## 📚 Shared Library Integration
 
 - [x] Depend on `firemud-common` via Gradle
-- [ ] Apply logging, tracing, and security interceptors from the library
-- [ ] Use provided autoconfiguration classes to reduce boilerplate
-- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+- [x] Apply logging, tracing, and security interceptors from the library
+- [x] Use provided autoconfiguration classes to reduce boilerplate
+- [x] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
 
 ---
 
@@ -110,11 +110,11 @@ participate in CI.
 
 ## 📈 Observability & Tracing
 
-- [ ] Use Micrometer for Prometheus metrics
-- [ ] Enable OpenTelemetry tracing
-- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [x] Use Micrometer for Prometheus metrics
+- [x] Enable OpenTelemetry tracing
+- [x] Use shared interceptors to propagate `traceId` and `correlationId`
 - [ ] Emit service metrics for ticks and Redis commands when relevant
-- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+- [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---
 

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -16,21 +16,32 @@ To run the entire stack:
 ./gradlew devUp
 ```
 
-## Environment Variables
+## Configuration
 
-The service relies on standard Spring Boot properties for database and Redis
-connections. Typical variables include:
+Connection settings are provided by `DatabaseAutoConfiguration` and
+`RedisProperties` from the common library. See
+[Deployment Environments](../../design/architecture/infrastructure/deployment-environments.md)
+for defaults. Typical values from `.env.sample`:
+
+```bash
+FIREMUD_POSTGRES_HOST=postgres
+FIREMUD_POSTGRES_PORT=5432
+FIREMUD_POSTGRES_USER=firemud
+FIREMUD_POSTGRES_PASSWORD=firemud
+FIREMUD_POSTGRES_DB=firemud
+FIREMUD_REDIS_HOST=redis
+FIREMUD_REDIS_PORT=6379
+```
 
 | Variable | Purpose |
 | --- | --- |
-| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL |
-| `SPRING_DATASOURCE_USERNAME` | Database user |
-| `SPRING_DATASOURCE_PASSWORD` | Database password |
-| `SPRING_REDIS_HOST` | Redis hostname |
-| `SPRING_REDIS_PORT` | Redis port |
-
-Values can also be specified in `application.yml` profiles for different
-environments.
+| `FIREMUD_POSTGRES_HOST` | PostgreSQL hostname |
+| `FIREMUD_POSTGRES_PORT` | PostgreSQL port |
+| `FIREMUD_POSTGRES_USER` | Database user |
+| `FIREMUD_POSTGRES_PASSWORD` | Database password |
+| `FIREMUD_POSTGRES_DB` | Database name |
+| `FIREMUD_REDIS_HOST` | Redis hostname |
+| `FIREMUD_REDIS_PORT` | Redis port |
 
 ## Redis Key Pattern
 

--- a/services/automation-scripting-service/design/README.md
+++ b/services/automation-scripting-service/design/README.md
@@ -6,6 +6,14 @@ The design for this service is located here:
 
 This stub exists to make the design easy to find from the service source tree.
 
+## Configuration
+
+PostgreSQL and Redis connections are configured via the common
+`DatabaseAutoConfiguration` and `RedisProperties` classes. Refer to
+[Deployment Environments](../../../design/architecture/infrastructure/deployment-environments.md)
+for default values. Local development typically uses the settings from
+`.env.sample`.
+
 ## REST & gRPC Endpoints
 
 ### REST


### PR DESCRIPTION
## Summary
- document use of DatabaseAutoConfiguration and RedisProperties
- mention default environment variables for the service
- explain configuration in the service design doc
- check off completed tasks in the automation-scripting-service checklist

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f54cfe0b083308b9e7479c99dd2af