### PR TITLE
Implement automation scripting seed data

### DIFF
--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -102,7 +102,7 @@ participate in CI.
 - [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [x] Use Spring Boot Test and Testcontainers for integration tests
 - [x] Validate contracts with smoke tests (gRPC and REST)
-- [ ] Seed minimal test data for local workflows
+- [x] Seed minimal test data for local workflows
 - [x] Run `./gradlew check` in CI to execute all tests
 - [ ] *(When workflows span services)* add cross-service integration tests
 

--- a/dev-tools/seed-automation-scripting-data.sh
+++ b/dev-tools/seed-automation-scripting-data.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Seeds minimal data for local testing of the Automation Scripting Service.
+# Requires PostgreSQL to be running from docker-compose.
+
+set -e
+
+psql -h localhost -U postgres -d firemud <<'SQL'
+INSERT INTO factions (id, tenant_id, name, description) VALUES
+  (1, 1, 'Guardians', 'Default faction for testing')
+  ON CONFLICT DO NOTHING;
+
+INSERT INTO scripts (id, tenant_id, name, version, definition) VALUES
+  (1, 1, 'hello_world', 'v1', '{"steps":[]}')
+  ON CONFLICT DO NOTHING;
+SQL
+
+echo "Automation Scripting Service seed data inserted."

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -17,6 +17,12 @@ To run the entire stack:
 ./gradlew devUp
 ```
 
+After starting the services you can insert minimal test data with:
+
+```bash
+./dev-tools/seed-automation-scripting-data.sh
+```
+
 ## Configuration
 
 Connection settings are provided by `DatabaseAutoConfiguration` and

--- a/services/automation-scripting-service/src/test/java/integration/net/firedevops/firemud/AutomationScriptingServiceApplicationIntegrationTest.java
+++ b/services/automation-scripting-service/src/test/java/integration/net/firedevops/firemud/AutomationScriptingServiceApplicationIntegrationTest.java
@@ -33,7 +33,8 @@ class AutomationScriptingServiceApplicationIntegrationTest {
   }
 
   @Configuration
-  @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+  @EnableAutoConfiguration(
+      exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
   @Import(CommonAutoConfiguration.class)
   static class TestApp {}
 }

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/CharacterControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/CharacterControllerTest.java
@@ -10,16 +10,16 @@ import java.util.Map;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.config.AuthConfig;
 import net.firedevops.firemud.config.WebConfig;
-import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.dto.CharacterDto;
+import net.firedevops.firemud.security.JwtAuthInterceptor;
 import net.firedevops.firemud.service.CharacterService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CharacterController.class)

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/controller/PingControllerTest.java
@@ -17,8 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PingController.class)


### PR DESCRIPTION
## Summary
- add script to seed test data for automation scripting service
- document seed script in service README
- mark task list item complete for seeding data
- run Spotless formatting updates

## Testing
- `./gradlew check --no-daemon --console=plain -q`

------
https://chatgpt.com/codex/tasks/task_e_68710269894c8330b777f36cb5211831