### PR TITLE
Implement gRPC error responses

### DIFF
--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.util.stream.Collectors;
 import net.firedevops.firemud.dto.CharacterDto;
@@ -11,6 +12,7 @@ import net.firedevops.firemud.entitymanagement.v1.PingRequest;
 import net.firedevops.firemud.entitymanagement.v1.PingResponse;
 import net.firedevops.firemud.service.CharacterService;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
 
 /** Simple gRPC service exposing the Ping RPC. */
@@ -27,23 +29,67 @@ public class EntityManagementGrpcService
 
   @Override
   public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
-    String msg = pingService.ping();
-    PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      String msg = pingService.ping();
+      PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      PingResponse response =
+          PingResponse.newBuilder()
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(ex.getMessage()).asRuntimeException());
+    }
   }
 
   @Override
   public void listCharactersByAccount(
       ListCharactersRequest request, StreamObserver<ListCharactersResponse> responseObserver) {
-    var characters =
-        characterService.listForAccount(Long.valueOf(request.getAccountId())).stream()
-            .map(this::toProto)
-            .collect(Collectors.toList());
-    ListCharactersResponse response =
-        ListCharactersResponse.newBuilder().addAllCharacters(characters).build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      long accountId = Long.parseLong(request.getAccountId());
+      var characters =
+          characterService.listForAccount(accountId).stream()
+              .map(this::toProto)
+              .collect(Collectors.toList());
+      ListCharactersResponse response =
+          ListCharactersResponse.newBuilder().addAllCharacters(characters).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (NumberFormatException ex) {
+      ListCharactersResponse response =
+          ListCharactersResponse.newBuilder()
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      ListCharactersResponse response =
+          ListCharactersResponse.newBuilder()
+              .setError(
+                  ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(ex.getMessage()).asRuntimeException());
+    }
   }
 
   private Character toProto(CharacterDto dto) {

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/EntityManagementGrpcServiceTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/EntityManagementGrpcServiceTest.java
@@ -2,6 +2,8 @@ package net.firedevops.firemud.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.entitymanagement.v1.PingRequest;
@@ -37,5 +39,122 @@ class EntityManagementGrpcServiceTest {
         });
 
     assertEquals("pong", ref.get().getMessage());
+  }
+
+  @Test
+  void pingValidationErrorReturnsErrorDetail() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenThrow(new IllegalArgumentException("bad"));
+    CharacterService characterService = Mockito.mock(CharacterService.class);
+    EntityManagementGrpcService service =
+        new EntityManagementGrpcService(pingService, characterService);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+
+  @Test
+  void pingUnexpectedErrorReturnsInternal() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenThrow(new RuntimeException("boom"));
+    CharacterService characterService = Mockito.mock(CharacterService.class);
+    EntityManagementGrpcService service =
+        new EntityManagementGrpcService(pingService, characterService);
+
+    AtomicReference<Throwable> err = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(PingResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {
+            err.set(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals(
+        io.grpc.Status.INTERNAL.getCode(),
+        ((io.grpc.StatusRuntimeException) err.get()).getStatus().getCode());
+  }
+
+  @Test
+  void listCharactersInvalidAccountIdReturnsErrorDetail() {
+    PingService pingService = Mockito.mock(PingService.class);
+    CharacterService characterService = Mockito.mock(CharacterService.class);
+    EntityManagementGrpcService service =
+        new EntityManagementGrpcService(pingService, characterService);
+
+    AtomicReference<net.firedevops.firemud.entitymanagement.v1.ListCharactersResponse> ref =
+        new AtomicReference<>();
+    service.listCharactersByAccount(
+        net.firedevops.firemud.entitymanagement.v1.ListCharactersRequest.newBuilder()
+            .setAccountId("bad")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(
+              net.firedevops.firemud.entitymanagement.v1.ListCharactersResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+
+  @Test
+  void listCharactersUnexpectedErrorReturnsInternal() {
+    PingService pingService = Mockito.mock(PingService.class);
+    CharacterService characterService = Mockito.mock(CharacterService.class);
+    Mockito.when(characterService.listForAccount(1L)).thenThrow(new RuntimeException("boom"));
+    EntityManagementGrpcService service =
+        new EntityManagementGrpcService(pingService, characterService);
+
+    AtomicReference<Throwable> err = new AtomicReference<>();
+    service.listCharactersByAccount(
+        net.firedevops.firemud.entitymanagement.v1.ListCharactersRequest.newBuilder()
+            .setAccountId("1")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(
+              net.firedevops.firemud.entitymanagement.v1.ListCharactersResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {
+            err.set(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals(
+        Status.INTERNAL.getCode(), ((StatusRuntimeException) err.get()).getStatus().getCode());
   }
 }


### PR DESCRIPTION
## Summary
- add ErrorDetail handling for Entity Management gRPC service
- test Ping and ListCharacters error paths

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6870e3ca55bc833091c983fc1bdd7996