### PR TITLE
Improve logging admin observability

### DIFF
--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -98,7 +98,7 @@ participate in CI.
 
 ## 🧪 Testing & Quality Gates
 
-- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [ ] Use Spring Boot Test and Testcontainers for integration tests
 - [ ] Validate contracts with smoke tests (gRPC and REST)
 - [ ] Seed minimal test data for local workflows
@@ -109,11 +109,11 @@ participate in CI.
 
 ## 📈 Observability & Tracing
 
-- [ ] Use Micrometer for Prometheus metrics
-- [ ] Enable OpenTelemetry tracing
-- [ ] Use shared interceptors to propagate `traceId` and `correlationId`
+- [x] Use Micrometer for Prometheus metrics
+- [x] Enable OpenTelemetry tracing
+- [x] Use shared interceptors to propagate `traceId` and `correlationId`
 - [ ] Emit service metrics for ticks and Redis commands when relevant
-- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+- [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---
 

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -16,6 +16,12 @@ To run the entire stack:
 ./gradlew devUp
 ```
 
+### Observability
+
+Metrics are available at `http://localhost:8080/actuator/prometheus` and
+OpenTelemetry traces are exported to the collector defined in
+[`GrpcConfig`](src/main/java/net/firedevops/firemud/config/GrpcConfig.java).
+
 ## Environment Variables
 
 The service relies on standard Spring Boot properties for PostgreSQL and Redis connections.

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/FeatureFlagController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/FeatureFlagController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.FeatureFlagDto;
@@ -21,6 +22,7 @@ public class FeatureFlagController {
   }
 
   @PostMapping("/toggle")
+  @Timed(value = "featureFlagToggle", description = "Toggle a runtime feature flag")
   public ResponseEntity<ApiResponse<FeatureFlagDto>> toggle(
       @Valid @RequestBody ToggleFeatureFlagRequest request) {
     FeatureFlagDto dto = service.toggleFlag(request);

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/PingController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/PingController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.service.PingService;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ public class PingController {
   }
 
   @GetMapping
+  @Timed(value = "ping", description = "Time spent responding to ping requests")
   public ResponseEntity<ApiResponse<String>> ping() {
     String result = pingService.ping();
     return ResponseEntity.ok(ApiResponse.success(result));

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/ReportController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/ReportController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.CreateReportRequest;
@@ -21,6 +22,7 @@ public class ReportController {
   }
 
   @PostMapping
+  @Timed(value = "createReport", description = "Create a player report")
   public ResponseEntity<ApiResponse<ReportDto>> createReport(
       @Valid @RequestBody CreateReportRequest request) {
     ReportDto dto = reportService.createReport(request);

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/SagaDashboardController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/SagaDashboardController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.SagaInstanceDto;
@@ -21,11 +22,13 @@ public class SagaDashboardController {
   }
 
   @GetMapping
+  @Timed(value = "listSagas", description = "List saga instances")
   public ResponseEntity<ApiResponse<List<SagaInstanceDto>>> listInstances() {
     return ResponseEntity.ok(ApiResponse.success(sagaDashboardService.listInstances()));
   }
 
   @GetMapping("/{id}/steps")
+  @Timed(value = "listSagaSteps", description = "List saga steps for instance")
   public ResponseEntity<ApiResponse<List<SagaStepDto>>> listSteps(@PathVariable Long id) {
     return ResponseEntity.ok(ApiResponse.success(sagaDashboardService.listSteps(id)));
   }

--- a/services/logging-admin-service/src/main/resources/application.yml
+++ b/services/logging-admin-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       probes:


### PR DESCRIPTION
## Summary
- expose Prometheus metrics endpoint
- annotate controllers with `@Timed` for Micrometer metrics
- document observability in the logging admin README
- check off completed items in the logging admin task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f6c6a81408330ae858ca9839627b0