### PR TITLE
Fix metrics exposure and lint warnings

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -84,7 +84,6 @@ default and can be enabled per tenant through configuration.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
-
 ## Operational Notes
 
 - Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -97,7 +97,6 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
-
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,7 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-
 ## Proto Contracts
 
 See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)

--- a/services/game-logic-service/src/main/resources/application.yml
+++ b/services/game-logic-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       probes:


### PR DESCRIPTION
## Summary
- expose Prometheus metrics endpoint for game-logic-service
- fix markdown lint issues in service docs

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68710f6b7220833087c8c6005e22c1f2