### PR TITLE
Improve telemetry guidance in AI docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@ These files describe style, architecture, and best practices for Java/Spring pro
 - Code quality tools (Checkstyle and SpotBugs) run during the `check` task, and JaCoCo produces coverage reports.
 - CI also performs a Trivy security scan.
 - When adding new features, include JUnit tests and instrument metrics and tracing as described in `design/architecture/system-architecture-logging-monitoring.md`.
+- Reuse the `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from `services/common-library` to ensure all gRPC endpoints emit logs, metrics, and spans consistently.

--- a/design/project-management/ai-rules-global.md
+++ b/design/project-management/ai-rules-global.md
@@ -65,3 +65,4 @@
 - Provide unit tests for new logic and integration tests for features that touch databases or external services.
 - Verify coverage with JaCoCo by running `./gradlew check` before committing.
 - Instrument new code with Micrometer metrics and OpenTelemetry tracing following `design/architecture/system-architecture-logging-monitoring.md`.
+- Use `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from the shared library when adding new gRPC endpoints so logs, metrics, and spans are recorded consistently.

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -132,4 +132,5 @@ Monetization:
 - Use `@Timed` for Prometheus metrics.
 - Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
 - Ensure new endpoints record metrics and create spans for business operations.
+- Run `pre-commit run --all-files` or `./gradlew check` before committing to verify formatting, tests, and coverage.
 - Avoid returning nulls; use transactions for DB consistency.


### PR DESCRIPTION
## Summary
- mention the instrumentation interceptors in AGENTS guidance
- clarify gRPC telemetry requirement in `ai-rules-global.md`
- note pre-commit and check commands in `ai-rules-local.md`

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check` *(failed to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686f76d6d9c0833099c1cafcba70da63