### PR TITLE
Fix social groups task list heading

### DIFF
--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -72,7 +72,7 @@ participate in CI.
 
 ---
 
--## 🔄 Saga Participation _(if used)_
+## 🔄 Saga Participation _(if used)_
 
 - [x] Use saga helpers from `firemud-common` for workflow steps
 - [x] Emit metrics and correlation IDs for compensation and retries


### PR DESCRIPTION
## Summary
- correct heading formatting in Social & Groups service task list

## Testing
- `./gradlew check --no-daemon` *(fails: automation-scripting-service Spotless)*

------
https://chatgpt.com/codex/tasks/task_e_6871d47f29dc8330b36ede77148f31f0