### PR TITLE
Fix tick lock key prefix

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -140,7 +140,7 @@ grpcurl -plaintext localhost:6565 entity_management.v1.EntityManagementService/P
 
 ### Tick Locking
 
-This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:lock:{entityId}` key described in the [Redis Architecture](../../../design/architecture/system-architecture-redis.md) document. Locks expire after `game.tick-duration-ms` (default 1000 ms) to ensure stalled ticks can be retried.
+This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:lock:{tenantId}:{entityId}` key described in the [Redis Architecture](../../../design/architecture/system-architecture-redis.md) document. Locks expire after `game.tick-duration-ms` (default 1000 ms) to ensure stalled ticks can be retried.
 
 - [System Architecture Diagram](../system-architecture-diagram.md)
 - [System Context Diagram](../system-context-diagram.md)

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -70,11 +70,11 @@ Redis keys follow strict naming conventions to ensure:
 
 | Redis Key                      | Description                              |
 |-------------------------------|------------------------------------------|
-| `tick:lock:{entityId}`        | Lock for entity during tick execution    |
-| `tick:pending:{regionId}`     | Staged results for a tick region         |
+| `tick:lock:{tenantId}:{entityId}` | Lock for entity during tick execution    |
+| `tick:pending:{tenantId}:{regionId}` | Staged results for a tick region         |
 | `room:{roomId}:occupants`     | Room occupancy snapshot                  |
 | `retry:{regionId}`            | Retry queue for failed actions           |
