### PR TITLE
Apply common config to Social Groups Service

### DIFF
--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -66,9 +66,9 @@ participate in CI.
 ## 📚 Shared Library Integration
 
 - [x] Depend on `firemud-common` via Gradle
-- [ ] Apply logging, tracing, and security interceptors from the library
-- [ ] Use provided autoconfiguration classes to reduce boilerplate
-- [ ] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
+- [x] Apply logging, tracing, and security interceptors from the library
+- [x] Use provided autoconfiguration classes to reduce boilerplate
+- [x] Reuse `DatabaseAutoConfiguration` and `RedisProperties` for environment setup
 
 ---
 
@@ -94,7 +94,7 @@ participate in CI.
 
 ## 🧪 Testing & Quality Gates
 
-- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [ ] Use Spring Boot Test and Testcontainers for integration tests
 - [ ] Validate contracts with smoke tests (gRPC and REST)
 - [ ] Seed minimal test data for local workflows
@@ -105,11 +105,11 @@ participate in CI.
 
 ## 📈 Observability & Tracing
 
-- [ ] Use Micrometer for Prometheus metrics
-- [ ] Enable OpenTelemetry tracing
-- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [x] Use Micrometer for Prometheus metrics
+- [x] Enable OpenTelemetry tracing
+- [x] Use shared interceptors to propagate `traceId` and `correlationId`
 - [ ] Emit service metrics for ticks and Redis commands when relevant
-- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+- [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---
 

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
@@ -13,7 +13,6 @@ import net.firedevops.firemud.logic.event.EventDispatcher;
 import net.firedevops.firemud.logic.script.NoOpScriptingHook;
 import net.firedevops.firemud.logic.service.CommandServiceImpl;
 import net.firedevops.firemud.service.PingService;
-import net.firedevops.firemud.service.impl.PingServiceImpl;
 import org.junit.jupiter.api.Test;
 
 class GameLogicGrpcServiceTest {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/SocialGroupsServiceApplication.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/SocialGroupsServiceApplication.java
@@ -1,9 +1,13 @@
 package net.firedevops.firemud;
 
+import net.firedevops.firemud.common.config.CommonAutoConfiguration;
+import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class})
 public class SocialGroupsServiceApplication {
   public static void main(String[] args) {
     SpringApplication.run(SocialGroupsServiceApplication.class, args);

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -1,7 +1,12 @@
 package net.firedevops.firemud.config;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
@@ -28,5 +33,19 @@ public class GrpcConfig {
   @GRpcGlobalInterceptor
   public TracingInterceptor tracingInterceptor(Tracer tracer) {
     return new TracingInterceptor(tracer);
+  }
+
+  @Bean
+  public OpenTelemetry openTelemetry() {
+    OtlpGrpcSpanExporter exporter =
+        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+    SdkTracerProvider provider =
+        SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
+    return OpenTelemetrySdk.builder().setTracerProvider(provider).build();
+  }
+
+  @Bean
+  public Tracer tracer(OpenTelemetry openTelemetry) {
+    return openTelemetry.getTracer("social-groups-service");
   }
 }


### PR DESCRIPTION
## Summary
- use `DatabaseAutoConfiguration` and `CommonAutoConfiguration` in the social groups service
- enable OpenTelemetry in `GrpcConfig`
- update social groups task list
- spotless formatting fixes

## Testing
- `./gradlew spotlessApply lintMarkdownFix --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686f66d7ef048330b8705b724459caa6