### PR TITLE
Update chat docs for service flow

### DIFF
--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -11,7 +11,8 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Interact with entity and world services for context data
 - Push results back to the Game Session Service for distribution
 - Forward chat actions to the Social & Groups Service for delivery and
-  profanity checks
+  profanity checks after verifying room context via the World Management
+  Service and character state via the Entity Management Service
 
 ## Architecture / Design Notes
 
@@ -36,7 +37,9 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Command parsing and alias system.
 - Rule processing for combat and progression.
 - Emote and roleplay action handling.
-- In-game chat processing for say, tell, guild chat, and mail actions.
+- In-game chat processing for say, tell, guild chat, and mail actions,
+  leveraging World Management and Entity Management for context before
+  delegating delivery and logging to the Social & Groups Service.
 - Event dispatcher for triggers and world events.
 - Effect stacking and cooldown calculation.
 - Environmental effect resolution (weather, lighting) influencing gameplay.

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -20,8 +20,10 @@ Provides chat, guild, and social networking features across games. Enables playe
 - Chat profanity triggers a gRPC call to the Logging & Admin Service to record a
   moderation report.
 - In-game chat commands such as say, tell, guild chat, and mail originate in the
-  Game Logic Service, which invokes this service to deliver messages and perform
-  profanity checks. All communications are logged for audit and moderation.
+  Game Logic Service and incorporate context from the World Management and
+  Entity Management services. The Game Logic Service invokes this service to
+  deliver messages, run profanity checks, and log all communications for audit
+  and moderation.
 - Messages are briefly cached in Redis streams to smooth bursts of activity and
   enable delivery retries.
 - Guild creation and membership changes participate in Saga workflows so other
@@ -91,7 +93,6 @@ default and can be enabled per tenant through configuration.
   - Account Service for user identities.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
-
 
 ## Operational Notes
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -97,7 +97,6 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
-
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -69,12 +69,15 @@ The Game Session Service handles login, session recovery, and active gameplay. P
 ## 6. Social Interaction
 
 During gameplay, players form groups and communicate via the [Social & Groups Service](./microservices/social-groups-service/README.md). Chat rooms, guilds, and friend lists are synchronized in real time.
-In-game chat commands (say, tell, guild chat, and mail) are processed by the Game Logic Service
-and forwarded to the Social & Groups Service, which performs profanity checks and logs
-all communication. Account-to-account messages and broadcast emails to active players
-use the same service. Per-game friend connections are stored on characters via the
-Entity Management Service while account-level friends automatically appear in-game
-when the feature is enabled.
+In-game chat commands (say, tell, guild chat, and mail) are processed by the Game
+Logic Service. These actions reference the World Management and Entity
+Management services to validate location and character state before the Game
+Logic Service forwards them to the Social & Groups Service. The Social & Groups
+Service performs profanity checks, logs all communication, and delivers the
+message. Account-to-account messages and broadcast emails to active players use
+the same service. Per-game friend connections are stored on characters via the
+Entity Management Service while account-level friends automatically appear in
+game when the feature is enabled.
 
 ---
 

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,7 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-
 ## Proto Contracts
 
 See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)


### PR DESCRIPTION
## Summary
- detail how chat commands consult world/entity services before using Social & Groups Service
- mention profanity checks and audit logging
- fix blank line lint errors in multiple READMEs

## Testing
- `./gradlew lintMarkdown`
- `./gradlew check` *(fails: There were failing tests. See the report at: file:///workspace/FireMUD/services/game-session-service/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_687113298e308330a444cd310858a509