### PR TITLE
Fix SpotBugs config for proto classes

### DIFF
--- a/config/spotbugs/spotbugs-exclude.xml
+++ b/config/spotbugs/spotbugs-exclude.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
+    <!-- Exclude all generated sources -->
     <Match>
-        <Source name=".*[\\/]build[\\/]generated[\\/].*"/>
+        <Source name=".*[\\/]build[\\/]generated[\\/].*" />
     </Match>
-    <!-- Exclude protobuf generated v1 classes -->
+    
+    <!-- Exclude all protobuf-generated classes in versioned packages (v1, v2, v3, ...) -->
     <Match>
-        <Class name="~.*\\.v1\\..*" />
+        <Class name="~.*\\.proto\\..*\\.v[0-9]+\\..*" />
     </Match>
 </FindBugsFilter>

--- a/config/spotbugs/spotbugs-exclude.xml
+++ b/config/spotbugs/spotbugs-exclude.xml
@@ -3,4 +3,8 @@
     <Match>
         <Source name=".*[\\/]build[\\/]generated[\\/].*"/>
     </Match>
+    <!-- Exclude protobuf generated v1 classes -->
+    <Match>
+        <Class name="~.*\\.v1\\..*" />
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary
- update SpotBugs filter to skip generated protobuf classes

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871e4c9eb6483309ed51e91d14e62de