### PR TITLE
Update AI rules for testing and telemetry

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -49,6 +49,7 @@ Testing:
 - Integration: Spring Test
 - Load: Gatling
 - New features must include unit tests and, where applicable, integration tests.
+- Verify coverage with JaCoCo by running `./gradlew check` before committing.
 
 Monetization:
 
@@ -130,4 +131,5 @@ Monetization:
 - Maintain clean project structure.
 - Use `@Timed` for Prometheus metrics.
 - Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
+- Ensure new endpoints record metrics and create spans for business operations.
 - Avoid returning nulls; use transactions for DB consistency.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ These files describe style, architecture, and best practices for Java/Spring pro
 - Keep documentation organized within `design/`.
 - Use clear commit messages summarizing changes.
 - Format and lint code with `./gradlew spotlessApply lintMarkdownFix` before committing.
+- Run `pre-commit run --all-files` or `./gradlew check` locally to execute tests and static analysis before pushing.
 - Unit tests run via `./gradlew test` and are executed in CI through the `check` task.
 - Code quality tools (Checkstyle and SpotBugs) run during the `check` task, and JaCoCo produces coverage reports.
 - CI also performs a Trivy security scan.

--- a/design/project-management/ai-rules-global.md
+++ b/design/project-management/ai-rules-global.md
@@ -59,3 +59,9 @@
 
 - Use standard directory layout for the tech stack
 - Avoid one-off scripts unless reused
+
+## 9. Testing & Observability
+
+- Provide unit tests for new logic and integration tests for features that touch databases or external services.
+- Verify coverage with JaCoCo by running `./gradlew check` before committing.
+- Instrument new code with Micrometer metrics and OpenTelemetry tracing following `design/architecture/system-architecture-logging-monitoring.md`.

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -49,6 +49,7 @@ Testing:
 - Integration: Spring Test
 - Load: Gatling
 - New features must include unit tests and, where applicable, integration tests.
+- Verify coverage with JaCoCo by running `./gradlew check` before committing.
 
 Monetization:
 
@@ -130,4 +131,5 @@ Monetization:
 - Maintain clean project structure.
 - Use `@Timed` for Prometheus metrics.
 - Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
+- Ensure new endpoints record metrics and create spans for business operations.
 - Avoid returning nulls; use transactions for DB consistency.


### PR DESCRIPTION
## Summary
- mention running pre-commit or `./gradlew check` in AGENTS doc
- document testing & observability in global rules
- highlight coverage and instrumentation in local rules
- mirror local rules in `.windsurfrules`

## Testing
- `./gradlew lintMarkdownFix`
- `./gradlew spotlessApply`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f739b0d68833094e0c5ff84a57686