### PR TITLE
Fix GameLogic gRPC error handling

### DIFF
--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
@@ -1,8 +1,7 @@
 package net.firedevops.firemud.service.impl;
 
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.gamelogic.v1.ExecuteCommandRequest;
 import net.firedevops.firemud.gamelogic.v1.ExecuteCommandResponse;
 import net.firedevops.firemud.gamelogic.v1.GameLogicServiceGrpc;
@@ -11,6 +10,7 @@ import net.firedevops.firemud.gamelogic.v1.PingResponse;
 import net.firedevops.firemud.logic.dto.CommandResult;
 import net.firedevops.firemud.logic.service.CommandService;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC endpoints for the Game Logic Service. */
@@ -18,10 +18,18 @@ import org.lognet.springboot.grpc.GRpcService;
 public class GameLogicGrpcService extends GameLogicServiceGrpc.GameLogicServiceImplBase {
   private final PingService pingService;
   private final CommandService commandService;
+  private final MeterRegistry meterRegistry;
 
-  public GameLogicGrpcService(PingService pingService, CommandService commandService) {
+  public GameLogicGrpcService(
+      PingService pingService, CommandService commandService, MeterRegistry meterRegistry) {
     this.pingService = pingService;
     this.commandService = commandService;
+    this.meterRegistry = meterRegistry;
+  }
+
+  private ErrorDetail error(String code, String message) {
+    meterRegistry.counter("grpc.app_error", "code", code).increment();
+    return ErrorDetail.newBuilder().setCode(code).setMessage(message).build();
   }
 
   @Override
@@ -35,15 +43,12 @@ public class GameLogicGrpcService extends GameLogicServiceGrpc.GameLogicServiceI
   public void executeCommand(
       ExecuteCommandRequest request, StreamObserver<ExecuteCommandResponse> responseObserver) {
     CommandResult result = commandService.handleCommand(request.getCommand());
+    ExecuteCommandResponse.Builder builder =
+        ExecuteCommandResponse.newBuilder().setResult(result.result());
     if (result.error() != null) {
-      StatusRuntimeException exception =
-          Status.INVALID_ARGUMENT.withDescription(result.error().message()).asRuntimeException();
-      responseObserver.onError(exception);
-      return;
+      builder.setError(error(result.error().code(), result.error().message()));
     }
-    ExecuteCommandResponse response =
-        ExecuteCommandResponse.newBuilder().setResult(result.result()).build();
-    responseObserver.onNext(response);
+    responseObserver.onNext(builder.build());
     responseObserver.onCompleted();
   }
 }

--- a/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
+++ b/services/game-logic-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameLogicGrpcServiceTest.java
@@ -1,12 +1,10 @@
 package net.firedevops.firemud.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.gamelogic.v1.ExecuteCommandRequest;
 import net.firedevops.firemud.gamelogic.v1.ExecuteCommandResponse;
@@ -27,7 +25,8 @@ class GameLogicGrpcServiceTest {
     var dispatcher = new EventDispatcher();
     var processor = new SimpleCommandProcessor(dispatcher, new NoOpScriptingHook());
     var commandService = new CommandServiceImpl(new DefaultCommandParser(), processor);
-    GameLogicGrpcService service = new GameLogicGrpcService(pingService, commandService);
+    GameLogicGrpcService service =
+        new GameLogicGrpcService(pingService, commandService, new SimpleMeterRegistry());
 
     AtomicReference<PingResponse> holder = new AtomicReference<>();
     service.ping(
@@ -56,28 +55,29 @@ class GameLogicGrpcServiceTest {
     var dispatcher = new EventDispatcher();
     var processor = new SimpleCommandProcessor(dispatcher, new NoOpScriptingHook());
     var commandService = new CommandServiceImpl(new DefaultCommandParser(), processor);
-    GameLogicGrpcService service = new GameLogicGrpcService(pingService, commandService);
+    GameLogicGrpcService service =
+        new GameLogicGrpcService(pingService, commandService, new SimpleMeterRegistry());
 
-    AtomicReference<Throwable> error = new AtomicReference<>();
+    AtomicReference<ExecuteCommandResponse> holder = new AtomicReference<>();
     service.executeCommand(
         ExecuteCommandRequest.newBuilder().setCommand("foo").build(),
         new StreamObserver<>() {
           @Override
           public void onNext(ExecuteCommandResponse value) {
-            fail("should not succeed");
+            holder.set(value);
           }
 
           @Override
           public void onError(Throwable t) {
-            error.set(t);
+            fail(t);
           }
 
           @Override
           public void onCompleted() {}
         });
 
-    assertTrue(error.get() instanceof StatusRuntimeException);
-    StatusRuntimeException ex = (StatusRuntimeException) error.get();
-    assertEquals(Status.INVALID_ARGUMENT.getCode(), ex.getStatus().getCode());
+    assertEquals("Unknown action", holder.get().getResult());
+    assertEquals("UNKNOWN_COMMAND", holder.get().getError().getCode());
+    assertEquals("Command not recognized", holder.get().getError().getMessage());
   }
 }


### PR DESCRIPTION
## Summary
- return structured errors for game logic gRPC calls instead of failing via onError
- update GameLogicGrpcService tests for new behavior

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6871091233f88330a6111726a32032f7