### PR TITLE
Implement missing Logging Admin endpoints

### DIFF
--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/LogQueryController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/LogQueryController.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.controller;
+
+import io.micrometer.core.annotation.Timed;
+import jakarta.validation.Valid;
+import java.util.List;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.QueryLogsRequest;
+import net.firedevops.firemud.service.LogQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/logs")
+public class LogQueryController {
+  private final LogQueryService service;
+
+  public LogQueryController(LogQueryService service) {
+    this.service = service;
+  }
+
+  @GetMapping
+  @Timed(value = "queryLogs", description = "Query log events")
+  public ResponseEntity<ApiResponse<List<String>>> query(
+      @Valid @RequestBody QueryLogsRequest request) {
+    return ResponseEntity.ok(ApiResponse.success(service.queryLogs(request)));
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/ModerationActionController.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/controller/ModerationActionController.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.controller;
+
+import io.micrometer.core.annotation.Timed;
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.ApplyModerationActionRequest;
+import net.firedevops.firemud.dto.ModerationActionDto;
+import net.firedevops.firemud.service.ModerationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/moderation")
+public class ModerationActionController {
+  private final ModerationService service;
+
+  public ModerationActionController(ModerationService service) {
+    this.service = service;
+  }
+
+  @PostMapping("/actions")
+  @Timed(value = "applyModerationAction", description = "Apply moderation action")
+  public ResponseEntity<ApiResponse<ModerationActionDto>> apply(
+      @Valid @RequestBody ApplyModerationActionRequest request) {
+    return ResponseEntity.ok(ApiResponse.success(service.applyAction(request)));
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/ApplyModerationActionRequest.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/ApplyModerationActionRequest.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ApplyModerationActionRequest(
+    @NotNull Long tenantId,
+    @NotNull Long accountId,
+    @NotBlank @Size(max = 20) String action,
+    @Size(max = 255) String reason) {}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/ModerationActionDto.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/ModerationActionDto.java
@@ -1,0 +1,15 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+public record ModerationActionDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull Long accountId,
+    @NotBlank @Size(max = 20) String action,
+    @Size(max = 255) String reason,
+    Instant createdAt,
+    Instant expiresAt) {}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/QueryLogsRequest.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/dto/QueryLogsRequest.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record QueryLogsRequest(@NotNull Long tenantId, @Size(max = 255) String filter) {}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/mapper/ModerationActionMapper.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/mapper/ModerationActionMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.ModerationActionDto;
+import net.firedevops.firemud.entity.ModerationAction;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ModerationActionMapper {
+  ModerationActionDto toDto(ModerationAction entity);
+
+  ModerationAction toEntity(ModerationActionDto dto);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/LogEventRepository.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/repository/LogEventRepository.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.repository;
 
+import java.util.List;
 import net.firedevops.firemud.entity.LogEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LogEventRepository extends JpaRepository<LogEvent, Long> {}
+public interface LogEventRepository extends JpaRepository<LogEvent, Long> {
+  List<LogEvent> findByTenantIdAndMessageContainingIgnoreCase(Long tenantId, String message);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/LogQueryService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/LogQueryService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import java.util.List;
+import net.firedevops.firemud.dto.QueryLogsRequest;
+
+public interface LogQueryService {
+  List<String> queryLogs(QueryLogsRequest request);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/ModerationService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/ModerationService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.ApplyModerationActionRequest;
+import net.firedevops.firemud.dto.ModerationActionDto;
+
+public interface ModerationService {
+  ModerationActionDto applyAction(ApplyModerationActionRequest request);
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LogQueryServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LogQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.List;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.QueryLogsRequest;
+import net.firedevops.firemud.entity.LogEvent;
+import net.firedevops.firemud.repository.LogEventRepository;
+import net.firedevops.firemud.service.LogQueryService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LogQueryServiceImpl implements LogQueryService {
+  private static final Logger logger = LoggingUtil.getLogger(LogQueryServiceImpl.class);
+
+  private final LogEventRepository repository;
+
+  public LogQueryServiceImpl(LogEventRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<String> queryLogs(QueryLogsRequest request) {
+    logger.info("Querying logs for tenant {}", request.tenantId());
+    List<LogEvent> events =
+        repository.findByTenantIdAndMessageContainingIgnoreCase(
+            request.tenantId(), request.filter() == null ? "" : request.filter());
+    return events.stream().map(LogEvent::getMessage).toList();
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
@@ -1,21 +1,27 @@
 package net.firedevops.firemud.service.impl;
 
 import io.grpc.stub.StreamObserver;
-import net.firedevops.firemud.loggingadmin.v1.LoggingAdminServiceGrpc;
-import net.firedevops.firemud.loggingadmin.v1.PingRequest;
-import net.firedevops.firemud.loggingadmin.v1.PingResponse;
-import net.firedevops.firemud.loggingadmin.v1.ToggleFeatureFlagRequest;
-import net.firedevops.firemud.loggingadmin.v1.ToggleFeatureFlagResponse;
+import java.util.List;
+import net.firedevops.firemud.loggingadmin.v1.*;
 import net.firedevops.firemud.service.FeatureFlagService;
+import net.firedevops.firemud.service.LogQueryService;
+import net.firedevops.firemud.service.ModerationService;
 import org.lognet.springboot.grpc.GRpcService;
 
 @GRpcService
 public class LoggingAdminGrpcService extends LoggingAdminServiceGrpc.LoggingAdminServiceImplBase {
 
   private final FeatureFlagService featureFlagService;
+  private final LogQueryService logQueryService;
+  private final ModerationService moderationService;
 
-  public LoggingAdminGrpcService(FeatureFlagService featureFlagService) {
+  public LoggingAdminGrpcService(
+      FeatureFlagService featureFlagService,
+      LogQueryService logQueryService,
+      ModerationService moderationService) {
     this.featureFlagService = featureFlagService;
+    this.logQueryService = logQueryService;
+    this.moderationService = moderationService;
   }
 
   @Override
@@ -34,6 +40,34 @@ public class LoggingAdminGrpcService extends LoggingAdminServiceGrpc.LoggingAdmi
             Long.valueOf(request.getTenantId()), request.getName(), request.getEnabled()));
     ToggleFeatureFlagResponse response =
         ToggleFeatureFlagResponse.newBuilder().setSuccess(true).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void queryLogs(
+      QueryLogsRequest request, StreamObserver<QueryLogsResponse> responseObserver) {
+    List<String> entries =
+        logQueryService.queryLogs(
+            new net.firedevops.firemud.dto.QueryLogsRequest(
+                Long.valueOf(request.getTenantId()), request.getFilter()));
+    QueryLogsResponse response = QueryLogsResponse.newBuilder().addAllEntries(entries).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void applyModerationAction(
+      ApplyModerationActionRequest request,
+      StreamObserver<ApplyModerationActionResponse> responseObserver) {
+    moderationService.applyAction(
+        new net.firedevops.firemud.dto.ApplyModerationActionRequest(
+            Long.valueOf(request.getTenantId()),
+            Long.valueOf(request.getAccountId()),
+            request.getAction(),
+            request.getReason()));
+    ApplyModerationActionResponse response =
+        ApplyModerationActionResponse.newBuilder().setSuccess(true).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
@@ -1,0 +1,42 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.dto.ApplyModerationActionRequest;
+import net.firedevops.firemud.dto.ModerationActionDto;
+import net.firedevops.firemud.entity.ModerationAction;
+import net.firedevops.firemud.mapper.ModerationActionMapper;
+import net.firedevops.firemud.repository.ModerationActionRepository;
+import net.firedevops.firemud.service.ModerationService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ModerationServiceImpl implements ModerationService {
+  private static final Logger logger = LoggingUtil.getLogger(ModerationServiceImpl.class);
+
+  private final ModerationActionRepository repository;
+  private final ModerationActionMapper mapper;
+
+  public ModerationServiceImpl(
+      ModerationActionRepository repository, ModerationActionMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  @Override
+  @Transactional
+  public ModerationActionDto applyAction(ApplyModerationActionRequest request) {
+    logger.info(
+        "Applying moderation action {} to account {}", request.action(), request.accountId());
+    ModerationAction entity = new ModerationAction();
+    entity.setTenantId(request.tenantId());
+    entity.setAccountId(request.accountId());
+    entity.setAction(request.action());
+    entity.setReason(request.reason());
+    entity.setCreatedAt(Instant.now());
+    entity = repository.save(entity);
+    return mapper.toDto(entity);
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/LogQueryControllerTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/LogQueryControllerTest.java
@@ -1,0 +1,60 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.dto.QueryLogsRequest;
+import net.firedevops.firemud.service.LogQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LogQueryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthConfig.class)
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
+class LogQueryControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000);
+
+  @MockitoBean private LogQueryService service;
+
+  @Test
+  void queryReturnsEntries() throws Exception {
+    QueryLogsRequest request = new QueryLogsRequest(1L, "msg");
+    when(service.queryLogs(request)).thenReturn(List.of("hello"));
+
+    mockMvc
+        .perform(
+            get("/logs")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    "Bearer "
+                        + jwtUtil.generateToken(
+                            "user",
+                            java.util.Map.of("globalRoles", java.util.List.of("platformAdmin"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0]").value("hello"));
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/ModerationActionControllerTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/controller/ModerationActionControllerTest.java
@@ -1,0 +1,62 @@
+package net.firedevops.firemud.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.dto.ApplyModerationActionRequest;
+import net.firedevops.firemud.dto.ModerationActionDto;
+import net.firedevops.firemud.service.ModerationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ModerationActionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthConfig.class)
+@TestPropertySource(
+    properties = {
+      "firemud.auth.jwt-secret=testsecretkeytestsecretkeytest1234",
+      "firemud.auth.jwt-expiration-ms=3600000"
+    })
+class ModerationActionControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000);
+
+  @MockitoBean private ModerationService service;
+
+  @Test
+  void applyReturnsDto() throws Exception {
+    ApplyModerationActionRequest req = new ApplyModerationActionRequest(1L, 2L, "ban", "");
+    ModerationActionDto dto =
+        new ModerationActionDto(1L, 1L, 2L, "ban", "", java.time.Instant.now(), null);
+    when(service.applyAction(req)).thenReturn(dto);
+
+    mockMvc
+        .perform(
+            post("/moderation/actions")
+                .header(
+                    HttpHeaders.AUTHORIZATION,
+                    "Bearer "
+                        + jwtUtil.generateToken(
+                            "user",
+                            java.util.Map.of("globalRoles", java.util.List.of("platformAdmin"))))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"));
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/LogQueryServiceImplTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/LogQueryServiceImplTest.java
@@ -1,0 +1,37 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import net.firedevops.firemud.dto.QueryLogsRequest;
+import net.firedevops.firemud.entity.LogEvent;
+import net.firedevops.firemud.repository.LogEventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class LogQueryServiceImplTest {
+  @Mock LogEventRepository repository;
+
+  @InjectMocks LogQueryServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void queryLogsReturnsMessages() {
+    LogEvent event = new LogEvent();
+    event.setMessage("hello");
+    when(repository.findByTenantIdAndMessageContainingIgnoreCase(1L, "test"))
+        .thenReturn(List.of(event));
+
+    List<String> result = service.queryLogs(new QueryLogsRequest(1L, "test"));
+
+    assertEquals(List.of("hello"), result);
+  }
+}

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/ModerationServiceImplTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/ModerationServiceImplTest.java
@@ -1,0 +1,48 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import net.firedevops.firemud.dto.ApplyModerationActionRequest;
+import net.firedevops.firemud.dto.ModerationActionDto;
+import net.firedevops.firemud.entity.ModerationAction;
+import net.firedevops.firemud.mapper.ModerationActionMapper;
+import net.firedevops.firemud.repository.ModerationActionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ModerationServiceImplTest {
+  @Mock ModerationActionRepository repository;
+  @Mock ModerationActionMapper mapper;
+
+  @InjectMocks ModerationServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void applyActionSavesEntity() {
+    ApplyModerationActionRequest req = new ApplyModerationActionRequest(1L, 2L, "ban", "test");
+    ModerationAction entity = new ModerationAction();
+    ModerationAction saved = new ModerationAction();
+    saved.setId(1L);
+    saved.setCreatedAt(Instant.now());
+    when(repository.save(any())).thenReturn(saved);
+    ModerationActionDto dto =
+        new ModerationActionDto(1L, 1L, 2L, "ban", "test", saved.getCreatedAt(), null);
+    when(mapper.toDto(saved)).thenReturn(dto);
+
+    ModerationActionDto result = service.applyAction(req);
+
+    assertEquals(dto, result);
+    verify(repository).save(any(ModerationAction.class));
+  }
+}


### PR DESCRIPTION
## Summary
- add LogQuery and ModerationAction APIs to logging-admin-service
- support moderation actions and log search via gRPC and REST
- implement service layer and unit tests

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_687102c76dec8330a8a611c7150a4132