### PR TITLE
Implement createGuild endpoint and gRPC service

### DIFF
--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
@@ -4,7 +4,9 @@ import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
 import net.firedevops.firemud.dto.CreateAllianceRequest;
+import net.firedevops.firemud.dto.CreateGuildRequest;
 import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.dto.GuildDto;
 import net.firedevops.firemud.dto.GuildStorageItemDto;
 import net.firedevops.firemud.service.GuildService;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,13 @@ public class GuildController {
 
   public GuildController(GuildService guildService) {
     this.guildService = guildService;
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<GuildDto>> createGuild(
+      @Valid @RequestBody CreateGuildRequest request) {
+    GuildDto dto = guildService.createGuild(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
   }
 
   @PostMapping("/storage")

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/CreateGuildRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/CreateGuildRequest.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/** Request body for creating a guild. */
+public record CreateGuildRequest(
+    @NotNull Long tenantId, @NotNull Long ownerAccountId, @NotBlank String name) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildDto.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+/** Response DTO representing a guild. */
+public record GuildDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotBlank String name,
+    @NotNull Long ownerAccountId,
+    Instant createdAt) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildMapper.java
@@ -1,0 +1,14 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GuildDto;
+import net.firedevops.firemud.entity.Guild;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+/** MapStruct mapper for {@link Guild} entities. */
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface GuildMapper {
+  GuildDto toDto(Guild entity);
+
+  Guild toEntity(GuildDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/GuildService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/GuildService.java
@@ -2,10 +2,14 @@ package net.firedevops.firemud.service;
 
 import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
 import net.firedevops.firemud.dto.CreateAllianceRequest;
+import net.firedevops.firemud.dto.CreateGuildRequest;
 import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.dto.GuildDto;
 import net.firedevops.firemud.dto.GuildStorageItemDto;
 
 public interface GuildService {
+  GuildDto createGuild(CreateGuildRequest request);
+
   GuildStorageItemDto addStorageItem(AddGuildStorageItemRequest request);
 
   GuildAllianceDto createAlliance(CreateAllianceRequest request);

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/GuildServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/GuildServiceImpl.java
@@ -5,13 +5,18 @@ import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
 import net.firedevops.firemud.dto.CreateAllianceRequest;
+import net.firedevops.firemud.dto.CreateGuildRequest;
 import net.firedevops.firemud.dto.GuildAllianceDto;
+import net.firedevops.firemud.dto.GuildDto;
 import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.entity.Guild;
 import net.firedevops.firemud.entity.GuildAlliance;
 import net.firedevops.firemud.entity.GuildStorageItem;
 import net.firedevops.firemud.mapper.GuildAllianceMapper;
+import net.firedevops.firemud.mapper.GuildMapper;
 import net.firedevops.firemud.mapper.GuildStorageItemMapper;
 import net.firedevops.firemud.repository.GuildAllianceRepository;
+import net.firedevops.firemud.repository.GuildRepository;
 import net.firedevops.firemud.repository.GuildStorageItemRepository;
 import net.firedevops.firemud.service.GuildService;
 import org.slf4j.Logger;
@@ -27,6 +32,20 @@ public class GuildServiceImpl implements GuildService {
   private final GuildStorageItemMapper storageMapper;
   private final GuildAllianceRepository allianceRepo;
   private final GuildAllianceMapper allianceMapper;
+  private final GuildRepository guildRepository;
+  private final GuildMapper guildMapper;
+
+  @Override
+  @Transactional
+  public GuildDto createGuild(CreateGuildRequest request) {
+    logger.info("Creating guild {}", request.name());
+    Guild guild = new Guild();
+    guild.setTenantId(request.tenantId());
+    guild.setOwnerAccountId(request.ownerAccountId());
+    guild.setName(request.name());
+    guild.setCreatedAt(Instant.now());
+    return guildMapper.toDto(guildRepository.save(guild));
+  }
 
   @Override
   @Transactional

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/SocialGroupsGrpcService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/SocialGroupsGrpcService.java
@@ -1,0 +1,160 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.stub.StreamObserver;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.CreateGuildRequest;
+import net.firedevops.firemud.dto.SendMailRequest;
+import net.firedevops.firemud.dto.SendMessageRequestDto;
+import net.firedevops.firemud.service.ChatService;
+import net.firedevops.firemud.service.FriendService;
+import net.firedevops.firemud.service.GuildService;
+import net.firedevops.firemud.service.MailService;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
+import net.firedevops.firemud.socialgroups.v1.AddFriendResponse;
+import net.firedevops.firemud.socialgroups.v1.CreateGuildResponse;
+import net.firedevops.firemud.socialgroups.v1.PingRequest;
+import net.firedevops.firemud.socialgroups.v1.PingResponse;
+import net.firedevops.firemud.socialgroups.v1.SendMailResponse;
+import net.firedevops.firemud.socialgroups.v1.SendMessageResponse;
+import net.firedevops.firemud.socialgroups.v1.SocialGroupsServiceGrpc;
+import org.lognet.springboot.grpc.GRpcService;
+
+/** gRPC service implementation for the SocialGroupsService API. */
+@GRpcService
+@RequiredArgsConstructor
+public class SocialGroupsGrpcService extends SocialGroupsServiceGrpc.SocialGroupsServiceImplBase {
+  private final PingService pingService;
+  private final ChatService chatService;
+  private final GuildService guildService;
+  private final FriendService friendService;
+  private final MailService mailService;
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    String msg = pingService.ping();
+    PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void sendMessage(
+      net.firedevops.firemud.socialgroups.v1.SendMessageRequest request,
+      StreamObserver<SendMessageResponse> responseObserver) {
+    try {
+      SendMessageRequestDto dto =
+          new SendMessageRequestDto(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getSenderId()),
+              request.getChannelId(),
+              request.getContent());
+      chatService.sendMessage(dto);
+      SendMessageResponse response = SendMessageResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      SendMessageResponse response =
+          SendMessageResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void createGuild(
+      net.firedevops.firemud.socialgroups.v1.CreateGuildRequest request,
+      StreamObserver<CreateGuildResponse> responseObserver) {
+    try {
+      CreateGuildRequest dto =
+          new CreateGuildRequest(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getOwnerAccountId()),
+              request.getName());
+      var guild = guildService.createGuild(dto);
+      CreateGuildResponse response =
+          CreateGuildResponse.newBuilder().setGuildId(guild.id().toString()).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      CreateGuildResponse response =
+          CreateGuildResponse.newBuilder()
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void addFriend(
+      net.firedevops.firemud.socialgroups.v1.AddFriendRequest request,
+      StreamObserver<AddFriendResponse> responseObserver) {
+    try {
+      AddFriendRequest dto =
+          new AddFriendRequest(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getAccountId()),
+              Long.valueOf(request.getFriendAccountId()));
+      friendService.addFriend(dto);
+      AddFriendResponse response = AddFriendResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      AddFriendResponse response =
+          AddFriendResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void sendMail(
+      net.firedevops.firemud.socialgroups.v1.SendMailRequest request,
+      StreamObserver<SendMailResponse> responseObserver) {
+    try {
+      SendMailRequest dto =
+          new SendMailRequest(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getSenderAccountId()),
+              Long.valueOf(request.getRecipientAccountId()),
+              request.getSubject(),
+              request.getContent());
+      mailService.sendMail(dto);
+      SendMailResponse response = SendMailResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      SendMailResponse response =
+          SendMailResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/services/social-groups-service/src/main/resources/openapi.yaml
+++ b/services/social-groups-service/src/main/resources/openapi.yaml
@@ -163,6 +163,26 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/ChatMessageDto'
+  /guilds:
+    post:
+      summary: Create guild
+      operationId: createGuild
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGuildRequest'
+      responses:
+        '200':
+          description: Guild created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GuildDto'
   /guilds/storage:
     post:
       summary: Add item to guild storage
@@ -287,6 +307,33 @@ paths:
         guildId:
           type: integer
         allyGuildId:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+    CreateGuildRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        ownerAccountId:
+          type: integer
+        name:
+          type: string
+      required:
+        - tenantId
+        - ownerAccountId
+        - name
+    GuildDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        name:
+          type: string
+        ownerAccountId:
           type: integer
         createdAt:
           type: string

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/SocialGroupsGrpcServiceTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/SocialGroupsGrpcServiceTest.java
@@ -1,0 +1,82 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.service.ChatService;
+import net.firedevops.firemud.service.FriendService;
+import net.firedevops.firemud.service.GuildService;
+import net.firedevops.firemud.service.MailService;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.socialgroups.v1.CreateGuildResponse;
+import net.firedevops.firemud.socialgroups.v1.PingRequest;
+import net.firedevops.firemud.socialgroups.v1.PingResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SocialGroupsGrpcServiceTest {
+  @Test
+  void pingReturnsPong() {
+    PingService ping = Mockito.mock(PingService.class);
+    Mockito.when(ping.ping()).thenReturn("pong");
+    ChatService chat = Mockito.mock(ChatService.class);
+    GuildService guild = Mockito.mock(GuildService.class);
+    FriendService friend = Mockito.mock(FriendService.class);
+    MailService mail = Mockito.mock(MailService.class);
+    SocialGroupsGrpcService service = new SocialGroupsGrpcService(ping, chat, guild, friend, mail);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("pong", ref.get().getMessage());
+  }
+
+  @Test
+  void createGuildErrorReturnsErrorDetail() {
+    PingService ping = Mockito.mock(PingService.class);
+    ChatService chat = Mockito.mock(ChatService.class);
+    GuildService guild = Mockito.mock(GuildService.class);
+    Mockito.when(guild.createGuild(Mockito.any())).thenThrow(new IllegalArgumentException("bad"));
+    FriendService friend = Mockito.mock(FriendService.class);
+    MailService mail = Mockito.mock(MailService.class);
+    SocialGroupsGrpcService service = new SocialGroupsGrpcService(ping, chat, guild, friend, mail);
+
+    AtomicReference<CreateGuildResponse> ref = new AtomicReference<>();
+    service.createGuild(
+        net.firedevops.firemud.socialgroups.v1.CreateGuildRequest.newBuilder()
+            .setTenantId("1")
+            .setOwnerAccountId("2")
+            .setName("test")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(CreateGuildResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+}


### PR DESCRIPTION
## Summary
- add CreateGuild DTOs and mapper
- implement createGuild in service layer
- expose createGuild via REST and gRPC endpoints
- document endpoint in OpenAPI spec
- add unit tests for SocialGroupsGrpcService

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6870e596a6448330af589c415335919d