### PR TITLE
Fix formatting for world management gRPC service

### DIFF
--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldManagementGrpcService.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldManagementGrpcService.java
@@ -11,6 +11,7 @@ import net.firedevops.firemud.dto.RoomDto;
 import net.firedevops.firemud.mapper.RoomMapper;
 import net.firedevops.firemud.service.PingService;
 import net.firedevops.firemud.service.RoomService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
 import net.firedevops.firemud.worldmanagement.v1.GetRoomRequest;
 import net.firedevops.firemud.worldmanagement.v1.GetRoomResponse;
 import net.firedevops.firemud.worldmanagement.v1.PingRequest;
@@ -18,7 +19,6 @@ import net.firedevops.firemud.worldmanagement.v1.PingResponse;
 import net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateRequest;
 import net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateResponse;
 import net.firedevops.firemud.worldmanagement.v1.WorldManagementServiceGrpc;
-import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC endpoints for the World Management Service. */
@@ -75,8 +75,7 @@ public class WorldManagementGrpcService
       }
     } catch (NumberFormatException ex) {
       GetRoomResponse response =
-          GetRoomResponse.newBuilder().setError(error("INVALID_ARGUMENT", "invalid id"))
-              .build();
+          GetRoomResponse.newBuilder().setError(error("INVALID_ARGUMENT", "invalid id")).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (IllegalArgumentException ex) {

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldManagementGrpcServiceTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/WorldManagementGrpcServiceTest.java
@@ -3,11 +3,11 @@ package net.firedevops.firemud.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.mapper.RoomMapper;
 import net.firedevops.firemud.service.PingService;
 import net.firedevops.firemud.service.RoomService;
-import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.worldmanagement.v1.PingRequest;
 import net.firedevops.firemud.worldmanagement.v1.PingResponse;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,8 @@ class WorldManagementGrpcServiceTest {
     Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
         .thenReturn(Mockito.mock(io.micrometer.core.instrument.Counter.class));
     WorldManagementGrpcService service =
-        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService, meterRegistry);
+        new WorldManagementGrpcService(
+            pingService, roomService, mapper, worldEventService, meterRegistry);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -57,7 +58,8 @@ class WorldManagementGrpcServiceTest {
     Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
         .thenReturn(Mockito.mock(io.micrometer.core.instrument.Counter.class));
     WorldManagementGrpcService service =
-        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService, meterRegistry);
+        new WorldManagementGrpcService(
+            pingService, roomService, mapper, worldEventService, meterRegistry);
 
     AtomicReference<net.firedevops.firemud.worldmanagement.v1.GetRoomResponse> ref =
         new AtomicReference<>();
@@ -92,7 +94,8 @@ class WorldManagementGrpcServiceTest {
     Mockito.when(meterRegistry.counter(Mockito.anyString(), Mockito.any(String[].class)))
         .thenReturn(Mockito.mock(io.micrometer.core.instrument.Counter.class));
     WorldManagementGrpcService service =
-        new WorldManagementGrpcService(pingService, roomService, mapper, worldEventService, meterRegistry);
+        new WorldManagementGrpcService(
+            pingService, roomService, mapper, worldEventService, meterRegistry);
 
     AtomicReference<net.firedevops.firemud.worldmanagement.v1.UpdateWorldStateResponse> ref =
         new AtomicReference<>();


### PR DESCRIPTION
## Summary
- run spotlessApply for world-management-service
- reformat `WorldManagementGrpcService` and unit test

## Testing
- `./gradlew :world-management-service:spotlessApply`
- `./gradlew :world-management-service:check`

------
https://chatgpt.com/codex/tasks/task_e_6871da3ce2b883308e49dff165fe7872