### PR TITLE
Improve user journeys doc

### DIFF
--- a/design/architecture/game-customization-options.md
+++ b/design/architecture/game-customization-options.md
@@ -19,3 +19,9 @@ This brief document summarizes the ways a hosted game can change its look and fe
 - Scripts are versioned alongside other game data and can be hot reloaded by the Automation & Scripting Service.
 
 These options allow extensive personalization while keeping the underlying platform maintainable.
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](./system-architecture-overview.md)
+- [Automation & Scripting Service](./microservices/automation-scripting-service/README.md)
+- [Game Design Service](./microservices/game-design-service/README.md)

--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -13,5 +13,11 @@ These notes summarize typical optimizations applied across FireMUD services.
 - gRPC calls use compression and keep-alive pings to reduce latency.
 - HTTP responses are compressed via Spring Boot's built-in support.
 - The Gateway applies connection pooling and caches static assets.
+- Redis caches common lookups to reduce database load.
 
 Following these patterns keeps resource usage low even as player counts grow.
+
+## 📚 Related Documentation
+
+- [Redis Architecture](./system-architecture-redis.md)
+- [System Architecture Overview](./system-architecture-overview.md)

--- a/design/architecture/repository-structure.md
+++ b/design/architecture/repository-structure.md
@@ -15,3 +15,8 @@ root
 ```
 
 Proto definitions live under `protos/` organized by service and version as described in the gRPC design document. Database migration scripts for each service reside in `src/main/resources/db/migration/`.
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](./system-architecture-overview.md)
+- [Microservices Overview](./microservices/README.md)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -110,4 +110,24 @@ Player → Account Service → Logging & Admin Service
 
 ---
 
+## 10. Password Resets & Account Recovery
+
+Players occasionally lose access to their accounts. Recovery is performed
+through the [Account Service](./microservices/account-service/README.md),
+which issues password reset emails and temporary login tokens. Suspicious
+attempts are logged by the
+[Logging & Admin Service](./microservices/logging-admin-service/README.md).
+
+```plaintext
+Player → Account Service → Logging & Admin Service (audit)
+```
+
+---
+
 These flows complement the architecture diagrams in [System Architecture Overview](./system-architecture-overview.md).
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](./system-architecture-overview.md)
+- [Service Responsibility Matrix](./service-responsibility-matrix.md)
+- [Microservices Overview](./microservices/README.md)


### PR DESCRIPTION
## Summary
- expand user journey docs with account recovery
- add `Related Documentation` sections to design docs
- note Redis caching in performance guide

## Testing
- `pre-commit run --files design/architecture/user-journeys.md design/architecture/game-customization-options.md design/architecture/performance-optimization.md design/architecture/repository-structure.md`

------
https://chatgpt.com/codex/tasks/task_e_6871e735a3c48330a35cbfeb0fa04c11