### PR TITLE
Add password reset workflow

### DIFF
--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -15,6 +15,8 @@ service AccountService {
   rpc UpdateProfile(UpdateProfileRequest) returns (UpdateProfileResponse);
   rpc ExportAccount(ExportAccountRequest) returns (ExportAccountResponse);
   rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse);
+  rpc RequestPasswordReset(RequestPasswordResetRequest) returns (RequestPasswordResetResponse);
+  rpc CompletePasswordReset(CompletePasswordResetRequest) returns (CompletePasswordResetResponse);
 }
 
 message PingRequest {}
@@ -86,6 +88,27 @@ message DeleteAccountRequest {
 }
 
 message DeleteAccountResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message RequestPasswordResetRequest {
+  string tenant_id = 1;
+  string email = 2;
+}
+
+message RequestPasswordResetResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message CompletePasswordResetRequest {
+  string tenant_id = 1;
+  string token = 2;
+  string new_password = 3;
+}
+
+message CompletePasswordResetResponse {
   bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
@@ -20,6 +20,12 @@ public class WebConfig implements WebMvcConfigurer {
   public void addInterceptors(InterceptorRegistry registry) {
     registry
         .addInterceptor(jwtAuthInterceptor)
-        .excludePathPatterns("/auth/login", "/accounts", "/ping", "/.well-known/**");
+        .excludePathPatterns(
+            "/auth/login",
+            "/auth/request-password-reset",
+            "/auth/complete-password-reset",
+            "/accounts",
+            "/ping",
+            "/.well-known/**");
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -3,7 +3,9 @@ package net.firedevops.firemud.controller;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AuthTokenDto;
+import net.firedevops.firemud.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.dto.LoginRequest;
+import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.service.AccountService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,5 +28,19 @@ public class AuthController {
         accountService.authenticate(
             request.tenantId(), request.username(), request.password(), request.otp());
     return ResponseEntity.ok(ApiResponse.success(new AuthTokenDto(token)));
+  }
+
+  @PostMapping("/request-password-reset")
+  public ResponseEntity<ApiResponse<Void>> requestPasswordReset(
+      @Valid @RequestBody PasswordResetRequest request) {
+    accountService.requestPasswordReset(request);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  @PostMapping("/complete-password-reset")
+  public ResponseEntity<ApiResponse<Void>> completePasswordReset(
+      @Valid @RequestBody CompletePasswordResetRequest request) {
+    accountService.completePasswordReset(request);
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/CompletePasswordResetRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/CompletePasswordResetRequest.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CompletePasswordResetRequest(
+    @NotNull Long tenantId,
+    @NotNull String token,
+    @NotNull @Size(min = 6, max = 100) String newPassword) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/PasswordResetRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/PasswordResetRequest.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetRequest(
+    @NotNull Long tenantId, @NotNull @Email @Size(max = 100) String email) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PasswordResetToken.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PasswordResetToken.java
@@ -1,0 +1,27 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "password_reset_token")
+public class PasswordResetToken {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "account_id", nullable = false)
+  private Account account;
+
+  @Column(nullable = false, length = 64)
+  private String token;
+
+  @Column(name = "expires_at", nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/AccountRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/AccountRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
   Optional<Account> findByTenantIdAndUsername(Long tenantId, String username);
+
+  Optional<Account> findByTenantIdAndEmail(Long tenantId, String email);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/PasswordResetTokenRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,21 @@
+package net.firedevops.firemud.repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import net.firedevops.firemud.entity.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+  Optional<PasswordResetToken> findByTokenAndTenantId(String token, Long tenantId);
+
+  @Modifying
+  @Transactional
+  @Query("delete from PasswordResetToken t where t.expiresAt < :now")
+  void deleteExpired(@Param("now") LocalDateTime now);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
@@ -2,7 +2,9 @@ package net.firedevops.firemud.service;
 
 import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
+import net.firedevops.firemud.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.dto.CreateAccountRequest;
+import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.dto.ProfileDto;
 import net.firedevops.firemud.dto.UpdateProfileRequest;
 
@@ -18,4 +20,8 @@ public interface AccountService {
   AccountDataExportDto exportAccountData(Long tenantId, Long accountId);
 
   void deleteAccount(Long tenantId, Long accountId);
+
+  void requestPasswordReset(PasswordResetRequest request);
+
+  void completePasswordReset(CompletePasswordResetRequest request);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -19,6 +19,8 @@ import net.firedevops.firemud.account.v1.PingResponse;
 import net.firedevops.firemud.account.v1.UpdateProfileRequest;
 import net.firedevops.firemud.account.v1.UpdateProfileResponse;
 import net.firedevops.firemud.common.security.RequireAdminRole;
+import net.firedevops.firemud.dto.CompletePasswordResetRequest;
+import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.service.AccountService;
 import net.firedevops.firemud.service.PingService;
 import org.lognet.springboot.grpc.GRpcService;
@@ -208,6 +210,65 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
               .setError(
                   net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
                       .setCode("NOT_FOUND")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void requestPasswordReset(
+      net.firedevops.firemud.account.v1.RequestPasswordResetRequest request,
+      StreamObserver<net.firedevops.firemud.account.v1.RequestPasswordResetResponse>
+          responseObserver) {
+    try {
+      accountService.requestPasswordReset(
+          new PasswordResetRequest(Long.valueOf(request.getTenantId()), request.getEmail()));
+      var response =
+          net.firedevops.firemud.account.v1.RequestPasswordResetResponse.newBuilder()
+              .setSuccess(true)
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      var response =
+          net.firedevops.firemud.account.v1.RequestPasswordResetResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void completePasswordReset(
+      net.firedevops.firemud.account.v1.CompletePasswordResetRequest request,
+      StreamObserver<net.firedevops.firemud.account.v1.CompletePasswordResetResponse>
+          responseObserver) {
+    try {
+      accountService.completePasswordReset(
+          new CompletePasswordResetRequest(
+              Long.valueOf(request.getTenantId()), request.getToken(), request.getNewPassword()));
+      var response =
+          net.firedevops.firemud.account.v1.CompletePasswordResetResponse.newBuilder()
+              .setSuccess(true)
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      var response =
+          net.firedevops.firemud.account.v1.CompletePasswordResetResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
                       .setMessage(ex.getMessage())
                       .build())
               .build();

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -14,7 +14,9 @@ import net.firedevops.firemud.common.saga.SagaException;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
+import net.firedevops.firemud.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.dto.CreateAccountRequest;
+import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.dto.ProfileDto;
 import net.firedevops.firemud.dto.UpdateProfileRequest;
 import net.firedevops.firemud.entity.Account;
@@ -22,6 +24,7 @@ import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.PasswordResetTokenRepository;
 import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
 import net.firedevops.firemud.repository.SubscriptionRepository;
@@ -41,6 +44,7 @@ public class AccountServiceImpl implements AccountService {
   private final ProfileMapper profileMapper;
   private final PaymentTransactionRepository paymentTransactionRepository;
   private final SubscriptionRepository subscriptionRepository;
+  private final PasswordResetTokenRepository passwordResetTokenRepository;
   private final NotificationService notificationService;
   private final LoggingAdminClient loggingAdminClient;
   private final JwtUtil jwtUtil;
@@ -53,6 +57,7 @@ public class AccountServiceImpl implements AccountService {
       ProfileMapper profileMapper,
       PaymentTransactionRepository paymentTransactionRepository,
       SubscriptionRepository subscriptionRepository,
+      PasswordResetTokenRepository passwordResetTokenRepository,
       NotificationService notificationService,
       LoggingAdminClient loggingAdminClient,
       JwtUtil jwtUtil,
@@ -63,6 +68,7 @@ public class AccountServiceImpl implements AccountService {
     this.profileMapper = profileMapper;
     this.paymentTransactionRepository = paymentTransactionRepository;
     this.subscriptionRepository = subscriptionRepository;
+    this.passwordResetTokenRepository = passwordResetTokenRepository;
     this.notificationService = notificationService;
     this.loggingAdminClient = loggingAdminClient;
     this.jwtUtil = jwtUtil;
@@ -195,6 +201,42 @@ public class AccountServiceImpl implements AccountService {
         .findByAccountIdAndTenantId(accountId, tenantId)
         .ifPresent(profileRepository::delete);
     accountRepository.delete(account);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.request_password_reset")
+  public void requestPasswordReset(PasswordResetRequest request) {
+    net.firedevops.firemud.entity.Account account =
+        accountRepository
+            .findByTenantIdAndEmail(request.tenantId(), request.email())
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    net.firedevops.firemud.entity.PasswordResetToken token =
+        new net.firedevops.firemud.entity.PasswordResetToken();
+    token.setAccount(account);
+    token.setTenantId(request.tenantId());
+    token.setToken(java.util.UUID.randomUUID().toString());
+    token.setExpiresAt(java.time.LocalDateTime.now().plusHours(1));
+    passwordResetTokenRepository.save(token);
+    notificationService.sendNotification(
+        request.tenantId(), account.getId(), "Password reset requested");
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.complete_password_reset")
+  public void completePasswordReset(CompletePasswordResetRequest request) {
+    net.firedevops.firemud.entity.PasswordResetToken token =
+        passwordResetTokenRepository
+            .findByTokenAndTenantId(request.token(), request.tenantId())
+            .orElseThrow(() -> new IllegalArgumentException("Invalid token"));
+    if (token.getExpiresAt().isBefore(java.time.LocalDateTime.now())) {
+      throw new IllegalArgumentException("Token expired");
+    }
+    net.firedevops.firemud.entity.Account account = token.getAccount();
+    account.setPasswordHash(hashPassword(request.newPassword()));
+    accountRepository.save(account);
+    passwordResetTokenRepository.delete(token);
   }
 
   private String hashPassword(String password) {

--- a/services/account-service/src/main/resources/db/migration/V6__password_reset_token.sql
+++ b/services/account-service/src/main/resources/db/migration/V6__password_reset_token.sql
@@ -1,0 +1,7 @@
+CREATE TABLE password_reset_token (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id),
+    token VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    tenant_id BIGINT NOT NULL DEFAULT 1
+);

--- a/services/account-service/src/main/resources/openapi.yaml
+++ b/services/account-service/src/main/resources/openapi.yaml
@@ -83,6 +83,24 @@ components:
         bio:
           type: string
       required: [tenantId, accountId]
+    PasswordResetRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        email:
+          type: string
+      required: [tenantId, email]
+    CompletePasswordResetRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        token:
+          type: string
+        newPassword:
+          type: string
+      required: [tenantId, token, newPassword]
 paths:
   /ping:
     get:
@@ -114,9 +132,35 @@ paths:
         '200':
           description: Auth token
           content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuthTokenDto'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthTokenDto'
+  /auth/request-password-reset:
+    post:
+      summary: Request password reset
+      operationId: requestPasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetRequest'
+      responses:
+        '200':
+          description: Request accepted
+  /auth/complete-password-reset:
+    post:
+      summary: Complete password reset
+      operationId: completePasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompletePasswordResetRequest'
+      responses:
+        '200':
+          description: Password updated
   /accounts:
     post:
       summary: Create a new account

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.firedevops.firemud.dto.LoginRequest;
+import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.service.AccountService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,5 +37,18 @@ class AuthControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(jsonPath("$.data.authToken").value("tok123"));
+  }
+
+  @Test
+  void requestPasswordResetReturnsSuccess() throws Exception {
+    PasswordResetRequest req = new PasswordResetRequest(1L, "demo@example.com");
+
+    mockMvc
+        .perform(
+            post("/auth/request-password-reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"));
   }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -10,6 +10,7 @@ import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.security.JwtUtil;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
+import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.entity.Account;
 import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
@@ -36,6 +37,10 @@ class AccountServiceImplTest {
   @Mock private PaymentTransactionRepository paymentTransactionRepository;
   @Mock private SubscriptionRepository subscriptionRepository;
 
+  @Mock
+  private net.firedevops.firemud.repository.PasswordResetTokenRepository
+      passwordResetTokenRepository;
+
   private AccountServiceImpl service;
 
   @BeforeEach
@@ -51,6 +56,7 @@ class AccountServiceImplTest {
             profileMapper,
             paymentTransactionRepository,
             subscriptionRepository,
+            passwordResetTokenRepository,
             notificationService,
             loggingAdminClient,
             jwtUtil,
@@ -125,6 +131,21 @@ class AccountServiceImplTest {
 
     assertEquals("demo", dto.displayName());
     org.mockito.Mockito.verify(notificationService).sendNotification(1L, 2L, "Profile updated");
+  }
+
+  @Test
+  void requestPasswordResetCreatesToken() {
+    Account account = new Account();
+    account.setId(1L);
+    when(accountRepository.findByTenantIdAndEmail(1L, "demo@example.com"))
+        .thenReturn(Optional.of(account));
+
+    service.requestPasswordReset(new PasswordResetRequest(1L, "demo@example.com"));
+
+    org.mockito.Mockito.verify(passwordResetTokenRepository)
+        .save(org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.verify(notificationService)
+        .sendNotification(1L, 1L, "Password reset requested");
   }
 
   private static String hash(String password) {


### PR DESCRIPTION
## Summary
- support password reset requests via REST and gRPC
- store reset tokens and handle completion
- expose endpoints in OpenAPI spec
- adjust interceptor exclusions
- unit tests for new logic

## Testing
- `./gradlew :account-service:test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871f016f9008330850e2eecd595bf48