### PR TITLE
Implement region shard management

### DIFF
--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -66,6 +66,9 @@ Large worlds can span multiple server clusters. Each `region` is assigned a
 `shard_id` so the Game Session Service knows which cluster hosts the active
 state for that region. When a player crosses into a region on another shard the
 session handoff flow described in the Game Session Service design is invoked.
+Administrators can reassign regions between shards using the `RegionController`
+endpoint `POST /regions/{id}/move`, which updates the `shard_id` column for the
+specified region.
 
 ### gRPC APIs
 

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -49,7 +49,7 @@ participate in CI.
 
 - [x] Meta and admin services validate JWTs using helpers from `firemud-common`
 - [x] Check `globalRoles` and `scopedRoles` where applicable
-- [x] *(N/A - meta service)* Gameplay services rely on the Game Session Service for session validation
+- [x] _(N/A - meta service)_ Gameplay services rely on the Game Session Service for session validation
 
 ---
 
@@ -57,7 +57,7 @@ participate in CI.
 
 - [x] Use `firemud-common` protobuf types for shared messages
 - [x] Map errors to `ErrorDetail` with appropriate gRPC status codes
-- [x] *(N/A - Kubernetes DNS)* Register with service discovery via helpers in `firemud-common`
+- [x] _(N/A - Kubernetes DNS)_ Register with service discovery via helpers in `firemud-common`
 - [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
 - [x] Internal traffic communicates directly over gRPC (Gateway not involved)
 

--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -10,7 +10,7 @@
   - [x] Implement A* or Dijkstra-based pathfinding for NPCs & movement validation
   - [x] Use saga orchestrator for world creation workflow
   - [x] Provide tools to fine-tune procedural generation rules
-  - [ ] Support multi-server world shards
+  - [x] Support multi-server world shards
 
 ## Reusable Microservice Checklist
 

--- a/services/social-groups-service/src/test/java/integration/net/firedevops/firemud/SocialGroupsApplicationIntegrationTest.java
+++ b/services/social-groups-service/src/test/java/integration/net/firedevops/firemud/SocialGroupsApplicationIntegrationTest.java
@@ -47,7 +47,8 @@ class SocialGroupsApplicationIntegrationTest {
   }
 
   @Configuration
-  @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+  @EnableAutoConfiguration(
+      exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
   @Import({CommonAutoConfiguration.class, DatabaseAutoConfiguration.class, AuthConfig.class})
   static class TestApp {}
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/controller/RegionController.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/controller/RegionController.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.RegionDto;
+import net.firedevops.firemud.service.RegionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/regions")
+@RequiredArgsConstructor
+public class RegionController {
+  private final RegionService regionService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<RegionDto>>> list(@RequestParam Long tenantId) {
+    return ResponseEntity.ok(ApiResponse.success(regionService.listRegions(tenantId)));
+  }
+
+  @PostMapping("/{id}/move")
+  public ResponseEntity<ApiResponse<RegionDto>> moveRegion(
+      @PathVariable Long id, @RequestParam Long tenantId, @RequestParam Integer shardId) {
+    RegionDto result = regionService.moveRegion(tenantId, id, shardId);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/repository/RegionRepository.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/repository/RegionRepository.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.repository;
 
+import java.util.List;
 import net.firedevops.firemud.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,4 +15,8 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
   @Transactional
   @Query("delete from Region r where r.tenantId = :tenantId")
   void deleteByTenantId(Long tenantId);
+
+  List<Region> findByTenantId(Long tenantId);
+
+  List<Region> findByTenantIdAndShardId(Long tenantId, Integer shardId);
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/RegionService.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/RegionService.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.service;
+
+import java.util.List;
+import net.firedevops.firemud.dto.RegionDto;
+
+/** Region management and shard assignment. */
+public interface RegionService {
+  /** List all regions for a tenant. */
+  List<RegionDto> listRegions(Long tenantId);
+
+  /** Move a region to a new shard. */
+  RegionDto moveRegion(Long tenantId, Long regionId, Integer shardId);
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RegionServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RegionServiceImpl.java
@@ -1,0 +1,34 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.dto.RegionDto;
+import net.firedevops.firemud.mapper.RegionMapper;
+import net.firedevops.firemud.repository.RegionRepository;
+import net.firedevops.firemud.service.RegionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RegionServiceImpl implements RegionService {
+  private final RegionRepository regionRepository;
+  private final RegionMapper regionMapper;
+
+  @Override
+  public List<RegionDto> listRegions(Long tenantId) {
+    return regionRepository.findByTenantId(tenantId).stream().map(regionMapper::toDto).toList();
+  }
+
+  @Override
+  @Transactional
+  public RegionDto moveRegion(Long tenantId, Long regionId, Integer shardId) {
+    var region =
+        regionRepository
+            .findById(regionId)
+            .filter(r -> r.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Region not found"));
+    region.setShardId(shardId);
+    return regionMapper.toDto(regionRepository.save(region));
+  }
+}


### PR DESCRIPTION
## Summary
- add RegionController with endpoints for moving regions between shards
- implement RegionService and repository methods
- document shard reassignment in the world management design
- update world-management task list
- fix MD lint in social groups task list

## Testing
- `./gradlew :world-management-service:check`
- `./gradlew check` *(fails: GameSessionService tests require Docker)*

------
https://chatgpt.com/codex/tasks/task_e_687114b910d083308cf3dea08d6ba283