### PR TITLE
Update social chat design

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -43,6 +43,7 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Supports instance-based spaces in conjunction with the World Management Service
   so characters can enter private dungeons or personalized housing without affecting
   the shared world state.
+- Stores per-game friendship links on characters for local social features.
 
 ### Data Model
 
@@ -52,6 +53,8 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Character location and instance membership are stored by the World Management
   Service rather than this service.
 - Entity graphs cache inventory relationships for fast lookups.
+- `character_friend` table stores per-game friend links used by the Game Logic
+  Service.
 
 ### gRPC APIs
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -10,6 +10,8 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Apply combat rules, cooldowns, and environmental effects
 - Interact with entity and world services for context data
 - Push results back to the Game Session Service for distribution
+- Forward chat actions to the Social & Groups Service for delivery and
+  profanity checks
 
 ## Architecture / Design Notes
 
@@ -34,6 +36,7 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Command parsing and alias system.
 - Rule processing for combat and progression.
 - Emote and roleplay action handling.
+- In-game chat processing for say, tell, guild chat, and mail actions.
 - Event dispatcher for triggers and world events.
 - Effect stacking and cooldown calculation.
 - Environmental effect resolution (weather, lighting) influencing gameplay.
@@ -66,6 +69,7 @@ This service is largely stateless. It relies on:
   - World Management Service for room and region data.
   - Game Session Service supplies tick context and command queues.
   - Automation & Scripting Service triggers additional effects during rule execution.
+  - Social & Groups Service handles chat delivery and profanity filtering.
 
 > See [**Gateway Architecture**](../../infrastructure/gateway-architecture.md),
 [**Deployment Environments**](../../infrastructure/deployment-environments.md),

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -10,6 +10,7 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Manage guild creation, membership, and roles
 - Maintain friend lists and cross-game social graphs
 - Feed chat logs to the Logging & Admin Service for moderation
+- Send out-of-game notifications and bulk emails on behalf of game creators
 
 ## Architecture / Design Notes
 
@@ -18,6 +19,9 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Integrates with the Logging & Admin Service for moderation events.
 - Chat profanity triggers a gRPC call to the Logging & Admin Service to record a
   moderation report.
+- In-game chat commands such as say, tell, guild chat, and mail originate in the
+  Game Logic Service, which invokes this service to deliver messages and perform
+  profanity checks. All communications are logged for audit and moderation.
 - Messages are briefly cached in Redis streams to smooth bursts of activity and
   enable delivery retries.
 - Guild creation and membership changes participate in Saga workflows so other
@@ -41,12 +45,16 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Cross-game presence lets players know when friends are online in any hosted
   game.
 - In-game social chat plus account-to-account direct messaging.
+- Broadcast email capability for game creators to reach all active players.
 
 ### Data Model
 
 - `chat_message` table persists guild and private messages.
 - `guild` and `guild_member` tables store group ownership and membership roles.
 - `friend_link` table tracks account or character friendships and blocks.
+- Per-game friendships are stored on character records in the Entity Management
+  Service. When a game opts in, account-level friends from this service are
+  mirrored as in-game friends automatically.
 - `mail_message` table stores asynchronous player mail.
 - `faction` and `faction_standing` tables maintain player reputation. The
   [Automation & Scripting Service](../automation-scripting-service/README.md)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -69,6 +69,12 @@ The Game Session Service handles login, session recovery, and active gameplay. P
 ## 6. Social Interaction
 
 During gameplay, players form groups and communicate via the [Social & Groups Service](./microservices/social-groups-service/README.md). Chat rooms, guilds, and friend lists are synchronized in real time.
+In-game chat commands (say, tell, guild chat, and mail) are processed by the Game Logic Service
+and forwarded to the Social & Groups Service, which performs profanity checks and logs
+all communication. Account-to-account messages and broadcast emails to active players
+use the same service. Per-game friend connections are stored on characters via the
+Entity Management Service while account-level friends automatically appear in-game
+when the feature is enabled.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that Social & Groups Service delivers in-game chat and emails
- call out chat processing in Game Logic Service
- note per-game friendships in Entity Management Service
- elaborate on social interaction in user journeys

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68710bbe32908330bfdb14080b2633d9