### PR TITLE
Account service grpc error handling

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -34,17 +34,29 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
   @Override
   public void createAccount(
       CreateAccountRequest request, StreamObserver<CreateAccountResponse> responseObserver) {
-    net.firedevops.firemud.dto.CreateAccountRequest dto =
-        new net.firedevops.firemud.dto.CreateAccountRequest(
-            Long.valueOf(request.getTenantId()),
-            request.getUsername(),
-            request.getEmail(),
-            request.getPassword());
-    var account = accountService.createAccount(dto);
-    CreateAccountResponse response =
-        CreateAccountResponse.newBuilder().setAccountId(account.id().toString()).build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      net.firedevops.firemud.dto.CreateAccountRequest dto =
+          new net.firedevops.firemud.dto.CreateAccountRequest(
+              Long.valueOf(request.getTenantId()),
+              request.getUsername(),
+              request.getEmail(),
+              request.getPassword());
+      var account = accountService.createAccount(dto);
+      CreateAccountResponse response =
+          CreateAccountResponse.newBuilder().setAccountId(account.id().toString()).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      responseObserver.onNext(
+          CreateAccountResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build());
+      responseObserver.onCompleted();
+    }
   }
 
   @Override

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationGrpcService.java
@@ -18,13 +18,18 @@ public class NotificationGrpcService extends NotificationServiceGrpc.Notificatio
   @Override
   public void sendNotification(
       SendNotificationRequest request, StreamObserver<SendNotificationResponse> responseObserver) {
-    notificationService.sendNotification(
-        Long.valueOf(request.getTenantId()),
-        Long.valueOf(request.getAccountId()),
-        request.getMessage());
-    SendNotificationResponse response =
-        SendNotificationResponse.newBuilder().setSuccess(true).build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      notificationService.sendNotification(
+          Long.valueOf(request.getTenantId()),
+          Long.valueOf(request.getAccountId()),
+          request.getMessage());
+      SendNotificationResponse response =
+          SendNotificationResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      responseObserver.onError(
+          io.grpc.Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+    }
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
@@ -23,32 +23,42 @@ public class PaymentGrpcService extends PaymentServiceGrpc.PaymentServiceImplBas
   public void createPaymentIntent(
       CreatePaymentIntentRequest request,
       StreamObserver<CreatePaymentIntentResponse> responseObserver) {
-    PaymentIntentDto dto =
-        paymentService.createPaymentIntent(
-            Long.valueOf(request.getTenantId()),
-            Long.valueOf(request.getAccountId()),
-            request.getAmountCents());
-    CreatePaymentIntentResponse response =
-        CreatePaymentIntentResponse.newBuilder()
-            .setIntentId(dto.id().toString())
-            .setClientSecret("test")
-            .build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      PaymentIntentDto dto =
+          paymentService.createPaymentIntent(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getAccountId()),
+              request.getAmountCents());
+      CreatePaymentIntentResponse response =
+          CreatePaymentIntentResponse.newBuilder()
+              .setIntentId(dto.id().toString())
+              .setClientSecret("test")
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      responseObserver.onError(
+          io.grpc.Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+    }
   }
 
   @Override
   public void createSubscription(
       CreateSubscriptionRequest request,
       StreamObserver<CreateSubscriptionResponse> responseObserver) {
-    SubscriptionDto dto =
-        paymentService.createSubscription(
-            Long.valueOf(request.getTenantId()),
-            Long.valueOf(request.getAccountId()),
-            request.getPlanId());
-    CreateSubscriptionResponse response =
-        CreateSubscriptionResponse.newBuilder().setSubscriptionId(dto.id().toString()).build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      SubscriptionDto dto =
+          paymentService.createSubscription(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getAccountId()),
+              request.getPlanId());
+      CreateSubscriptionResponse response =
+          CreateSubscriptionResponse.newBuilder().setSubscriptionId(dto.id().toString()).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      responseObserver.onError(
+          io.grpc.Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+    }
   }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -1,0 +1,113 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.account.v1.AuthenticateRequest;
+import net.firedevops.firemud.account.v1.AuthenticateResponse;
+import net.firedevops.firemud.account.v1.CreateAccountRequest;
+import net.firedevops.firemud.account.v1.CreateAccountResponse;
+import net.firedevops.firemud.account.v1.PingRequest;
+import net.firedevops.firemud.account.v1.PingResponse;
+import net.firedevops.firemud.service.AccountService;
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AccountGrpcServiceTest {
+  @Test
+  void pingReturnsPong() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenReturn("pong");
+    AccountService accountService = Mockito.mock(AccountService.class);
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("pong", ref.get().getMessage());
+  }
+
+  @Test
+  void authenticateFailureReturnsUnauthenticated() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    Mockito.when(accountService.authenticate(1L, "demo", "bad"))
+        .thenThrow(new IllegalArgumentException("invalid"));
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    service.authenticate(
+        AuthenticateRequest.newBuilder()
+            .setTenantId("1")
+            .setUsername("demo")
+            .setPassword("bad")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(AuthenticateResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {
+            errorRef.set(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(errorRef.get());
+    StatusRuntimeException ex = (StatusRuntimeException) errorRef.get();
+    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+  }
+
+  @Test
+  void createAccountValidationErrorReturnsErrorDetail() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    Mockito.when(accountService.createAccount(Mockito.any()))
+        .thenThrow(new IllegalArgumentException("bad"));
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<CreateAccountResponse> ref = new AtomicReference<>();
+    service.createAccount(
+        CreateAccountRequest.newBuilder()
+            .setTenantId("1")
+            .setUsername("demo")
+            .setEmail("e@example.com")
+            .setPassword("pass")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(CreateAccountResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+}


### PR DESCRIPTION
## Summary
- map errors to shared `ErrorDetail` in `AccountGrpcService`
- add basic error handling for `PaymentGrpcService` and `NotificationGrpcService`
- introduce `AccountGrpcServiceTest` for ping and error paths

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f6f7272f883308d8b12b314c084c7