### PR TITLE
Fix TcpProxyCrossServiceIntegrationTest

### DIFF
--- a/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
@@ -46,6 +46,9 @@ class TcpProxyCrossServiceIntegrationTest {
   @DynamicPropertySource
   static void registerProperties(DynamicPropertyRegistry registry) {
     if (DockerClientFactory.instance().isDockerAvailable()) {
+      if (!gateway.isRunning()) {
+        gateway.start();
+      }
       registry.add(
           "GATEWAY_WS_URL",
           () -> "ws://" + gateway.getHost() + ":" + gateway.getMappedPort(8080) + "/ws");


### PR DESCRIPTION
## Summary
- fix dynamic property registration in `TcpProxyCrossServiceIntegrationTest`
- ensure gateway container is started before fetching host/port

## Testing
- `./gradlew :tcp-proxy-service:test --no-daemon`
- `./gradlew :tcp-proxy-service:check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6871e4dd36988330893a423ed939f594