### PR TITLE
Remove outdated automation scripting line

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -48,7 +48,7 @@ For details on how scripts are authored and executed safely, see [System Archite
 
 ### Script Lifecycle
 
-- Scripts reside in the Automation & Scripting Service database and are versioned independently from running game sessions.
+- Scripts reside in the Automation & Scripting Service database and are versioned along with other game data as described in the design service versioning process.
 - Events from the Game Session Service trigger script execution via gRPC.
 - The sandboxed engine limits CPU time and memory for each script to prevent
   runaway behavior.


### PR DESCRIPTION
## Summary
- clarify script versioning in automation-scripting-service

## Testing
- `./gradlew check` *(fails: process took too long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68710045f76c833099d59a605ed4ff64