### PR TITLE
Fix gRPC error handling for world management

### DIFF
--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldManagementGrpcService.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldManagementGrpcService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.dto.RoomDto;
@@ -17,6 +18,7 @@ import net.firedevops.firemud.worldmanagement.v1.PingResponse;
 import net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateRequest;
 import net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateResponse;
 import net.firedevops.firemud.worldmanagement.v1.WorldManagementServiceGrpc;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC endpoints for the World Management Service. */
@@ -28,14 +30,30 @@ public class WorldManagementGrpcService
   private final RoomService roomService;
   private final RoomMapper roomMapper;
   private final net.firedevops.firemud.service.WorldEventService worldEventService;
+  private final MeterRegistry meterRegistry;
   private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private ErrorDetail error(String code, String message) {
+    meterRegistry.counter("grpc.app_error", "code", code).increment();
+    return ErrorDetail.newBuilder().setCode(code).setMessage(message).build();
+  }
 
   @Override
   public void ping(PingRequest request, StreamObserver<PingResponse> responseObserver) {
-    String msg = pingService.ping();
-    PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+    try {
+      String msg = pingService.ping();
+      PingResponse response = PingResponse.newBuilder().setMessage(msg).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      PingResponse response =
+          PingResponse.newBuilder().setError(error("INVALID_ARGUMENT", ex.getMessage())).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(ex.getMessage()).asRuntimeException());
+    }
   }
 
   @Override
@@ -50,12 +68,22 @@ public class WorldManagementGrpcService
         responseObserver.onNext(response);
         responseObserver.onCompleted();
       } else {
-        responseObserver.onError(
-            Status.NOT_FOUND.withDescription("room not found").asRuntimeException());
+        GetRoomResponse response =
+            GetRoomResponse.newBuilder().setError(error("NOT_FOUND", "room not found")).build();
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
       }
     } catch (NumberFormatException ex) {
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT.withDescription("invalid id").asRuntimeException());
+      GetRoomResponse response =
+          GetRoomResponse.newBuilder().setError(error("INVALID_ARGUMENT", "invalid id"))
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      GetRoomResponse response =
+          GetRoomResponse.newBuilder().setError(error("NOT_FOUND", ex.getMessage())).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
     }
   }
 
@@ -66,6 +94,14 @@ public class WorldManagementGrpcService
       worldEventService.processDueEvents();
       UpdateWorldStateResponse response =
           UpdateWorldStateResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      UpdateWorldStateResponse response =
+          UpdateWorldStateResponse.newBuilder()
+              .setSuccess(false)
+              .setError(error("INVALID_ARGUMENT", ex.getMessage()))
+              .build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (Exception ex) {

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldManagementGrpcServiceTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldManagementGrpcServiceTest.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.mapper.RoomMapper;
 import net.firedevops.firemud.service.PingService;
 import net.firedevops.firemud.service.RoomService;
+import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.worldmanagement.v1.PingRequest;
 import net.firedevops.firemud.worldmanagement.v1.PingResponse;
 import org.junit.jupiter.api.Test;
@@ -21,8 +22,11 @@ class WorldManagementGrpcServiceTest {
     RoomService roomService = Mockito.mock(RoomService.class);
     RoomMapper mapper = Mappers.getMapper(RoomMapper.class);
     var worldEventService = Mockito.mock(net.firedevops.firemud.service.WorldEventService.class);
+    MeterRegistry meterRegistry = Mockito.mock(MeterRegistry.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(Mockito.mock(io.micrometer.core.instrument.Counter.class));
     WorldManagementGrpcService service =
-        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService);
+        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService, meterRegistry);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -41,5 +45,75 @@ class WorldManagementGrpcServiceTest {
         });
 
     assertEquals("pong", ref.get().getMessage());
+  }
+
+  @Test
+  void getRoomInvalidIdReturnsErrorDetail() {
+    PingService pingService = Mockito.mock(PingService.class);
+    RoomService roomService = Mockito.mock(RoomService.class);
+    RoomMapper mapper = Mappers.getMapper(RoomMapper.class);
+    var worldEventService = Mockito.mock(net.firedevops.firemud.service.WorldEventService.class);
+    MeterRegistry meterRegistry = Mockito.mock(MeterRegistry.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(Mockito.mock(io.micrometer.core.instrument.Counter.class));
+    WorldManagementGrpcService service =
+        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService, meterRegistry);
+
+    AtomicReference<net.firedevops.firemud.worldmanagement.v1.GetRoomResponse> ref =
+        new AtomicReference<>();
+    service.getRoom(
+        net.firedevops.firemud.worldmanagement.v1.GetRoomRequest.newBuilder()
+            .setTenantId("bad")
+            .setRoomId("1")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(net.firedevops.firemud.worldmanagement.v1.GetRoomResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+
+  @Test
+  void updateWorldStateSuccess() {
+    PingService pingService = Mockito.mock(PingService.class);
+    RoomService roomService = Mockito.mock(RoomService.class);
+    RoomMapper mapper = Mappers.getMapper(RoomMapper.class);
+    var worldEventService = Mockito.mock(net.firedevops.firemud.service.WorldEventService.class);
+    MeterRegistry meterRegistry = Mockito.mock(MeterRegistry.class);
+    Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
+        .thenReturn(Mockito.mock(io.micrometer.core.instrument.Counter.class));
+    WorldManagementGrpcService service =
+        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService, meterRegistry);
+
+    AtomicReference<net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateResponse> ref =
+        new AtomicReference<>();
+    service.updateWorldState(
+        net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateRequest.newBuilder()
+            .setTenantId("1")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(
+              net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals(true, ref.get().getSuccess());
   }
 }


### PR DESCRIPTION
## Summary
- follow global rules for gRPC error handling in WorldManagementService
- track app errors using meter counter
- add tests for invalid getRoom id and updateWorldState

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6871d69b8060833093ca4b9e1099995b