### PR TITLE
Fix style warnings

### DIFF
--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -1,6 +1,6 @@
 # Social & Groups Service Task List
 
-- [ ] **Develop Social & Groups Service**
+- [ ] __Develop Social & Groups Service__
   - [x] Enable cross-game friend lists and social graph
   - [x] Support private messages, global chat, and guild channels
   - [x] Implement player-to-player mail system (asynchronous in-game messaging)
@@ -49,7 +49,7 @@ participate in CI.
 
 - [x] Meta and admin services validate JWTs using helpers from `firemud-common`
 - [x] Check `globalRoles` and `scopedRoles` where applicable
-- [x] *(N/A - meta service)* Gameplay services rely on the Game Session Service for session validation
+- [x] _(N/A - meta service)_ Gameplay services rely on the Game Session Service for session validation
 
 ---
 
@@ -57,7 +57,7 @@ participate in CI.
 
 - [x] Use `firemud-common` protobuf types for shared messages
 - [x] Map errors to `ErrorDetail` with appropriate gRPC status codes
-- [x] *(N/A - Kubernetes DNS)* Register with service discovery via helpers in `firemud-common`
+- [x] _(N/A - Kubernetes DNS)_ Register with service discovery via helpers in `firemud-common`
 - [ ] Ensure gRPC calls use mTLS certificates issued by cert-manager
 - [x] Internal traffic communicates directly over gRPC (Gateway not involved)
 

--- a/services/social-groups-service/src/test/java/integration/net/firedevops/firemud/SocialGroupsApplicationIntegrationTest.java
+++ b/services/social-groups-service/src/test/java/integration/net/firedevops/firemud/SocialGroupsApplicationIntegrationTest.java
@@ -47,7 +47,8 @@ class SocialGroupsApplicationIntegrationTest {
   }
 
   @Configuration
-  @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+  @EnableAutoConfiguration(
+      exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
   @Import({CommonAutoConfiguration.class, DatabaseAutoConfiguration.class, AuthConfig.class})
   static class TestApp {}
 }


### PR DESCRIPTION
## Summary
- fix emphasis style in social-groups task list
- apply spotless formatting to SocialGroupsApplicationIntegrationTest

## Testing
- `./gradlew check` *(fails: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_e_6871143fa1508330818ebafe533b78ae