### PR TITLE
Implement JWT auth and voice chat docs

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -55,6 +55,15 @@ Provides chat, guild, and social networking features across games. Enables playe
   through the Spring Cloud Gateway.
 - Guild and direct messages share a common persistence model for history.
 
+### Voice Chat Integration
+
+Voice chat is an optional feature built on top of a lightweight WebRTC gateway.
+The gateway establishes peer-to-peer connections between players and relays
+media streams when direct communication is not possible. The Social & Groups
+Service issues temporary WebRTC tokens and records basic session metadata so the
+Logging & Admin Service can audit voice activity. Voice chat is disabled by
+default and can be enabled per tenant through configuration.
+
 ### gRPC/REST APIs
 
 - `SendMessage` – publishes a chat message to an in-game channel or player.

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-api:1.38.0")
     implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }
 

--- a/services/social-groups-service/design/README.md
+++ b/services/social-groups-service/design/README.md
@@ -65,3 +65,11 @@ via gRPC.
 Prometheus scrapes metrics from `/actuator/prometheus`. OpenTelemetry spans are
 exported to the collector defined in the shared configuration. No additional
 setup is required when running `./gradlew bootRun`.
+
+## Voice Chat
+
+The service can optionally integrate with a WebRTC gateway to provide voice
+channels for guilds and parties. When enabled, the REST API issues short-lived
+WebRTC tokens and records connection events so moderation actions can be traced.
+This feature is disabled by default and is intended for games that wish to offer
+in-client voice without relying on external tools.

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,0 +1,15 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+public class AuthConfig {
+  @Bean
+  public JwtUtil jwtUtil(AuthProperties props) {
+    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "firemud.auth")
+public class AuthProperties {
+  private String jwtSecret;
+  private long jwtExpirationMs;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
@@ -1,0 +1,22 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.security.JwtAuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  private final JwtAuthInterceptor jwtAuthInterceptor;
+
+  @Autowired
+  public WebConfig(JwtAuthInterceptor jwtAuthInterceptor) {
+    this.jwtAuthInterceptor = jwtAuthInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(jwtAuthInterceptor);
+  }
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
@@ -1,0 +1,62 @@
+package net.firedevops.firemud.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** Intercepts requests to validate JWTs and roles. */
+@Component
+public class JwtAuthInterceptor implements HandlerInterceptor {
+  private final JwtUtil jwtUtil;
+
+  public JwtAuthInterceptor(JwtUtil jwtUtil) {
+    this.jwtUtil = jwtUtil;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return false;
+    }
+    String token = authHeader.substring(7);
+    try {
+      Jws<Claims> claims = jwtUtil.parseToken(token);
+      List<String> globalRoles = claims.getBody().get("globalRoles", List.class);
+      Map<String, List<String>> scopedRoles = claims.getBody().get("scopedRoles", Map.class);
+
+      boolean allowed = false;
+      if (globalRoles != null) {
+        allowed = globalRoles.contains("platformAdmin") || globalRoles.contains("moderator");
+      }
+      if (!allowed && scopedRoles != null) {
+        for (List<String> roles : scopedRoles.values()) {
+          if (roles.contains("admin") || roles.contains("moderator")) {
+            allowed = true;
+            break;
+          }
+        }
+      }
+
+      if (!allowed) {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        return false;
+      }
+      return true;
+    } catch (JwtException ex) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return false;
+    }
+  }
+}

--- a/services/social-groups-service/src/main/resources/application.yml
+++ b/services/social-groups-service/src/main/resources/application.yml
@@ -19,3 +19,7 @@ management:
 loggingAdmin:
   host: logging-admin-service
   port: 6565
+firemud:
+  auth:
+    jwt-secret: changemechangemechangeme123456
+    jwt-expiration-ms: 3600000

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/FriendControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/FriendControllerTest.java
@@ -6,20 +6,36 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.config.WebConfig;
 import net.firedevops.firemud.dto.AddFriendRequest;
 import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.FriendService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FriendController.class)
+@Import({AuthConfig.class, WebConfig.class, JwtAuthInterceptor.class})
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
 class FriendControllerTest {
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private JwtUtil jwtUtil;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @MockitoBean private FriendService friendService;
@@ -30,10 +46,12 @@ class FriendControllerTest {
     FriendLinkDto response = new FriendLinkDto(1L, 1L, 2L, 3L, "active", null);
     when(friendService.addFriend(request)).thenReturn(response);
 
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
     mockMvc
         .perform(
             post("/friends")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/MailControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/MailControllerTest.java
@@ -6,19 +6,35 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.config.WebConfig;
 import net.firedevops.firemud.dto.MailMessageDto;
 import net.firedevops.firemud.dto.SendMailRequest;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.MailService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(MailController.class)
+@Import({AuthConfig.class, WebConfig.class, JwtAuthInterceptor.class})
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
 class MailControllerTest {
   @Autowired private MockMvc mockMvc;
+  @Autowired private JwtUtil jwtUtil;
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @MockitoBean private MailService mailService;
@@ -29,10 +45,12 @@ class MailControllerTest {
     MailMessageDto response = new MailMessageDto(1L, 1L, 2L, 3L, "hello", "test body", null, null);
     when(mailService.sendMail(request)).thenReturn(response);
 
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
     mockMvc
         .perform(
             post("/mail")
                 .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -5,17 +5,33 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.config.WebConfig;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.PingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PingController.class)
+@Import({AuthConfig.class, WebConfig.class, JwtAuthInterceptor.class})
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
 class PingControllerTest {
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private JwtUtil jwtUtil;
 
   @MockitoBean private PingService pingService;
 
@@ -23,8 +39,9 @@ class PingControllerTest {
   void pingEndpointReturnsPong() throws Exception {
     when(pingService.ping()).thenReturn("pong");
 
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
     mockMvc
-        .perform(get("/ping"))
+        .perform(get("/ping").header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(jsonPath("$.data").value("pong"));

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
@@ -1,0 +1,43 @@
+package net.firedevops.firemud.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class JwtAuthInterceptorTest {
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000L);
+  private final JwtAuthInterceptor interceptor = new JwtAuthInterceptor(jwtUtil);
+
+  @Test
+  void rejectsRequestWithoutToken() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertFalse(result);
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+  }
+
+  @Test
+  void allowsRequestWithValidRole() throws Exception {
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertTrue(result);
+    assertEquals(200, response.getStatus());
+  }
+}


### PR DESCRIPTION
## Summary
- add JWT interceptor and configuration to Social Groups Service
- document optional voice chat via WebRTC gateway
- update unit tests to include auth header

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6870df7a8e708330ba4bb22afa00e95f