### PR TITLE
Document saga workflow in World Management docs

### DIFF
--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -60,7 +60,7 @@ participate in CI.
 - [x] Map errors to `ErrorDetail` with appropriate gRPC status codes
 - [ ] Register with service discovery via helpers in `firemud-common`
 - [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
-- [ ] Internal traffic communicates directly over gRPC (Gateway not involved)
+- [x] Internal traffic communicates directly over gRPC (Gateway not involved)
 
 ---
 
@@ -75,9 +75,9 @@ participate in CI.
 
 ## 🔄 Saga Participation *(if used)*
 
-- [ ] Use saga helpers from `firemud-common` for workflow steps
+- [x] Use saga helpers from `firemud-common` for workflow steps
 - [ ] Emit metrics and correlation IDs for compensation and retries
-- [ ] Document saga participation in `design/README.md`
+- [x] Document saga participation in `design/README.md`
 
 ---
 

--- a/services/world-management-service/design/README.md
+++ b/services/world-management-service/design/README.md
@@ -48,3 +48,11 @@ Expected response:
 World events are persisted in the `world_event` table and processed
 periodically by `WorldEventService`. A weather change event updates the
 `region.weather` column before notifying other services.
+
+## Saga Participation
+
+World creation for a new tenant runs as a Saga using the helper utilities from
+`firemud-common`. Each step is described in
+[world-creation-workflow.md](../../../design/architecture/microservices/world-management-service/world-creation-workflow.md)
+and can be rolled back if a later step fails. This ensures worlds are created
+consistently even when the workflow spans multiple services.


### PR DESCRIPTION
## Summary
- document saga participation in world management design docs
- check off completed saga tasks in project management list

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check` *(failed: process interrupted, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_686f95b199f083309fb084b9a4b5d755