### PR TITLE
Implement CommandResult and controller tests

### DIFF
--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
     implementation("io.micrometer:micrometer-registry-prometheus:1.15.1")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     implementation(project(":common-library"))
 }
 

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/controller/CommandController.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/controller/CommandController.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.controller;
 
 import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.logic.dto.CommandResult;
 import net.firedevops.firemud.logic.service.CommandService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +21,10 @@ public class CommandController {
 
   @PostMapping
   public ResponseEntity<ApiResponse<String>> execute(@RequestBody String body) {
-    String result = commandService.handleCommand(body);
-    return ResponseEntity.ok(ApiResponse.success(result));
+    CommandResult result = commandService.handleCommand(body);
+    if (result.error() != null) {
+      return ResponseEntity.badRequest().body(ApiResponse.error(result.error()));
+    }
+    return ResponseEntity.ok(ApiResponse.success(result.result()));
   }
 }

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/CommandProcessor.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/CommandProcessor.java
@@ -1,6 +1,8 @@
 package net.firedevops.firemud.logic.command;
 
-/** Processes parsed commands and returns outcome text. */
+import net.firedevops.firemud.logic.dto.CommandResult;
+
+/** Processes parsed commands and returns a result object. */
 public interface CommandProcessor {
-  String process(Command command);
+  CommandResult process(Command command);
 }

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/SimpleCommandProcessor.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/SimpleCommandProcessor.java
@@ -1,6 +1,8 @@
 package net.firedevops.firemud.logic.command;
 
+import net.firedevops.firemud.common.ErrorDetail;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.logic.dto.CommandResult;
 import net.firedevops.firemud.logic.event.EventDispatcher;
 import net.firedevops.firemud.logic.event.GameEvent;
 import net.firedevops.firemud.logic.event.GameEventType;
@@ -22,7 +24,7 @@ public class SimpleCommandProcessor implements CommandProcessor {
   }
 
   @Override
