### PR TITLE
Implement Redis metrics

### DIFF
--- a/design/project-management/task-list-entity-management-service.md
+++ b/design/project-management/task-list-entity-management-service.md
@@ -85,7 +85,7 @@ participate in CI.
 - [x] Access Redis through helpers in `firemud-common`
 - [x] Follow key conventions such as `tick:*`, `timer:*`, and `session:*` with `tenantId` prefixes
 - [x] Validate shard-local key usage and avoid per-service caching
-- [ ] Emit metrics for Redis connectivity and commands
+- [x] Emit metrics for Redis connectivity and commands
 - [ ] *(If participating in ticks)* implement locking and staging per the Tick System docs
 - [x] Prefix all keys with `tenantId` to isolate game data
 
@@ -107,7 +107,7 @@ participate in CI.
 - [x] Use Micrometer for Prometheus metrics
 - [x] Enable OpenTelemetry tracing
 - [x] Use shared interceptors to propagate `traceId` and `correlationId`
-- [ ] Emit service metrics for ticks and Redis commands when relevant
+- [x] Emit service metrics for ticks and Redis commands when relevant
 - [x] Expose `/actuator/prometheus` for scraping by Prometheus
 
 ---

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
@@ -1,7 +1,15 @@
 package net.firedevops.firemud.common.config;
 
+import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
+import io.lettuce.core.metrics.MicrometerOptions;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.resource.DefaultClientResources;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
@@ -31,8 +39,39 @@ public class DatabaseAutoConfiguration {
   }
 
   @Bean
-  public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory(redis.getHost(), redis.getPort());
+  @ConditionalOnMissingBean(MeterRegistry.class)
+  public MeterRegistry meterRegistry() {
+    return new SimpleMeterRegistry();
+  }
+
+  @Bean
+  public ClientResources lettuceClientResources(MeterRegistry registry) {
+    MicrometerOptions options = MicrometerOptions.create();
+    return DefaultClientResources.builder()
+        .commandLatencyRecorder(new MicrometerCommandLatencyRecorder(registry, options))
+        .build();
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory(ClientResources resources) {
+    LettuceConnectionFactory factory =
+        new LettuceConnectionFactory(redis.getHost(), redis.getPort());
+    factory.setClientResources(resources);
+    return factory;
+  }
+
+  @Bean
+  public Gauge redisUpGauge(RedisConnectionFactory factory, MeterRegistry registry) {
+    return Gauge.builder(
+            "redis.up",
+            () -> {
+              try (var conn = factory.getConnection()) {
+                return "PONG".equalsIgnoreCase(conn.ping()) ? 1.0 : 0.0;
+              } catch (Exception e) {
+                return 0.0;
+              }
+            })
+        .register(registry);
   }
 
   @Bean

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -67,4 +67,5 @@ persistent data.
 
 Prometheus scrapes metrics from `/actuator/prometheus`. Service methods emit
 `@Timed` metrics and traces are exported to the collector configured in
-`application.yml`.
+`application.yml`. Redis command latency is recorded via Micrometer and
+exposed under the `redis` metric namespace.


### PR DESCRIPTION
## Summary
- instrument lettuce with Micrometer in `DatabaseAutoConfiguration`
- expose Redis connectivity gauge
- document new metrics in the service README
- mark metrics tasks complete

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_686f741404f88330971217ea028e2d7a