### PR TITLE
Add JWT interceptor to Automation Scripting Service

### DIFF
--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:1.15.1")
     implementation("io.opentelemetry:opentelemetry-sdk:1.38.0")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.38.0")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
     runtimeOnly("org.postgresql:postgresql:42.7.7")
 }
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/AutomationScriptingServiceApplication.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/AutomationScriptingServiceApplication.java
@@ -2,11 +2,14 @@ package net.firedevops.firemud;
 
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
+import net.firedevops.firemud.config.AuthProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@EnableConfigurationProperties(AuthProperties.class)
 @Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class})
 public class AutomationScriptingServiceApplication {
   public static void main(String[] args) {

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,0 +1,15 @@
+package net.firedevops.firemud.config;
+
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AuthProperties.class)
+public class AuthConfig {
+  @Bean
+  public JwtUtil jwtUtil(AuthProperties props) {
+    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "firemud.auth")
+public class AuthProperties {
+  private String jwtSecret;
+  private long jwtExpirationMs;
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -10,6 +10,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
+import net.firedevops.firemud.security.GrpcJwtAuthInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,6 +34,13 @@ public class GrpcConfig {
   @GRpcGlobalInterceptor
   public TracingInterceptor tracingInterceptor(Tracer tracer) {
     return new TracingInterceptor(tracer);
+  }
+
+  @Bean
+  @GRpcGlobalInterceptor
+  public GrpcJwtAuthInterceptor grpcJwtAuthInterceptor(
+      net.firedevops.firemud.common.security.JwtUtil jwtUtil) {
+    return new GrpcJwtAuthInterceptor(jwtUtil);
   }
 
   @Bean

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/security/GrpcJwtAuthInterceptor.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/security/GrpcJwtAuthInterceptor.java
@@ -1,0 +1,61 @@
+package net.firedevops.firemud.security;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+
+/** gRPC interceptor validating JWT tokens and roles. */
+public class GrpcJwtAuthInterceptor implements ServerInterceptor {
+  private static final Metadata.Key<String> AUTH_HEADER =
+      Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  private final JwtUtil jwtUtil;
+
+  public GrpcJwtAuthInterceptor(JwtUtil jwtUtil) {
+    this.jwtUtil = jwtUtil;
+  }
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    String authHeader = headers.get(AUTH_HEADER);
+    if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+      call.close(Status.UNAUTHENTICATED.withDescription("Missing token"), new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+    String token = authHeader.substring(7);
+    try {
+      Jws<Claims> claims = jwtUtil.parseToken(token);
+      List<String> globalRoles = claims.getBody().get("globalRoles", List.class);
+      Map<String, List<String>> scopedRoles = claims.getBody().get("scopedRoles", Map.class);
+      boolean hasGlobal =
+          globalRoles != null &&
+              (globalRoles.contains("platformAdmin") || globalRoles.contains("moderator"));
+      boolean hasScoped = false;
+      if (scopedRoles != null) {
+        for (List<String> roles : scopedRoles.values()) {
+          if (roles.contains("admin") || roles.contains("moderator")) {
+            hasScoped = true;
+            break;
+          }
+        }
+      }
+      if (!hasGlobal && !hasScoped) {
+        call.close(Status.PERMISSION_DENIED.withDescription("Insufficient role"), new Metadata());
+        return new ServerCall.Listener<>() {};
+      }
+    } catch (JwtException ex) {
+      call.close(Status.UNAUTHENTICATED.withDescription("Invalid token"), new Metadata());
+      return new ServerCall.Listener<>() {};
+    }
+    return next.startCall(call, headers);
+  }
+}

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/security/GrpcJwtAuthInterceptorTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/security/GrpcJwtAuthInterceptorTest.java
@@ -1,0 +1,75 @@
+package net.firedevops.firemud.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GrpcJwtAuthInterceptorTest {
+  private JwtUtil jwtUtil;
+  private GrpcJwtAuthInterceptor interceptor;
+
+  @BeforeEach
+  void setUp() {
+    jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000L);
+    interceptor = new GrpcJwtAuthInterceptor(jwtUtil);
+  }
+
+  @Test
+  void rejectsMissingToken() {
+    TestServerCall call = new TestServerCall();
+    Metadata headers = new Metadata();
+    interceptor.interceptCall(call, headers, (c, h) -> new ServerCall.Listener<>() {});
+    assertEquals(Status.UNAUTHENTICATED.getCode(), call.status.getCode());
+  }
+
+  @Test
+  void allowsValidToken() {
+    String token =
+        jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+    TestServerCall call = new TestServerCall();
+    Metadata headers = new Metadata();
+    headers.put(
+        Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer " + token);
+    ServerCall.Listener<?> listener =
+        interceptor.interceptCall(call, headers, (c, h) -> new ServerCall.Listener<>() {});
+    assertNotNull(listener);
+    assertEquals(null, call.status); // call not closed
+  }
+
+  private static class TestServerCall extends ServerCall<Object, Object> {
+    Status status;
+
+    @Override
+    public void request(int numMessages) {}
+
+    @Override
+    public void sendHeaders(Metadata headers) {}
+
+    @Override
+    public void sendMessage(Object message) {}
+
+    @Override
+    public void close(Status status, Metadata trailers) {
+      this.status = status;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public MethodDescriptor<Object, Object> getMethodDescriptor() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement JWT utilities in automation-scripting-service
- wire auth config and interceptor into gRPC config
- add unit test for interceptor

## Testing
- `./gradlew test` *(fails: JwtUsageTest in entity-management-service)*

------
https://chatgpt.com/codex/tasks/task_e_68714d78f1888330b01dc527fd6dc5e0