### PR TITLE
Add PingController test and update tasks

### DIFF
--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -56,7 +56,7 @@ participate in CI.
 
 ## 🔁 Inter-Service Communication
 
-- [ ] Use `firemud-common` protobuf types for shared messages
+- [x] Use `firemud-common` protobuf types for shared messages
 - [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
 - [ ] Register with service discovery via helpers in `firemud-common`
 - [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
@@ -95,7 +95,7 @@ participate in CI.
 
 ## 🧪 Testing & Quality Gates
 
-- [ ] Add unit tests for gRPC, REST (if present), and startup behaviour
+- [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [ ] Use Spring Boot Test and Testcontainers for integration tests
 - [ ] Validate contracts with smoke tests (gRPC and REST)
 - [ ] Seed minimal test data for local workflows
@@ -110,7 +110,7 @@ participate in CI.
 - [x] Enable OpenTelemetry tracing
 - [x] Use shared interceptors to propagate `traceId` and `correlationId`
 - [ ] Emit service metrics for ticks and Redis commands when relevant
-- [ ] Expose `/actuator/prometheus` for scraping by Prometheus
+- [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---
 

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.firedevops.firemud.service.PingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PingController.class)
+class PingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PingService pingService;
+
+  @Test
+  void pingEndpointReturnsPong() throws Exception {
+    when(pingService.ping()).thenReturn("pong");
+
+    mockMvc
+        .perform(get("/ping"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"))
+        .andExpect(jsonPath("$.data").value("pong"));
+  }
+}


### PR DESCRIPTION
## Summary
- add REST controller test for world-management service
- mark completed tasks in world-management service task list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew :world-management-service:test`


------
https://chatgpt.com/codex/tasks/task_e_686f722453b88330ae134a37f3c1a245