-  public String process(Command command) {
+  public CommandResult process(Command command) {
     scriptingHook.execute(command);
     String result =
         switch (command.actionType()) {
@@ -34,6 +36,10 @@ public class SimpleCommandProcessor implements CommandProcessor {
         };
     logger.info("Processed action {} -> {}", command.actionType(), result);
     dispatcher.dispatch(new GameEvent(GameEventType.ACTION_EXECUTED, command, result));
-    return result;
+    if ("Unknown action".equals(result)) {
+      ErrorDetail error = new ErrorDetail("UNKNOWN_COMMAND", "Command not recognized");
+      return new CommandResult(result, error);
+    }
+    return new CommandResult(result, null);
   }
 }

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/dto/CommandResult.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/dto/CommandResult.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.logic.dto;
+
+import net.firedevops.firemud.common.ErrorDetail;
+
+/** Result of executing a command, optionally containing an error. */
+public record CommandResult(String result, ErrorDetail error) {}

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/service/CommandService.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/service/CommandService.java
@@ -1,5 +1,7 @@
 package net.firedevops.firemud.logic.service;
 
+import net.firedevops.firemud.logic.dto.CommandResult;
+
 public interface CommandService {
-  String handleCommand(String commandText);
+  CommandResult handleCommand(String commandText);
 }

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/service/CommandServiceImpl.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/service/CommandServiceImpl.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.logic.service;
 import net.firedevops.firemud.logic.command.Command;
 import net.firedevops.firemud.logic.command.CommandParser;
 import net.firedevops.firemud.logic.command.CommandProcessor;
+import net.firedevops.firemud.logic.dto.CommandResult;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,7 +17,7 @@ public class CommandServiceImpl implements CommandService {
   }
 
   @Override
-  public String handleCommand(String commandText) {
+  public CommandResult handleCommand(String commandText) {
     Command cmd = parser.parse(commandText);
     return processor.process(cmd);
   }

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
@@ -6,8 +6,10 @@ import net.firedevops.firemud.gamelogic.v1.ExecuteCommandResponse;
 import net.firedevops.firemud.gamelogic.v1.GameLogicServiceGrpc;
 import net.firedevops.firemud.gamelogic.v1.PingRequest;
 import net.firedevops.firemud.gamelogic.v1.PingResponse;
+import net.firedevops.firemud.logic.dto.CommandResult;
 import net.firedevops.firemud.logic.service.CommandService;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC endpoints for the Game Logic Service. */
@@ -31,9 +33,17 @@ public class GameLogicGrpcService extends GameLogicServiceGrpc.GameLogicServiceI
   @Override
   public void executeCommand(
       ExecuteCommandRequest request, StreamObserver<ExecuteCommandResponse> responseObserver) {
-    String result = commandService.handleCommand(request.getCommand());
-    ExecuteCommandResponse response = ExecuteCommandResponse.newBuilder().setResult(result).build();
-    responseObserver.onNext(response);
+    CommandResult result = commandService.handleCommand(request.getCommand());
+    ExecuteCommandResponse.Builder builder =
+        ExecuteCommandResponse.newBuilder().setResult(result.result());
+    if (result.error() != null) {
+      builder.setError(
+          ErrorDetail.newBuilder()
+              .setCode(result.error().code())
+              .setMessage(result.error().message())
+              .build());
+    }
+    responseObserver.onNext(builder.build());
     responseObserver.onCompleted();
   }
 }

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/controller/CommandControllerTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/controller/CommandControllerTest.java
@@ -1,0 +1,51 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.firedevops.firemud.logic.dto.CommandResult;
+import net.firedevops.firemud.logic.service.CommandService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CommandController.class)
+class CommandControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private CommandService commandService;
+
+  @Test
+  void executeReturnsResult() throws Exception {
+    when(commandService.handleCommand("north"))
+        .thenReturn(new CommandResult("You move north", null));
+
+    mockMvc
+        .perform(post("/command").contentType(MediaType.TEXT_PLAIN).content("north"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data").value("You move north"));
+  }
+
+  @Test
+  void executeReturnsError() throws Exception {
+    CommandResult errorResult =
+        new CommandResult(
+            "Unknown action",
+            new net.firedevops.firemud.common.ErrorDetail(
+                "UNKNOWN_COMMAND", "Command not recognized"));
+    when(commandService.handleCommand("foo")).thenReturn(errorResult);
+
+    mockMvc
+        .perform(post("/command").contentType(MediaType.TEXT_PLAIN).content("foo"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status").value("ERROR"))
+        .andExpect(jsonPath("$.error.code").value("UNKNOWN_COMMAND"));
+  }
+}

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PingController.class)
+class PingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PingService pingService;
+
+  @Test
+  void pingEndpointReturnsPong() throws Exception {
+    when(pingService.ping()).thenReturn("pong");
+
+    mockMvc
+        .perform(get("/ping"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data").value("pong"));
+  }
+}

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/logic/service/CommandServiceImplTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/logic/service/CommandServiceImplTest.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.logic.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import net.firedevops.firemud.logic.command.*;
+import net.firedevops.firemud.logic.dto.CommandResult;
 import net.firedevops.firemud.logic.event.EventDispatcher;
 import net.firedevops.firemud.logic.script.NoOpScriptingHook;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +22,7 @@ class CommandServiceImplTest {
 
   @Test
   void processesMoveCommand() {
-    String result = service.handleCommand("north");
-    assertEquals("You move north", result);
+    CommandResult result = service.handleCommand("north");
+    assertEquals("You move north", result.result());
   }
 }


### PR DESCRIPTION
## Summary
- support error handling in Game Logic Service commands
- expose errors through gRPC and REST
- add Ping and Command controller unit tests
- generate OpenAPI docs with springdoc

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f57c18dd08330bb66f91f6afb97c6