### PR TITLE
Fix Markdown lint in automation-scripting-service README

### DIFF
--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -3,7 +3,7 @@
 Design documentation lives at:
 [📄 Automation Scripting Service Design](../../design/architecture/microservices/automation-scripting-service/README.md)
 
-### Script Upload Workflow
+## Script Upload Workflow
 
 Scripts are uploaded via the `UpdateScript` gRPC method. The operation runs as a
 Saga using `SagaBuilder` and `SagaRunner` from the shared library so that


### PR DESCRIPTION
## Summary
- adjust heading level in automation-scripting-service README to satisfy markdownlint

## Testing
- `./gradlew lintMarkdown`
- `pre-commit run markdownlint --files services/automation-scripting-service/README.md`
- `pre-commit run --all-files` *(fails: spotless violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6871d3ec605c8330a43bc15d3ce2b9a2