### PR TITLE
Implement NPC formation support

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -169,6 +169,7 @@ Expected response:
 - Additional AI modules for advanced behaviors.
 - Procedural world generation hooks working in tandem with the World Management Service. The initial implementation uses a lightweight dungeon generator described in [System Architecture: Procedural Generation](../system-architecture-procedural-generation.md).
 - NPC fleeing and surrender logic.
-- NPC formations and squad AI for coordinated encounters.
+- NPC formations and squad AI for coordinated encounters. Implemented via
+  `NpcFormationService`.
 - Fairness quotas and per-script resource limits to prevent abuse, as outlined
   in [System Architecture: Scripting & Automation](../system-architecture-scripting.md#fairness--abuse-prevention-planned).

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -92,7 +92,6 @@ default and can be enabled per tenant through configuration.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
-
 ## Operational Notes
 
 - Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -97,7 +97,6 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
-
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -85,3 +85,9 @@ A lightweight dungeon generator is provided for early world creation. It generat
 `PveEncounterService` offers random encounters and environmental hazards. Events
 are selected from predefined lists based on the region type and a random seed so
 results can be reproduced during testing.
+
+### NPC Formations
+
+`NpcFormationService` groups NPCs into squads. Formations have a leader and a
+type (`LINE`, `WEDGE`, or `CIRCLE`). Squad members are persisted in the
+`npc_formation_member` table and can be queried to coordinate group behaviour.

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormation.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormation.java
@@ -1,0 +1,27 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import net.firedevops.firemud.model.FormationType;
+
+@Data
+@Entity
+@Table(name = "npc_formations")
+public class NpcFormation {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Column(name = "leader_npc_id", nullable = false)
+  private Long leaderNpcId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "formation_type", nullable = false)
+  private FormationType formationType;
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormationMember.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormationMember.java
@@ -1,0 +1,20 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "npc_formation_member")
+public class NpcFormationMember {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "formation_id", nullable = false)
+  private NpcFormation formation;
+
+  @Column(name = "npc_id", nullable = false)
+  private Long npcId;
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/model/FormationType.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/model/FormationType.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.model;
+
+/** Types of NPC formations used for squad AI behavior. */
+public enum FormationType {
+  LINE,
+  WEDGE,
+  CIRCLE
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/NpcFormationMemberRepository.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/NpcFormationMemberRepository.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.repository;
+
+import java.util.List;
+import net.firedevops.firemud.entity.NpcFormationMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NpcFormationMemberRepository extends JpaRepository<NpcFormationMember, Long> {
+  List<NpcFormationMember> findByFormation_TenantIdAndFormation_Id(Long tenantId, Long formationId);
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/NpcFormationRepository.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/NpcFormationRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.NpcFormation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NpcFormationRepository extends JpaRepository<NpcFormation, Long> {}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/NpcFormationService.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/NpcFormationService.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.service;
+
+import java.util.List;
+import net.firedevops.firemud.model.FormationType;
+
+/** Manages NPC formations for squad AI behaviour. */
+public interface NpcFormationService {
+  Long createFormation(Long tenantId, String name, Long leaderNpcId, FormationType type);
+
+  void addMember(Long tenantId, Long formationId, Long npcId);
+
+  List<Long> getMembers(Long tenantId, Long formationId);
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/NpcFormationServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/NpcFormationServiceImpl.java
@@ -1,0 +1,52 @@
+package net.firedevops.firemud.service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.entity.NpcFormation;
+import net.firedevops.firemud.entity.NpcFormationMember;
+import net.firedevops.firemud.model.FormationType;
+import net.firedevops.firemud.repository.NpcFormationMemberRepository;
+import net.firedevops.firemud.repository.NpcFormationRepository;
+import net.firedevops.firemud.service.NpcFormationService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NpcFormationServiceImpl implements NpcFormationService {
+  private final NpcFormationRepository formationRepository;
+  private final NpcFormationMemberRepository memberRepository;
+
+  @Override
+  @Transactional
+  public Long createFormation(Long tenantId, String name, Long leaderNpcId, FormationType type) {
+    NpcFormation formation = new NpcFormation();
+    formation.setTenantId(tenantId);
+    formation.setName(name);
+    formation.setLeaderNpcId(leaderNpcId);
+    formation.setFormationType(type);
+    return formationRepository.save(formation).getId();
+  }
+
+  @Override
+  @Transactional
+  public void addMember(Long tenantId, Long formationId, Long npcId) {
+    NpcFormation formation = formationRepository.findById(formationId).orElseThrow();
+    if (!formation.getTenantId().equals(tenantId)) {
+      throw new IllegalArgumentException("tenant mismatch");
+    }
+    NpcFormationMember member = new NpcFormationMember();
+    member.setFormation(formation);
+    member.setNpcId(npcId);
+    memberRepository.save(member);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Long> getMembers(Long tenantId, Long formationId) {
+    return memberRepository.findByFormation_TenantIdAndFormation_Id(tenantId, formationId).stream()
+        .map(NpcFormationMember::getNpcId)
+        .collect(Collectors.toList());
+  }
+}

--- a/services/automation-scripting-service/src/main/resources/db/migration/V2__npc_formations.sql
+++ b/services/automation-scripting-service/src/main/resources/db/migration/V2__npc_formations.sql
@@ -1,0 +1,13 @@
+CREATE TABLE npc_formations (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id BIGINT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    leader_npc_id BIGINT NOT NULL,
+    formation_type VARCHAR(20) NOT NULL
+);
+
+CREATE TABLE npc_formation_member (
+    id BIGSERIAL PRIMARY KEY,
+    formation_id BIGINT NOT NULL REFERENCES npc_formations(id),
+    npc_id BIGINT NOT NULL
+);

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/NpcFormationServiceImplTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/NpcFormationServiceImplTest.java
@@ -1,0 +1,63 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import net.firedevops.firemud.entity.NpcFormation;
+import net.firedevops.firemud.entity.NpcFormationMember;
+import net.firedevops.firemud.model.FormationType;
+import net.firedevops.firemud.repository.NpcFormationMemberRepository;
+import net.firedevops.firemud.repository.NpcFormationRepository;
+import net.firedevops.firemud.service.NpcFormationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NpcFormationServiceImplTest {
+  private NpcFormationRepository formationRepo;
+  private NpcFormationMemberRepository memberRepo;
+  private NpcFormationService service;
+
+  @BeforeEach
+  void setup() {
+    formationRepo = mock(NpcFormationRepository.class);
+    memberRepo = mock(NpcFormationMemberRepository.class);
+    service = new NpcFormationServiceImpl(formationRepo, memberRepo);
+  }
+
+  @Test
+  void createFormationPersistsEntity() {
+    NpcFormation saved = new NpcFormation();
+    saved.setId(10L);
+    when(formationRepo.save(any())).thenReturn(saved);
+    Long id = service.createFormation(1L, "alpha", 2L, FormationType.LINE);
+    assertEquals(10L, id);
+  }
+
+  @Test
+  void addMemberValidatesTenant() {
+    NpcFormation formation = new NpcFormation();
+    formation.setId(5L);
+    formation.setTenantId(1L);
+    when(formationRepo.findById(5L)).thenReturn(Optional.of(formation));
+
+    service.addMember(1L, 5L, 3L);
+    verify(memberRepo).save(any(NpcFormationMember.class));
+  }
+
+  @Test
+  void getMembersReturnsNpcIds() {
+    when(memberRepo.findByFormation_TenantIdAndFormation_Id(1L, 5L))
+        .thenReturn(List.of(createMember(3L), createMember(4L)));
+    List<Long> ids = service.getMembers(1L, 5L);
+    assertEquals(List.of(3L, 4L), ids);
+  }
+
+  private NpcFormationMember createMember(Long npcId) {
+    NpcFormationMember m = new NpcFormationMember();
+    m.setNpcId(npcId);
+    return m;
+  }
+}

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,7 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-
 ## Proto Contracts
 
 See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)


### PR DESCRIPTION
## Summary
- add `NpcFormation` and `NpcFormationMember` entities
- implement `NpcFormationService` with basic squad management
- document formations in the automation-scripting README and design
- clean up markdown formatting for social-groups and world-management docs
- add new DB migration and unit tests

## Testing
- `./gradlew check` *(fails: Process 'npx' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_687113a669788330a3e9bb17bf20d716