### PR TITLE
Implement AutomationScripting gRPC service

### DIFF
--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -45,7 +45,7 @@ participate in CI.
 - [x] Generate gRPC stubs via Gradle and include them in the source set
 - [x] Add the proto directory to `buf.yaml` for lint and breaking change checks
 - [x] Provide contract smoke tests using `grpcurl`
-- [ ] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
+- [x] *(If REST endpoints are exposed)* implement controllers and generate OpenAPI specs
 - [x] *(If persistent storage is used)* define JPA entities, repositories, and Flyway migrations with `tenantId` filtering
 
 ---
@@ -60,8 +60,8 @@ participate in CI.
 
 ## 🔁 Inter-Service Communication
 
-- [ ] Use `firemud-common` protobuf types for shared messages
-- [ ] Map errors to `ErrorDetail` with appropriate gRPC status codes
+- [x] Use `firemud-common` protobuf types for shared messages
+- [x] Map errors to `ErrorDetail` with appropriate gRPC status codes
 - [ ] Register with service discovery via helpers in `firemud-common`
 - [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
 - [ ] Internal traffic communicates directly over gRPC (Gateway not involved)

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/AutomationScriptingGrpcService.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/AutomationScriptingGrpcService.java
@@ -1,0 +1,44 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.automationscripting.v1.AutomationScriptingServiceGrpc;
+import net.firedevops.firemud.automationscripting.v1.PingRequest;
+import net.firedevops.firemud.automationscripting.v1.PingResponse;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
+import org.lognet.springboot.grpc.GRpcService;
+
+@GRpcService
+public class AutomationScriptingGrpcService
+    extends AutomationScriptingServiceGrpc.AutomationScriptingServiceImplBase {
+  private final PingService pingService;
+
+  public AutomationScriptingGrpcService(PingService pingService) {
+    this.pingService = pingService;
+  }
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    try {
+      String msg = pingService.ping();
+      PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      PingResponse response =
+          PingResponse.newBuilder()
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(ex.getMessage()).asRuntimeException());
+    }
+  }
+}

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/AutomationScriptingGrpcServiceTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/AutomationScriptingGrpcServiceTest.java
@@ -1,0 +1,96 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.automationscripting.v1.PingRequest;
+import net.firedevops.firemud.automationscripting.v1.PingResponse;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AutomationScriptingGrpcServiceTest {
+  @Test
+  void pingReturnsPong() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenReturn("pong");
+    AutomationScriptingGrpcService service = new AutomationScriptingGrpcService(pingService);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("pong", ref.get().getMessage());
+  }
+
+  @Test
+  void validationErrorReturnsErrorDetail() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenThrow(new IllegalArgumentException("bad"));
+    AutomationScriptingGrpcService service = new AutomationScriptingGrpcService(pingService);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    ErrorDetail error = ref.get().getError();
+    assertEquals("INVALID_ARGUMENT", error.getCode());
+  }
+
+  @Test
+  void unexpectedErrorReturnsInternal() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenThrow(new RuntimeException("boom"));
+    AutomationScriptingGrpcService service = new AutomationScriptingGrpcService(pingService);
+
+    AtomicReference<Throwable> err = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {
+            err.set(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(err.get());
+    StatusRuntimeException ex = (StatusRuntimeException) err.get();
+    assertEquals(Status.INTERNAL.getCode(), ex.getStatus().getCode());
+  }
+}


### PR DESCRIPTION
## Summary
- create `AutomationScriptingGrpcService` with error mapping
- add unit tests for the gRPC service
- update task list to reflect completed items

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_686f90dca04483308fc73e3f905cbd90