### PR TITLE
Implement guild storage and chat moderation

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -34,6 +34,7 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Private messaging and presence indicators.
 - Asynchronous player-to-player mail.
 - Guild creation and membership management.
+- Shared guild storage and alliance system.
 - Friend lists scoped both to individual games and to overall accounts.
 - Cross-game presence lets players know when friends are online in any hosted
   game.
@@ -137,5 +138,5 @@ files change.
 
 ## Future Enhancements
 
-- Rich moderation tools for chat.
-- Optional voice chat integration.
+- Rich moderation tools for chat including profanity filtering and moderator dashboards.
+- Optional voice chat integration via a WebRTC gateway.

--- a/services/social-groups-service/design/README.md
+++ b/services/social-groups-service/design/README.md
@@ -33,12 +33,28 @@ curl -X POST http://localhost:8080/mail \
   -d '{"tenantId":1,"senderAccountId":100,"recipientAccountId":200,"subject":"Hi","content":"Hello"}'
 ```
 
+- `POST /guilds/storage` – add an item to guild storage.
+
+```bash
+curl -X POST http://localhost:8080/guilds/storage \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"guildId":10,"itemName":"Sword","quantity":1}'
+```
+
 ### gRPC
 
 - `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`social_groups_service.proto`](../../../protos/social-groups/v1/social_groups_service.proto).
 
 ```bash
 grpcurl -plaintext localhost:6565 social_groups.v1.SocialGroupsService/Ping
+```
+
+- `POST /chat` – send a chat message filtered for profanity.
+
+```bash
+curl -X POST http://localhost:8080/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"senderAccountId":100,"content":"hello"}'
 ```
 
 ## Metrics & Tracing

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/ChatController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/ChatController.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.ChatMessageDto;
+import net.firedevops.firemud.dto.SendMessageRequestDto;
+import net.firedevops.firemud.service.ChatService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/chat")
+public class ChatController {
+  private final ChatService chatService;
+
+  public ChatController(ChatService chatService) {
+    this.chatService = chatService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<ChatMessageDto>> sendMessage(
+      @Valid @RequestBody SendMessageRequestDto request) {
+    ChatMessageDto dto = chatService.sendMessage(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
@@ -1,0 +1,38 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
+import net.firedevops.firemud.dto.CreateAllianceRequest;
+import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.service.GuildService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/guilds")
+public class GuildController {
+  private final GuildService guildService;
+
+  public GuildController(GuildService guildService) {
+    this.guildService = guildService;
+  }
+
+  @PostMapping("/storage")
+  public ResponseEntity<ApiResponse<GuildStorageItemDto>> addItem(
+      @Valid @RequestBody AddGuildStorageItemRequest request) {
+    GuildStorageItemDto dto = guildService.addStorageItem(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @PostMapping("/alliances")
+  public ResponseEntity<ApiResponse<GuildAllianceDto>> createAlliance(
+      @Valid @RequestBody CreateAllianceRequest request) {
+    GuildAllianceDto dto = guildService.createAlliance(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddGuildStorageItemRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddGuildStorageItemRequest.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AddGuildStorageItemRequest(
+    @NotNull Long tenantId, @NotNull Long guildId, @NotBlank String itemName, int quantity) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/ChatMessageDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/ChatMessageDto.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.dto;
+
+import java.time.Instant;
+
+public record ChatMessageDto(
+    Long id,
+    Long tenantId,
+    Long senderAccountId,
+    String content,
+    Instant timestamp,
+    Long guildId,
+    Long recipientAccountId) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/CreateAllianceRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/CreateAllianceRequest.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateAllianceRequest(
+    @NotNull Long tenantId, @NotNull Long guildId, @NotNull Long allyGuildId) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildAllianceDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildAllianceDto.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record GuildAllianceDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull Long guildId,
+    @NotNull Long allyGuildId,
+    Instant createdAt) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildStorageItemDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildStorageItemDto.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record GuildStorageItemDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull Long guildId,
+    @NotBlank String itemName,
+    int quantity) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/SendMessageRequestDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/SendMessageRequestDto.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SendMessageRequestDto(
+    @NotNull Long tenantId,
+    @NotNull Long senderAccountId,
+    String channelId,
+    @NotBlank String content) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/GuildAlliance.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/GuildAlliance.java
@@ -1,0 +1,26 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "guild_alliances")
+public class GuildAlliance {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false)
+  private Long guildId;
+
+  @Column(nullable = false)
+  private Long allyGuildId;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/GuildStorageItem.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/GuildStorageItem.java
@@ -1,0 +1,25 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "guild_storage_items")
+public class GuildStorageItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false)
+  private Long guildId;
+
+  @Column(nullable = false, length = 100)
+  private String itemName;
+
+  @Column(nullable = false)
+  private int quantity;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/ChatMessageMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/ChatMessageMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.ChatMessageDto;
+import net.firedevops.firemud.entity.ChatMessage;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ChatMessageMapper {
+  ChatMessageDto toDto(ChatMessage entity);
+
+  ChatMessage toEntity(ChatMessageDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildAllianceMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildAllianceMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.entity.GuildAlliance;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface GuildAllianceMapper {
+  GuildAllianceDto toDto(GuildAlliance entity);
+
+  GuildAlliance toEntity(GuildAllianceDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildStorageItemMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildStorageItemMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.entity.GuildStorageItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface GuildStorageItemMapper {
+  GuildStorageItemDto toDto(GuildStorageItem entity);
+
+  GuildStorageItem toEntity(GuildStorageItemDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildAllianceRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildAllianceRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.GuildAlliance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuildAllianceRepository extends JpaRepository<GuildAlliance, Long> {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildStorageItemRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildStorageItemRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.GuildStorageItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuildStorageItemRepository extends JpaRepository<GuildStorageItem, Long> {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/ChatService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/ChatService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.ChatMessageDto;
+import net.firedevops.firemud.dto.SendMessageRequestDto;
+
+public interface ChatService {
+  ChatMessageDto sendMessage(SendMessageRequestDto request);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/GuildService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/GuildService.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
+import net.firedevops.firemud.dto.CreateAllianceRequest;
+import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.dto.GuildStorageItemDto;
+
+public interface GuildService {
+  GuildStorageItemDto addStorageItem(AddGuildStorageItemRequest request);
+
+  GuildAllianceDto createAlliance(CreateAllianceRequest request);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
@@ -1,0 +1,39 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.ChatMessageDto;
+import net.firedevops.firemud.dto.SendMessageRequestDto;
+import net.firedevops.firemud.entity.ChatMessage;
+import net.firedevops.firemud.mapper.ChatMessageMapper;
+import net.firedevops.firemud.repository.ChatMessageRepository;
+import net.firedevops.firemud.service.ChatService;
+import net.firedevops.firemud.util.ProfanityFilter;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+  private static final Logger logger = LoggingUtil.getLogger(ChatServiceImpl.class);
+
+  private final ChatMessageRepository repository;
+  private final ChatMessageMapper mapper;
+  private final ProfanityFilter profanityFilter;
+
+  @Override
+  @Transactional
+  public ChatMessageDto sendMessage(SendMessageRequestDto request) {
+    logger.info("Chat message from {}", request.senderAccountId());
+    ChatMessage message = new ChatMessage();
+    message.setTenantId(request.tenantId());
+    message.setSenderAccountId(request.senderAccountId());
+    message.setContent(profanityFilter.filter(request.content()));
+    message.setTimestamp(Instant.now());
+    message.setGuildId(null);
+    message.setRecipientAccountId(null);
+    return mapper.toDto(repository.save(message));
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/GuildServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/GuildServiceImpl.java
@@ -1,0 +1,54 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
+import net.firedevops.firemud.dto.CreateAllianceRequest;
+import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.entity.GuildAlliance;
+import net.firedevops.firemud.entity.GuildStorageItem;
+import net.firedevops.firemud.mapper.GuildAllianceMapper;
+import net.firedevops.firemud.mapper.GuildStorageItemMapper;
+import net.firedevops.firemud.repository.GuildAllianceRepository;
+import net.firedevops.firemud.repository.GuildStorageItemRepository;
+import net.firedevops.firemud.service.GuildService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GuildServiceImpl implements GuildService {
+  private static final Logger logger = LoggingUtil.getLogger(GuildServiceImpl.class);
+
+  private final GuildStorageItemRepository storageRepo;
+  private final GuildStorageItemMapper storageMapper;
+  private final GuildAllianceRepository allianceRepo;
+  private final GuildAllianceMapper allianceMapper;
+
+  @Override
+  @Transactional
+  public GuildStorageItemDto addStorageItem(AddGuildStorageItemRequest request) {
+    logger.info("Adding item {} to guild {}", request.itemName(), request.guildId());
+    GuildStorageItem item = new GuildStorageItem();
+    item.setTenantId(request.tenantId());
+    item.setGuildId(request.guildId());
+    item.setItemName(request.itemName());
+    item.setQuantity(request.quantity());
+    return storageMapper.toDto(storageRepo.save(item));
+  }
+
+  @Override
+  @Transactional
+  public GuildAllianceDto createAlliance(CreateAllianceRequest request) {
+    logger.info("Creating alliance {} -> {}", request.guildId(), request.allyGuildId());
+    GuildAlliance alliance = new GuildAlliance();
+    alliance.setTenantId(request.tenantId());
+    alliance.setGuildId(request.guildId());
+    alliance.setAllyGuildId(request.allyGuildId());
+    alliance.setCreatedAt(Instant.now());
+    return allianceMapper.toDto(allianceRepo.save(alliance));
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/util/ProfanityFilter.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/util/ProfanityFilter.java
@@ -1,0 +1,45 @@
+package net.firedevops.firemud.util;
+
+import jakarta.annotation.PostConstruct;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfanityFilter {
+  private final Set<String> bannedWords = new HashSet<>();
+
+  @PostConstruct
+  void loadWords() throws IOException {
+    try (BufferedReader reader =
+        new BufferedReader(
+            new InputStreamReader(
+                getClass().getResourceAsStream("/profanity-words.txt"), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        bannedWords.add(line.trim().toLowerCase());
+      }
+    }
+  }
+
+  public String filter(String message) {
+    String[] parts = message.split(" ");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < parts.length; i++) {
+      String word = parts[i];
+      if (bannedWords.contains(word.toLowerCase())) {
+        sb.append("*".repeat(word.length()));
+      } else {
+        sb.append(word);
+      }
+      if (i < parts.length - 1) {
+        sb.append(' ');
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/services/social-groups-service/src/main/resources/db/migration/V3__guild_storage_alliance.sql
+++ b/services/social-groups-service/src/main/resources/db/migration/V3__guild_storage_alliance.sql
@@ -1,0 +1,15 @@
+CREATE TABLE guild_storage_items (
+    id SERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    item_name VARCHAR(100) NOT NULL,
+    quantity INTEGER NOT NULL
+);
+
+CREATE TABLE guild_alliances (
+    id SERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    ally_guild_id BIGINT NOT NULL,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);

--- a/services/social-groups-service/src/main/resources/openapi.yaml
+++ b/services/social-groups-service/src/main/resources/openapi.yaml
@@ -143,3 +143,151 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/MailMessageDto'
+  /chat:
+    post:
+      summary: Send chat message
+      operationId: sendMessage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendMessageRequestDto'
+      responses:
+        '200':
+          description: Message sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/ChatMessageDto'
+  /guilds/storage:
+    post:
+      summary: Add item to guild storage
+      operationId: addStorageItem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGuildStorageItemRequest'
+      responses:
+        '200':
+          description: Item added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GuildStorageItemDto'
+  /guilds/alliances:
+    post:
+      summary: Create guild alliance
+      operationId: createAlliance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAllianceRequest'
+      responses:
+        '200':
+          description: Alliance created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GuildAllianceDto'
+    SendMessageRequestDto:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        senderAccountId:
+          type: integer
+        channelId:
+          type: string
+        content:
+          type: string
+      required:
+        - tenantId
+        - senderAccountId
+        - content
+    ChatMessageDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        senderAccountId:
+          type: integer
+        content:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        guildId:
+          type: integer
+        recipientAccountId:
+          type: integer
+    AddGuildStorageItemRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        itemName:
+          type: string
+        quantity:
+          type: integer
+      required:
+        - tenantId
+        - guildId
+        - itemName
+    GuildStorageItemDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        itemName:
+          type: string
+        quantity:
+          type: integer
+    CreateAllianceRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        allyGuildId:
+          type: integer
+      required:
+        - tenantId
+        - guildId
+        - allyGuildId
+    GuildAllianceDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        allyGuildId:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time

--- a/services/social-groups-service/src/main/resources/profanity-words.txt
+++ b/services/social-groups-service/src/main/resources/profanity-words.txt
@@ -1,0 +1,2 @@
+badword
+verybad


### PR DESCRIPTION
## Summary
- add guild storage and alliance entities with service and controllers
- create profanity filter and chat endpoints
- document new APIs and features in design docs
- update OpenAPI specification

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_686f73f2bd648330ac84c96a5cb56fdb