### PR TITLE
Update TCP Proxy docs

### DIFF
--- a/design/project-management/task-list-tcp-proxy-service.md
+++ b/design/project-management/task-list-tcp-proxy-service.md
@@ -7,8 +7,8 @@
   - [x] Buffer Telnet input and discard on disconnect to support reconnection
   - [x] Initialize `TcpProxyServiceApplication` with Netty server (implement connection pipeline)
   - [ ] Enforce Telnet protocol command whitelist and input sanitization
-  - [ ] Implement connection throttling and rate limits
-  - [ ] Support TLS termination for secure Telnet clients
+  - [x] Implement connection throttling and rate limits
+  - [x] Support TLS termination for secure Telnet clients
 
 ## Reusable Microservice Checklist
 
@@ -39,8 +39,8 @@ participate in CI.
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
-- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
-- [ ] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
+- [x] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [x] *(N/A - stateless service)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
 
 ---
 
@@ -93,10 +93,10 @@ participate in CI.
 
 ## 🧪 Testing & Quality Gates
 
-- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [ ] Use Spring Boot Test and Testcontainers for integration tests
 - [ ] Validate contracts with smoke tests (gRPC and REST)
-- [ ] Seed minimal test data for local workflows
+- [x] *(N/A - stateless service)* Seed minimal test data for local workflows
 - [x] Run `./gradlew check` in CI to execute all tests
 - [ ] *(When workflows span services)* add cross-service integration tests
 

--- a/services/tcp-proxy-service/README.md
+++ b/services/tcp-proxy-service/README.md
@@ -5,6 +5,7 @@ Refer to [design/README.md](design/README.md) for architecture details.
 - **Proto definitions**: [../../protos/tcp-proxy/v1](../../protos/tcp-proxy/v1)
   include events used to notify the Game Session Service when clients disconnect
   and to push buffered commands after a reconnect.
+- **OpenAPI spec**: [src/main/resources/openapi.yaml](src/main/resources/openapi.yaml)
 
 ## Running Locally
 

--- a/services/tcp-proxy-service/src/main/resources/openapi.yaml
+++ b/services/tcp-proxy-service/src/main/resources/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: TCP Proxy Service API
+  description: Health endpoint for the TCP Proxy Service
+  version: 1.0.0
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: https://api.firemud.com
+security: []
+paths:
+  /ping:
+    get:
+      summary: Health check endpoint
+      operationId: ping
+      responses:
+        '200':
+          description: Pong response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
+                    example: pong


### PR DESCRIPTION
## Summary
- mark completed TCP Proxy tasks
- document OpenAPI spec in service README
- add OpenAPI spec file for the TCP Proxy service

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f71283ce483308a40676d7840c581