### PR TITLE
Fix accessibility issues

### DIFF
--- a/web-client/src/App.css
+++ b/web-client/src/App.css
@@ -38,5 +38,11 @@
 }
 
 .read-the-docs {
-  color: #888;
+  color: #333;
+}
+
+@media (prefers-color-scheme: dark) {
+  .read-the-docs {
+    color: #ccc;
+  }
 }

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -12,45 +12,47 @@ function App() {
 
   return (
     <>
-      <div>
+      <header>
         <a href="https://vite.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
         <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
-      </div>
-      <h1>Vite + React</h1>
-      <Button variant="outlined" onClick={() => setMode('game')} sx={{ mr: 1 }}>
-        Game Editor
-      </Button>
-      <Button
-        variant="outlined"
-        onClick={() => setMode('script')}
-        sx={{ mr: 1 }}
-      >
-        Script Editor
-      </Button>
-      <Button variant="outlined" onClick={() => setMode('demo')}>
-        Demo
-      </Button>
-      <div className="card">
-        {mode === 'game' && <GameEditor />}
-        {mode === 'script' && <ScriptEditor />}
-        {mode === 'demo' && (
-          <>
-            <Button variant="contained" onClick={() => setCount((c) => c + 1)}>
-              count is {count}
-            </Button>
-            <p>
-              Edit <code>src/App.tsx</code> and save to test HMR
-            </p>
-          </>
-        )}
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      </header>
+      <main>
+        <h1>Vite + React</h1>
+        <Button variant="outlined" onClick={() => setMode('game')} sx={{ mr: 1 }}>
+          Game Editor
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={() => setMode('script')}
+          sx={{ mr: 1 }}
+        >
+          Script Editor
+        </Button>
+        <Button variant="outlined" onClick={() => setMode('demo')}>
+          Demo
+        </Button>
+        <div className="card">
+          {mode === 'game' && <GameEditor />}
+          {mode === 'script' && <ScriptEditor />}
+          {mode === 'demo' && (
+            <>
+              <Button variant="contained" onClick={() => setCount((c) => c + 1)}>
+                count is {count}
+              </Button>
+              <p>
+                Edit <code>src/App.tsx</code> and save to test HMR
+              </p>
+            </>
+          )}
+        </div>
+        <p className="read-the-docs">
+          Click on the Vite and React logos to learn more
+        </p>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add semantic header/main structure in App
- improve read-the-docs color contrast for light/dark themes

## Testing
- `npm install`
- `npm run accessibility` *(fails: session not created, chrome binary issues)*
- `./gradlew check` *(fails: `:account-service:spotlessJavaCheck` format violations)*

------
https://chatgpt.com/codex/tasks/task_e_6871c8ed52f88330bb81022716f84a22