### PR TITLE
Implement session management in Account Service

### DIFF
--- a/services/account-service/README.md
+++ b/services/account-service/README.md
@@ -31,6 +31,9 @@ connections. Typical variables when running locally are:
 | `SPRING_DATASOURCE_PASSWORD` | Database password |
 | `SPRING_REDIS_HOST` | Redis hostname |
 | `SPRING_REDIS_PORT` | Redis port |
+| `FIREMUD_AUTH_JWT_SECRET` | Secret key for JWT signing |
+| `FIREMUD_AUTH_JWT_EXPIRATION_MS` | JWT expiration time in ms |
+| `FIREMUD_AUTH_SESSION_EXPIRATION_MS` | Session token TTL in ms |
 
 Values can also be configured via `application.yml` profiles for different
 environments.

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-actuator:3.5.3")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.5.3")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis:3.5.3")
     implementation(project(":common-library"))
     implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
     implementation("io.micrometer:micrometer-core:1.15.1")

--- a/services/account-service/design/README.md
+++ b/services/account-service/design/README.md
@@ -15,6 +15,10 @@ The proto definitions live in [`payment_service.proto`](../../../protos/account/
 
 This service sends verification and password reset emails using a configured SMTP provider. Notifications for suspicious logins or account events are queued for asynchronous delivery via a gRPC `NotificationService`. Sample templates live under `resources/templates/` and environment variables specify SMTP credentials. The gRPC API is defined in [`notification_service.proto`](../../../protos/account/v1/notification_service.proto).
 
+## Session Management
+
+Authentication returns a JWT token which is stored in Redis for quick reconnects. Keys follow `session:{tenantId}:{token}` and expire after the duration configured by `session-expiration-ms` in `AuthProperties`.
+
 ## REST & gRPC Endpoints
 
 ### REST

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -8,4 +8,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AuthProperties {
   private String jwtSecret;
   private long jwtExpirationMs;
+  private long sessionExpirationMs = 3600000L;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -24,12 +24,17 @@ public class AccountServiceImpl implements AccountService {
   private final AccountRepository accountRepository;
   private final AccountMapper accountMapper;
   private final JwtUtil jwtUtil;
+  private final net.firedevops.firemud.service.session.SessionService sessionService;
 
   public AccountServiceImpl(
-      AccountRepository accountRepository, AccountMapper accountMapper, JwtUtil jwtUtil) {
+      AccountRepository accountRepository,
+      AccountMapper accountMapper,
+      JwtUtil jwtUtil,
+      net.firedevops.firemud.service.session.SessionService sessionService) {
     this.accountRepository = accountRepository;
     this.accountMapper = accountMapper;
     this.jwtUtil = jwtUtil;
+    this.sessionService = sessionService;
   }
 
   @Override
@@ -55,7 +60,10 @@ public class AccountServiceImpl implements AccountService {
     if (!hash.equals(account.getPasswordHash())) {
       throw new IllegalArgumentException("Invalid credentials");
     }
-    return jwtUtil.generateToken(account.getId().toString(), Map.of("accountId", account.getId()));
+    String token =
+        jwtUtil.generateToken(account.getId().toString(), Map.of("accountId", account.getId()));
+    sessionService.storeSession(tenantId, account.getId(), token);
+    return token;
   }
 
   private String hashPassword(String password) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionService.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.service.session;
+
+public interface SessionService {
+  void storeSession(Long tenantId, Long accountId, String token);
+
+  Long getAccountId(Long tenantId, String token);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionServiceImpl.java
@@ -1,0 +1,36 @@
+package net.firedevops.firemud.service.session;
+
+import java.time.Duration;
+import net.firedevops.firemud.config.AuthProperties;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SessionServiceImpl implements SessionService {
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final AuthProperties authProperties;
+
+  public SessionServiceImpl(
+      RedisTemplate<String, Object> redisTemplate, AuthProperties authProperties) {
+    this.redisTemplate = redisTemplate;
+    this.authProperties = authProperties;
+  }
+
+  @Override
+  public void storeSession(Long tenantId, Long accountId, String token) {
+    String key = buildKey(tenantId, token);
+    redisTemplate
+        .opsForValue()
+        .set(key, accountId, Duration.ofMillis(authProperties.getSessionExpirationMs()));
+  }
+
+  @Override
+  public Long getAccountId(Long tenantId, String token) {
+    Object value = redisTemplate.opsForValue().get(buildKey(tenantId, token));
+    return value != null ? Long.valueOf(value.toString()) : null;
+  }
+
+  private String buildKey(Long tenantId, String token) {
+    return "session:" + tenantId + ":" + token;
+  }
+}

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -13,6 +13,7 @@ firemud:
   auth:
     jwt-secret: changeit-changeit-changeit-changeit
     jwt-expiration-ms: 3600000
+    session-expiration-ms: 3600000
 
 management:
   endpoints:

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.entity.Account;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.service.session.SessionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -20,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 
 class AccountServiceImplTest {
   @Mock private AccountRepository accountRepository;
+  @Mock private SessionService sessionService;
 
   private AccountServiceImpl service;
 
@@ -28,7 +30,7 @@ class AccountServiceImplTest {
     MockitoAnnotations.openMocks(this);
     AccountMapper mapper = Mappers.getMapper(AccountMapper.class);
     JwtUtil jwtUtil = new JwtUtil("mysecretkey123456789012345678901", 3600000L);
-    service = new AccountServiceImpl(accountRepository, mapper, jwtUtil);
+    service = new AccountServiceImpl(accountRepository, mapper, jwtUtil, sessionService);
   }
 
   @Test
@@ -56,6 +58,7 @@ class AccountServiceImplTest {
     String token = service.authenticate(1L, "demo", "password");
 
     assertNotNull(token);
+    org.mockito.Mockito.verify(sessionService).storeSession(1L, 1L, token);
   }
 
   @Test

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
@@ -13,7 +13,6 @@ import net.firedevops.firemud.logic.event.EventDispatcher;
 import net.firedevops.firemud.logic.script.NoOpScriptingHook;
 import net.firedevops.firemud.logic.service.CommandServiceImpl;
 import net.firedevops.firemud.service.PingService;
-import net.firedevops.firemud.service.impl.PingServiceImpl;
 import org.junit.jupiter.api.Test;
 
 class GameLogicGrpcServiceTest {


### PR DESCRIPTION
## Summary
- add Redis-based session management service
- store session tokens on authentication
- expose session expiration property
- document new environment variables and session behavior
- include missing dependency

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f5a3d0414833092e5d01fbf7d143b