### PR TITLE
Add local shard configuration for World Management Service

### DIFF
--- a/services/world-management-service/src/main/java/net/firedevops/firemud/WorldManagementServiceApplication.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/WorldManagementServiceApplication.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
+import net.firedevops.firemud.config.WorldConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
@@ -12,7 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @OpenAPIDefinition(info = @Info(title = "World Management Service", version = "v1"))
 @EnableScheduling
-@Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class})
+@Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, WorldConfig.class})
 public class WorldManagementServiceApplication {
   public static void main(String[] args) {
     SpringApplication.run(WorldManagementServiceApplication.class, args);

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldConfig.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldConfig.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Registers world-related configuration properties. */
+@Configuration
+@EnableConfigurationProperties(WorldProperties.class)
+public class WorldConfig {}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration properties for world settings such as the local shard. */
+@Data
+@ConfigurationProperties(prefix = "world")
+public class WorldProperties {
+  /** Identifier of the shard this service instance hosts. */
+  private int localShardId = 0;
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/repository/WorldEventRepository.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/repository/WorldEventRepository.java
@@ -4,9 +4,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 import net.firedevops.firemud.entity.WorldEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WorldEventRepository extends JpaRepository<WorldEvent, Long> {
   List<WorldEvent> findByProcessedFalseAndExecuteAtBefore(LocalDateTime time);
+
+  @Query(
+      "select e from WorldEvent e where e.processed = false and e.executeAt <= :time"
+          + " and (e.region is null or e.region.shardId = :shardId)")
+  List<WorldEvent> findDueEventsForShard(LocalDateTime time, Integer shardId);
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
 import net.firedevops.firemud.common.saga.SagaException;
+import net.firedevops.firemud.config.WorldProperties;
 import net.firedevops.firemud.entity.Region;
 import net.firedevops.firemud.repository.RegionRepository;
 import net.firedevops.firemud.service.WorldCreationService;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class WorldCreationServiceImpl implements WorldCreationService {
   private final RegionRepository regionRepository;
   private final MeterRegistry meterRegistry;
+  private final WorldProperties worldProperties;
 
   private Counter sagaStartedCounter;
   private Counter sagaFailedCounter;
@@ -74,9 +76,9 @@ public class WorldCreationServiceImpl implements WorldCreationService {
     // TODO fetch data from Game Design Service. For now create a single region.
     Region region = new Region();
     region.setTenantId(tenantId);
-    // newly created worlds start on shard 0. Admin tooling can redistribute
-    // regions to other shards later for scaling.
-    region.setShardId(0);
+    // Newly created worlds start on the local shard. Admin tooling can
+    // redistribute regions later for scaling.
+    region.setShardId(worldProperties.getLocalShardId());
     region.setName("Starter Region");
     regionRepository.save(region);
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldEventServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldEventServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.config.WorldProperties;
 import net.firedevops.firemud.dto.WorldEventDto;
 import net.firedevops.firemud.entity.Region;
 import net.firedevops.firemud.entity.WorldEvent;
@@ -26,6 +27,7 @@ public class WorldEventServiceImpl implements WorldEventService {
   private final RegionRepository regionRepository;
   private final WorldEventMapper mapper;
   private final MeterRegistry meterRegistry;
+  private final WorldProperties worldProperties;
   private Counter eventsProcessedCounter;
   private static final Logger logger = LoggingUtil.getLogger(WorldEventServiceImpl.class);
 
@@ -49,7 +51,8 @@ public class WorldEventServiceImpl implements WorldEventService {
   @Transactional
   public void processDueEvents() {
     LocalDateTime now = LocalDateTime.now();
-    List<WorldEvent> events = eventRepository.findByProcessedFalseAndExecuteAtBefore(now);
+    List<WorldEvent> events =
+        eventRepository.findDueEventsForShard(now, worldProperties.getLocalShardId());
     for (WorldEvent event : events) {
       handleEvent(event);
       event.setProcessed(true);

--- a/services/world-management-service/src/main/resources/application.yml
+++ b/services/world-management-service/src/main/resources/application.yml
@@ -17,5 +17,6 @@ management:
         enabled: true
 
 world:
+  local-shard-id: 0
   instance:
     expiration-hours: 24

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldCreationServiceImplTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldCreationServiceImplTest.java
@@ -13,13 +13,16 @@ class WorldCreationServiceImplTest {
   private RegionRepository regionRepository;
   private WorldCreationServiceImpl service;
   private MeterRegistry meterRegistry;
+  private net.firedevops.firemud.config.WorldProperties worldProperties;
 
   @BeforeEach
   void setup() {
     regionRepository = mock(RegionRepository.class);
     meterRegistry = mock(MeterRegistry.class);
     when(meterRegistry.counter(anyString())).thenReturn(mock(Counter.class));
-    service = new WorldCreationServiceImpl(regionRepository, meterRegistry);
+    worldProperties = new net.firedevops.firemud.config.WorldProperties();
+    worldProperties.setLocalShardId(0);
+    service = new WorldCreationServiceImpl(regionRepository, meterRegistry, worldProperties);
   }
 
   @Test

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldEventServiceImplTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldEventServiceImplTest.java
@@ -22,13 +22,18 @@ class WorldEventServiceImplTest {
   private WorldEventMapper mapper = Mappers.getMapper(WorldEventMapper.class);
   private WorldEventServiceImpl service;
   private SimpleMeterRegistry meterRegistry;
+  private net.firedevops.firemud.config.WorldProperties worldProperties;
 
   @BeforeEach
   void setUp() {
     eventRepository = mock(WorldEventRepository.class);
     regionRepository = mock(RegionRepository.class);
     meterRegistry = new SimpleMeterRegistry();
-    service = new WorldEventServiceImpl(eventRepository, regionRepository, mapper, meterRegistry);
+    worldProperties = new net.firedevops.firemud.config.WorldProperties();
+    worldProperties.setLocalShardId(0);
+    service =
+        new WorldEventServiceImpl(
+            eventRepository, regionRepository, mapper, meterRegistry, worldProperties);
     service.initMetrics();
   }
 
@@ -53,7 +58,7 @@ class WorldEventServiceImplTest {
     event.setExecuteAt(LocalDateTime.now().minusMinutes(1));
     event.setProcessed(false);
 
-    when(eventRepository.findByProcessedFalseAndExecuteAtBefore(any()))
+    when(eventRepository.findDueEventsForShard(any(), anyInt()))
         .thenReturn(Collections.singletonList(event));
     when(regionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 


### PR DESCRIPTION
## Summary
- introduce `WorldProperties` and `WorldConfig`
- wire shard config into application and services
- filter world events by shard
- use shard id during world creation
- update unit tests

## Testing
- `./gradlew :world-management-service:spotlessApply`
- `./gradlew :world-management-service:check`

------
https://chatgpt.com/codex/tasks/task_e_68710f8272088330a6378b39625f7120