### PR TITLE
Add asset upload API to Game Design Service

### DIFF
--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -47,6 +47,7 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - `revision` table stores individual asset changes with author metadata.
 - `version` table groups revisions into immutable snapshots for publishing.
 - `runtime_flag` table holds feature flag definitions copied to the Game Session Service.
+- `game_assets` table stores uploaded binary files such as icons or sound effects.
 
 ### Design Workflow
 
@@ -103,6 +104,7 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 - [User Journeys – World and Entity Design](../user-journeys.md#2-world-and-entity-design)
 - [User Journeys – Publish and Start a Game Instance](../user-journeys.md#4-publish-and-start-a-game-instance)
 - [User Journeys – Patch and Update a Live Game](../user-journeys.md#8-patch-and-update-a-live-game)
+- [Asset Storage Setup](../../../../services/game-design-service/design/asset-storage.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Database Migrations](../system-architecture-database-migrations.md)

--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -16,9 +16,9 @@
   - [x] Track version history and patch notes for published games
   - [ ] Build a web-based visual design interface
   - [ ] Integrate version control for design assets
-  - [ ] Configure database storage for game assets
-    - Provide asset upload API in Game Design Service
-    - Document asset storage setup and configuration
+  - [x] Configure database storage for game assets
+    - [x] Provide asset upload API in Game Design Service
+    - [x] Document asset storage setup and configuration
 - [ ] **Expand Scripting & Modding**
   - [ ] Implement event-driven scripting API for game creators
   - [ ] Implement in-game modding/plugin framework

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -3,6 +3,7 @@
 Refer to [design/README.md](design/README.md) for architecture details. A new
 document describing game templates and configuration tools is available at
 [design/game-templates.md](design/game-templates.md).
+[design/asset-storage.md](design/asset-storage.md) explains how uploaded assets are stored.
 
 - **Proto definitions**: [../../protos/game-design/v1](../../protos/game-design/v1)
 

--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -6,6 +6,7 @@ The design for this service is located here:
 
 Additional details on template management can be found in
 [game-templates.md](game-templates.md).
+Asset storage details are documented in [asset-storage.md](asset-storage.md).
 
 This stub exists to make the design easy to find from the service source tree.
 
@@ -14,6 +15,7 @@ This stub exists to make the design easy to find from the service source tree.
 ### REST
 
 - `GET /ping` – basic health check returning `"pong"`.
+- `POST /assets` – upload a binary asset for a tenant.
 
 ```bash
 curl http://localhost:8080/ping

--- a/services/game-design-service/design/asset-storage.md
+++ b/services/game-design-service/design/asset-storage.md
@@ -1,0 +1,20 @@
+# Asset Storage Setup
+
+Game assets such as icons or sound files are stored directly in the Game Design Service database.
+Each record is tied to a `tenantId` so assets remain isolated between games.
+
+## Table Structure
+
+The `game_assets` table stores the raw binary data. Columns include:
+
+- `id` – primary key
+- `tenant_id` – identifies the owner game
+- `file_name` – original file name
+- `content_type` – MIME type
+- `data` – binary blob
+- `created_at` – upload timestamp
+
+Assets are uploaded via `POST /assets` and returned as `GameAssetDto` objects.
+A basic repository and service persist uploads using Spring Data JPA.
+
+See [Game Design Service Architecture](../../../design/architecture/microservices/game-design-service/README.md) for how these assets fit into published versions.

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/controller/AssetController.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/controller/AssetController.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.GameAssetDto;
+import net.firedevops.firemud.service.GameAssetService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/assets")
+@RequiredArgsConstructor
+public class AssetController {
+  private final GameAssetService assetService;
+
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ApiResponse<GameAssetDto>> upload(
+      @RequestParam Long tenantId, @RequestParam("file") @NotNull MultipartFile file) {
+    GameAssetDto dto = assetService.uploadAsset(tenantId, file);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameAssetDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameAssetDto.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record GameAssetDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull @Size(max = 255) String fileName,
+    @NotNull @Size(max = 100) String contentType,
+    byte[] data,
+    LocalDateTime createdAt) {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/GameAsset.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/GameAsset.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "game_assets")
+public class GameAsset {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 255)
+  private String fileName;
+
+  @Column(nullable = false, length = 100)
+  private String contentType;
+
+  @Lob
+  @Column(nullable = false)
+  private byte[] data;
+
+  @Column(nullable = false)
+  private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/GameAssetMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/GameAssetMapper.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GameAssetDto;
+import net.firedevops.firemud.entity.GameAsset;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface GameAssetMapper {
+  GameAssetDto toDto(GameAsset entity);
+
+  GameAsset toEntity(GameAssetDto dto);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameAssetRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameAssetRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.GameAsset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameAssetRepository extends JpaRepository<GameAsset, Long> {}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/GameAssetService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/GameAssetService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.GameAssetDto;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface GameAssetService {
+  GameAssetDto uploadAsset(Long tenantId, MultipartFile file);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameAssetServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameAssetServiceImpl.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.service.impl;
+
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.GameAssetDto;
+import net.firedevops.firemud.entity.GameAsset;
+import net.firedevops.firemud.mapper.GameAssetMapper;
+import net.firedevops.firemud.repository.GameAssetRepository;
+import net.firedevops.firemud.service.GameAssetService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class GameAssetServiceImpl implements GameAssetService {
+  private static final Logger logger = LoggingUtil.getLogger(GameAssetServiceImpl.class);
+
+  private final GameAssetRepository repository;
+  private final GameAssetMapper mapper;
+
+  @Override
+  @Transactional
+  public GameAssetDto uploadAsset(Long tenantId, MultipartFile file) {
+    logger.info("Uploading asset {}", file.getOriginalFilename());
+    GameAsset entity = new GameAsset();
+    entity.setTenantId(tenantId);
+    entity.setFileName(file.getOriginalFilename());
+    entity.setContentType(file.getContentType());
+    try {
+      entity.setData(file.getBytes());
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Failed to read file", e);
+    }
+    entity = repository.save(entity);
+    return mapper.toDto(entity);
+  }
+}

--- a/services/game-design-service/src/main/resources/db/migration/V3__game_assets.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V3__game_assets.sql
@@ -1,0 +1,10 @@
+CREATE TABLE game_assets (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    content_type VARCHAR(100) NOT NULL,
+    data BYTEA NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_game_assets_tenant ON game_assets(tenant_id);


### PR DESCRIPTION
## Summary
- implement asset upload endpoint and DTO
- persist uploads in `game_assets` table
- document asset storage configuration
- mark task list items as complete

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f719200c083309fffe2dd548762ef