### PR TITLE
Add LoggingAdmin client & saga to account service

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/AccountServiceApplication.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/AccountServiceApplication.java
@@ -3,11 +3,14 @@ package net.firedevops.firemud;
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.config.GrpcClientProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@EnableConfigurationProperties(GrpcClientProperties.class)
 @Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, AuthConfig.class})
 public class AccountServiceApplication {
   public static void main(String[] args) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -1,0 +1,65 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import net.firedevops.firemud.loggingadmin.v1.ApplyModerationActionRequest;
+import net.firedevops.firemud.loggingadmin.v1.LoggingAdminServiceGrpc;
+import org.springframework.stereotype.Component;
+
+/** Client for communicating with the Logging & Admin Service. */
+@Component
+public class LoggingAdminClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+
+  private ManagedChannel channel;
+  private LoggingAdminServiceGrpc.LoggingAdminServiceBlockingStub stub;
+
+  public LoggingAdminClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getLoggingAdminService();
+    if (target == null || target.isEmpty()) {
+      target = "logging-admin-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = LoggingAdminServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Log that a new account was created. */
+  public void logAccountCreation(long tenantId, long accountId) {
+    ApplyModerationActionRequest request =
+        ApplyModerationActionRequest.newBuilder()
+            .setTenantId(Long.toString(tenantId))
+            .setAccountId(Long.toString(accountId))
+            .setAction("ACCOUNT_CREATED")
+            .setReason("")
+            .build();
+    stub.applyModerationAction(request);
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
@@ -1,0 +1,19 @@
+package net.firedevops.firemud.config;
+
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.client.LoggingAdminClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Bean configuration for outbound gRPC clients. */
+@Configuration
+public class GrpcClientConfig {
+
+  @Bean
+  public LoggingAdminClient loggingAdminClient(
+      net.firedevops.firemud.common.config.ServiceEndpointsProperties endpoints,
+      GrpcClientProperties properties)
+      throws SSLException {
+    return new LoggingAdminClient(endpoints, properties);
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** TLS configuration for outbound gRPC connections. */
+@Data
+@ConfigurationProperties(prefix = "firemud.grpc")
+public class GrpcClientProperties {
+  private String certChain;
+  private String privateKey;
+  private String caCert;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -7,7 +7,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Optional;
+import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.saga.SagaBuilder;
+import net.firedevops.firemud.common.saga.SagaException;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
@@ -39,6 +42,7 @@ public class AccountServiceImpl implements AccountService {
   private final PaymentTransactionRepository paymentTransactionRepository;
   private final SubscriptionRepository subscriptionRepository;
   private final NotificationService notificationService;
+  private final LoggingAdminClient loggingAdminClient;
   private final JwtUtil jwtUtil;
   private final net.firedevops.firemud.service.session.SessionService sessionService;
 
@@ -50,6 +54,7 @@ public class AccountServiceImpl implements AccountService {
       PaymentTransactionRepository paymentTransactionRepository,
       SubscriptionRepository subscriptionRepository,
       NotificationService notificationService,
+      LoggingAdminClient loggingAdminClient,
       JwtUtil jwtUtil,
       net.firedevops.firemud.service.session.SessionService sessionService) {
     this.accountRepository = accountRepository;
@@ -59,6 +64,7 @@ public class AccountServiceImpl implements AccountService {
     this.paymentTransactionRepository = paymentTransactionRepository;
     this.subscriptionRepository = subscriptionRepository;
     this.notificationService = notificationService;
+    this.loggingAdminClient = loggingAdminClient;
     this.jwtUtil = jwtUtil;
     this.sessionService = sessionService;
   }
@@ -74,11 +80,34 @@ public class AccountServiceImpl implements AccountService {
     account.setEmail(request.email());
     account.setPasswordHash(hashPassword(request.password()));
     account.setRole("player");
-    account = accountRepository.save(account);
     Profile profile = new Profile();
-    profile.setAccount(account);
-    profile.setTenantId(account.getTenantId());
-    profileRepository.save(profile);
+    profile.setTenantId(request.tenantId());
+
+    SagaBuilder builder = new SagaBuilder();
+    builder
+        .step(
+            "persistAccount",
+            () -> {
+              Account saved = accountRepository.save(account);
+              account.setId(saved.getId());
+              profile.setAccount(saved);
+              profileRepository.save(profile);
+            },
+            () -> {
+              profileRepository.delete(profile);
+              accountRepository.delete(account);
+            })
+        .step(
+            "logCreation",
+            () -> loggingAdminClient.logAccountCreation(account.getTenantId(), account.getId()));
+
+    try {
+      builder.run();
+    } catch (SagaException e) {
+      logger.warn("Account creation saga failed", e);
+      throw new IllegalStateException("Account creation failed", e);
+    }
+
     return accountMapper.toDto(account);
   }
 

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
@@ -30,6 +31,7 @@ class AccountServiceImplTest {
   @Mock private ProfileRepository profileRepository;
   @Mock private ProfileMapper profileMapper;
   @Mock private NotificationService notificationService;
+  @Mock private LoggingAdminClient loggingAdminClient;
   @Mock private SessionService sessionService;
   @Mock private PaymentTransactionRepository paymentTransactionRepository;
   @Mock private SubscriptionRepository subscriptionRepository;
@@ -50,6 +52,7 @@ class AccountServiceImplTest {
             paymentTransactionRepository,
             subscriptionRepository,
             notificationService,
+            loggingAdminClient,
             jwtUtil,
             sessionService);
   }


### PR DESCRIPTION
## Summary
- add gRPC client for Logging & Admin Service
- register gRPC client properties for account service
- orchestrate account creation using SagaBuilder
- update unit tests

## Testing
- `./gradlew :account-service:spotlessApply`
- `./gradlew :account-service:check --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6871e438bfb08330b125196b147f18a7