### PR TITLE
Implement JWT validation for World Management Service

### DIFF
--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -48,8 +48,8 @@ participate in CI.
 
 ## 🔒 Authentication & Authorization
 
-- [ ] Meta and admin services validate JWTs using helpers from `firemud-common`
-- [ ] Check `globalRoles` and `scopedRoles` where applicable
+- [x] Meta and admin services validate JWTs using helpers from `firemud-common`
+- [x] Check `globalRoles` and `scopedRoles` where applicable
 - [ ] Gameplay services rely on the Game Session Service for session validation
 
 ---

--- a/services/world-management-service/README.md
+++ b/services/world-management-service/README.md
@@ -32,6 +32,8 @@ connections. Typical variables in development are:
 | `SPRING_DATASOURCE_PASSWORD` | Database password |
 | `SPRING_REDIS_HOST` | Redis hostname |
 | `SPRING_REDIS_PORT` | Redis port |
+| `FIREMUD_AUTH_JWT_SECRET` | JWT signing secret |
+| `FIREMUD_AUTH_JWT_EXPIRATION_MS` | JWT expiration in milliseconds |
 
 Configuration values can also be set through profiles in `application.yml`.
 

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }
 

--- a/services/world-management-service/design/README.md
+++ b/services/world-management-service/design/README.md
@@ -23,6 +23,10 @@ UI at `/swagger-ui.html` when running locally.
 curl http://localhost:8080/ping
 ```
 
+All requests must include a valid JWT in the `Authorization` header. See the
+[Security Architecture](../../../design/architecture/system-architecture-security.md)
+for accepted claims.
+
 ### gRPC
 
 - `Ping(PingRequest) returns (PingResponse)` – basic connectivity check defined in [`world_management_service.proto`](../../../protos/world-management/v1/world_management_service.proto).

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,0 +1,16 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Beans for JWT utilities. */
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+public class AuthConfig {
+  @Bean
+  public JwtUtil jwtUtil(AuthProperties props) {
+    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+  }
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration properties for JWT handling. */
+@Data
+@ConfigurationProperties(prefix = "firemud.auth")
+public class AuthProperties {
+  private String jwtSecret;
+  private long jwtExpirationMs;
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
@@ -1,0 +1,23 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.security.JwtAuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/** Registers web MVC interceptors. */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+  private final JwtAuthInterceptor jwtAuthInterceptor;
+
+  @Autowired
+  public WebConfig(JwtAuthInterceptor jwtAuthInterceptor) {
+    this.jwtAuthInterceptor = jwtAuthInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(jwtAuthInterceptor);
+  }
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
@@ -1,0 +1,62 @@
+package net.firedevops.firemud.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** Intercepts requests to validate JWTs and roles. */
+@Component
+public class JwtAuthInterceptor implements HandlerInterceptor {
+  private final JwtUtil jwtUtil;
+
+  public JwtAuthInterceptor(JwtUtil jwtUtil) {
+    this.jwtUtil = jwtUtil;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return false;
+    }
+    String token = authHeader.substring(7);
+    try {
+      Jws<Claims> claims = jwtUtil.parseToken(token);
+      List<String> globalRoles = claims.getBody().get("globalRoles", List.class);
+      Map<String, List<String>> scopedRoles = claims.getBody().get("scopedRoles", Map.class);
+
+      boolean allowed = false;
+      if (globalRoles != null) {
+        allowed = globalRoles.contains("platformAdmin") || globalRoles.contains("moderator");
+      }
+      if (!allowed && scopedRoles != null) {
+        for (List<String> roles : scopedRoles.values()) {
+          if (roles.contains("admin") || roles.contains("moderator")) {
+            allowed = true;
+            break;
+          }
+        }
+      }
+
+      if (!allowed) {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        return false;
+      }
+      return true;
+    } catch (JwtException ex) {
+      response.setStatus(HttpStatus.UNAUTHORIZED.value());
+      return false;
+    }
+  }
+}

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -5,17 +5,33 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.config.WebConfig;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.PingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PingController.class)
+@Import({AuthConfig.class, WebConfig.class, JwtAuthInterceptor.class})
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
 class PingControllerTest {
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private JwtUtil jwtUtil;
 
   @MockitoBean private PingService pingService;
 
@@ -23,8 +39,10 @@ class PingControllerTest {
   void pingEndpointReturnsPong() throws Exception {
     when(pingService.ping()).thenReturn("pong");
 
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+
     mockMvc
-        .perform(get("/ping"))
+        .perform(get("/ping").header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(jsonPath("$.data").value("pong"));

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
@@ -1,0 +1,43 @@
+package net.firedevops.firemud.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class JwtAuthInterceptorTest {
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000L);
+  private final JwtAuthInterceptor interceptor = new JwtAuthInterceptor(jwtUtil);
+
+  @Test
+  void rejectsRequestWithoutToken() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertFalse(result);
+    assertEquals(HttpStatus.UNAUTHORIZED.value(), response.getStatus());
+  }
+
+  @Test
+  void allowsRequestWithValidRole() throws Exception {
+    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    boolean result = interceptor.preHandle(request, response, new Object());
+
+    assertTrue(result);
+    assertEquals(200, response.getStatus());
+  }
+}


### PR DESCRIPTION
## Summary
- add JWT auth interceptor with config beans
- secure `/ping` endpoint using `JwtAuthInterceptor`
- add unit tests for the interceptor and controller
- document required JWT environment variables and mention token requirement in service design
- mark auth tasks complete in world-management task list

## Testing
- `./gradlew --no-daemon check`

------
https://chatgpt.com/codex/tasks/task_e_6870fc812f148330aedba03b912a5794