### PR TITLE
Update faction reputation docs

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -44,7 +44,9 @@ For details on how scripts are authored and executed safely, see [System Archite
 - `automation_queue` keys in Redis buffer triggered events until a script runs.
 - `automation_queue_enqueued_total` and `automation_queue_drained_total` metrics
   track Redis queue activity.
-- `factions` and `faction_standing` tables track player reputation.
+- Player reputation data is stored in the Social & Groups Service; see its
+  [data model](../social-groups-service/README.md#data-model) for the
+  `faction` and `faction_standing` tables.
 
 ### Script Lifecycle
 
@@ -63,13 +65,11 @@ For details on how scripts are authored and executed safely, see [System Archite
 
 ## Faction & Reputation System
 
-NPCs belong to factions that track each player's reputation. Reputation scores
-range from negative to positive values and directly influence NPC aggression
-states. A higher reputation with a faction results in more neutral or friendly
-behaviour from its members, while negative reputation can make them hostile.
-
-Reputation changes are persisted in the `faction_standing` table and exposed via
-REST endpoints so other services can query or modify standings.
+NPC behaviour references player reputation to decide when to become hostile,
+flee, or surrender. These reputation scores are maintained by the Social &
+Groups Service rather than this service. See the
+[Social & Groups Service](../social-groups-service/README.md#data-model) for the
+`faction` and `faction_standing` tables that store reputation data.
 
 ## Dependencies
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -67,7 +67,7 @@ For details on how scripts are authored and executed safely, see [System Archite
 
 NPC behaviour references player reputation to decide when to become hostile,
 flee, or surrender. These reputation scores are maintained by the Social &
-Groups Service rather than this service. See the
+Groups Service. See the
 [Social & Groups Service](../social-groups-service/README.md#data-model) for the
 `faction` and `faction_standing` tables that store reputation data.
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -48,6 +48,9 @@ Provides chat, guild, and social networking features across games. Enables playe
 - `guild` and `guild_member` tables store group ownership and membership roles.
 - `friend_link` table tracks account or character friendships and blocks.
 - `mail_message` table stores asynchronous player mail.
+- `faction` and `faction_standing` tables maintain player reputation. The
+  [Automation & Scripting Service](../automation-scripting-service/README.md)
+  queries these standings to influence NPC behaviour.
 
 ### Chat Pipeline
 

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -54,9 +54,11 @@ automation_queue:{tenantId}:{entityId}
 
 These ephemeral keys queue triggered events until a script runs.
 
-Faction reputation is stored in the `faction_standing` table and determines how
-aggressive NPCs behave toward each player. When health or morale drops too low,
-NPCs may enter a `FLEEING` or `SURRENDERED` state to avoid lethal outcomes.
+NPCs consult player reputation to decide whether to fight, flee, or surrender.
+The underlying `faction` and `faction_standing` tables live in the Social &
+Groups Service; see its
+[documentation](../../design/architecture/microservices/social-groups-service/README.md#data-model)
+for details.
 
 ## Tenant Handling and Dependencies
 


### PR DESCRIPTION
## Summary
- clarify that faction reputation tables live in the Social & Groups Service
- link Automation & Scripting Service docs to the Social & Groups Service

## Testing
- `./gradlew lintMarkdown`
- `./gradlew check -x test` *(fails: `:account-service:spotlessJavaCheck`)*

------
https://chatgpt.com/codex/tasks/task_e_6870fffcdeac83309c1d4883dc018fdb