### PR TITLE
Implement RBAC enforcement in Account Service

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
@@ -6,6 +6,7 @@ import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.service.AccountService;
+import net.firedevops.firemud.common.security.RequireAdminRole;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +40,7 @@ public class AccountController {
   }
 
   @DeleteMapping("/{accountId}")
+  @RequireAdminRole
   public ResponseEntity<ApiResponse<Void>> deleteAccount(
       @PathVariable Long accountId, Long tenantId) {
     accountService.deleteAccount(tenantId, accountId);

--- a/services/account-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/security/JwtAuthInterceptor.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.SessionContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
     String token = authHeader.substring(7);
     try {
       Jws<Claims> claims = jwtUtil.parseToken(token);
+      String accountId = claims.getBody().get("accountId", String.class);
       List<String> globalRoles = claims.getBody().get("globalRoles", List.class);
       Map<String, List<String>> scopedRoles = claims.getBody().get("scopedRoles", Map.class);
 
@@ -53,10 +55,18 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         response.setStatus(HttpStatus.FORBIDDEN.value());
         return false;
       }
+      SessionContext.setContext(accountId, globalRoles, scopedRoles);
       return true;
     } catch (JwtException ex) {
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       return false;
     }
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+      throws Exception {
+    SessionContext.clear();
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -20,6 +20,7 @@ import net.firedevops.firemud.account.v1.UpdateProfileRequest;
 import net.firedevops.firemud.account.v1.UpdateProfileResponse;
 import net.firedevops.firemud.service.AccountService;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.common.security.RequireAdminRole;
 import org.lognet.springboot.grpc.GRpcService;
 
 @GRpcService
@@ -191,6 +192,7 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
   }
 
   @Override
+  @RequireAdminRole
   public void deleteAccount(
       DeleteAccountRequest request, StreamObserver<DeleteAccountResponse> responseObserver) {
     try {

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/NotificationGrpcService.java
@@ -5,6 +5,7 @@ import net.firedevops.firemud.account.v1.NotificationServiceGrpc;
 import net.firedevops.firemud.account.v1.SendNotificationRequest;
 import net.firedevops.firemud.account.v1.SendNotificationResponse;
 import net.firedevops.firemud.service.NotificationService;
+import net.firedevops.firemud.common.security.RequireAdminRole;
 import org.lognet.springboot.grpc.GRpcService;
 
 @GRpcService
@@ -16,6 +17,7 @@ public class NotificationGrpcService extends NotificationServiceGrpc.Notificatio
   }
 
   @Override
+  @RequireAdminRole
   public void sendNotification(
       SendNotificationRequest request, StreamObserver<SendNotificationResponse> responseObserver) {
     try {

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/security/JwtAuthInterceptorTest.java
@@ -3,10 +3,12 @@ package net.firedevops.firemud.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.Map;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.SessionContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -39,5 +41,8 @@ class JwtAuthInterceptorTest {
 
     assertTrue(result);
     assertEquals(200, response.getStatus());
+    assertEquals(List.of("platformAdmin"), SessionContext.getGlobalRoles());
+    interceptor.afterCompletion(request, response, new Object(), null);
+    assertTrue(SessionContext.getGlobalRoles().isEmpty());
   }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/security/RequireAdminRoleAspectTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/security/RequireAdminRoleAspectTest.java
@@ -1,0 +1,33 @@
+package net.firedevops.firemud.security;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.grpc.StatusRuntimeException;
+import java.util.List;
+import java.util.Map;
+import net.firedevops.firemud.common.security.RequireAdminRoleAspect;
+import net.firedevops.firemud.common.security.SessionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class RequireAdminRoleAspectTest {
+  private final RequireAdminRoleAspect aspect = new RequireAdminRoleAspect();
+
+  @AfterEach
+  void clear() {
+    SessionContext.clear();
+  }
+
+  @Test
+  void failsWithoutAdminRole() {
+    SessionContext.setContext("1", List.of("player"), Map.of());
+    assertThrows(StatusRuntimeException.class, aspect::checkRole);
+  }
+
+  @Test
+  void succeedsWithAdminRole() {
+    SessionContext.setContext("1", List.of("platformAdmin"), Map.of());
+    assertDoesNotThrow(() -> aspect.checkRole());
+  }
+}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/SessionContext.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/SessionContext.java
@@ -10,12 +10,12 @@ public final class SessionContext {
 
   private static final ThreadLocal<ClaimsData> HOLDER = new ThreadLocal<>();
 
-  static void setContext(
+  public static void setContext(
       String accountId, List<String> globalRoles, Map<String, List<String>> scopedRoles) {
     HOLDER.set(new ClaimsData(accountId, globalRoles, scopedRoles));
   }
 
-  static void clear() {
+  public static void clear() {
     HOLDER.remove();
   }
 


### PR DESCRIPTION
## Summary
- expose `SessionContext.setContext` for cross-module use
- store JWT claims for REST requests to enable `RequireAdminRole`
- restrict account deletion and notifications to admin users
- add unit tests for session context behavior and RBAC aspect

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6871da2053c483308fbf959f01552c97