### PR TITLE
Add metrics and tracing to Social Groups Service

### DIFF
--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -18,6 +18,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.5.3")
     implementation(project(":common-library"))
+    implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
+    implementation("io.micrometer:micrometer-core:1.15.1")
+    implementation("io.micrometer:micrometer-registry-prometheus:1.15.1")
+    implementation("io.opentelemetry:opentelemetry-api:1.38.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }
 

--- a/services/social-groups-service/design/README.md
+++ b/services/social-groups-service/design/README.md
@@ -32,3 +32,9 @@ curl -X POST http://localhost:8080/friends \
 ```bash
 grpcurl -plaintext localhost:6565 social_groups.v1.SocialGroupsService/Ping
 ```
+
+## Metrics & Tracing
+
+Prometheus scrapes metrics from `/actuator/prometheus`. OpenTelemetry spans are
+exported to the collector defined in the shared configuration. No additional
+setup is required when running `./gradlew bootRun`.

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+import net.firedevops.firemud.common.grpc.LoggingInterceptor;
+import net.firedevops.firemud.common.grpc.MetricsInterceptor;
+import net.firedevops.firemud.common.grpc.TracingInterceptor;
+import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Registers common gRPC interceptors for logging, metrics and tracing. */
+@Configuration
+public class GrpcConfig {
+  @Bean
+  @GRpcGlobalInterceptor
+  public LoggingInterceptor loggingInterceptor() {
+    return new LoggingInterceptor();
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public MetricsInterceptor metricsInterceptor(MeterRegistry registry) {
+    return new MetricsInterceptor(registry);
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public TracingInterceptor tracingInterceptor(Tracer tracer) {
+    return new TracingInterceptor(tracer);
+  }
+}

--- a/services/social-groups-service/src/main/resources/application.yml
+++ b/services/social-groups-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       probes:

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PingController.class)
+class PingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PingService pingService;
+
+  @Test
+  void pingEndpointReturnsPong() throws Exception {
+    when(pingService.ping()).thenReturn("pong");
+
+    mockMvc
+        .perform(get("/ping"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data").value("pong"));
+  }
+}


### PR DESCRIPTION
## Summary
- enable Prometheus endpoint in Social Groups application
- register gRPC logging/tracing/metrics interceptors
- add Micrometer/OTel dependencies
- document metrics and tracing
- add Ping controller unit test

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f5a50ceac8330bb29bbea5fcff9f3