### PR TITLE
Implement script quota check

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -9,6 +9,7 @@ import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.service.tick.ScriptTickService;
+import net.firedevops.firemud.service.quota.ScriptQuotaService;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
@@ -25,6 +26,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
 
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;
+  private final net.firedevops.firemud.service.quota.ScriptQuotaService quotaService;
 
   @Value("${automation.tick-duration-ms:1000}")
   private long tickDurationMs;
@@ -54,6 +56,10 @@ public class ScriptTickServiceImpl implements ScriptTickService {
 
   @Override
   public void enqueueEvent(Long tenantId, Long scriptId, String eventJson) {
+    if (!quotaService.tryAcquire(tenantId, scriptId)) {
+      logger.warn("Script quota exceeded for {}:{}", tenantId, scriptId);
+      return;
+    }
     redisTemplate.opsForList().rightPush(queueKey(tenantId, scriptId), eventJson);
     enqueueCounter.increment();
     logger.debug("Queued script event for {}:{}", tenantId, scriptId);

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptTickServiceImplTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptTickServiceImplTest.java
@@ -3,11 +3,13 @@ package net.firedevops.firemud.service.impl;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import net.firedevops.firemud.service.tick.ScriptTickService;
+import net.firedevops.firemud.service.quota.ScriptQuotaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +21,7 @@ class ScriptTickServiceImplTest {
   private org.springframework.data.redis.core.ListOperations<String, Object> listOps;
   private org.springframework.data.redis.core.ValueOperations<String, Object> valueOps;
   private SimpleMeterRegistry meterRegistry;
+  private ScriptQuotaService quotaService;
   private ScriptTickService service;
 
   @BeforeEach
@@ -28,8 +31,10 @@ class ScriptTickServiceImplTest {
     valueOps = mock(org.springframework.data.redis.core.ValueOperations.class);
     when(redisTemplate.opsForList()).thenReturn(listOps);
     when(redisTemplate.opsForValue()).thenReturn(valueOps);
+    quotaService = mock(ScriptQuotaService.class);
+    when(quotaService.tryAcquire(any(), any())).thenReturn(true);
     meterRegistry = new SimpleMeterRegistry();
-    service = new ScriptTickServiceImpl(redisTemplate, meterRegistry);
+    service = new ScriptTickServiceImpl(redisTemplate, meterRegistry, quotaService);
     ((ScriptTickServiceImpl) service).init();
   }
 
@@ -37,6 +42,14 @@ class ScriptTickServiceImplTest {
   void enqueueEventPushesToQueue() {
     service.enqueueEvent(1L, 2L, "evt");
     verify(listOps).rightPush(any(String.class), any());
+    verify(quotaService).tryAcquire(1L, 2L);
+  }
+
+  @Test
+  void enqueueEventSkippedWhenQuotaExceeded() {
+    when(quotaService.tryAcquire(any(), any())).thenReturn(false);
+    service.enqueueEvent(1L, 2L, "evt");
+    org.mockito.Mockito.verifyNoInteractions(listOps);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- enforce script quota when enqueuing tick events
- test quota enforcement in ScriptTickServiceImpl

## Testing
- `./gradlew :automation-scripting-service:test`

------
https://chatgpt.com/codex/tasks/task_e_6871dc0df930833090028a63eef88162