### PR TITLE
Cleanup TenantId heading in service design docs

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -25,6 +25,8 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Chat history and guild data are stored with a `tenantId` so conversations are
   isolated per game. Redis stream keys also include this prefix. See
   [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+- Cross-service calls always forward the `tenantId` so features remain isolated;
+  see [Multi-Tenancy](../system-architecture-multi-tenancy.md) for details.
 - APIs require authenticated JWTs from the Account Service and all inter-service
   communication is encrypted via mutual TLS, following the
   [Security Architecture](../system-architecture-security.md).
@@ -82,18 +84,6 @@ default and can be enabled per tenant through configuration.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
-### TenantId Handling & Cross-Service Dependencies
-
-All data models include a `tenantId` column so chat history and guild
-information remain isolated per game. Redis keys use the same prefix. The service
-validates this context on every request and forwards the identifier to other
-services, such as the Logging & Admin Service, to maintain isolation across the
-platform.
-
-> See [**Gateway Architecture**](../../infrastructure/gateway-architecture.md),
-[**Deployment Environments**](../../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../../infrastructure/protocol-bridging.md) for
-details on shared infrastructure components.
 
 ## Operational Notes
 

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,13 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-## Cross-Service Dependencies
-
-Entity data is scoped by `tenantId` as described in the
-[Multi-Tenancy design](../../design/architecture/system-architecture-multi-tenancy.md).
-The service relies on the **Game Design Service** for character templates and
-item definitions and coordinates runtime persistence with the
-**Game Session Service**.
 
 ## Proto Contracts
 


### PR DESCRIPTION
## Summary
- prune TenantId Handling header from social service doc
- remove Cross-Service section from entity management README
- mention tenantId forwarding in design notes

## Testing
- `./gradlew check` *(fails: Spotless violation in unrelated module)*

------
https://chatgpt.com/codex/tasks/task_e_68710685c7308330be9f07c48a6042a8