### PR TITLE
Fix persistence timing note

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -17,7 +17,7 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Exposes gRPC endpoints for other microservices.
 - Caches frequently accessed character data in Redis for quick lookups.
 - Applies **optimistic locking** to avoid conflicting updates on the same entity.
-- **Database writes are deferred and batched**, not triggered on every gameplay action. The Game Session Service coordinates real-time updates using Redis; the database is only updated during safe persistence boundaries (e.g. logout, autosave).
+- **Database writes are deferred and batched**, not triggered on every gameplay action. The Game Session Service coordinates real-time updates using Redis; the database is only updated when ticks complete.
 - This design reduces write frequency and contention, making optimistic locking a natural fit — most entities are updated by only one process at a time, and conflicts are rare.
 - Item transfers and other gameplay actions span services but execute within ticks
   using Redis scripts for rollback. Sagas are reserved for non-gameplay

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -57,7 +57,7 @@ participate in CI.
 
 - [x] Use `firemud-common` protobuf types for shared messages
 - [x] Map errors to `ErrorDetail` with appropriate gRPC status codes
-- [x] *(N/A - Kubernetes DNS)* Register with service discovery via helpers in `firemud-common`
+- [x] _(N/A - Kubernetes DNS)_ Register with service discovery via helpers in `firemud-common`
 - [x] Ensure gRPC calls use mTLS certificates issued by cert-manager
 - [x] Internal traffic communicates directly over gRPC (Gateway not involved)
 

--- a/services/game-design-service/design/README.md
+++ b/services/game-design-service/design/README.md
@@ -47,8 +47,5 @@ document for the overall flow.
 `TestDataSeeder` populates a demo game, template, revision and version when the
 `dev` Spring profile is active. A simple smoke-test script verifies both REST and
 gRPC endpoints. Cross-service integration tests live under
-`src/test/java/crossservice` and can be executed once dependent services are
-available.
-
-This stub exists only to link to the real design document. **Do not add design details here.*
-
+`src/test/java/crossservice` and can be executed once dependent services are available.
+This stub exists only to link to the real design document. **Do not add design details here.**


### PR DESCRIPTION
## Summary
- clarify that entity writes persist on tick completion
- fix Markdown lint warnings in docs

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871429608e08330b42c0531c0a98bf2