### PR TITLE
Implement Logging Admin seeder

### DIFF
--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -1,19 +1,19 @@
 # Logging & Admin Service Task List
 
-- [ ] **Develop Logging & Admin Service**
-  - [x] Collect logs from all services and provide search dashboards
-  - [x] Allow players to report others for abuse/violations
-  - [x] Store logs for admin moderation and auditing
-  - [x] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
-    - [x] Provide analytics dashboards for operators
-    - [x] Define moderation policies including profanity filters
-  - [x] Integrate Alertmanager for automated alerts
-  - [x] Deploy Fluent Bit sidecars to forward logs to Elasticsearch
-  - [x] Evaluate adopting a zero-trust network model for internal traffic
-  - [x] Create **Saga Dashboard** to inspect workflow states and failures
-  - [x] Integrate saga metrics and timeout recovery
-  - [x] Use saga orchestrator for multi-service admin operations (bans, content revocation)
-  - [x] Build role-based admin UI
+- [x] **Develop Logging & Admin Service**
+- [x] Collect logs from all services and provide search dashboards
+- [x] Allow players to report others for abuse/violations
+- [x] Store logs for admin moderation and auditing
+- [x] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
+  - [x] Provide analytics dashboards for operators
+  - [x] Define moderation policies including profanity filters
+- [x] Integrate Alertmanager for automated alerts
+- [x] Deploy Fluent Bit sidecars to forward logs to Elasticsearch
+- [x] Evaluate adopting a zero-trust network model for internal traffic
+- [x] Create **Saga Dashboard** to inspect workflow states and failures
+- [x] Integrate saga metrics and timeout recovery
+- [x] Use saga orchestrator for multi-service admin operations (bans, content revocation)
+- [x] Build role-based admin UI
 
 ## Reusable Microservice Checklist
 
@@ -61,7 +61,7 @@ participate in CI.
 
 - [x] Use `firemud-common` protobuf types for shared messages
 - [x] Map errors to `ErrorDetail` with appropriate gRPC status codes
-- [ ] Register with service discovery via helpers in `firemud-common`
+- [x] Register with service discovery via helpers in `firemud-common`
 - [x] Ensure gRPC calls use mTLS certificates issued by cert-manager
 - [x] Internal traffic communicates directly over gRPC (Gateway not involved)
 
@@ -101,7 +101,7 @@ participate in CI.
 - [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [x] Use Spring Boot Test and Testcontainers for integration tests
 - [x] Validate contracts with smoke tests (gRPC and REST)
-- [ ] Seed minimal test data for local workflows
+- [x] Seed minimal test data for local workflows
 - [x] Run `./gradlew check` in CI to execute all tests
 - [ ] *(When workflows span services)* add cross-service integration tests
 

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -37,6 +37,10 @@ Typical variables when running locally are:
 
 Values may also be provided through `application.yml` profiles.
 
+### Test Data
+
+Running with the `dev` profile automatically seeds a few example records. The `TestDataSeeder` creates a feature flag, log event, player report, and moderation action when the database tables are empty.
+
 ## Tenant Handling and Dependencies
 
 All log and moderation records contain a `tenantId` column to ensure operators only

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/data/TestDataSeeder.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/data/TestDataSeeder.java
@@ -1,0 +1,69 @@
+package net.firedevops.firemud.data;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.entity.FeatureFlag;
+import net.firedevops.firemud.entity.LogEvent;
+import net.firedevops.firemud.entity.ModerationAction;
+import net.firedevops.firemud.entity.PlayerReport;
+import net.firedevops.firemud.repository.FeatureFlagRepository;
+import net.firedevops.firemud.repository.LogEventRepository;
+import net.firedevops.firemud.repository.ModerationActionRepository;
+import net.firedevops.firemud.repository.PlayerReportRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class TestDataSeeder implements ApplicationRunner {
+  private final FeatureFlagRepository featureFlagRepository;
+  private final LogEventRepository logEventRepository;
+  private final PlayerReportRepository playerReportRepository;
+  private final ModerationActionRepository moderationActionRepository;
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) {
+    if (featureFlagRepository.count() == 0) {
+      FeatureFlag flag = new FeatureFlag();
+      flag.setTenantId(1L);
+      flag.setName("beta_feature");
+      flag.setEnabled(false);
+      featureFlagRepository.save(flag);
+    }
+
+    if (logEventRepository.count() == 0) {
+      LogEvent event = new LogEvent();
+      event.setTenantId(1L);
+      event.setType("INFO");
+      event.setMessage("Service started");
+      event.setTimestamp(Instant.now());
+      logEventRepository.save(event);
+    }
+
+    if (playerReportRepository.count() == 0) {
+      PlayerReport report = new PlayerReport();
+      report.setTenantId(1L);
+      report.setReporterAccountId(1L);
+      report.setTargetAccountId(2L);
+      report.setType("bug");
+      report.setDescription("Sample report");
+      report.setCreatedAt(Instant.now());
+      playerReportRepository.save(report);
+    }
+
+    if (moderationActionRepository.count() == 0) {
+      ModerationAction action = new ModerationAction();
+      action.setTenantId(1L);
+      action.setAccountId(2L);
+      action.setAction("warning");
+      action.setReason("initial seed");
+      action.setCreatedAt(Instant.now());
+      moderationActionRepository.save(action);
+    }
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/data/TestDataSeederTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/data/TestDataSeederTest.java
@@ -1,0 +1,50 @@
+package net.firedevops.firemud.data;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import net.firedevops.firemud.repository.FeatureFlagRepository;
+import net.firedevops.firemud.repository.LogEventRepository;
+import net.firedevops.firemud.repository.ModerationActionRepository;
+import net.firedevops.firemud.repository.PlayerReportRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.DefaultApplicationArguments;
+
+class TestDataSeederTest {
+  @Mock FeatureFlagRepository featureFlagRepository;
+  @Mock LogEventRepository logEventRepository;
+  @Mock PlayerReportRepository playerReportRepository;
+  @Mock ModerationActionRepository moderationActionRepository;
+
+  private TestDataSeeder seeder;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+    seeder =
+        new TestDataSeeder(
+            featureFlagRepository,
+            logEventRepository,
+            playerReportRepository,
+            moderationActionRepository);
+  }
+
+  @Test
+  void runSeedsDataWhenRepositoriesEmpty() throws Exception {
+    when(featureFlagRepository.count()).thenReturn(0L);
+    when(logEventRepository.count()).thenReturn(0L);
+    when(playerReportRepository.count()).thenReturn(0L);
+    when(moderationActionRepository.count()).thenReturn(0L);
+
+    seeder.run(new DefaultApplicationArguments(new String[] {}));
+
+    verify(featureFlagRepository).save(any());
+    verify(logEventRepository).save(any());
+    verify(playerReportRepository).save(any());
+    verify(moderationActionRepository).save(any());
+  }
+}


### PR DESCRIPTION
## Summary
- seed minimal data for Logging Admin Service on dev profile
- document automatic data seeding in the README
- tick completed items in the Logging Admin Service task list
- cover the new seeder with unit tests

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_686f94bd48448330aac615a735953712