### PR TITLE
Implement Prometheus metrics for Entity Management

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -31,6 +31,7 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
   outlined in the [Security Architecture](../system-architecture-security.md).
 
 - Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+- Service methods are annotated with `@Timed` so inventory and character operations emit Prometheus metrics.
 
 ## Key Features
 
@@ -72,8 +73,8 @@ details on shared infrastructure components.
 ## Operational Notes
 
 - Runs as a scalable Deployment in Kubernetes, exposing `/actuator/health` for
-  readiness and liveness checks.
-- Prometheus scrapes service metrics while Fluent Bit ships logs to
+  readiness and liveness checks. Metrics are available at `/actuator/prometheus`.
+- Prometheus scrapes these metrics while Fluent Bit ships logs to
   Elasticsearch; tracing integrates with OpenTelemetry.
 - Local Docker Compose uses the same Spring profiles to mimic production, as
   documented in

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -61,3 +61,9 @@ timer:{tenantId}:{entityId}:{effectId}
 
 These keys coordinate tick execution and cooldown timers but contain no
 persistent data.
+
+## Metrics & Tracing
+
+Prometheus scrapes metrics from `/actuator/prometheus`. Service methods emit
+`@Timed` metrics and traces are exported to the collector configured in
+`application.yml`.

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/CharacterServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/CharacterServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.dto.CharacterDto;
 import net.firedevops.firemud.entity.Character;
@@ -22,6 +23,7 @@ public class CharacterServiceImpl implements CharacterService {
   @Override
   @Transactional(readOnly = true)
   @Cacheable(value = "characterGraph", key = "#characterId")
+  @Timed(value = "character.get")
   public CharacterDto getWithInventory(Long characterId) {
     Character character = characterRepository.findWithInventoryById(characterId).orElseThrow();
     return characterMapper.toDto(character);
@@ -29,6 +31,7 @@ public class CharacterServiceImpl implements CharacterService {
 
   @Override
   @Transactional
+  @Timed(value = "character.gainExperience")
   public CharacterDto gainExperience(Long characterId, int amount) {
     Character character = characterRepository.findById(characterId).orElseThrow();
     character.setExperience(character.getExperience() + amount);

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/InventoryServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/InventoryServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.dto.InventoryEntryDto;
@@ -24,6 +25,7 @@ public class InventoryServiceImpl implements InventoryService {
   private final ItemRepository itemRepository;
 
   @Override
+  @Timed(value = "inventory.list")
   public List<InventoryEntryDto> listInventory(Long characterId) {
     return repository.findAll().stream()
         .filter(e -> e.getId().getCharacterId().equals(characterId))
@@ -33,6 +35,7 @@ public class InventoryServiceImpl implements InventoryService {
 
   @Override
   @Transactional
+  @Timed(value = "inventory.add")
   public InventoryEntryDto addItem(Long characterId, Long itemId, int quantity) {
     InventoryKey key = new InventoryKey();
     key.setCharacterId(characterId);
@@ -55,6 +58,7 @@ public class InventoryServiceImpl implements InventoryService {
 
   @Override
   @Transactional
+  @Timed(value = "inventory.remove")
   public void removeItem(Long characterId, Long itemId) {
     InventoryKey key = new InventoryKey();
     key.setCharacterId(characterId);

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/PingServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/PingServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.service.PingService;
 import org.slf4j.Logger;
@@ -10,6 +11,7 @@ public class PingServiceImpl implements PingService {
   private static final Logger logger = LoggingUtil.getLogger(PingServiceImpl.class);
 
   @Override
+  @Timed(value = "service.ping")
   public String ping() {
     logger.info("Ping called");
     return "pong";

--- a/services/entity-management-service/src/main/resources/application.yml
+++ b/services/entity-management-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: "health,prometheus"
   endpoint:
     health:
       probes:

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PingController.class)
+class PingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PingService pingService;
+
+  @Test
+  void pingEndpointReturnsPong() throws Exception {
+    when(pingService.ping()).thenReturn("pong");
+
+    mockMvc
+        .perform(get("/ping"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data").value("pong"));
+  }
+}

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/EntityManagementGrpcServiceTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/EntityManagementGrpcServiceTest.java
@@ -1,0 +1,38 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.entitymanagement.v1.PingRequest;
+import net.firedevops.firemud.entitymanagement.v1.PingResponse;
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class EntityManagementGrpcServiceTest {
+  @Test
+  void pingReturnsPong() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenReturn("pong");
+    EntityManagementGrpcService service = new EntityManagementGrpcService(pingService);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("pong", ref.get().getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
- expose Prometheus endpoint in application.yml
- instrument service methods with Micrometer `@Timed`
- document metrics in design docs
- add Ping controller and gRPC unit tests

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f59ba6434833087286e9e5d4fc9cc