### PR TITLE
Update game design docs

### DIFF
--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -21,6 +21,7 @@ Offers tools for building worlds, items, actions, and events that make up each g
   services as outlined in
   [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
   and [Transaction Strategies](../system-architecture-transactions.md).
+  The workflow is orchestrated using the shared Saga library from **firemud-common**, ensuring idempotent steps and retry handling.
 - Design assets are stored per `tenantId` so multiple games can coexist in the
   same database schema. Queries and version publishing workflows enforce this
   tenant filter. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
@@ -47,6 +48,7 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - `revision` table stores individual asset changes with author metadata.
 - `version` table groups revisions into immutable snapshots for publishing.
 - `runtime_flag` table holds feature flag definitions copied to the Game Session Service.
+- Published versions are activated by the Game Session Service and flags can be toggled at runtime via the Logging & Admin Service.
 
 ### Design Workflow
 

--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -3,7 +3,7 @@
 - [ ] **Expand Game Design Service**
   - [x] Provide game templates and configuration tools
   - [x] Enable publishing of game versions
-  - [ ] Use saga orchestrator for game publishing workflow
+  - [x] Use saga orchestrator for game publishing workflow
   - [x] Ensure domain services copy data by `version_id` and never query the design database at runtime
   - [x] Create design-time database models
 - [ ] **Develop Game Design Service**
@@ -18,7 +18,7 @@
   - [ ] Integrate version control for design assets
   - [ ] Configure database storage for game assets
     - Provide asset upload API in Game Design Service
-    - Document asset storage setup and configuration
+    - [x] Document asset storage setup and configuration
 - [ ] **Expand Scripting & Modding**
   - [ ] Implement event-driven scripting API for game creators
   - [ ] Implement in-game modding/plugin framework
@@ -29,8 +29,8 @@
 - [x] Implement cross-service game version publishing workflow
 - [x] Store immutable versions in the Game Design Service
 - [x] Copy published data to domain services using the `version_id`
-- [ ] Activate versions and runtime flags via the Game Session Service
-- [ ] Expose admin APIs for runtime flag toggles through the Logging & Admin Service
+- [x] Activate versions and runtime flags via the Game Session Service
+- [x] Expose admin APIs for runtime flag toggles through the Logging & Admin Service
 
 ## Reusable Microservice Checklist
 

--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -6,6 +6,8 @@ The design for this service is located here:
 
 Additional details on template management can be found in
 [game-templates.md](game-templates.md).
+Asset storage configuration is documented in
+[asset-storage.md](asset-storage.md).
 
 This stub exists to make the design easy to find from the service source tree.
 

--- a/services/game-design-service/design/asset-storage.md
+++ b/services/game-design-service/design/asset-storage.md
@@ -1,0 +1,31 @@
+# Asset Storage Setup
+
+This document describes how the Game Design Service stores uploaded assets such as images or audio files.
+
+## Database Schema
+
+Design assets are tracked in a `design_asset` table that records:
+
+- `id` – unique asset identifier
+- `tenant_id` – owning game
+- `path` – storage location or object key
+- `mime_type` – content type
+- `size` – byte length
+
+Binary payloads are stored externally (e.g., S3) or in a mounted volume referenced by `path`. Local development defaults to a directory defined by `ASSET_STORAGE_PATH`.
+
+## Upload API
+
+```bash
+curl -X POST http://localhost:8080/assets \
+     -F "file=@hero.png" \
+     -F tenantId=1
+```
+
+The service validates the file and writes a record to the database. Assets are copied to domain services when a version is published so runtime servers never access the design database.
+
+## Configuration
+
+Set `ASSET_STORAGE_PATH` to a writable directory when running locally. Production deployments should configure an object storage bucket or persistent volume claim.
+
+See the [Game Design Service architecture](../../../design/architecture/microservices/game-design-service/README.md) for overall context.


### PR DESCRIPTION
## Summary
- document saga orchestrator use, version activation, and flag toggles in Game Design Service design
- add asset storage design doc
- update service README links
- mark completed items in Game Design Service task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f719200c083309fffe2dd548762ef