-| `timer:{entityId}:{effectId}` | Cooldown/effect timer metadata (in ms)   |
+| `timer:{tenantId}:{entityId}:{effectId}` | Cooldown/effect timer metadata (in ms)   |
 
 > 📌 For session-related keys and structure, see [Session Keys and Gameplay Binding](#-session-keys-and-gameplay-binding)
 > ⚠️ Tick regions and player sessions are **always scoped to a single Redis shard** to preserve atomicity. Cross-shard operations are avoided.
@@ -103,10 +103,10 @@ All Lua scripts are:
 
 ### Example Lock Workflow
 
-1. Acquire `tick:lock:{entityId}` using `SET NX PX` with a TTL equal to the tick duration.
-2. Stage updates under `tick:pending:{regionId}` via Lua script while the lock is held.
+1. Acquire `tick:lock:{tenantId}:{entityId}` using `SET NX PX` with a TTL equal to the tick duration.
+2. Stage updates under `tick:pending:{tenantId}:{regionId}` via Lua script while the lock is held.
 3. On successful commit the lock is released and staged data is flushed.
-4. If the lock expires, the next tick replays `tick:pending:{regionId}` and attempts the workflow again.
+4. If the lock expires, the next tick replays `tick:pending:{tenantId}:{regionId}` and attempts the workflow again.
 
 ---
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -32,7 +32,7 @@ This model ensures:
 
 To prevent concurrent entity updates, ticks acquire **distributed locks** in Redis using:
 
-- `tick:lock:{entityId}` (see [Redis Key Reference](./system-architecture-redis.md#🗂️-key-naming-and-shard-discipline))
+- `tick:lock:{tenantId}:{entityId}` (see [Redis Key Reference](./system-architecture-redis.md#🗂️-key-naming-and-shard-discipline))
 - `SET NX PX` with expiry for exclusive ownership
 - Lua-based atomic checks to avoid race conditions
 
@@ -108,7 +108,7 @@ The **Game Session Service** manages orchestration, while gameplay rules are res
 
 ## 🧮 Tick Staging and Commit Flow
 
-State changes are first **staged in Redis** under keys like `tick:pending:{regionId}`:
+State changes are first **staged in Redis** under keys like `tick:pending:{tenantId}:{regionId}`:
 
 - Only committed if **all actions succeed**
 - Timeout or failed actions are **excluded** and **rescheduled with priority**
@@ -151,7 +151,7 @@ This guarantees **clean, deterministic ticks** and safe replays after crash or r
 
 Time-based effects (e.g., cooldowns, regeneration) are managed with **real-time timers in milliseconds**, stored as:
 
-- `timer:{entityId}:{effectId}`
+- `timer:{tenantId}:{entityId}:{effectId}`
 
 Each tick scans timers for expirations and triggers corresponding events. If delayed, multiple may fire at once.
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/security/GrpcJwtAuthInterceptor.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/security/GrpcJwtAuthInterceptor.java
@@ -37,7 +37,8 @@ public class GrpcJwtAuthInterceptor implements ServerInterceptor {
       List<String> globalRoles = claims.getBody().get("globalRoles", List.class);
       Map<String, List<String>> scopedRoles = claims.getBody().get("scopedRoles", Map.class);
       boolean hasGlobal =
-          globalRoles != null && (globalRoles.contains("platformAdmin") || globalRoles.contains("moderator"));
+          globalRoles != null
+              && (globalRoles.contains("platformAdmin") || globalRoles.contains("moderator"));
       boolean hasScoped = false;
       if (scopedRoles != null) {
         for (List<String> roles : scopedRoles.values()) {

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/TickLockService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/TickLockService.java
@@ -2,9 +2,20 @@ package net.firedevops.firemud.service;
 
 /** Simple service for acquiring per-entity tick locks in Redis. */
 public interface TickLockService {
-  /** Acquire a tick lock for the entity. Returns true if obtained. */
-  boolean acquireLock(Long entityId);
+  /**
+   * Acquire a tick lock for the entity. Returns true if obtained.
+   *
+   * @param tenantId game identifier used to prefix the Redis key
+   * @param entityId unique entity identifier
+   * @return {@code true} if the lock was successfully acquired
+   */
+  boolean acquireLock(Long tenantId, Long entityId);
 
-  /** Release the previously acquired lock. */
-  void releaseLock(Long entityId);
+  /**
+   * Release the previously acquired lock.
+   *
+   * @param tenantId game identifier used to prefix the Redis key
+   * @param entityId unique entity identifier
+   */
+  void releaseLock(Long tenantId, Long entityId);
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
@@ -17,19 +17,19 @@ public class TickLockServiceImpl implements TickLockService {
   private long tickDurationMs;
 
   @Override
-  public boolean acquireLock(Long entityId) {
-    String key = lockKey(entityId);
+  public boolean acquireLock(Long tenantId, Long entityId) {
+    String key = lockKey(tenantId, entityId);
     Boolean result =
         redisTemplate.opsForValue().setIfAbsent(key, "1", Duration.ofMillis(tickDurationMs));
     return Boolean.TRUE.equals(result);
   }
 
   @Override
-  public void releaseLock(Long entityId) {
-    redisTemplate.delete(lockKey(entityId));
+  public void releaseLock(Long tenantId, Long entityId) {
+    redisTemplate.delete(lockKey(tenantId, entityId));
   }
 
-  private String lockKey(Long entityId) {
-    return "tick:lock:" + entityId;
+  private String lockKey(Long tenantId, Long entityId) {
+    return "tick:lock:" + tenantId + ":" + entityId;
   }
 }

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickLockServiceImplTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickLockServiceImplTest.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TickLockServiceImplTest {
+  private StringRedisTemplate redisTemplate;
+  private ValueOperations<String, String> valueOps;
+  private TickLockServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    redisTemplate = mock(StringRedisTemplate.class);
+    valueOps = mock(ValueOperations.class);
+    when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    service = new TickLockServiceImpl(redisTemplate);
+    ReflectionTestUtils.setField(service, "tickDurationMs", 1000L);
+  }
+
+  @Test
+  void acquireAndReleaseLock() {
+    when(valueOps.setIfAbsent(eq("tick:lock:1:2"), eq("1"), any(Duration.class))).thenReturn(true);
+
+    assertTrue(service.acquireLock(1L, 2L));
+    service.releaseLock(1L, 2L);
+
+    verify(redisTemplate).delete("tick:lock:1:2");
+  }
+}


### PR DESCRIPTION
## Summary
- prefix tick lock keys with tenantId in Entity Management Service
- update design docs for Redis key conventions and tick workflow
- adjust formatting in account service
- add TickLockService unit test

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871c872501c833087642f73bbee22ea