### PR TITLE
Implement login endpoint in account service

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -2,7 +2,7 @@
 
 - [ ] **Develop Account Service**
   - [ ] Implement user registration and authentication (OAuth2, JWT)
-  - [ ] Implement session management and persistent logins
+  - [x] Implement session management and persistent logins
   - [ ] Implement role-based access control (RBAC) for admins, moderators, and players
   - [ ] Enable external account linking (Google, Discord, Steam)
   - [ ] Implement profile system with achievements, game history, and social features

--- a/services/account-service/README.md
+++ b/services/account-service/README.md
@@ -19,6 +19,27 @@ Or start all services:
 ./gradlew devUp
 ```
 
+## REST Authentication Endpoint
+
+Request a JWT token using the `/auth/login` route:
+
+```bash
+curl -X POST http://localhost:8080/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"username":"demo","password":"secret"}'
+```
+
+Sample response:
+
+```json
+{
+  "status": "SUCCESS",
+  "data": {
+    "authToken": "<token>"
+  }
+}
+```
+
 ## Environment Variables
 
 The service relies on standard Spring Boot properties for database and Redis

--- a/services/account-service/design/README.md
+++ b/services/account-service/design/README.md
@@ -25,9 +25,10 @@ Authentication returns a JWT token which is stored in Redis for quick reconnects
 
 - `GET /ping` – basic health check returning `"pong"`.
 - `POST /accounts` – create a new account and profile.
+- `POST /auth/login` – authenticate and return a JWT token.
 - `GET /.well-known/jwks.json` – JWKS for verifying issued JWT tokens.
 
-Example request:
+Example account creation request:
 
 ```bash
 curl -X POST http://localhost:8080/accounts \
@@ -43,6 +44,25 @@ Example response:
   "tenantId": 1,
   "username": "demo",
   "email": "demo@example.com"
+}
+```
+
+Example login request:
+
+```bash
+curl -X POST http://localhost:8080/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"username":"demo","password":"secret"}'
+```
+
+Example login response:
+
+```json
+{
+  "status": "SUCCESS",
+  "data": {
+    "authToken": "<token>"
+  }
 }
 ```
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AuthTokenDto;
+import net.firedevops.firemud.dto.LoginRequest;
+import net.firedevops.firemud.service.AccountService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+  private final AccountService accountService;
+
+  public AuthController(AccountService accountService) {
+    this.accountService = accountService;
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<ApiResponse<AuthTokenDto>> login(@Valid @RequestBody LoginRequest request) {
+    String token =
+        accountService.authenticate(request.tenantId(), request.username(), request.password());
+    return ResponseEntity.ok(ApiResponse.success(new AuthTokenDto(token)));
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/AuthTokenDto.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/AuthTokenDto.java
@@ -1,0 +1,3 @@
+package net.firedevops.firemud.dto;
+
+public record AuthTokenDto(String authToken) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/LoginRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record LoginRequest(
+    @NotNull Long tenantId,
+    @NotNull @Size(max = 50) String username,
+    @NotNull @Size(min = 6, max = 100) String password) {}

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.dto.LoginRequest;
+import net.firedevops.firemud.service.AccountService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockitoBean private AccountService accountService;
+
+  @Test
+  void loginReturnsToken() throws Exception {
+    LoginRequest request = new LoginRequest(1L, "demo", "password");
+    when(accountService.authenticate(1L, "demo", "password")).thenReturn("tok123");
+
+    mockMvc
+        .perform(
+            post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data.authToken").value("tok123"));
+  }
+}


### PR DESCRIPTION
## Summary
- add REST login endpoint with AuthController and DTOs
- document the new endpoint in service README and design docs
- update task list to mark session management complete
- test login controller

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_686f6ad403ec83308a5e5a1cd2b4cc3a