### PR TITLE
Update AI guidelines for tests and telemetry

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -48,6 +48,7 @@ Testing:
 - Unit: JUnit, Mockito
 - Integration: Spring Test
 - Load: Gatling
+- New features must include unit tests and, where applicable, integration tests.
 
 Monetization:
 
@@ -128,4 +129,5 @@ Monetization:
 - Prioritize security, validation, scalability.
 - Maintain clean project structure.
 - Use `@Timed` for Prometheus metrics.
+- Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
 - Avoid returning nulls; use transactions for DB consistency.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,4 @@ These files describe style, architecture, and best practices for Java/Spring pro
 - Unit tests run via `./gradlew test` and are executed in CI through the `check` task.
 - Code quality tools (Checkstyle and SpotBugs) run during the `check` task, and JaCoCo produces coverage reports.
 - CI also performs a Trivy security scan.
+- When adding new features, include JUnit tests and instrument metrics and tracing as described in `design/architecture/system-architecture-logging-monitoring.md`.

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -48,6 +48,7 @@ Testing:
 - Unit: JUnit, Mockito
 - Integration: Spring Test
 - Load: Gatling
+- New features must include unit tests and, where applicable, integration tests.
 
 Monetization:
 
@@ -128,4 +129,5 @@ Monetization:
 - Prioritize security, validation, scalability.
 - Maintain clean project structure.
 - Use `@Timed` for Prometheus metrics.
+- Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
 - Avoid returning nulls; use transactions for DB consistency.


### PR DESCRIPTION
## Summary
- clarify the AGENTS guide to mention adding tests and instrumentation when implementing new features
- instruct in the AI rules that new code needs unit/integration tests
- ensure the AI rules mention Micrometer and OpenTelemetry instrumentation

## Testing
- `./gradlew spotlessApply lintMarkdownFix test`

------
https://chatgpt.com/codex/tasks/task_e_686f709f889c8330ae1c7f509d25da31