### PR TITLE
Add saga metrics for world creation

### DIFF
--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -47,7 +47,9 @@ class AccountGrpcServiceTest {
   void authenticateFailureReturnsErrorDetail() {
     PingService pingService = Mockito.mock(PingService.class);
     AccountService accountService = Mockito.mock(AccountService.class);
-    Mockito.when(accountService.authenticate(Mockito.eq(1L), Mockito.eq("demo"), Mockito.eq("bad"), Mockito.any()))
+    Mockito.when(
+            accountService.authenticate(
+                Mockito.eq(1L), Mockito.eq("demo"), Mockito.eq("bad"), Mockito.any()))
         .thenThrow(new IllegalArgumentException("invalid"));
     AccountGrpcService service = new AccountGrpcService(pingService, accountService);
 

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
@@ -1,5 +1,9 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
@@ -19,12 +23,36 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class WorldCreationServiceImpl implements WorldCreationService {
   private final RegionRepository regionRepository;
+  private final MeterRegistry meterRegistry;
+
+  private Counter sagaStartedCounter;
+  private Counter sagaFailedCounter;
+
   private static final Logger logger = LoggingUtil.getLogger(WorldCreationServiceImpl.class);
+
+  @PostConstruct
+  void initMetrics() {
+    sagaStartedCounter = meterRegistry.counter("world_creation_saga_started_total");
+    sagaFailedCounter = meterRegistry.counter("world_creation_saga_failed_total");
+  }
+
+  private void ensureMetrics() {
+    if (sagaStartedCounter == null || sagaFailedCounter == null) {
+      initMetrics();
+    }
+  }
 
   @Override
   @Transactional
   public void createWorld(Long tenantId, Long versionId) throws SagaException {
-    logger.info("Creating world for tenant {} from version {}", tenantId, versionId);
+    String correlationId = UUID.randomUUID().toString();
+    ensureMetrics();
+    logger.info(
+        "Creating world for tenant {} from version {} correlationId={}",
+        tenantId,
+        versionId,
+        correlationId);
+    sagaStartedCounter.increment();
     SagaBuilder builder = new SagaBuilder();
     builder
         .step(
@@ -32,7 +60,14 @@ public class WorldCreationServiceImpl implements WorldCreationService {
             () -> copyDesignData(tenantId, versionId),
             () -> rollbackDesignCopy(tenantId))
         .step("scheduleEvents", () -> scheduleInitialEvents(tenantId));
-    builder.run();
+    try {
+      builder.run();
+    } catch (SagaException ex) {
+      sagaFailedCounter.increment();
+      logger.warn(
+          "World creation saga failed for tenant {} correlationId={}", tenantId, correlationId);
+      throw ex;
+    }
   }
 
   private void copyDesignData(Long tenantId, Long versionId) {

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldCreationServiceImplTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldCreationServiceImplTest.java
@@ -3,6 +3,8 @@ package net.firedevops.firemud.service.impl;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.entity.Region;
 import net.firedevops.firemud.repository.RegionRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,11 +13,14 @@ import org.junit.jupiter.api.Test;
 class WorldCreationServiceImplTest {
   private RegionRepository regionRepository;
   private WorldCreationServiceImpl service;
+  private MeterRegistry meterRegistry;
 
   @BeforeEach
   void setup() {
     regionRepository = mock(RegionRepository.class);
-    service = new WorldCreationServiceImpl(regionRepository);
+    meterRegistry = mock(MeterRegistry.class);
+    when(meterRegistry.counter(anyString())).thenReturn(mock(Counter.class));
+    service = new WorldCreationServiceImpl(regionRepository, meterRegistry);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- track metrics for WorldCreation saga
- adjust unit tests for new metrics dependency
- run spotless to fix formatting

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_687101c806d08330b2ff287e5761042b