### PR TITLE
Implement GDPR export & deletion for accounts

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -84,7 +84,6 @@ default and can be enabled per tenant through configuration.
   - Logging & Admin Service consumes chat logs for moderation.
 - **External:** PostgreSQL for social data.
 
-
 ## Operational Notes
 
 - Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -97,7 +97,6 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
-
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
@@ -2,10 +2,14 @@ package net.firedevops.firemud.controller;
 
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.service.AccountService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +29,19 @@ public class AccountController {
       @Valid @RequestBody CreateAccountRequest request) {
     AccountDto dto = accountService.createAccount(request);
     return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @GetMapping("/{accountId}/export")
+  public ResponseEntity<ApiResponse<AccountDataExportDto>> exportAccount(
+      @PathVariable Long accountId, Long tenantId) {
+    AccountDataExportDto data = accountService.exportAccountData(tenantId, accountId);
+    return ResponseEntity.ok(ApiResponse.success(data));
+  }
+
+  @DeleteMapping("/{accountId}")
+  public ResponseEntity<ApiResponse<Void>> deleteAccount(
+      @PathVariable Long accountId, Long tenantId) {
+    accountService.deleteAccount(tenantId, accountId);
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/AccountDataExportDto.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/AccountDataExportDto.java
@@ -1,0 +1,3 @@
+package net.firedevops.firemud.dto;
+
+public record AccountDataExportDto(AccountDto account, ProfileDto profile) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/PaymentTransactionRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/PaymentTransactionRepository.java
@@ -2,7 +2,17 @@ package net.firedevops.firemud.repository;
 
 import net.firedevops.firemud.entity.PaymentTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface PaymentTransactionRepository extends JpaRepository<PaymentTransaction, Long> {}
+public interface PaymentTransactionRepository extends JpaRepository<PaymentTransaction, Long> {
+
+  @Modifying
+  @Transactional
+  @Query("delete from PaymentTransaction pt where pt.account.id = :accountId")
+  void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/SubscriptionRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/SubscriptionRepository.java
@@ -2,7 +2,17 @@ package net.firedevops.firemud.repository;
 
 import net.firedevops.firemud.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {}
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+  @Modifying
+  @Transactional
+  @Query("delete from Subscription s where s.account.id = :accountId")
+  void deleteByAccountId(@Param("accountId") Long accountId);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service;
 
+import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.dto.ProfileDto;
@@ -13,4 +14,8 @@ public interface AccountService {
   ProfileDto getProfile(Long tenantId, Long accountId);
 
   ProfileDto updateProfile(UpdateProfileRequest request);
+
+  AccountDataExportDto exportAccountData(Long tenantId, Long accountId);
+
+  void deleteAccount(Long tenantId, Long accountId);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.dto.ProfileDto;
@@ -18,7 +19,9 @@ import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
+import net.firedevops.firemud.repository.SubscriptionRepository;
 import net.firedevops.firemud.service.AccountService;
 import net.firedevops.firemud.service.NotificationService;
 import org.slf4j.Logger;
@@ -33,6 +36,8 @@ public class AccountServiceImpl implements AccountService {
   private final AccountMapper accountMapper;
   private final ProfileRepository profileRepository;
   private final ProfileMapper profileMapper;
+  private final PaymentTransactionRepository paymentTransactionRepository;
+  private final SubscriptionRepository subscriptionRepository;
   private final NotificationService notificationService;
   private final JwtUtil jwtUtil;
   private final net.firedevops.firemud.service.session.SessionService sessionService;
@@ -42,6 +47,8 @@ public class AccountServiceImpl implements AccountService {
       AccountMapper accountMapper,
       ProfileRepository profileRepository,
       ProfileMapper profileMapper,
+      PaymentTransactionRepository paymentTransactionRepository,
+      SubscriptionRepository subscriptionRepository,
       NotificationService notificationService,
       JwtUtil jwtUtil,
       net.firedevops.firemud.service.session.SessionService sessionService) {
@@ -49,6 +56,8 @@ public class AccountServiceImpl implements AccountService {
     this.accountMapper = accountMapper;
     this.profileRepository = profileRepository;
     this.profileMapper = profileMapper;
+    this.paymentTransactionRepository = paymentTransactionRepository;
+    this.subscriptionRepository = subscriptionRepository;
     this.notificationService = notificationService;
     this.jwtUtil = jwtUtil;
     this.sessionService = sessionService;
@@ -125,6 +134,38 @@ public class AccountServiceImpl implements AccountService {
     notificationService.sendNotification(
         request.tenantId(), request.accountId(), "Profile updated");
     return profileMapper.toDto(profile);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  @Timed(value = "account.export")
+  public AccountDataExportDto exportAccountData(Long tenantId, Long accountId) {
+    Account account =
+        accountRepository
+            .findById(accountId)
+            .filter(a -> a.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    Profile profile =
+        profileRepository.findByAccountIdAndTenantId(accountId, tenantId).orElse(null);
+    return new AccountDataExportDto(
+        accountMapper.toDto(account), profile != null ? profileMapper.toDto(profile) : null);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.delete")
+  public void deleteAccount(Long tenantId, Long accountId) {
+    Account account =
+        accountRepository
+            .findById(accountId)
+            .filter(a -> a.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    paymentTransactionRepository.deleteByAccountId(accountId);
+    subscriptionRepository.deleteByAccountId(accountId);
+    profileRepository
+        .findByAccountIdAndTenantId(accountId, tenantId)
+        .ifPresent(profileRepository::delete);
+    accountRepository.delete(account);
   }
 
   private String hashPassword(String password) {

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -14,7 +14,9 @@ import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
+import net.firedevops.firemud.repository.SubscriptionRepository;
 import net.firedevops.firemud.service.NotificationService;
 import net.firedevops.firemud.service.session.SessionService;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,8 @@ class AccountServiceImplTest {
   @Mock private ProfileMapper profileMapper;
   @Mock private NotificationService notificationService;
   @Mock private SessionService sessionService;
+  @Mock private PaymentTransactionRepository paymentTransactionRepository;
+  @Mock private SubscriptionRepository subscriptionRepository;
 
   private AccountServiceImpl service;
 
@@ -43,6 +47,8 @@ class AccountServiceImplTest {
             mapper,
             profileRepository,
             profileMapper,
+            paymentTransactionRepository,
+            subscriptionRepository,
             notificationService,
             jwtUtil,
             sessionService);

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -41,7 +41,6 @@ contain either `platformAdmin` or `moderator` in the `globalRoles` claim, or an
 `admin`/`moderator` role within the `scopedRoles` map. Include the token using
 the standard `Authorization: Bearer <token>` header.
 
-
 ## Proto Contracts
 
 See [`entity_management_service.proto`](../../protos/entity-management/v1/entity_management_service.proto)


### PR DESCRIPTION
## Summary
- add AccountDataExportDto
- add export and delete methods to AccountService
- implement export/delete logic with repository cleanup
- expose `/accounts/{id}/export` and `DELETE /accounts/{id}` endpoints
- update unit test constructor parameters
- fix markdown lint errors in documentation

## Testing
- `./gradlew :account-service:spotlessApply`
- `./gradlew lintMarkdown`
- `./gradlew check` *(fails: GameSessionApplicationIntegrationTest requires Docker)*

------
https://chatgpt.com/codex/tasks/task_e_68711230651c833085380f3c5a99e9d8