### PR TITLE
Clean service design stubs

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -24,7 +24,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 - AI computations are optimized for large worlds using tick-based batching.
 - Script definitions are versioned and can be hot reloaded without downtime as
   described in [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
-- Uploading or replacing scripts is handled as a Saga workflow so that failures
+- Uploading or replacing scripts via the `UpdateScript` gRPC method is handled as a Saga workflow so that failures
     can be rolled back. The service uses the shared `SagaBuilder` and
     `SagaRunner` helpers to persist the script and emit `sagas.active` metrics
     with a `correlationId` for troubleshooting. See

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -1,14 +1,7 @@
 # Automation Scripting Service
 
 Design documentation lives at:
+
 [📄 Automation Scripting Service Design](../../design/architecture/microservices/automation-scripting-service/README.md)
 
-### Script Upload Workflow
-
-Scripts are uploaded via the `UpdateScript` gRPC method. The operation runs as a
-Saga using `SagaBuilder` and `SagaRunner` from the shared library so that
-failures can roll back the persisted record. A `correlationId` is attached to
-logs for each saga execution and the number of active sagas is exported via the
-`sagas.active` metric.
-
-This README is a stub. **Do not place design details here.**
+This README is only a stub linking to the main design document. **Do not add design details here.**


### PR DESCRIPTION
## Summary
- keep Automation Scripting Service README as a stub linking to the real design
- document `UpdateScript` saga workflow in the central design doc

## Testing
- `./gradlew check` *(fails: spotlessJavaCheck formatting violations)*

------
https://chatgpt.com/codex/tasks/task_e_6871d40cea3c8330854b3a0edd741e85