### PR TITLE
Add Game Logic Service smoke tests

### DIFF
--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -94,7 +94,7 @@ participate in CI.
 
 - [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [x] Use Spring Boot Test and Testcontainers for integration tests
-- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [x] Validate contracts with smoke tests (gRPC and REST)
 - [ ] Seed minimal test data for local workflows
 - [x] Run `./gradlew check` in CI to execute all tests
 - [ ] *(When workflows span services)* add cross-service integration tests

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -10,6 +10,13 @@ The service exposes a minimal REST endpoint for testing command parsing:
 curl -X POST http://localhost:8080/command -d "attack goblin"
 ```
 
+Run `smoke-test.sh` while the service is running to perform basic REST and gRPC
+contract checks:
+
+```bash
+./smoke-test.sh
+```
+
 ## Running Locally
 
 ```bash

--- a/services/game-logic-service/smoke-test.sh
+++ b/services/game-logic-service/smoke-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Simple smoke test for Game Logic Service REST and gRPC endpoints
+set -euo pipefail
+
+HTTP_URL=${HTTP_URL:-http://localhost:8080}
+GRPC_ADDR=${GRPC_ADDR:-localhost:6565}
+
+function require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo >&2 "Required command '$1' not found"; exit 1; }
+}
+
+require_cmd curl
+require_cmd grpcurl
+
+echo "Checking REST /ping"
+resp=$(curl -fsSL "$HTTP_URL/ping")
+if ! echo "$resp" | grep -q '"SUCCESS"'; then
+  echo "REST ping failed" >&2
+  exit 1
+fi
+
+echo "Checking REST /command"
+resp=$(curl -fsSL -X POST "$HTTP_URL/command" -d "say hello")
+if ! echo "$resp" | grep -q 'hello'; then
+  echo "REST command failed" >&2
+  exit 1
+fi
+
+echo "Checking gRPC Ping"
+resp=$(grpcurl -plaintext "$GRPC_ADDR" game_logic.v1.GameLogicService/Ping)
+if ! echo "$resp" | grep -q 'pong'; then
+  echo "gRPC ping failed" >&2
+  exit 1
+fi
+
+echo "Checking gRPC ExecuteCommand"
+resp=$(grpcurl -plaintext -d '{"tenant_id":"demo","session_id":"demo","command":"north"}' "$GRPC_ADDR" game_logic.v1.GameLogicService/ExecuteCommand)
+if ! echo "$resp" | grep -q 'You move'; then
+  echo "gRPC command failed" >&2
+  exit 1
+fi
+
+echo "Smoke tests passed"


### PR DESCRIPTION
## Summary
- add `smoke-test.sh` for Game Logic Service
- document smoke test usage in service README
- mark task list item for contract smoke tests as completed

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_686f74b55a548330ae8312af1dd6bea7