### PR TITLE
Fix failing markdown lint

### DIFF
--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -50,5 +50,4 @@ gRPC endpoints. Cross-service integration tests live under
 `src/test/java/crossservice` and can be executed once dependent services are
 available.
 
-This stub exists only to link to the real design document. **Do not add design details here.*
-
+This stub exists only to link to the real design document. **Do not add design details here.**


### PR DESCRIPTION
## Summary
- fix markdown lint errors in Game Design Service docs

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68713f899c4083308a7a6c8bb38d0b08