### PR TITLE
Seed Game Logic test data

### DIFF
--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -95,7 +95,7 @@ participate in CI.
 - [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [x] Use Spring Boot Test and Testcontainers for integration tests
 - [x] Validate contracts with smoke tests (gRPC and REST)
-- [ ] Seed minimal test data for local workflows
+- [x] Seed minimal test data for local workflows
 - [x] Run `./gradlew check` in CI to execute all tests
 - [x] *(N/A - no cross-service flows yet)* *(When workflows span services)* add cross-service integration tests
 

--- a/dev-tools/seed-test-data.sh
+++ b/dev-tools/seed-test-data.sh
@@ -5,10 +5,20 @@
 set -e
 
 psql -h localhost -U postgres -d firemud <<'SQL'
--- Sample region and room for quick manual testing
+-- Sample region, rooms, and exits
 INSERT INTO region (id, name, tenant_id) VALUES (1, 'Demo Region', 1) ON CONFLICT DO NOTHING;
 INSERT INTO zone (id, region_id, name) VALUES (1, 1, 'Demo Zone') ON CONFLICT DO NOTHING;
 INSERT INTO room (id, zone_id, name, description) VALUES (1, 1, 'Start Room', 'A place to begin.') ON CONFLICT DO NOTHING;
+INSERT INTO room (id, zone_id, name, description) VALUES (2, 1, 'North Room', 'Just north of start.') ON CONFLICT DO NOTHING;
+INSERT INTO room_exit (id, tenant_id, from_room_id, to_room_id, cost) VALUES
+  (1, 1, 1, 2, 1) ON CONFLICT DO NOTHING;
+INSERT INTO room_exit (id, tenant_id, from_room_id, to_room_id, cost) VALUES
+  (2, 1, 2, 1, 1) ON CONFLICT DO NOTHING;
+
+-- Sample item and character
+INSERT INTO item (id, name, tenant_id) VALUES (1, 'Sword', 1) ON CONFLICT DO NOTHING;
+INSERT INTO character (id, account_id, name, tenant_id) VALUES (1, 1, 'Hero', 1) ON CONFLICT DO NOTHING;
+INSERT INTO inventory (character_id, item_id, quantity) VALUES (1, 1, 1) ON CONFLICT DO NOTHING;
 SQL
 
 echo "Seed data inserted."

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -47,7 +47,9 @@ class AccountGrpcServiceTest {
   void authenticateFailureReturnsErrorDetail() {
     PingService pingService = Mockito.mock(PingService.class);
     AccountService accountService = Mockito.mock(AccountService.class);
-    Mockito.when(accountService.authenticate(Mockito.eq(1L), Mockito.eq("demo"), Mockito.eq("bad"), Mockito.any()))
+    Mockito.when(
+            accountService.authenticate(
+                Mockito.eq(1L), Mockito.eq("demo"), Mockito.eq("bad"), Mockito.any()))
         .thenThrow(new IllegalArgumentException("invalid"));
     AccountGrpcService service = new AccountGrpcService(pingService, accountService);
 

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -29,7 +29,8 @@ To run the entire stack:
 ./gradlew devUp
 ```
 
-After starting the services you can seed minimal test data with:
+After starting the services you can seed minimal test data from the repository
+root:
 
 ```bash
 ./dev-tools/seed-test-data.sh


### PR DESCRIPTION
## Summary
- add basic world and character records to seed-test-data.sh
- document seeding path in Game Logic README
- mark test-data task as complete
- apply Spotless formatting fixes

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6870fe69f6148330a413d1c93f94b459