### PR TITLE
Add export/delete RPCs to account service

### DIFF
--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -13,6 +13,8 @@ service AccountService {
   rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
   rpc GetProfile(GetProfileRequest) returns (GetProfileResponse);
   rpc UpdateProfile(UpdateProfileRequest) returns (UpdateProfileResponse);
+  rpc ExportAccount(ExportAccountRequest) returns (ExportAccountResponse);
+  rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse);
 }
 
 message PingRequest {}
@@ -63,6 +65,27 @@ message UpdateProfileRequest {
 }
 
 message UpdateProfileResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message ExportAccountRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+}
+
+message ExportAccountResponse {
+  string account_json = 1;
+  string profile_json = 2;
+  shared.v1.ErrorDetail error = 3;
+}
+
+message DeleteAccountRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+}
+
+message DeleteAccountResponse {
   bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -8,6 +8,10 @@ import net.firedevops.firemud.account.v1.AuthenticateRequest;
 import net.firedevops.firemud.account.v1.AuthenticateResponse;
 import net.firedevops.firemud.account.v1.CreateAccountRequest;
 import net.firedevops.firemud.account.v1.CreateAccountResponse;
+import net.firedevops.firemud.account.v1.DeleteAccountRequest;
+import net.firedevops.firemud.account.v1.DeleteAccountResponse;
+import net.firedevops.firemud.account.v1.ExportAccountRequest;
+import net.firedevops.firemud.account.v1.ExportAccountResponse;
 import net.firedevops.firemud.account.v1.GetProfileRequest;
 import net.firedevops.firemud.account.v1.GetProfileResponse;
 import net.firedevops.firemud.account.v1.PingRequest;
@@ -147,6 +151,61 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
               .setError(
                   net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
                       .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void exportAccount(
+      ExportAccountRequest request, StreamObserver<ExportAccountResponse> responseObserver) {
+    try {
+      var data =
+          accountService.exportAccountData(
+              Long.valueOf(request.getTenantId()), Long.valueOf(request.getAccountId()));
+      ExportAccountResponse response =
+          ExportAccountResponse.newBuilder()
+              .setAccountJson(JsonMapper.builder().build().writeValueAsString(data.account()))
+              .setProfileJson(
+                  data.profile() != null
+                      ? JsonMapper.builder().build().writeValueAsString(data.profile())
+                      : "")
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      ExportAccountResponse response =
+          ExportAccountResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("NOT_FOUND")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void deleteAccount(
+      DeleteAccountRequest request, StreamObserver<DeleteAccountResponse> responseObserver) {
+    try {
+      accountService.deleteAccount(
+          Long.valueOf(request.getTenantId()), Long.valueOf(request.getAccountId()));
+      DeleteAccountResponse response = DeleteAccountResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      DeleteAccountResponse response =
+          DeleteAccountResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("NOT_FOUND")
                       .setMessage(ex.getMessage())
                       .build())
               .build();

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.atomic.AtomicReference;
@@ -9,6 +10,10 @@ import net.firedevops.firemud.account.v1.AuthenticateRequest;
 import net.firedevops.firemud.account.v1.AuthenticateResponse;
 import net.firedevops.firemud.account.v1.CreateAccountRequest;
 import net.firedevops.firemud.account.v1.CreateAccountResponse;
+import net.firedevops.firemud.account.v1.DeleteAccountRequest;
+import net.firedevops.firemud.account.v1.DeleteAccountResponse;
+import net.firedevops.firemud.account.v1.ExportAccountRequest;
+import net.firedevops.firemud.account.v1.ExportAccountResponse;
 import net.firedevops.firemud.account.v1.GetProfileRequest;
 import net.firedevops.firemud.account.v1.GetProfileResponse;
 import net.firedevops.firemud.account.v1.PingRequest;
@@ -178,5 +183,59 @@ class AccountGrpcServiceTest {
 
     assertNotNull(ref.get());
     assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+
+  @Test
+  void exportAccountErrorReturnsDetail() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    Mockito.when(accountService.exportAccountData(1L, 2L))
+        .thenThrow(new IllegalArgumentException("missing"));
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<ExportAccountResponse> ref = new AtomicReference<>();
+    service.exportAccount(
+        ExportAccountRequest.newBuilder().setTenantId("1").setAccountId("2").build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(ExportAccountResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertEquals("NOT_FOUND", ref.get().getError().getCode());
+  }
+
+  @Test
+  void deleteAccountSuccess() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<DeleteAccountResponse> ref = new AtomicReference<>();
+    service.deleteAccount(
+        DeleteAccountRequest.newBuilder().setTenantId("1").setAccountId("2").build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(DeleteAccountResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertTrue(ref.get().getSuccess());
   }
 }


### PR DESCRIPTION
## Summary
- extend account service proto for ExportAccount and DeleteAccount RPCs
- implement new gRPC methods
- cover new behavior in unit tests

## Testing
- `./gradlew check` *(fails: Process 'npx' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_6871410cff28833088b838282e2b401a