### PR TITLE
Add mail feature to Social Groups Service

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -32,6 +32,7 @@ Provides chat, guild, and social networking features across games. Enables playe
 
 - Global and guild chat rooms.
 - Private messaging and presence indicators.
+- Asynchronous player-to-player mail.
 - Guild creation and membership management.
 - Friend lists scoped both to individual games and to overall accounts.
 - Cross-game presence lets players know when friends are online in any hosted
@@ -43,6 +44,7 @@ Provides chat, guild, and social networking features across games. Enables playe
 - `chat_message` table persists guild and private messages.
 - `guild` and `guild_member` tables store group ownership and membership roles.
 - `friend_link` table tracks account or character friendships and blocks.
+- `mail_message` table stores asynchronous player mail.
 
 ### Chat Pipeline
 
@@ -56,6 +58,7 @@ Provides chat, guild, and social networking features across games. Enables playe
 - `SendAccountMessage` – delivers a direct message between account holders.
 - `CreateGuild` – establishes a new guild with an owner account.
 - `AddFriend` – adds a friend relationship at the game or account level.
+- `SendMail` – stores asynchronous player mail for later retrieval.
 
 ## Dependencies
 

--- a/protos/social-groups/v1/social_groups_service.proto
+++ b/protos/social-groups/v1/social_groups_service.proto
@@ -11,6 +11,7 @@ service SocialGroupsService {
   rpc SendMessage(SendMessageRequest) returns (SendMessageResponse);
   rpc CreateGuild(CreateGuildRequest) returns (CreateGuildResponse);
   rpc AddFriend(AddFriendRequest) returns (AddFriendResponse);
+  rpc SendMail(SendMailRequest) returns (SendMailResponse);
 }
 
 message PingRequest {}
