### PR TITLE
Add documentation stubs for Game Design Service

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -84,7 +84,6 @@ default and can be enabled per tenant through configuration.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
-
 ## Operational Notes
 
 - Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -97,7 +97,6 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
-
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,7 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-
 ## Proto Contracts
 
 See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)

--- a/services/game-design-service/design/asset-storage.md
+++ b/services/game-design-service/design/asset-storage.md
@@ -1,0 +1,5 @@
+# Asset Storage
+
+The authoritative design document is located at [../../design/architecture/microservices/game-design-service/asset-storage.md](../../../design/architecture/microservices/game-design-service/asset-storage.md).
+
+This stub exists for convenience. Please see the linked file for details about asset upload and storage configuration.

--- a/services/game-design-service/design/game-templates.md
+++ b/services/game-design-service/design/game-templates.md
@@ -1,0 +1,5 @@
+# Game Templates
+
+The authoritative design document is located at [../../design/architecture/microservices/game-design-service/game-templates.md](../../../design/architecture/microservices/game-design-service/game-templates.md).
+
+This stub exists for convenience. Please see the linked file for details about template management and configuration.


### PR DESCRIPTION
## Summary
- provide stub links for game design docs
- fix markdown lint warnings in a few service docs

## Testing
- `./gradlew check --no-daemon` *(fails: Execution failed for task ':game-session-service:test')*

------
https://chatgpt.com/codex/tasks/task_e_687112855c748330a57849408ea94eef