### PR TITLE
Implement TcpProxy gRPC service

### DIFF
--- a/services/automation-scripting-service/src/test/java/integration/net/firedevops/firemud/AutomationScriptingServiceApplicationIntegrationTest.java
+++ b/services/automation-scripting-service/src/test/java/integration/net/firedevops/firemud/AutomationScriptingServiceApplicationIntegrationTest.java
@@ -33,7 +33,8 @@ class AutomationScriptingServiceApplicationIntegrationTest {
   }
 
   @Configuration
-  @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+  @EnableAutoConfiguration(
+      exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
   @Import(CommonAutoConfiguration.class)
   static class TestApp {}
 }

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/CharacterControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/CharacterControllerTest.java
@@ -10,16 +10,16 @@ import java.util.Map;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.config.AuthConfig;
 import net.firedevops.firemud.config.WebConfig;
-import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.dto.CharacterDto;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.CharacterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CharacterController.class)

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -17,8 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PingController.class)

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/service/impl/TcpProxyGrpcService.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/service/impl/TcpProxyGrpcService.java
@@ -1,0 +1,56 @@
+package net.firedevops.firemud.service.impl;
+
+import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.tcpproxy.v1.NotifyDisconnectRequest;
+import net.firedevops.firemud.tcpproxy.v1.NotifyDisconnectResponse;
+import net.firedevops.firemud.tcpproxy.v1.PingRequest;
+import net.firedevops.firemud.tcpproxy.v1.PingResponse;
+import net.firedevops.firemud.tcpproxy.v1.PushBufferedInputRequest;
+import net.firedevops.firemud.tcpproxy.v1.PushBufferedInputResponse;
+import net.firedevops.firemud.tcpproxy.v1.TcpProxyServiceGrpc;
+import org.lognet.springboot.grpc.GRpcService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** gRPC endpoints for the TCP Proxy Service. */
+@GRpcService
+public class TcpProxyGrpcService extends TcpProxyServiceGrpc.TcpProxyServiceImplBase {
+  private static final Logger logger = LoggerFactory.getLogger(TcpProxyGrpcService.class);
+  private final PingService pingService;
+
+  public TcpProxyGrpcService(PingService pingService) {
+    this.pingService = pingService;
+  }
+
+  @Override
+  public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
+    String msg = pingService.ping();
+    PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void notifyDisconnect(
+      NotifyDisconnectRequest request, StreamObserver<NotifyDisconnectResponse> responseObserver) {
+    logger.info(
+        "NotifyDisconnect for session {} tenant {}", request.getSessionId(), request.getTenantId());
+    NotifyDisconnectResponse response = NotifyDisconnectResponse.newBuilder().build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void pushBufferedInput(
+      PushBufferedInputRequest request,
+      StreamObserver<PushBufferedInputResponse> responseObserver) {
+    logger.info(
+        "PushBufferedInput for session {} commands {}",
+        request.getSessionId(),
+        request.getCommandsCount());
+    PushBufferedInputResponse response = PushBufferedInputResponse.newBuilder().build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/service/impl/TcpProxyGrpcServiceTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/service/impl/TcpProxyGrpcServiceTest.java
@@ -1,0 +1,41 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.tcpproxy.v1.PingRequest;
+import net.firedevops.firemud.tcpproxy.v1.PingResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TcpProxyGrpcServiceTest {
+  @Test
+  void pingReturnsPong() {
+    PingService pingService = Mockito.mock(PingService.class);
+    Mockito.when(pingService.ping()).thenReturn("pong");
+    TcpProxyGrpcService service = new TcpProxyGrpcService(pingService);
+
+    AtomicReference<PingResponse> ref = new AtomicReference<>();
+    service.ping(
+        PingRequest.getDefaultInstance(),
+        new StreamObserver<PingResponse>() {
+          @Override
+          public void onNext(PingResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            fail(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("pong", ref.get().getMessage());
+  }
+}


### PR DESCRIPTION
## Summary
- implement TcpProxyGrpcService with Ping, NotifyDisconnect and PushBufferedInput RPCs
- add unit test for grpc service
- fix formatting in various tests

## Testing
- `./gradlew :tcp-proxy-service:test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_687102d8475c8330bbefa9e9b1b6c63c