### PR TITLE
Add metrics instrumentation for Account Service

### DIFF
--- a/services/account-service/design/README.md
+++ b/services/account-service/design/README.md
@@ -95,7 +95,9 @@ Expected response:
 
 ## Metrics & Tracing
 
-Prometheus scrapes metrics from `/actuator/prometheus`. OpenTelemetry spans are
-exported to the collector service so traces can be viewed in Jaeger. No
-additional configuration is required when running via `./gradlew bootRun` as the
-default properties target `http://otel-collector:4317`.
+Prometheus scrapes metrics from `/actuator/prometheus`. Service methods expose
+`account.*`, `payment.*`, `notification.*`, and `session.*` timers via
+`@Timed` annotations. OpenTelemetry spans are exported to the collector service
+so traces can be viewed in Jaeger. No additional configuration is required when
+running via `./gradlew bootRun` as the default properties target
+`http://otel-collector:4317`.

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -39,6 +40,7 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   @Transactional
+  @Timed(value = "account.create")
   public AccountDto createAccount(CreateAccountRequest request) {
     logger.info("Creating account {}", request.username());
     Account account = new Account();
@@ -52,6 +54,7 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   @Transactional(readOnly = true)
+  @Timed(value = "account.authenticate")
   public String authenticate(Long tenantId, String username, String password) {
     Optional<Account> accountOpt = accountRepository.findByTenantIdAndUsername(tenantId, username);
     Account account =

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.service.NotificationService;
 import org.slf4j.Logger;
@@ -10,6 +11,7 @@ public class NotificationServiceImpl implements NotificationService {
   private static final Logger logger = LoggingUtil.getLogger(NotificationServiceImpl.class);
 
   @Override
+  @Timed(value = "notification.send")
   public void sendNotification(Long tenantId, Long accountId, String message) {
     logger.info("Send notification to account {} tenant {}: {}", accountId, tenantId, message);
   }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import java.time.LocalDateTime;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.dto.PaymentIntentDto;
@@ -34,6 +35,7 @@ public class PaymentServiceImpl implements PaymentService {
 
   @Override
   @Transactional
+  @Timed(value = "payment.create_intent")
   public PaymentIntentDto createPaymentIntent(Long tenantId, Long accountId, Long amountCents) {
     logger.info("Create payment intent {} cents for account {}", amountCents, accountId);
     Account account = accountRepository.findById(accountId).orElseThrow();
@@ -49,6 +51,7 @@ public class PaymentServiceImpl implements PaymentService {
 
   @Override
   @Transactional
+  @Timed(value = "payment.create_subscription")
   public SubscriptionDto createSubscription(Long tenantId, Long accountId, String planId) {
     logger.info("Create subscription {} for account {}", planId, accountId);
     Account account = accountRepository.findById(accountId).orElseThrow();

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PingServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PingServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.service.PingService;
 import org.slf4j.Logger;
@@ -10,6 +11,7 @@ public class PingServiceImpl implements PingService {
   private static final Logger logger = LoggingUtil.getLogger(PingServiceImpl.class);
 
   @Override
+  @Timed(value = "account.ping")
   public String ping() {
     logger.info("Ping called");
     return "pong";

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.session;
 
+import io.micrometer.core.annotation.Timed;
 import java.time.Duration;
 import net.firedevops.firemud.config.AuthProperties;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -17,6 +18,7 @@ public class SessionServiceImpl implements SessionService {
   }
 
   @Override
+  @Timed(value = "session.store")
   public void storeSession(Long tenantId, Long accountId, String token) {
     String key = buildKey(tenantId, token);
     redisTemplate
@@ -25,6 +27,7 @@ public class SessionServiceImpl implements SessionService {
   }
 
   @Override
+  @Timed(value = "session.get")
   public Long getAccountId(Long tenantId, String token) {
     Object value = redisTemplate.opsForValue().get(buildKey(tenantId, token));
     return value != null ? Long.valueOf(value.toString()) : null;


### PR DESCRIPTION
## Summary
- add `@Timed` metrics to Account Service implementations
- document exported metric names in service design docs

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_686f934106548330b3d1d2c663e705cb