### PR TITLE
Add character friend management

### DIFF
--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
@@ -1,0 +1,40 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AddFriendRequest;
+import net.firedevops.firemud.dto.CharacterFriendDto;
+import net.firedevops.firemud.service.FriendService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/** REST endpoints for managing per-game friend links. */
+@RestController
+@RequestMapping("/characters/{characterId}/friends")
+@RequiredArgsConstructor
+public class FriendController {
+  private final FriendService friendService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<CharacterFriendDto>>> list(
+      @PathVariable Long characterId) {
+    List<CharacterFriendDto> list = friendService.listFriends(characterId);
+    return ResponseEntity.ok(ApiResponse.success(list));
+  }
+
+  @PostMapping
+  public ResponseEntity<ApiResponse<CharacterFriendDto>> add(
+      @PathVariable Long characterId, @Valid @RequestBody AddFriendRequest request) {
+    CharacterFriendDto dto = friendService.addFriend(characterId, request.friendId());
+    return ResponseEntity.ok(ApiResponse.success(dto));
+  }
+
+  @DeleteMapping("/{friendId}")
+  public ResponseEntity<ApiResponse<Void>> remove(
+      @PathVariable Long characterId, @PathVariable Long friendId) {
+    friendService.removeFriend(characterId, friendId);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/AddFriendRequest.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/AddFriendRequest.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/** Request body for adding a friend to a character. */
+public record AddFriendRequest(@NotNull Long friendId) {}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/CharacterFriendDto.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/CharacterFriendDto.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/** DTO representing a per-game friend link between characters. */
+public record CharacterFriendDto(
+    @NotNull Long characterId, @NotNull Long friendId, Long createdAtEpochMs) {}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CharacterFriend.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CharacterFriend.java
@@ -1,0 +1,26 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "character_friend")
+public class CharacterFriend {
+  @EmbeddedId private CharacterFriendKey id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("characterId")
+  private Character character;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("friendId")
+  private Character friend;
+
+  @Column(nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false)
+  private Instant createdAt = Instant.now();
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CharacterFriendKey.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CharacterFriendKey.java
@@ -1,0 +1,16 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+@Embeddable
+public class CharacterFriendKey implements Serializable {
+  @Column(name = "character_id")
+  private Long characterId;
+
+  @Column(name = "friend_id")
+  private Long friendId;
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CharacterFriendMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CharacterFriendMapper.java
@@ -1,0 +1,17 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.CharacterFriendDto;
+import net.firedevops.firemud.entity.CharacterFriend;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CharacterFriendMapper {
+  @Mapping(target = "characterId", source = "id.characterId")
+  @Mapping(target = "friendId", source = "id.friendId")
+  @Mapping(
+      target = "createdAtEpochMs",
+      expression =
+          "java(entity.getCreatedAt() == null ? null : entity.getCreatedAt().toEpochMilli())")
+  CharacterFriendDto toDto(CharacterFriend entity);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/CharacterFriendRepository.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/CharacterFriendRepository.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.repository;
+
+import java.util.List;
+import net.firedevops.firemud.entity.CharacterFriend;
+import net.firedevops.firemud.entity.CharacterFriendKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CharacterFriendRepository
+    extends JpaRepository<CharacterFriend, CharacterFriendKey> {
+  List<CharacterFriend> findByIdCharacterId(Long characterId);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/FriendService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/FriendService.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.service;
+
+import java.util.List;
+import net.firedevops.firemud.dto.CharacterFriendDto;
+
+public interface FriendService {
+  List<CharacterFriendDto> listFriends(Long characterId);
+
+  CharacterFriendDto addFriend(Long characterId, Long friendId);
+
+  void removeFriend(Long characterId, Long friendId);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
@@ -1,0 +1,59 @@
+package net.firedevops.firemud.service.impl;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.dto.CharacterFriendDto;
+import net.firedevops.firemud.entity.Character;
+import net.firedevops.firemud.entity.CharacterFriend;
+import net.firedevops.firemud.entity.CharacterFriendKey;
+import net.firedevops.firemud.mapper.CharacterFriendMapper;
+import net.firedevops.firemud.repository.CharacterFriendRepository;
+import net.firedevops.firemud.repository.CharacterRepository;
+import net.firedevops.firemud.service.FriendService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FriendServiceImpl implements FriendService {
+  private final CharacterFriendRepository repository;
+  private final CharacterRepository characterRepository;
+  private final CharacterFriendMapper mapper;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<CharacterFriendDto> listFriends(Long characterId) {
+    return repository.findByIdCharacterId(characterId).stream().map(mapper::toDto).toList();
+  }
+
+  @Override
+  @Transactional
+  public CharacterFriendDto addFriend(Long characterId, Long friendId) {
+    CharacterFriendKey key = new CharacterFriendKey();
+    key.setCharacterId(characterId);
+    key.setFriendId(friendId);
+    CharacterFriend entity = repository.findById(key).orElse(null);
+    if (entity == null) {
+      Character character = characterRepository.findById(characterId).orElseThrow();
+      Character friend = characterRepository.findById(friendId).orElseThrow();
+      entity = new CharacterFriend();
+      entity.setId(key);
+      entity.setCharacter(character);
+      entity.setFriend(friend);
+      entity.setTenantId(character.getTenantId());
+      entity.setCreatedAt(Instant.now());
+    }
+    entity = repository.save(entity);
+    return mapper.toDto(entity);
+  }
+
+  @Override
+  @Transactional
+  public void removeFriend(Long characterId, Long friendId) {
+    CharacterFriendKey key = new CharacterFriendKey();
+    key.setCharacterId(characterId);
+    key.setFriendId(friendId);
+    repository.deleteById(key);
+  }
+}

--- a/services/entity-management-service/src/main/resources/db/migration/V4__character_friend.sql
+++ b/services/entity-management-service/src/main/resources/db/migration/V4__character_friend.sql
@@ -1,0 +1,8 @@
+CREATE TABLE character_friend (
+    character_id BIGINT NOT NULL REFERENCES characters(id),
+    friend_id BIGINT NOT NULL REFERENCES characters(id),
+    tenant_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (character_id, friend_id)
+);


### PR DESCRIPTION
## Summary
- implement per‑game friend management for characters
- add `character_friend` table migration
- expose REST endpoints for adding, listing, and removing friends

## Testing
- `./gradlew :entity-management-service:check`

------
https://chatgpt.com/codex/tasks/task_e_6871d364e3b0833094890f38399edd2b