### PR TITLE
Add metrics filter to gateway

### DIFF
--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -74,6 +74,7 @@ details on shared infrastructure components.
 - `/actuator/health` endpoints are used for readiness and liveness probes.
 - Prometheus scrapes metrics such as connection counts while Fluent Bit forwards
   structured logs to Elasticsearch; tracing integrates with OpenTelemetry.
+- Metrics are published as `gateway.connections.total` and `gateway.connections.active` for Prometheus.
 - [Deployment Environments](../../infrastructure/deployment-environments.md)
   explains how routes and certificates differ between Docker Compose and
   production clusters.

--- a/services/spring-cloud-gateway/README.md
+++ b/services/spring-cloud-gateway/README.md
@@ -45,3 +45,12 @@ several backends:
 
 All game data remains isolated by tenant; the gateway simply passes the
 identifier to downstream services.
+
+## Metrics
+
+The gateway exposes Prometheus metrics for monitoring connection load. Counters and gauges include:
+
+- `gateway.connections.total` – total number of HTTP/WebSocket requests handled
+- `gateway.connections.active` – active in-flight connections
+
+Metrics are available at `/actuator/prometheus` and scraped automatically in Docker Compose and Kubernetes environments.

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/ConnectionMetricsFilter.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/ConnectionMetricsFilter.java
@@ -1,0 +1,38 @@
+package net.firedevops.firemud.filter;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/** Tracks connection metrics for monitoring purposes. */
+@Component
+public class ConnectionMetricsFilter implements WebFilter, Ordered {
+
+  private final AtomicInteger activeConnections = new AtomicInteger();
+  private final Counter connectionCounter;
+
+  public ConnectionMetricsFilter(MeterRegistry meterRegistry) {
+    this.connectionCounter = meterRegistry.counter("gateway.connections.total");
+    Gauge.builder("gateway.connections.active", activeConnections, AtomicInteger::get)
+        .register(meterRegistry);
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    connectionCounter.increment();
+    activeConnections.incrementAndGet();
+    return chain.filter(exchange).doFinally(signalType -> activeConnections.decrementAndGet());
+  }
+
+  @Override
+  public int getOrder() {
+    return -2;
+  }
+}

--- a/services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/ConnectionMetricsFilterTest.java
+++ b/services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/ConnectionMetricsFilterTest.java
@@ -1,0 +1,25 @@
+package net.firedevops.firemud.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import reactor.core.publisher.Mono;
+
+class ConnectionMetricsFilterTest {
+
+  @Test
+  void incrementsConnectionMetrics() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    ConnectionMetricsFilter filter = new ConnectionMetricsFilter(registry);
+
+    MockServerWebExchange exchange =
+        MockServerWebExchange.from(MockServerHttpRequest.get("/test").build());
+    filter.filter(exchange, e -> Mono.empty()).block();
+
+    assertEquals(1.0, registry.get("gateway.connections.total").counter().count(), 0.001);
+    assertEquals(0.0, registry.get("gateway.connections.active").gauge().value(), 0.001);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ConnectionMetricsFilter` to track connection counts
- document exported metrics in the gateway docs
- add unit tests for the filter

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_686f6d159c64833080f29b428937ebc7