### PR TITLE
Centralize operational notes

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -86,19 +86,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Deployed via Kubernetes as a horizontally scalable Deployment. Local
-  development uses Docker Compose with the same Spring profiles.
-- Exposes `/actuator/health` for readiness and liveness probes consumed by the
-  cluster.
-- Metrics are scraped by Prometheus from `/actuator/prometheus` and logs shipped through Fluent Bit to Elasticsearch. Traces are exported via OpenTelemetry to the collector service for visualization in Jaeger.
-- Configuration differences between environments are described in
-  [Deployment Environments](../../infrastructure/deployment-environments.md).
-
-## Proto Files
-
-The gRPC schemas for this service live in
-[../../../../protos/account/v1](../../../../protos/account/v1). Use
-`./gradlew generateProto` to regenerate Java stubs when the definitions change.
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## 📚 Related Documentation
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -86,13 +86,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Deployed as a Kubernetes Deployment with optional horizontal scaling.
-- Exposes Spring Boot health endpoints for readiness and liveness probing.
-- Prometheus and Fluent Bit collect metrics and logs for Elasticsearch analysis,
-  with traces emitted via OpenTelemetry.
-- Development under Docker Compose mirrors this setup using the same Spring
-  profiles as described in
-  [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Proto Files
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -73,13 +73,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a scalable Deployment in Kubernetes, exposing `/actuator/health` for
-  readiness and liveness checks. Metrics are available at `/actuator/prometheus`.
-- Prometheus scrapes these metrics while Fluent Bit ships logs to
-  Elasticsearch; tracing integrates with OpenTelemetry.
-- Local Docker Compose uses the same Spring profiles to mimic production, as
-  documented in
-  [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -79,15 +79,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment with optional horizontal scaling controlled by
-  HPA.
-- Health and readiness are exposed via `/actuator/health` and monitored by the
-  cluster.
-- Metrics and traces integrate with Prometheus and OpenTelemetry, while logs are
-  forwarded through Fluent Bit to Elasticsearch.
-- Local Docker Compose uses the same Spring profiles; see
-  [Deployment Environments](../../infrastructure/deployment-environments.md) for
-  details.
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -74,14 +74,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Deployed as a stateless Kubernetes Deployment with horizontal scaling enabled
-  for high concurrency.
-- `/actuator/health` is used for readiness and liveness probes in the cluster.
-- Prometheus collects command execution metrics while Fluent Bit forwards logs
-  to Elasticsearch with trace context from OpenTelemetry.
-- For environment-specific configuration see
-
-  [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -78,16 +78,8 @@ Orchestrates live game sessions, including tick execution, player input validati
 
 ## Operational Notes
 
-Environment variables supply PostgreSQL and Redis connection details. The
-common library's `DatabaseAutoConfiguration` reads values from
-`FIREMUD_POSTGRES_*` and `FIREMUD_REDIS_*` as described in the
-[Deployment Environments](../../infrastructure/deployment-environments.md)
-document.
-
-- Deployed in Kubernetes with multiple replicas; Redis provides the shared state needed for sticky sessions.
-- Exposes `/actuator/health` for readiness and liveness probes used by the cluster.
-- Metrics and traces flow to Prometheus and OpenTelemetry, and logs are shipped via Fluent Bit to Elasticsearch.
-- Refer to [Deployment Environments](../../infrastructure/deployment-environments.md) for differences between Docker Compose and production setups.
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Proto Files
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -77,13 +77,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Deployed as a Kubernetes Deployment with horizontal scaling for log-processing
-  workloads.
-- Health endpoints under `/actuator/health` feed readiness and liveness probes.
-- Metrics and OpenTelemetry traces are scraped by Prometheus. Each pod runs a Fluent Bit
-  sidecar that forwards JSON logs to Elasticsearch for search.
-- Environment differences are outlined in
-  [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Saga Dashboard
 

--- a/design/architecture/microservices/service-template.md
+++ b/design/architecture/microservices/service-template.md
@@ -22,6 +22,11 @@
 
 > See [**Gateway Architecture**](../../infrastructure/gateway-architecture.md), [**Deployment Environments**](../../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for details on shared infrastructure components.
 
+## Operational Notes
+
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
+
 ## 📚 Related Documentation
 
 - {{ Links to other design docs that expand on this service. }}

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -94,13 +94,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment. WebSocket chat traffic scales horizontally
-  with multiple replicas.
-- The service publishes metrics scraped by Prometheus and forwards logs through
-  Fluent Bit to Elasticsearch with trace IDs from OpenTelemetry.
-- Health is monitored via `/actuator/health`; see
-  [Deployment Environments](../../infrastructure/deployment-environments.md) for
-  differences between local Docker Compose and production.
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -69,15 +69,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a stateless gateway Deployment in Kubernetes, typically exposed via a
-  load balancer service.
-- `/actuator/health` endpoints are used for readiness and liveness probes.
-- Prometheus scrapes metrics such as connection counts while Fluent Bit forwards
-  structured logs to Elasticsearch; tracing integrates with OpenTelemetry.
-- Metrics are published as `gateway.connections.total` and `gateway.connections.active` for Prometheus.
-- [Deployment Environments](../../infrastructure/deployment-environments.md)
-  explains how routes and certificates differ between Docker Compose and
-  production clusters.
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -81,12 +81,8 @@ details on how Telnet connections are integrated into the platform.
 
 ## Operational Notes
 
-- Deployed alongside the gateway in the DMZ as a lightweight container.
-- Health is checked using a custom TCP probe defined in the Kubernetes manifest.
-- Logs are forwarded via Fluent Bit and metrics are exported for Prometheus via
-  a minimal collector endpoint.
-- Configuration for local Docker Compose versus production clusters is described
-  in [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Metrics & Tracing
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -74,14 +74,8 @@ details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment with horizontal scaling to serve large world
-  datasets.
-- Health endpoints (`/actuator/health`) are used for readiness and liveness
-  checks.
-- Metrics and traces are collected by Prometheus and OpenTelemetry, and logs are
-  shipped via Fluent Bit to Elasticsearch.
-- Environment-specific configuration values are described in
-  [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Proto Files
 

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -47,7 +47,9 @@ class AccountGrpcServiceTest {
   void authenticateFailureReturnsErrorDetail() {
     PingService pingService = Mockito.mock(PingService.class);
     AccountService accountService = Mockito.mock(AccountService.class);
-    Mockito.when(accountService.authenticate(Mockito.eq(1L), Mockito.eq("demo"), Mockito.eq("bad"), Mockito.any()))
+    Mockito.when(
+            accountService.authenticate(
+                Mockito.eq(1L), Mockito.eq("demo"), Mockito.eq("bad"), Mockito.any()))
         .thenThrow(new IllegalArgumentException("invalid"));
     AccountGrpcService service = new AccountGrpcService(pingService, accountService);
 


### PR DESCRIPTION
## Summary
- replace verbose `Operational Notes` sections in service design docs with a shared high-level snippet
- add same section to the service template for new services
- run `spotlessApply` which reformatted one test file

## Testing
- `./gradlew spotlessApply --no-daemon`
- `./gradlew check --no-daemon` *(failed: build timed out in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_687100fb5dd88330854725ace90000fc