### PR TITLE
Remove S3 asset storage support

### DIFF
--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -16,7 +16,7 @@
   - [x] Track version history and patch notes for published games
   - [ ] Build a web-based visual design interface
   - [ ] Integrate version control for design assets
-  - [ ] Configure S3-compatible object storage for game assets
+  - [ ] Configure database storage for game assets
     - Provide asset upload API in Game Design Service
     - Document asset storage setup and configuration
 - [ ] **Expand Scripting & Modding**

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
@@ -13,7 +13,6 @@ import net.firedevops.firemud.logic.event.EventDispatcher;
 import net.firedevops.firemud.logic.script.NoOpScriptingHook;
 import net.firedevops.firemud.logic.service.CommandServiceImpl;
 import net.firedevops.firemud.service.PingService;
-import net.firedevops.firemud.service.impl.PingServiceImpl;
 import org.junit.jupiter.api.Test;
 
 class GameLogicGrpcServiceTest {


### PR DESCRIPTION
## Summary
- revert object storage design and implementation
- drop S3 environment variables and documentation
- uncheck and reword tasks to reflect DB asset storage

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f586417088330a4f66beefb69815f