### PR TITLE
Improve gRPC error handling

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -84,7 +84,6 @@ default and can be enabled per tenant through configuration.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
-
 ## Operational Notes
 
 - Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -97,7 +97,6 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
-
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,7 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-
 ## Proto Contracts
 
 See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.stream.Collectors;
 import net.firedevops.firemud.dto.CharacterDto;
 import net.firedevops.firemud.entitymanagement.v1.Character;
@@ -21,10 +22,18 @@ public class EntityManagementGrpcService
     extends EntityManagementServiceGrpc.EntityManagementServiceImplBase {
   private final PingService pingService;
   private final CharacterService characterService;
+  private final MeterRegistry meterRegistry;
 
-  public EntityManagementGrpcService(PingService pingService, CharacterService characterService) {
+  public EntityManagementGrpcService(
+      PingService pingService, CharacterService characterService, MeterRegistry meterRegistry) {
     this.pingService = pingService;
     this.characterService = characterService;
+    this.meterRegistry = meterRegistry;
+  }
+
+  private ErrorDetail error(String code, String message) {
+    meterRegistry.counter("grpc.app_error", "code", code).increment();
+    return ErrorDetail.newBuilder().setCode(code).setMessage(message).build();
   }
 
   @Override
@@ -36,13 +45,7 @@ public class EntityManagementGrpcService
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {
       PingResponse response =
-          PingResponse.newBuilder()
-              .setError(
-                  ErrorDetail.newBuilder()
-                      .setCode("INVALID_ARGUMENT")
-                      .setMessage(ex.getMessage())
-                      .build())
-              .build();
+          PingResponse.newBuilder().setError(error("INVALID_ARGUMENT", ex.getMessage())).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (Exception ex) {
@@ -67,22 +70,14 @@ public class EntityManagementGrpcService
     } catch (NumberFormatException ex) {
       ListCharactersResponse response =
           ListCharactersResponse.newBuilder()
-              .setError(
-                  ErrorDetail.newBuilder()
-                      .setCode("INVALID_ARGUMENT")
-                      .setMessage(ex.getMessage())
-                      .build())
+              .setError(error("INVALID_ARGUMENT", ex.getMessage()))
               .build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {
       ListCharactersResponse response =
           ListCharactersResponse.newBuilder()
-              .setError(
-                  ErrorDetail.newBuilder()
-                      .setCode("INVALID_ARGUMENT")
-                      .setMessage(ex.getMessage())
-                      .build())
+              .setError(error("INVALID_ARGUMENT", ex.getMessage()))
               .build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/EntityManagementGrpcServiceTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/EntityManagementGrpcServiceTest.java
@@ -19,8 +19,14 @@ class EntityManagementGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     Mockito.when(pingService.ping()).thenReturn("pong");
     CharacterService characterService = Mockito.mock(CharacterService.class);
+    io.micrometer.core.instrument.MeterRegistry meterRegistry =
+        Mockito.mock(io.micrometer.core.instrument.MeterRegistry.class);
+    io.micrometer.core.instrument.Counter counter =
+        Mockito.mock(io.micrometer.core.instrument.Counter.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(counter);
     EntityManagementGrpcService service =
-        new EntityManagementGrpcService(pingService, characterService);
+        new EntityManagementGrpcService(pingService, characterService, meterRegistry);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -46,8 +52,14 @@ class EntityManagementGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     Mockito.when(pingService.ping()).thenThrow(new IllegalArgumentException("bad"));
     CharacterService characterService = Mockito.mock(CharacterService.class);
+    io.micrometer.core.instrument.MeterRegistry meterRegistry =
+        Mockito.mock(io.micrometer.core.instrument.MeterRegistry.class);
+    io.micrometer.core.instrument.Counter counter =
+        Mockito.mock(io.micrometer.core.instrument.Counter.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(counter);
     EntityManagementGrpcService service =
-        new EntityManagementGrpcService(pingService, characterService);
+        new EntityManagementGrpcService(pingService, characterService, meterRegistry);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -73,8 +85,14 @@ class EntityManagementGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     Mockito.when(pingService.ping()).thenThrow(new RuntimeException("boom"));
     CharacterService characterService = Mockito.mock(CharacterService.class);
+    io.micrometer.core.instrument.MeterRegistry meterRegistry =
+        Mockito.mock(io.micrometer.core.instrument.MeterRegistry.class);
+    io.micrometer.core.instrument.Counter counter =
+        Mockito.mock(io.micrometer.core.instrument.Counter.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(counter);
     EntityManagementGrpcService service =
-        new EntityManagementGrpcService(pingService, characterService);
+        new EntityManagementGrpcService(pingService, characterService, meterRegistry);
 
     AtomicReference<Throwable> err = new AtomicReference<>();
     service.ping(
@@ -101,8 +119,14 @@ class EntityManagementGrpcServiceTest {
   void listCharactersInvalidAccountIdReturnsErrorDetail() {
     PingService pingService = Mockito.mock(PingService.class);
     CharacterService characterService = Mockito.mock(CharacterService.class);
+    io.micrometer.core.instrument.MeterRegistry meterRegistry =
+        Mockito.mock(io.micrometer.core.instrument.MeterRegistry.class);
+    io.micrometer.core.instrument.Counter counter =
+        Mockito.mock(io.micrometer.core.instrument.Counter.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(counter);
     EntityManagementGrpcService service =
-        new EntityManagementGrpcService(pingService, characterService);
+        new EntityManagementGrpcService(pingService, characterService, meterRegistry);
 
     AtomicReference<net.firedevops.firemud.entitymanagement.v1.ListCharactersResponse> ref =
         new AtomicReference<>();
@@ -132,8 +156,14 @@ class EntityManagementGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     CharacterService characterService = Mockito.mock(CharacterService.class);
     Mockito.when(characterService.listForAccount(1L)).thenThrow(new RuntimeException("boom"));
+    io.micrometer.core.instrument.MeterRegistry meterRegistry =
+        Mockito.mock(io.micrometer.core.instrument.MeterRegistry.class);
+    io.micrometer.core.instrument.Counter counter =
+        Mockito.mock(io.micrometer.core.instrument.Counter.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(counter);
     EntityManagementGrpcService service =
-        new EntityManagementGrpcService(pingService, characterService);
+        new EntityManagementGrpcService(pingService, characterService, meterRegistry);
 
     AtomicReference<Throwable> err = new AtomicReference<>();
     service.listCharactersByAccount(


### PR DESCRIPTION
## Summary
- add metrics-based error helper to EntityManagementGrpcService
- update tests for MeterRegistry
- remove extra blank lines in docs

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68710fd6b21483309e57d841b817010c