### PR TITLE
Account Service gRPC error responses

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.service.impl;
 
-import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import net.firedevops.firemud.account.v1.AccountServiceGrpc;
 import net.firedevops.firemud.account.v1.AuthenticateRequest;
@@ -70,8 +69,16 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          Status.UNAUTHENTICATED.withDescription(ex.getMessage()).asRuntimeException());
+      AuthenticateResponse response =
+          AuthenticateResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("UNAUTHENTICATED")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
     }
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationGrpcService.java
@@ -28,8 +28,17 @@ public class NotificationGrpcService extends NotificationServiceGrpc.Notificatio
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          io.grpc.Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+      SendNotificationResponse response =
+          SendNotificationResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
     }
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
@@ -37,8 +37,16 @@ public class PaymentGrpcService extends PaymentServiceGrpc.PaymentServiceImplBas
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          io.grpc.Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+      CreatePaymentIntentResponse response =
+          CreatePaymentIntentResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
     }
   }
 
@@ -57,8 +65,16 @@ public class PaymentGrpcService extends PaymentServiceGrpc.PaymentServiceImplBas
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          io.grpc.Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+      CreateSubscriptionResponse response =
+          CreateSubscriptionResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
     }
   }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -3,8 +3,6 @@ package net.firedevops.firemud.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.account.v1.AuthenticateRequest;
@@ -46,14 +44,14 @@ class AccountGrpcServiceTest {
   }
 
   @Test
-  void authenticateFailureReturnsUnauthenticated() {
+  void authenticateFailureReturnsErrorDetail() {
     PingService pingService = Mockito.mock(PingService.class);
     AccountService accountService = Mockito.mock(AccountService.class);
     Mockito.when(accountService.authenticate(1L, "demo", "bad"))
         .thenThrow(new IllegalArgumentException("invalid"));
     AccountGrpcService service = new AccountGrpcService(pingService, accountService);
 
-    AtomicReference<Throwable> errorRef = new AtomicReference<>();
+    AtomicReference<AuthenticateResponse> ref = new AtomicReference<>();
     service.authenticate(
         AuthenticateRequest.newBuilder()
             .setTenantId("1")
@@ -62,20 +60,19 @@ class AccountGrpcServiceTest {
             .build(),
         new StreamObserver<>() {
           @Override
-          public void onNext(AuthenticateResponse value) {}
+          public void onNext(AuthenticateResponse value) {
+            ref.set(value);
+          }
 
           @Override
-          public void onError(Throwable t) {
-            errorRef.set(t);
-          }
+          public void onError(Throwable t) {}
 
           @Override
           public void onCompleted() {}
         });
 
-    assertNotNull(errorRef.get());
-    StatusRuntimeException ex = (StatusRuntimeException) errorRef.get();
-    assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode());
+    assertNotNull(ref.get());
+    assertEquals("UNAUTHENTICATED", ref.get().getError().getCode());
   }
 
   @Test

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/NotificationGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/NotificationGrpcServiceTest.java
@@ -1,0 +1,74 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.account.v1.SendNotificationRequest;
+import net.firedevops.firemud.account.v1.SendNotificationResponse;
+import net.firedevops.firemud.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NotificationGrpcServiceTest {
+  @Test
+  void sendNotificationReturnsSuccess() {
+    NotificationService notificationService = Mockito.mock(NotificationService.class);
+    NotificationGrpcService service = new NotificationGrpcService(notificationService);
+
+    AtomicReference<SendNotificationResponse> ref = new AtomicReference<>();
+    service.sendNotification(
+        SendNotificationRequest.newBuilder()
+            .setTenantId("1")
+            .setAccountId("2")
+            .setMessage("hi")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(SendNotificationResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals(true, ref.get().getSuccess());
+  }
+
+  @Test
+  void sendNotificationErrorReturnsErrorDetail() {
+    NotificationService notificationService = Mockito.mock(NotificationService.class);
+    Mockito.doThrow(new IllegalArgumentException("bad"))
+        .when(notificationService)
+        .sendNotification(1L, 2L, "hi");
+    NotificationGrpcService service = new NotificationGrpcService(notificationService);
+
+    AtomicReference<SendNotificationResponse> ref = new AtomicReference<>();
+    service.sendNotification(
+        SendNotificationRequest.newBuilder()
+            .setTenantId("1")
+            .setAccountId("2")
+            .setMessage("hi")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(SendNotificationResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+}

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentGrpcServiceTest.java
@@ -1,0 +1,78 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.account.v1.CreatePaymentIntentRequest;
+import net.firedevops.firemud.account.v1.CreatePaymentIntentResponse;
+import net.firedevops.firemud.account.v1.CreateSubscriptionRequest;
+import net.firedevops.firemud.account.v1.CreateSubscriptionResponse;
+import net.firedevops.firemud.dto.PaymentIntentDto;
+import net.firedevops.firemud.service.PaymentService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class PaymentGrpcServiceTest {
+  @Test
+  void createPaymentIntentReturnsResponse() {
+    PaymentService paymentService = Mockito.mock(PaymentService.class);
+    Mockito.when(paymentService.createPaymentIntent(1L, 2L, 500L))
+        .thenReturn(new PaymentIntentDto(10L, 1L, 2L, 500L, "USD"));
+    PaymentGrpcService service = new PaymentGrpcService(paymentService);
+
+    AtomicReference<CreatePaymentIntentResponse> ref = new AtomicReference<>();
+    service.createPaymentIntent(
+        CreatePaymentIntentRequest.newBuilder()
+            .setTenantId("1")
+            .setAccountId("2")
+            .setAmountCents(500)
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(CreatePaymentIntentResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("10", ref.get().getIntentId());
+  }
+
+  @Test
+  void createSubscriptionErrorReturnsErrorDetail() {
+    PaymentService paymentService = Mockito.mock(PaymentService.class);
+    Mockito.when(paymentService.createSubscription(1L, 2L, "plan"))
+        .thenThrow(new IllegalArgumentException("bad"));
+    PaymentGrpcService service = new PaymentGrpcService(paymentService);
+
+    AtomicReference<CreateSubscriptionResponse> ref = new AtomicReference<>();
+    service.createSubscription(
+        CreateSubscriptionRequest.newBuilder()
+            .setTenantId("1")
+            .setAccountId("2")
+            .setPlanId("plan")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(CreateSubscriptionResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+}


### PR DESCRIPTION
## Summary
- map AccountService authentication errors to `ErrorDetail`
- map Payment and Notification gRPC errors to `ErrorDetail`
- add unit tests for new gRPC behaviour

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686f74a5def48330a8d528fd10b112e6