### PR TITLE
Fix automation scripting service design stub

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -173,6 +173,14 @@ Expected response:
 }
 ```
 
+### Fairness Quotas
+
+`ScriptQuotaService` limits how many times a script may execute within a
+configurable window. Counters are stored in Redis using keys of the form
+`script_quota:{tenantId}:{scriptId}`. When the quota is exceeded the event is
+ignored and `script_quota_denied_total` is incremented. Enforcement metrics are
+exported via the standard `sagas.active` gauge.
+
 - [System Architecture Diagram](../system-architecture-diagram.md)
 - [System Context Diagram](../system-context-diagram.md)
 

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -3,12 +3,5 @@
 Design documentation lives at:
 [📄 Automation Scripting Service Design](../../design/architecture/microservices/automation-scripting-service/README.md)
 
-## Fairness Quotas
-
-`ScriptQuotaService` limits how many times a script may execute within a
-configurable window. Counters are stored in Redis using keys of the form
-`script_quota:{tenantId}:{scriptId}`. When the quota is exceeded the event is
-ignored and `script_quota_denied_total` is incremented.
-`sagas.active` metric.
-
-This README is a stub. **Do not place design details here.**
+This README is a stub that only links to the real design document.
+**Do not place design details here.**


### PR DESCRIPTION
## Summary
- update `automation-scripting-service` design stub to only link to real design
- move fairness quota details into the central design doc

## Testing
- `pre-commit run --files design/architecture/microservices/automation-scripting-service/README.md services/automation-scripting-service/README.md` *(fails: Buf Lint reports proto naming issues)*

------
https://chatgpt.com/codex/tasks/task_e_6871e43d84648330b271c54a7f4f62fa