### PR TITLE
Implement guild member management

### DIFF
--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
@@ -2,12 +2,15 @@ package net.firedevops.firemud.controller;
 
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AddGuildMemberRequest;
 import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
 import net.firedevops.firemud.dto.CreateAllianceRequest;
 import net.firedevops.firemud.dto.CreateGuildRequest;
 import net.firedevops.firemud.dto.GuildAllianceDto;
 import net.firedevops.firemud.dto.GuildDto;
+import net.firedevops.firemud.dto.GuildMemberDto;
 import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.dto.UpdateGuildMemberRoleRequest;
 import net.firedevops.firemud.service.GuildService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,5 +46,26 @@ public class GuildController {
       @Valid @RequestBody CreateAllianceRequest request) {
     GuildAllianceDto dto = guildService.createAlliance(request);
     return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @PostMapping("/members")
+  public ResponseEntity<ApiResponse<GuildMemberDto>> addMember(
+      @Valid @RequestBody AddGuildMemberRequest request) {
+    GuildMemberDto dto = guildService.addMember(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @PostMapping("/members/role")
+  public ResponseEntity<ApiResponse<GuildMemberDto>> updateMemberRole(
+      @Valid @RequestBody UpdateGuildMemberRoleRequest request) {
+    GuildMemberDto dto = guildService.updateMemberRole(request);
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @PostMapping("/members/remove")
+  public ResponseEntity<ApiResponse<String>> removeMember(
+      @Valid @RequestBody AddGuildMemberRequest request) {
+    guildService.removeMember(request.tenantId(), request.guildId(), request.accountId());
+    return ResponseEntity.ok(ApiResponse.success("removed"));
   }
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddGuildMemberRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddGuildMemberRequest.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AddGuildMemberRequest(
+    @NotNull Long tenantId,
+    @NotNull Long guildId,
+    @NotNull Long accountId,
+    @NotBlank String role) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildMemberDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/GuildMemberDto.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/** DTO for guild member information. */
+public record GuildMemberDto(
+    Long id,
+    @NotNull Long tenantId,
+    @NotNull Long guildId,
+    @NotNull Long accountId,
+    @NotBlank String role) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/UpdateGuildMemberRoleRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/UpdateGuildMemberRoleRequest.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateGuildMemberRoleRequest(
+    @NotNull Long tenantId,
+    @NotNull Long guildId,
+    @NotNull Long accountId,
+    @NotBlank String role) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/GuildMember.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/GuildMember.java
@@ -1,0 +1,25 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "guild_members")
+public class GuildMember {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false)
+  private Long guildId;
+
+  @Column(nullable = false)
+  private Long accountId;
+
+  @Column(nullable = false, length = 50)
+  private String role;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildMemberMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/GuildMemberMapper.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.GuildMemberDto;
+import net.firedevops.firemud.entity.GuildMember;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface GuildMemberMapper {
+  GuildMemberDto toDto(GuildMember entity);
+
+  GuildMember toEntity(GuildMemberDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildMemberRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/GuildMemberRepository.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.GuildMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GuildMemberRepository extends JpaRepository<GuildMember, Long> {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/GuildService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/GuildService.java
@@ -1,11 +1,14 @@
 package net.firedevops.firemud.service;
 
+import net.firedevops.firemud.dto.AddGuildMemberRequest;
 import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
 import net.firedevops.firemud.dto.CreateAllianceRequest;
 import net.firedevops.firemud.dto.CreateGuildRequest;
 import net.firedevops.firemud.dto.GuildAllianceDto;
 import net.firedevops.firemud.dto.GuildDto;
+import net.firedevops.firemud.dto.GuildMemberDto;
 import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.dto.UpdateGuildMemberRoleRequest;
 
 public interface GuildService {
   GuildDto createGuild(CreateGuildRequest request);
@@ -13,4 +16,10 @@ public interface GuildService {
   GuildStorageItemDto addStorageItem(AddGuildStorageItemRequest request);
 
   GuildAllianceDto createAlliance(CreateAllianceRequest request);
+
+  GuildMemberDto addMember(AddGuildMemberRequest request);
+
+  GuildMemberDto updateMemberRole(UpdateGuildMemberRoleRequest request);
+
+  void removeMember(long tenantId, long guildId, long accountId);
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/GuildServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/GuildServiceImpl.java
@@ -6,19 +6,25 @@ import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
 import net.firedevops.firemud.common.saga.SagaException;
+import net.firedevops.firemud.dto.AddGuildMemberRequest;
 import net.firedevops.firemud.dto.AddGuildStorageItemRequest;
 import net.firedevops.firemud.dto.CreateAllianceRequest;
 import net.firedevops.firemud.dto.CreateGuildRequest;
 import net.firedevops.firemud.dto.GuildAllianceDto;
 import net.firedevops.firemud.dto.GuildDto;
+import net.firedevops.firemud.dto.GuildMemberDto;
 import net.firedevops.firemud.dto.GuildStorageItemDto;
+import net.firedevops.firemud.dto.UpdateGuildMemberRoleRequest;
 import net.firedevops.firemud.entity.Guild;
 import net.firedevops.firemud.entity.GuildAlliance;
+import net.firedevops.firemud.entity.GuildMember;
 import net.firedevops.firemud.entity.GuildStorageItem;
 import net.firedevops.firemud.mapper.GuildAllianceMapper;
 import net.firedevops.firemud.mapper.GuildMapper;
+import net.firedevops.firemud.mapper.GuildMemberMapper;
 import net.firedevops.firemud.mapper.GuildStorageItemMapper;
 import net.firedevops.firemud.repository.GuildAllianceRepository;
+import net.firedevops.firemud.repository.GuildMemberRepository;
 import net.firedevops.firemud.repository.GuildRepository;
 import net.firedevops.firemud.repository.GuildStorageItemRepository;
 import net.firedevops.firemud.service.GuildService;
@@ -38,6 +44,8 @@ public class GuildServiceImpl implements GuildService {
   private final GuildAllianceMapper allianceMapper;
   private final GuildRepository guildRepository;
   private final GuildMapper guildMapper;
+  private final GuildMemberRepository guildMemberRepository;
+  private final GuildMemberMapper guildMemberMapper;
   private final LoggingAdminClient loggingAdminClient;
   private final SagaRunner sagaRunner;
 
@@ -97,5 +105,52 @@ public class GuildServiceImpl implements GuildService {
     alliance.setAllyGuildId(request.allyGuildId());
     alliance.setCreatedAt(Instant.now());
     return allianceMapper.toDto(allianceRepo.save(alliance));
+  }
+
+  @Override
+  @Transactional
+  public GuildMemberDto addMember(AddGuildMemberRequest request) {
+    logger.info("Adding member {} to guild {}", request.accountId(), request.guildId());
+    GuildMember member = new GuildMember();
+    member.setTenantId(request.tenantId());
+    member.setGuildId(request.guildId());
+    member.setAccountId(request.accountId());
+    member.setRole(request.role());
+    return guildMemberMapper.toDto(guildMemberRepository.save(member));
+  }
+
+  @Override
+  @Transactional
+  public GuildMemberDto updateMemberRole(UpdateGuildMemberRoleRequest request) {
+    logger.info(
+        "Updating member {} in guild {} to role {}",
+        request.accountId(),
+        request.guildId(),
+        request.role());
+    GuildMember member =
+        guildMemberRepository.findAll().stream()
+            .filter(
+                m ->
+                    m.getTenantId().equals(request.tenantId())
+                        && m.getGuildId().equals(request.guildId())
+                        && m.getAccountId().equals(request.accountId()))
+            .findFirst()
+            .orElseThrow();
+    member.setRole(request.role());
+    return guildMemberMapper.toDto(guildMemberRepository.save(member));
+  }
+
+  @Override
+  @Transactional
+  public void removeMember(long tenantId, long guildId, long accountId) {
+    logger.info("Removing member {} from guild {}", accountId, guildId);
+    guildMemberRepository.findAll().stream()
+        .filter(
+            m ->
+                m.getTenantId().equals(tenantId)
+                    && m.getGuildId().equals(guildId)
+                    && m.getAccountId().equals(accountId))
+        .findFirst()
+        .ifPresent(guildMemberRepository::delete);
   }
 }

--- a/services/social-groups-service/src/main/resources/openapi.yaml
+++ b/services/social-groups-service/src/main/resources/openapi.yaml
@@ -221,6 +221,51 @@ components:
         expiresAt:
           type: string
           format: date-time
+    AddGuildMemberRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        accountId:
+          type: integer
+        role:
+          type: string
+      required:
+        - tenantId
+        - guildId
+        - accountId
+        - role
+    UpdateGuildMemberRoleRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        accountId:
+          type: integer
+        role:
+          type: string
+      required:
+        - tenantId
+        - guildId
+        - accountId
+        - role
+    GuildMemberDto:
+      type: object
+      properties:
+        id:
+          type: integer
+        tenantId:
+          type: integer
+        guildId:
+          type: integer
+        accountId:
+          type: integer
+        role:
+          type: string
 paths:
   /ping:
     get:
@@ -369,6 +414,72 @@ paths:
                 properties:
                   data:
                     $ref: '#/components/schemas/GuildAllianceDto'
+        '400':
+          description: Invalid request
+  /guilds/members:
+    post:
+      summary: Add guild member
+      operationId: addGuildMember
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGuildMemberRequest'
+      responses:
+        '200':
+          description: Member added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GuildMemberDto'
+        '400':
+          description: Invalid request
+  /guilds/members/role:
+    post:
+      summary: Update guild member role
+      operationId: updateGuildMemberRole
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGuildMemberRoleRequest'
+      responses:
+        '200':
+          description: Role updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GuildMemberDto'
+        '400':
+          description: Invalid request
+  /guilds/members/remove:
+    post:
+      summary: Remove guild member
+      operationId: removeGuildMember
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGuildMemberRequest'
+      responses:
+        '200':
+          description: Member removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: string
         '400':
           description: Invalid request
   /voice/token:

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/GuildServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/GuildServiceImplTest.java
@@ -1,0 +1,53 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import net.firedevops.firemud.dto.AddGuildMemberRequest;
+import net.firedevops.firemud.dto.GuildMemberDto;
+import net.firedevops.firemud.entity.GuildMember;
+import net.firedevops.firemud.mapper.GuildMemberMapper;
+import net.firedevops.firemud.repository.GuildMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mockito;
+
+class GuildServiceImplTest {
+  private GuildMemberRepository repository;
+  private GuildServiceImpl service;
+
+  @BeforeEach
+  void setUp() {
+    repository = Mockito.mock(GuildMemberRepository.class);
+    service =
+        new GuildServiceImpl(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            repository,
+            Mappers.getMapper(GuildMemberMapper.class),
+            null,
+            null);
+  }
+
+  @Test
+  void addMemberReturnsDto() {
+    AddGuildMemberRequest request = new AddGuildMemberRequest(1L, 2L, 3L, "member");
+    GuildMember saved = new GuildMember();
+    saved.setId(1L);
+    saved.setTenantId(1L);
+    saved.setGuildId(2L);
+    saved.setAccountId(3L);
+    saved.setRole("member");
+    when(repository.save(any(GuildMember.class))).thenReturn(saved);
+
+    GuildMemberDto dto = service.addMember(request);
+    assertEquals(3L, dto.accountId());
+    assertEquals("member", dto.role());
+  }
+}


### PR DESCRIPTION
## Summary
- add entity/repository for GuildMember
- support guild member operations in service layer
- expose REST endpoints for guild member management
- document new API in OpenAPI spec
- cover new logic with unit test

## Testing
- `./gradlew :social-groups-service:spotlessApply`
- `./gradlew :social-groups-service:check`

------
https://chatgpt.com/codex/tasks/task_e_6871cdeb9ee08330b63306ebe154a0d6