### PR TITLE
Clarify instance handling

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -8,7 +8,7 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 
 - Persist characters, NPCs, and items with optimistic locking
 - Provide CRUD and query APIs for other services
-- Manage inventories and instanced zones
+- Manage inventories; location and instance data live in the World Management Service
 - Coordinate deferred writes through Game Session Service
 
 ## Architecture / Design Notes
@@ -40,16 +40,17 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Experience and level tracking.
 - NPC respawn scheduling with configurable delays.
 - Character creation templates pulled from the Game Design Service.
-- Supports instance-based spaces so characters can enter private dungeons or
-  personalized housing without affecting the main world state.
+- Supports instance-based spaces in conjunction with the World Management Service
+  so characters can enter private dungeons or personalized housing without affecting
+  the shared world state.
 
 ### Data Model
 
 - `character` and `npc` tables share a base entity for stats and inventory slots.
 - `item` table stores equipment, consumables, and quest objects.
 - Many-to-many tables define inventory and equipment relationships.
-- `instance_member` table tracks which characters are present in optional
-  instance-based spaces.
+- Character location and instance membership are stored by the World Management
+  Service rather than this service.
 - Entity graphs cache inventory relationships for fast lookups.
 
 ### gRPC APIs

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -10,6 +10,7 @@ The World Management Service stores and manages game world data such as rooms, r
 - Execute scheduled world events and procedural generation
 - Provide pathfinding and navmesh information
 - Notify Game Session and Automation services when the world changes
+- Track character locations and instance occupancy
 
 ## Architecture / Design Notes
 
@@ -36,8 +37,9 @@ The World Management Service stores and manages game world data such as rooms, r
 ## Key Features
 
 - Region and location management with shard support.
-- Instance-based zones allow temporary dungeons or housing separate from the
-  shared world map.
+- Instance-based zones are treated as regular rooms; this service records which
+  characters occupy each instance so private dungeons or housing do not affect
+  the shared world map.
 - Persistent world state with incremental saves.
 - Procedural generation tools for rooms and terrain.
 - `TravelService` implements Dijkstra-based pathfinding using the `room_exit` table.
@@ -50,6 +52,8 @@ The World Management Service stores and manages game world data such as rooms, r
 - `terrain` and `object_spawn` tables support procedural generation.
 - `instance` table tracks temporary copies of zones for instanced gameplay.
 - `expires_at` column defines when instances are cleaned up by a scheduled job.
+- `character_location` table records the current room for each character,
+  including which instance they are in.
 - `world_event` table stores timed changes such as weather updates.
 - `region.weather` column records the current weather state.
 - Redis caches hot rooms for active sessions to speed up lookups.

--- a/services/automation-scripting-service/src/test/java/integration/net/firedevops/firemud/AutomationScriptingServiceApplicationIntegrationTest.java
+++ b/services/automation-scripting-service/src/test/java/integration/net/firedevops/firemud/AutomationScriptingServiceApplicationIntegrationTest.java
@@ -33,7 +33,8 @@ class AutomationScriptingServiceApplicationIntegrationTest {
   }
 
   @Configuration
-  @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+  @EnableAutoConfiguration(
+      exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
   @Import(CommonAutoConfiguration.class)
   static class TestApp {}
 }

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/CharacterControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/CharacterControllerTest.java
@@ -10,16 +10,16 @@ import java.util.Map;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.config.AuthConfig;
 import net.firedevops.firemud.config.WebConfig;
-import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.dto.CharacterDto;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.CharacterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CharacterController.class)

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -17,8 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PingController.class)


### PR DESCRIPTION
## Summary
- explain that entity management relies on world management for location and instance data
- document instance occupancy in world management service
- format tests via Spotless

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68710183085c8330a81888ae0810c717