@@ -50,6 +51,19 @@ message AddFriendRequest {
 }
 
 message AddFriendResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message SendMailRequest {
+  string tenant_id = 1;
+  string sender_account_id = 2;
+  string recipient_account_id = 3;
+  string subject = 4;
+  string content = 5;
+}
+
+message SendMailResponse {
   bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/social-groups-service/design/README.md
+++ b/services/social-groups-service/design/README.md
@@ -25,6 +25,14 @@ curl -X POST http://localhost:8080/friends \
   -d '{"tenantId":1,"accountId":100,"friendAccountId":200}'
 ```
 
+- `POST /mail` – send an asynchronous in-game mail message.
+
+```bash
+curl -X POST http://localhost:8080/mail \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"senderAccountId":100,"recipientAccountId":200,"subject":"Hi","content":"Hello"}'
+```
+
 ### gRPC
 
 - `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`social_groups_service.proto`](../../../protos/social-groups/v1/social_groups_service.proto).

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/MailController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/MailController.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.MailMessageDto;
+import net.firedevops.firemud.dto.SendMailRequest;
+import net.firedevops.firemud.service.MailService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mail")
+public class MailController {
+  private final MailService mailService;
+
+  public MailController(MailService mailService) {
+    this.mailService = mailService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<MailMessageDto>> sendMail(
+      @Valid @RequestBody SendMailRequest request) {
+    MailMessageDto dto = mailService.sendMail(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/MailMessageDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/MailMessageDto.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.dto;
+
+import java.time.Instant;
+
+public record MailMessageDto(
+    Long id,
+    Long tenantId,
+    Long senderAccountId,
+    Long recipientAccountId,
+    String subject,
+    String content,
+    Instant sentAt,
+    Instant readAt) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/SendMailRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/SendMailRequest.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SendMailRequest(
+    @NotNull Long tenantId,
+    @NotNull Long senderAccountId,
+    @NotNull Long recipientAccountId,
+    @NotBlank String subject,
+    @NotBlank String content) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/MailMessage.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/MailMessage.java
@@ -1,0 +1,34 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "mail_messages")
+public class MailMessage {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false)
+  private Long senderAccountId;
+
+  @Column(nullable = false)
+  private Long recipientAccountId;
+
+  @Column(nullable = false, length = 100)
+  private String subject;
+
+  @Column(nullable = false, length = 1000)
+  private String content;
+
+  @Column(nullable = false)
+  private Instant sentAt;
+
+  @Column private Instant readAt;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/MailMessageMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/MailMessageMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.MailMessageDto;
+import net.firedevops.firemud.entity.MailMessage;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface MailMessageMapper {
+  MailMessageDto toDto(MailMessage entity);
+
+  MailMessage toEntity(MailMessageDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/MailMessageRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/MailMessageRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.MailMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MailMessageRepository extends JpaRepository<MailMessage, Long> {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/MailService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/MailService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.MailMessageDto;
+import net.firedevops.firemud.dto.SendMailRequest;
+
+public interface MailService {
+  MailMessageDto sendMail(SendMailRequest request);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/MailServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/MailServiceImpl.java
@@ -1,0 +1,37 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.MailMessageDto;
+import net.firedevops.firemud.dto.SendMailRequest;
+import net.firedevops.firemud.entity.MailMessage;
+import net.firedevops.firemud.mapper.MailMessageMapper;
+import net.firedevops.firemud.repository.MailMessageRepository;
+import net.firedevops.firemud.service.MailService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MailServiceImpl implements MailService {
+  private static final Logger logger = LoggingUtil.getLogger(MailServiceImpl.class);
+
+  private final MailMessageRepository mailRepository;
+  private final MailMessageMapper mapper;
+
+  @Override
+  @Transactional
+  public MailMessageDto sendMail(SendMailRequest request) {
+    logger.info("Mail from {} to {}", request.senderAccountId(), request.recipientAccountId());
+    MailMessage msg = new MailMessage();
+    msg.setTenantId(request.tenantId());
+    msg.setSenderAccountId(request.senderAccountId());
+    msg.setRecipientAccountId(request.recipientAccountId());
+    msg.setSubject(request.subject());
+    msg.setContent(request.content());
+    msg.setSentAt(Instant.now());
+    return mapper.toDto(mailRepository.save(msg));
+  }
+}

--- a/services/social-groups-service/src/main/resources/db/migration/V2__mail.sql
+++ b/services/social-groups-service/src/main/resources/db/migration/V2__mail.sql
@@ -1,0 +1,10 @@
+CREATE TABLE mail_messages (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    sender_account_id BIGINT NOT NULL,
+    recipient_account_id BIGINT NOT NULL,
+    subject VARCHAR(100) NOT NULL,
+    content TEXT NOT NULL,
+    sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    read_at TIMESTAMP
+);

--- a/services/social-groups-service/src/main/resources/openapi.yaml
+++ b/services/social-groups-service/src/main/resources/openapi.yaml
@@ -45,6 +45,46 @@ components:
         createdAt:
           type: string
           format: date-time
+    SendMailRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        senderAccountId:
+          type: integer
+        recipientAccountId:
+          type: integer
+        subject:
+          type: string
+        content:
+          type: string
+      required:
+        - tenantId
+        - senderAccountId
+        - recipientAccountId
+        - subject
+        - content
+    MailMessageDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        senderAccountId:
+          type: integer
+        recipientAccountId:
+          type: integer
+        subject:
+          type: string
+        content:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
+        readAt:
+          type: string
+          format: date-time
 paths:
   /ping:
     get:
@@ -83,3 +123,23 @@ paths:
                     $ref: '#/components/schemas/FriendLinkDto'
         '400':
           description: Invalid request
+  /mail:
+    post:
+      summary: Send in-game mail
+      operationId: sendMail
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendMailRequest'
+      responses:
+        '200':
+          description: Mail sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/MailMessageDto'

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/MailControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/MailControllerTest.java
@@ -1,0 +1,41 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.dto.MailMessageDto;
+import net.firedevops.firemud.dto.SendMailRequest;
+import net.firedevops.firemud.service.MailService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MailController.class)
+class MailControllerTest {
+  @Autowired private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @MockitoBean private MailService mailService;
+
+  @Test
+  void sendMailReturnsDto() throws Exception {
+    SendMailRequest request = new SendMailRequest(1L, 2L, 3L, "hello", "test body");
+    MailMessageDto response = new MailMessageDto(1L, 1L, 2L, 3L, "hello", "test body", null, null);
+    when(mailService.sendMail(request)).thenReturn(response);
+
+    mockMvc
+        .perform(
+            post("/mail")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data.subject").value("hello"));
+  }
+}

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/MailServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/MailServiceImplTest.java
@@ -1,0 +1,46 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import net.firedevops.firemud.dto.MailMessageDto;
+import net.firedevops.firemud.dto.SendMailRequest;
+import net.firedevops.firemud.entity.MailMessage;
+import net.firedevops.firemud.mapper.MailMessageMapper;
+import net.firedevops.firemud.repository.MailMessageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mockito;
+
+class MailServiceImplTest {
+  private MailMessageRepository repository;
+  private MailServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    repository = Mockito.mock(MailMessageRepository.class);
+    MailMessageMapper mapper = Mappers.getMapper(MailMessageMapper.class);
+    service = new MailServiceImpl(repository, mapper);
+  }
+
+  @Test
+  void sendMailReturnsDto() {
+    SendMailRequest request = new SendMailRequest(1L, 2L, 3L, "hello", "body");
+    MailMessage saved = new MailMessage();
+    saved.setId(1L);
+    saved.setTenantId(1L);
+    saved.setSenderAccountId(2L);
+    saved.setRecipientAccountId(3L);
+    saved.setSubject("hello");
+    saved.setContent("body");
+    saved.setSentAt(Instant.now());
+    when(repository.save(any(MailMessage.class))).thenReturn(saved);
+
+    MailMessageDto result = service.sendMail(request);
+    assertEquals("hello", result.subject());
+    assertEquals(3L, result.recipientAccountId());
+  }
+}


### PR DESCRIPTION
## Summary
- implement player mail: new MailMessage entity, repository, mapper and service
- expose POST /mail endpoint and document usage
- extend proto with SendMail RPC
- add database migration for mail_messages table
- update design docs to reflect mail functionality
- add unit tests for controller and service

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f6d24819c8330824db201c11967d6