### PR TITLE
Add basic tick orchestration

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/GameSessionServiceApplication.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/GameSessionServiceApplication.java
@@ -5,8 +5,10 @@ import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class})
 public class GameSessionServiceApplication {
   public static void main(String[] args) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/repository/GameInstanceRepository.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/repository/GameInstanceRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GameInstanceRepository extends JpaRepository<GameInstance, Long> {
   Optional<GameInstance> findFirstByOwnerAccountIdAndStatus(Long ownerAccountId, String status);
+
+  java.util.List<GameInstance> findByStatus(String status);
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/TickService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/TickService.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.service;
+
+/** Coordinates tick execution and command queues using Redis. */
+public interface TickService {
+  /** Add a command to the queue for the next tick. */
+  void enqueueCommand(Long sessionId, String command);
+
+  /** Execute a single tick if the lock is acquired. */
+  void processTick(Long sessionId);
+
+  /** Retrieve the latest persisted state for monitoring. */
+  String queryState(Long sessionId);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -21,6 +21,7 @@ import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagResponse;
 import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.service.TickService;
 import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC endpoints for the Game Session Service. */
@@ -29,14 +30,17 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
   private final PingService pingService;
   private final GameInstanceService gameInstanceService;
   private final FeatureFlagService featureFlagService;
+  private final TickService tickService;
 
   public GameSessionGrpcService(
       PingService pingService,
       GameInstanceService gameInstanceService,
-      FeatureFlagService featureFlagService) {
+      FeatureFlagService featureFlagService,
+      TickService tickService) {
     this.pingService = pingService;
     this.gameInstanceService = gameInstanceService;
     this.featureFlagService = featureFlagService;
+    this.tickService = tickService;
   }
 
   @Override
@@ -93,7 +97,7 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
   @Override
   public void enqueueCommand(
       EnqueueCommandRequest request, StreamObserver<EnqueueCommandResponse> responseObserver) {
-    // command queuing not yet implemented
+    tickService.enqueueCommand(Long.valueOf(request.getSessionId()), request.getCommand());
     EnqueueCommandResponse response = EnqueueCommandResponse.newBuilder().setAccepted(true).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
@@ -102,8 +106,8 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
   @Override
   public void queryState(
       QueryStateRequest request, StreamObserver<QueryStateResponse> responseObserver) {
-    // state query not yet implemented
-    QueryStateResponse response = QueryStateResponse.newBuilder().setStateJson("{}").build();
+    String state = tickService.queryState(Long.valueOf(request.getSessionId()));
+    QueryStateResponse response = QueryStateResponse.newBuilder().setStateJson(state).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
@@ -1,0 +1,25 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.entity.GameInstance;
+import net.firedevops.firemud.repository.GameInstanceRepository;
+import net.firedevops.firemud.service.TickService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Periodically processes ticks for all running sessions. */
+@Component
+@RequiredArgsConstructor
+public class TickScheduler {
+  private final GameInstanceRepository repository;
+  private final TickService tickService;
+
+  @Scheduled(fixedDelayString = "${game.tick-duration-ms:1000}")
+  public void runTicks() {
+    List<GameInstance> running = repository.findByStatus("RUNNING");
+    for (GameInstance instance : running) {
+      tickService.processTick(instance.getId());
+    }
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -1,0 +1,85 @@
+package net.firedevops.firemud.service.impl;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.List;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.service.TickService;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
+import org.springframework.stereotype.Service;
+
+/** Default Redis-backed implementation of {@link TickService}. */
+@Service
+@RequiredArgsConstructor
+public class TickServiceImpl implements TickService {
+  private static final Logger logger = LoggingUtil.getLogger(TickServiceImpl.class);
+
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final MeterRegistry meterRegistry;
+
+  @Value("${game.tick-duration-ms:1000}")
+  private long tickDurationMs;
+
+  private Counter enqueueCounter;
+  private Timer tickTimer;
+  private RedisScript<Long> commitScript;
+
+  @PostConstruct
+  void init() {
+    this.enqueueCounter = meterRegistry.counter("game_session_commands_enqueued_total");
+    this.tickTimer = meterRegistry.timer("game_session_tick_duration_ms");
+    ResourceScriptSource source =
+        new ResourceScriptSource(new ClassPathResource("redis/tick_commit.lua"));
+    this.commitScript = RedisScript.of(source.getResource(), Long.class);
+  }
+
+  @Override
+  public void enqueueCommand(Long sessionId, String command) {
+    redisTemplate.opsForList().rightPush(queueKey(sessionId), command);
+    enqueueCounter.increment();
+    logger.debug("Queued command for {}", sessionId);
+  }
+
+  @Override
+  public void processTick(Long sessionId) {
+    String lockKey = lockKey(sessionId);
+    Boolean acquired =
+        redisTemplate.opsForValue().setIfAbsent(lockKey, "1", Duration.ofMillis(tickDurationMs));
+    if (Boolean.FALSE.equals(acquired)) {
+      logger.debug("Could not acquire tick lock {}", lockKey);
+      return;
+    }
+    try {
+      tickTimer.record(() -> redisTemplate.execute(commitScript, List.of(queueKey(sessionId))));
+    } finally {
+      redisTemplate.delete(lockKey);
+    }
+  }
+
+  @Override
+  public String queryState(Long sessionId) {
+    Object state = redisTemplate.opsForValue().get(stateKey(sessionId));
+    return state != null ? state.toString() : "{}";
+  }
+
+  private String queueKey(Long sessionId) {
+    return "tick:queue:" + sessionId;
+  }
+
+  private String lockKey(Long sessionId) {
+    return "tick:lock:" + sessionId;
+  }
+
+  private String stateKey(Long sessionId) {
+    return "session:" + sessionId;
+  }
+}

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -15,3 +15,5 @@ management:
     health:
       probes:
         enabled: true
+game:
+  tick-duration-ms: 1000

--- a/services/game-session-service/src/main/resources/redis/tick_commit.lua
+++ b/services/game-session-service/src/main/resources/redis/tick_commit.lua
@@ -1,0 +1,10 @@
+local queue = KEYS[1]
+local processed = 0
+while true do
+  local cmd = redis.call('LPOP', queue)
+  if not cmd then
+    break
+  end
+  processed = processed + 1
+end
+return processed

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
@@ -10,9 +10,10 @@ import net.firedevops.firemud.gamesession.v1.PingRequest;
 import net.firedevops.firemud.gamesession.v1.PingResponse;
 import net.firedevops.firemud.gamesession.v1.StartSessionRequest;
 import net.firedevops.firemud.gamesession.v1.StartSessionResponse;
+import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.PingService;
-import net.firedevops.firemud.service.FeatureFlagService;
+import net.firedevops.firemud.service.TickService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -23,8 +24,10 @@ class GameSessionGrpcServiceTest {
     Mockito.when(pingService.ping()).thenReturn("pong");
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    TickService tickService = Mockito.mock(TickService.class);
     GameSessionGrpcService service =
-        new GameSessionGrpcService(pingService, gameInstanceService, featureFlagService);
+        new GameSessionGrpcService(
+            pingService, gameInstanceService, featureFlagService, tickService);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -52,12 +55,14 @@ class GameSessionGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    TickService tickService = Mockito.mock(TickService.class);
     Mockito.when(
             gameInstanceService.startSession(
                 Mockito.any(net.firedevops.firemud.dto.StartSessionRequest.class)))
         .thenReturn(new GameInstanceDto(1L, 1L, "v1", 0L, "RUNNING"));
     GameSessionGrpcService service =
-        new GameSessionGrpcService(pingService, gameInstanceService, featureFlagService);
+        new GameSessionGrpcService(
+            pingService, gameInstanceService, featureFlagService, tickService);
 
     AtomicReference<StartSessionResponse> ref = new AtomicReference<>();
     service.startSession(

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -1,0 +1,49 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import net.firedevops.firemud.service.TickService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+class TickServiceImplTest {
+  private RedisTemplate<String, Object> redisTemplate;
+  private org.springframework.data.redis.core.ListOperations<String, Object> listOps;
+  private org.springframework.data.redis.core.ValueOperations<String, Object> valueOps;
+  private SimpleMeterRegistry meterRegistry;
+  private TickService service;
+
+  @BeforeEach
+  void setup() {
+    redisTemplate = mock(RedisTemplate.class);
+    listOps = mock(org.springframework.data.redis.core.ListOperations.class);
+    valueOps = mock(org.springframework.data.redis.core.ValueOperations.class);
+    when(redisTemplate.opsForList()).thenReturn(listOps);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    meterRegistry = new SimpleMeterRegistry();
+    service = new TickServiceImpl(redisTemplate, meterRegistry);
+    ((TickServiceImpl) service).init();
+  }
+
+  @Test
+  void enqueueCommandPushesToQueue() {
+    service.enqueueCommand(2L, "look");
+    verify(listOps).rightPush(any(String.class), any());
+  }
+
+  @Test
+  void processTickAttemptsLockAndExecutesScript() {
+    when(valueOps.setIfAbsent(any(), any(), any())).thenReturn(true);
+    service.processTick(2L);
+    ArgumentCaptor<RedisScript> scriptCaptor = ArgumentCaptor.forClass(RedisScript.class);
+    verify(redisTemplate).execute(scriptCaptor.capture(), any(List.class));
+  }
+}


### PR DESCRIPTION
## Summary
- implement Redis based TickService with Lua commit script
- schedule ticks for running sessions
- expose tick operations via gRPC
- add unit tests

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_686f75d3af548330a81c209c3e89881d