### PR TITLE
Implement security and OpenAPI for logging-admin-service

### DIFF
--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:1.15.1")
     implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }
 

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/LoggingAdminServiceApplication.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/LoggingAdminServiceApplication.java
@@ -1,9 +1,17 @@
 package net.firedevops.firemud;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import net.firedevops.firemud.common.config.CommonAutoConfiguration;
+import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
+import net.firedevops.firemud.config.AuthConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "Logging Admin Service", version = "v1"))
+@Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, AuthConfig.class})
 public class LoggingAdminServiceApplication {
   public static void main(String[] args) {
     SpringApplication.run(LoggingAdminServiceApplication.class, args);

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,0 +1,15 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+public class AuthConfig {
+  @Bean
+  public JwtUtil jwtUtil(AuthProperties props) {
+    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "firemud.auth")
+public class AuthProperties {
+  private String jwtSecret;
+  private long jwtExpirationMs;
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
@@ -1,0 +1,22 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.security.JwtAuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  private final JwtAuthInterceptor jwtAuthInterceptor;
+
+  @Autowired
+  public WebConfig(JwtAuthInterceptor jwtAuthInterceptor) {
+    this.jwtAuthInterceptor = jwtAuthInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(jwtAuthInterceptor);
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
@@ -1,0 +1,45 @@
+package net.firedevops.firemud.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class JwtAuthInterceptor implements HandlerInterceptor {
+  private final JwtUtil jwtUtil;
+
+  public JwtAuthInterceptor(JwtUtil jwtUtil) {
+    this.jwtUtil = jwtUtil;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return false;
+    }
+    String token = authHeader.substring(7);
+    try {
+      Jws<Claims> claims = jwtUtil.parseToken(token);
+      List<String> roles = claims.getBody().get("globalRoles", List.class);
+      if (roles == null || (!roles.contains("platformAdmin") && !roles.contains("moderator"))) {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        return false;
+      }
+      return true;
+    } catch (JwtException ex) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return false;
+    }
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/FeatureFlagControllerTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/FeatureFlagControllerTest.java
@@ -6,21 +6,35 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
 import net.firedevops.firemud.dto.FeatureFlagDto;
 import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
 import net.firedevops.firemud.service.FeatureFlagService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FeatureFlagController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthConfig.class)
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
 class FeatureFlagControllerTest {
 
   @Autowired private MockMvc mockMvc;
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000);
 
   @MockitoBean private FeatureFlagService service;
 
@@ -33,6 +47,12 @@ class FeatureFlagControllerTest {
     mockMvc
         .perform(
             post("/feature-flags/toggle")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    "Bearer "
+                        + jwtUtil.generateToken(
+                            "user",
+                            java.util.Map.of("globalRoles", java.util.List.of("platformAdmin"))))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/SagaDashboardControllerTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/SagaDashboardControllerTest.java
@@ -6,19 +6,33 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
 import net.firedevops.firemud.dto.SagaInstanceDto;
 import net.firedevops.firemud.dto.SagaStepDto;
 import net.firedevops.firemud.service.SagaDashboardService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SagaDashboardController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthConfig.class)
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
 class SagaDashboardControllerTest {
 
   @Autowired private MockMvc mockMvc;
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000);
 
   @MockitoBean private SagaDashboardService service;
 
@@ -28,7 +42,14 @@ class SagaDashboardControllerTest {
         .thenReturn(List.of(new SagaInstanceDto(1L, "demo", "DONE", null, null)));
 
     mockMvc
-        .perform(get("/sagas"))
+        .perform(
+            get("/sagas")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    "Bearer "
+                        + jwtUtil.generateToken(
+                            "user",
+                            java.util.Map.of("globalRoles", java.util.List.of("platformAdmin")))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data[0].sagaName").value("demo"));
   }
@@ -39,7 +60,14 @@ class SagaDashboardControllerTest {
         .thenReturn(List.of(new SagaStepDto(1L, 1L, "step", "OK", 0, null, null)));
 
     mockMvc
-        .perform(get("/sagas/1/steps"))
+        .perform(
+            get("/sagas/1/steps")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    "Bearer "
+                        + jwtUtil.generateToken(
+                            "user",
+                            java.util.Map.of("globalRoles", java.util.List.of("platformAdmin")))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data[0].name").value("step"));
   }

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
@@ -1,0 +1,43 @@
+package net.firedevops.firemud.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class JwtAuthInterceptorTest {
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000L);
+  private final JwtAuthInterceptor interceptor = new JwtAuthInterceptor(jwtUtil);
+
+  @Test
+  void rejectsRequestWithoutToken() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertFalse(result);
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+  }
+
+  @Test
+  void allowsRequestWithValidRole() throws Exception {
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertTrue(result);
+    assertEquals(200, response.getStatus());
+  }
+}


### PR DESCRIPTION
## Summary
- add JWT-based auth interceptor and wiring
- import shared autoconfiguration and add OpenAPI annotation
- expose OpenAPI UI and jjwt dependency
- update unit tests with auth tokens

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f724ab1b88330a1347c7e2d1c715d