### PR TITLE
Implement gRPC auth and client for World Management

### DIFF
--- a/services/world-management-service/src/main/java/net/firedevops/firemud/WorldManagementServiceApplication.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/WorldManagementServiceApplication.java
@@ -5,14 +5,17 @@ import io.swagger.v3.oas.annotations.info.Info;
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.config.WorldConfig;
+import net.firedevops.firemud.config.GrpcClientProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @OpenAPIDefinition(info = @Info(title = "World Management Service", version = "v1"))
 @EnableScheduling
+@EnableConfigurationProperties(GrpcClientProperties.class)
 @Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, WorldConfig.class})
 public class WorldManagementServiceApplication {
   public static void main(String[] args) {

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -1,0 +1,58 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import net.firedevops.firemud.gamesession.v1.GameSessionServiceGrpc;
+import net.firedevops.firemud.gamesession.v1.PingRequest;
+import net.firedevops.firemud.gamesession.v1.PingResponse;
+import org.springframework.stereotype.Component;
+
+/** gRPC client for communicating with the Game Session Service. */
+@Component
+public class GameSessionClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+  private ManagedChannel channel;
+  private GameSessionServiceGrpc.GameSessionServiceBlockingStub stub;
+
+  public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getGameSessionService();
+    if (target == null || target.isEmpty()) {
+      target = "game-session-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = GameSessionServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Simple ping to verify connectivity. */
+  public PingResponse ping() {
+    return stub.ping(PingRequest.newBuilder().build());
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
@@ -1,0 +1,18 @@
+package net.firedevops.firemud.config;
+
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.client.GameSessionClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Bean configuration for outbound gRPC clients. */
+@Configuration
+public class GrpcClientConfig {
+
+  @Bean
+  public GameSessionClient gameSessionClient(
+      net.firedevops.firemud.common.config.ServiceEndpointsProperties endpoints,
+      GrpcClientProperties properties) throws SSLException {
+    return new GameSessionClient(endpoints, properties);
+  }
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** TLS configuration for outbound gRPC connections. */
+@Data
+@ConfigurationProperties(prefix = "firemud.grpc")
+public class GrpcClientProperties {
+  private String certChain;
+  private String privateKey;
+  private String caCert;
+}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -10,6 +10,8 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
+import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.security.GrpcJwtAuthInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +36,12 @@ public class GrpcConfig {
   @GRpcGlobalInterceptor
   public TracingInterceptor tracingInterceptor(Tracer tracer) {
     return new TracingInterceptor(tracer);
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public GrpcJwtAuthInterceptor grpcJwtAuthInterceptor(JwtUtil jwtUtil) {
+    return new GrpcJwtAuthInterceptor(jwtUtil);
   }
 
   @Bean

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/security/GrpcJwtAuthInterceptor.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/security/GrpcJwtAuthInterceptor.java
@@ -1,0 +1,61 @@
+package net.firedevops.firemud.security;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+
+/** gRPC interceptor validating JWT tokens and roles. */
+public class GrpcJwtAuthInterceptor implements ServerInterceptor {
+  private static final Metadata.Key<String> AUTH_HEADER =
+      Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final JwtUtil jwtUtil;
+
+  public GrpcJwtAuthInterceptor(JwtUtil jwtUtil) {
+    this.jwtUtil = jwtUtil;
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    String authHeader = headers.get(AUTH_HEADER);
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      call.close(Status.UNAUTHENTICATED.withDescription("Missing token"), new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+    String token = authHeader.substring(7);
+    try {
+      Jws<Claims> claims = jwtUtil.parseToken(token);
+      List<String> globalRoles = claims.getBody().get("globalRoles", List.class);
+      Map<String, List<String>> scopedRoles = claims.getBody().get("scopedRoles", Map.class);
+      boolean hasGlobal =
+          globalRoles != null
+              && (globalRoles.contains("platformAdmin") || globalRoles.contains("moderator"));
+      boolean hasScoped = false;
+      if (scopedRoles != null) {
+        for (List<String> roles : scopedRoles.values()) {
+          if (roles.contains("admin") || roles.contains("moderator")) {
+            hasScoped = true;
+            break;
+          }
+        }
+      }
+      if (!hasGlobal && !hasScoped) {
+        call.close(Status.PERMISSION_DENIED.withDescription("Insufficient role"), new Metadata());
+        return new ServerCall.Listener<>() {};
+      }
+    } catch (JwtException ex) {
+      call.close(Status.UNAUTHENTICATED.withDescription("Invalid token"), new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+    return next.startCall(call, headers);
+  }
+}

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/security/GrpcJwtAuthInterceptorTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/security/GrpcJwtAuthInterceptorTest.java
@@ -1,0 +1,76 @@
+package net.firedevops.firemud.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GrpcJwtAuthInterceptorTest {
+  private JwtUtil jwtUtil;
+  private GrpcJwtAuthInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000L);
+    interceptor = new GrpcJwtAuthInterceptor(jwtUtil);
+  }
+
+  @Test
+  void rejectsMissingToken() {
+    TestServerCall call = new TestServerCall();
+    Metadata headers = new Metadata();
+    interceptor.interceptCall(call, headers, (c, h) -> new ServerCall.Listener<>() {});
+    assertEquals(Status.UNAUTHENTICATED.getCode(), call.status.getCode());
+  }
+
+  @Test
+  void allowsValidToken() {
+    String token =
+        jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+    TestServerCall call = new TestServerCall();
+    Metadata headers = new Metadata();
+    headers.put(
+        Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER),
+        "Bearer " + token);
+    ServerCall.Listener<?> listener =
+        interceptor.interceptCall(call, headers, (c, h) -> new ServerCall.Listener<>() {});
+    assertNotNull(listener);
+    assertEquals(null, call.status); // call not closed
+  }
+
+  private static class TestServerCall extends ServerCall<Object, Object> {
+    Status status;
+
+    @Override
+    public void request(int numMessages) {}
+
+    @Override
+    public void sendHeaders(Metadata headers) {}
+
+    @Override
+    public void sendMessage(Object message) {}
+
+    @Override
+    public void close(Status status, Metadata trailers) {
+      this.status = status;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public MethodDescriptor<Object, Object> getMethodDescriptor() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enable gRPC client properties in `WorldManagementServiceApplication`
- register `GrpcJwtAuthInterceptor`
- add `GameSessionClient` with mTLS using service discovery
- configure client bean
- provide tests for new interceptor

## Testing
- `./gradlew test classes`

------
https://chatgpt.com/codex/tasks/task_e_687147bc5f748330b89cb6f3dc297711