### PR TITLE
Implement runtime feature flags in Game Session Service

### DIFF
--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -51,6 +51,7 @@ Orchestrates live game sessions, including tick execution, player input validati
 ### Data Model
 
 - `session` table tracks active games, associated `version_id`, and owner account.
+- `feature_flag` table stores runtime configuration overrides per tenant.
 - Redis stores volatile queues, timers, and reconnect metadata.
 
 ### Tick Execution Model
@@ -64,6 +65,7 @@ Orchestrates live game sessions, including tick execution, player input validati
 - `StartSession` – spins up a game instance from a published version.
 - `EnqueueCommand` – adds a player action to the next tick's queue.
 - `QueryState` – retrieves condensed session or player state for monitoring.
+- `ToggleFeatureFlag` – updates runtime flags for a tenant.
 
 ## Dependencies
 

--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -14,6 +14,7 @@ service GameSessionService {
   rpc RestartSession(RestartSessionRequest) returns (RestartSessionResponse);
   rpc EnqueueCommand(EnqueueCommandRequest) returns (EnqueueCommandResponse);
   rpc QueryState(QueryStateRequest) returns (QueryStateResponse);
+  rpc ToggleFeatureFlag(ToggleFeatureFlagRequest) returns (ToggleFeatureFlagResponse);
 }
 
 message StartSessionRequest {
@@ -67,5 +68,16 @@ message PingRequest {}
 
 message PingResponse {
   string message = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message ToggleFeatureFlagRequest {
+  string tenant_id = 1;
+  string name = 2;
+  bool enabled = 3;
+}
+
+message ToggleFeatureFlagResponse {
+  bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -11,6 +11,9 @@ POST /sessions/{id}/stop    # stop a running session
 POST /sessions/{id}/restart # restart a stopped session
 ```
 
+The gRPC API also exposes `ToggleFeatureFlag` to update runtime configuration
+for a tenant. See the design document for message details.
+
 ## Configuration
 
 The service relies on `DatabaseAutoConfiguration` and `RedisProperties` from the

--- a/services/game-session-service/design/README.md
+++ b/services/game-session-service/design/README.md
@@ -65,6 +65,13 @@ grpcurl -plaintext -d '{"tenantId":"demo","versionId":1}' \
   [Analytics Dashboards](../../../design/architecture/microservices/logging-admin-service/analytics-dashboards.md).
 Prometheus scrapes metrics from `/actuator/prometheus`.
 
+## Runtime Feature Flags
+
+Feature flags are stored in the `feature_flag` table and can be toggled through
+the Logging & Admin Service. The Game Session Service exposes a gRPC
+`ToggleFeatureFlag` method so administrators can enable or disable experimental
+behavior without restarting a session.
+
 ## Saga Participation
 
 Game startup and shutdown are coordinated using the shared `Saga` helpers from

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/FeatureFlagDto.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/FeatureFlagDto.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record FeatureFlagDto(
+    Long id, @NotNull Long tenantId, @NotBlank @Size(max = 100) String name, boolean enabled) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/ToggleFeatureFlagRequest.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/ToggleFeatureFlagRequest.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ToggleFeatureFlagRequest(
+    @NotNull Long tenantId, @NotBlank @Size(max = 100) String name, boolean enabled) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/entity/FeatureFlag.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/entity/FeatureFlag.java
@@ -1,0 +1,22 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "feature_flag")
+public class FeatureFlag {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Column(nullable = false)
+  private boolean enabled;
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/mapper/FeatureFlagMapper.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/mapper/FeatureFlagMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.entity.FeatureFlag;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FeatureFlagMapper {
+  FeatureFlagDto toDto(FeatureFlag entity);
+
+  FeatureFlag toEntity(FeatureFlagDto dto);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/repository/FeatureFlagRepository.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/repository/FeatureFlagRepository.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.repository;
+
+import java.util.Optional;
+import net.firedevops.firemud.entity.FeatureFlag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeatureFlagRepository extends JpaRepository<FeatureFlag, Long> {
+  Optional<FeatureFlag> findByTenantIdAndName(Long tenantId, String name);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/FeatureFlagService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/FeatureFlagService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+
+public interface FeatureFlagService {
+  FeatureFlagDto toggleFlag(ToggleFeatureFlagRequest request);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
@@ -1,0 +1,37 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.FeatureFlagDto;
+import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.entity.FeatureFlag;
+import net.firedevops.firemud.mapper.FeatureFlagMapper;
+import net.firedevops.firemud.repository.FeatureFlagRepository;
+import net.firedevops.firemud.service.FeatureFlagService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeatureFlagServiceImpl implements FeatureFlagService {
+  private static final Logger logger = LoggingUtil.getLogger(FeatureFlagServiceImpl.class);
+
+  private final FeatureFlagRepository repository;
+  private final FeatureFlagMapper mapper;
+
+  @Override
+  @Transactional
+  public FeatureFlagDto toggleFlag(ToggleFeatureFlagRequest request) {
+    logger.info("Toggling feature flag {} for tenant {}", request.name(), request.tenantId());
+    Optional<FeatureFlag> existing =
+        repository.findByTenantIdAndName(request.tenantId(), request.name());
+    FeatureFlag flag = existing.orElseGet(FeatureFlag::new);
+    flag.setTenantId(request.tenantId());
+    flag.setName(request.name());
+    flag.setEnabled(request.enabled());
+    flag = repository.save(flag);
+    return mapper.toDto(flag);
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -16,6 +16,9 @@ import net.firedevops.firemud.gamesession.v1.RestartSessionResponse;
 import net.firedevops.firemud.gamesession.v1.StartSessionResponse;
 import net.firedevops.firemud.gamesession.v1.StopSessionRequest;
 import net.firedevops.firemud.gamesession.v1.StopSessionResponse;
+import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagRequest;
+import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagResponse;
+import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.PingService;
 import org.lognet.springboot.grpc.GRpcService;
@@ -25,10 +28,15 @@ import org.lognet.springboot.grpc.GRpcService;
 public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionServiceImplBase {
   private final PingService pingService;
   private final GameInstanceService gameInstanceService;
+  private final FeatureFlagService featureFlagService;
 
-  public GameSessionGrpcService(PingService pingService, GameInstanceService gameInstanceService) {
+  public GameSessionGrpcService(
+      PingService pingService,
+      GameInstanceService gameInstanceService,
+      FeatureFlagService featureFlagService) {
     this.pingService = pingService;
     this.gameInstanceService = gameInstanceService;
+    this.featureFlagService = featureFlagService;
   }
 
   @Override
@@ -96,6 +104,19 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
       QueryStateRequest request, StreamObserver<QueryStateResponse> responseObserver) {
     // state query not yet implemented
     QueryStateResponse response = QueryStateResponse.newBuilder().setStateJson("{}").build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void toggleFeatureFlag(
+      ToggleFeatureFlagRequest request,
+      StreamObserver<ToggleFeatureFlagResponse> responseObserver) {
+    featureFlagService.toggleFlag(
+        new net.firedevops.firemud.dto.ToggleFeatureFlagRequest(
+            Long.valueOf(request.getTenantId()), request.getName(), request.getEnabled()));
+    ToggleFeatureFlagResponse response =
+        ToggleFeatureFlagResponse.newBuilder().setSuccess(true).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }

--- a/services/game-session-service/src/main/resources/db/migration/V3__create_feature_flag.sql
+++ b/services/game-session-service/src/main/resources/db/migration/V3__create_feature_flag.sql
@@ -1,0 +1,7 @@
+CREATE TABLE feature_flag (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    enabled BOOLEAN NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.gamesession.v1.StartSessionRequest;
 import net.firedevops.firemud.gamesession.v1.StartSessionResponse;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.service.FeatureFlagService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -21,7 +22,9 @@ class GameSessionGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     Mockito.when(pingService.ping()).thenReturn("pong");
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
-    GameSessionGrpcService service = new GameSessionGrpcService(pingService, gameInstanceService);
+    FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    GameSessionGrpcService service =
+        new GameSessionGrpcService(pingService, gameInstanceService, featureFlagService);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -48,11 +51,13 @@ class GameSessionGrpcServiceTest {
   void startSessionReturnsId() {
     PingService pingService = Mockito.mock(PingService.class);
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
+    FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
     Mockito.when(
             gameInstanceService.startSession(
                 Mockito.any(net.firedevops.firemud.dto.StartSessionRequest.class)))
         .thenReturn(new GameInstanceDto(1L, 1L, "v1", 0L, "RUNNING"));
-    GameSessionGrpcService service = new GameSessionGrpcService(pingService, gameInstanceService);
+    GameSessionGrpcService service =
+        new GameSessionGrpcService(pingService, gameInstanceService, featureFlagService);
 
     AtomicReference<StartSessionResponse> ref = new AtomicReference<>();
     service.startSession(


### PR DESCRIPTION
## Summary
- support runtime feature flags in Game Session Service
- expose ToggleFeatureFlag gRPC endpoint
- document feature flag table and endpoint
- add migration for feature_flag table

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f71a6e6d883308d46272a19f5cb3f