### PR TITLE
Add OpenAPI spec for Automation & Scripting Service

### DIFF
--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -3,6 +3,7 @@
 Refer to [design/README.md](design/README.md) for architecture details.
 
 - **Proto definitions**: [../../protos/automation-scripting/v1](../../protos/automation-scripting/v1) (uses shared `ErrorDetail`)
+- **OpenAPI spec**: [src/main/resources/openapi.yaml](src/main/resources/openapi.yaml)
 
 ## Running Locally
 

--- a/services/automation-scripting-service/design/README.md
+++ b/services/automation-scripting-service/design/README.md
@@ -5,6 +5,7 @@ The design for this service is located here:
 [📄 Central Architecture: Automation Scripting Service Design](../../../design/architecture/microservices/automation-scripting-service/README.md)
 
 This stub exists to make the design easy to find from the service source tree.
+An OpenAPI specification is available at `src/main/resources/openapi.yaml`.
 
 ## Configuration
 

--- a/services/automation-scripting-service/src/main/resources/openapi.yaml
+++ b/services/automation-scripting-service/src/main/resources/openapi.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.3
+info:
+  title: Automation Scripting Service API
+  description: API for NPC automation and script management
+  version: 1.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: https://api.firemud.com
+security: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    ScriptDefinitionDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        name:
+          type: string
+        version:
+          type: string
+        definition:
+          type: string
+    CreateScriptRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        name:
+          type: string
+        version:
+          type: string
+        definition:
+          type: string
+      required:
+        - tenantId
+        - name
+        - version
+        - definition
+paths:
+  /ping:
+    get:
+      summary: Health check endpoint
+      operationId: ping
+      responses:
+        '200':
+          description: Pong response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+                    example: pong


### PR DESCRIPTION
## Summary
- document REST endpoints for Automation & Scripting Service
- add `openapi.yaml`
- mention spec in both service README and design doc

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f6b1e114883309677eb8388f2e26d