### PR TITLE
Fix Markdown heading formatting

### DIFF
--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -2,7 +2,8 @@
 
 Design documentation lives at:
 [📄 Automation Scripting Service Design](../../design/architecture/microservices/automation-scripting-service/README.md)
-### Fairness Quotas
+
+## Fairness Quotas
 
 `ScriptQuotaService` limits how many times a script may execute within a
 configurable window. Counters are stored in Redis using keys of the form


### PR DESCRIPTION
## Summary
- fix heading level in automation-scripting-service README
- ensure blank lines around the heading

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871dd0ee9ec83309596ca035056fb30