### PR TITLE
Update AI docs for gRPC error handling

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -132,4 +132,5 @@ Monetization:
 - Use `@Timed` for Prometheus metrics.
 - Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
 - Ensure new endpoints record metrics and create spans for business operations.
+- gRPC endpoints must return `ErrorDetail` objects for application errors. Wrap response observers to log warnings, increment `grpc.app_error` with the error code, and tag spans. Only call `onError()` for transport or infrastructure failures.
 - Avoid returning nulls; use transactions for DB consistency.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,4 @@ These files describe style, architecture, and best practices for Java/Spring pro
 - CI also performs a Trivy security scan.
 - When adding new features, include JUnit tests and instrument metrics and tracing as described in `design/architecture/system-architecture-logging-monitoring.md`.
 - Reuse the `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from `services/common-library` to ensure all gRPC endpoints emit logs, metrics, and spans consistently.
+- gRPC services must return structured `ErrorDetail` objects on application failures. Wrap response observers to log warnings, increment a `grpc.app_error` metric with the error code, and tag tracing spans. Use `onError()` only for transport or infrastructure issues.

--- a/design/architecture/system-architecture-grpc.md
+++ b/design/architecture/system-architecture-grpc.md
@@ -70,6 +70,7 @@ Shared message types (for example `EntitySummary` or `ErrorDetail`) live under `
 - Map application-level failures to appropriate gRPC status codes (`INVALID_ARGUMENT`, `NOT_FOUND`, etc.).
 - Use a shared `ErrorDetail` message (e.g., `shared/errors.proto`) when returning rich error info.
 - Prefer returning structured errors over using gRPC metadata for application faults.
+- All RPCs that can fail should include an `ErrorDetail` field in the response instead of invoking `onError()`. Wrap response observers or use an interceptor to log warnings, increment a `grpc.app_error` metric labeled with `error.code`, and tag tracing spans. `onError()` is reserved for transport-level or infrastructure failures.
 
 ## 🧪 Example Code Generation (Java)
 

--- a/design/project-management/ai-rules-global.md
+++ b/design/project-management/ai-rules-global.md
@@ -26,6 +26,7 @@
 - Ensure valid syntax
 - Include basic error handling (e.g., try/catch, null checks)
 - Log errors with enough context for debugging
+- gRPC services must return `ErrorDetail` fields on logical failures instead of throwing transport exceptions. Wrap response observers or use an interceptor to log warnings, increment a `grpc.app_error` metric with the error code, and tag tracing spans. Use `onError()` only for transport or infrastructure issues.
 
 ## 4. Comments and Explanation
 

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -132,5 +132,6 @@ Monetization:
 - Use `@Timed` for Prometheus metrics.
 - Instrument new services with Micrometer metrics and OpenTelemetry tracing using existing interceptors and configuration.
 - Ensure new endpoints record metrics and create spans for business operations.
+- gRPC endpoints must return `ErrorDetail` objects for application errors. Wrap response observers to log warnings, increment `grpc.app_error` with the error code, and tag spans. Only call `onError()` for transport or infrastructure failures.
 - Run `pre-commit run --all-files` or `./gradlew check` before committing to verify formatting, tests, and coverage.
 - Avoid returning nulls; use transactions for DB consistency.


### PR DESCRIPTION
## Summary
- document structured gRPC `ErrorDetail` pattern and metrics in AGENTS.md
- add same rule to global and local AI guidelines
- sync update in `.windsurfrules`
- clarify error-handling section of gRPC architecture doc

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_686f927a15ec8330a7f720162b1f01a1