### PR TITLE
Fix Gradle buildDir usage and update frontend deps

### DIFF
--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -64,18 +64,18 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
-        )
+    )
 }
 
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
-        )
+    )
 }
 

--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -63,7 +63,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -72,7 +72,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -41,7 +41,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -64,7 +64,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -73,7 +73,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -60,7 +60,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -69,7 +69,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -58,7 +58,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -67,7 +67,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -60,7 +60,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -69,7 +69,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -64,7 +64,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -73,7 +73,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -65,7 +65,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -74,7 +74,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -60,7 +60,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -69,7 +69,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -62,7 +62,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -71,7 +71,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/services/world-management-service/build.gradle.kts
+++ b/services/world-management-service/build.gradle.kts
@@ -64,7 +64,7 @@ sourceSets {
 tasks.named<SpotBugsTask>("spotbugsMain") {
     dependsOn(tasks.named("compileJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/main") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/main")) {
             exclude("**/proto/**")
         }
     )
@@ -73,7 +73,7 @@ tasks.named<SpotBugsTask>("spotbugsMain") {
 tasks.named<SpotBugsTask>("spotbugsTest") {
     dependsOn(tasks.named("compileTestJava"))
     classes = files(
-        fileTree("$buildDir/classes/java/test") {
+        fileTree(project.layout.buildDirectory.dir("classes/java/test")) {
             exclude("**/proto/**")
         }
     )

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -16,19 +16,19 @@
       },
       "devDependencies": {
         "@axe-core/cli": "^4.10.2",
-        "@eslint/js": "^9.30.1",
+        "@eslint/js": "^9.31.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
-        "eslint": "^9.30.1",
+        "eslint": "^9.31.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
         "prettier": "^3.6.2",
         "serve": "^14.2.4",
         "typescript": "~5.8.3",
-        "typescript-eslint": "^8.35.1",
-        "vite": "^7.0.3",
+        "typescript-eslint": "^8.36.0",
+        "vite": "^7.0.4",
         "wait-on": "^8.0.3"
       }
     },
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1075,9 +1075,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1106,19 +1106,6 @@
       "dependencies": {
         "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3243,9 +3230,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.30.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
-      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3253,9 +3240,9 @@
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.30.1",
+        "@eslint/js": "9.31.0",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -5786,9 +5773,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.3.tgz",
-      "integrity": "sha512-y2L5oJZF7bj4c0jgGYgBNSdIu+5HF+m68rn2cQXFbGoShdhV1phX9rbnxy9YXj82aS8MMsCLAAFkRxZeWdldrQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.4.tgz",
+      "integrity": "sha512-SkaSguuS7nnmV7mfJ8l81JGBFV7Gvzp8IzgE8A8t23+AxuNX61Q5H1Tpz5efduSN7NHC8nQXD3sKQKZAu5mNEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -21,19 +21,19 @@
   },
   "devDependencies": {
     "@axe-core/cli": "^4.10.2",
-    "@eslint/js": "^9.30.1",
+    "@eslint/js": "^9.31.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
-    "eslint": "^9.30.1",
+    "eslint": "^9.31.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "prettier": "^3.6.2",
     "serve": "^14.2.4",
     "typescript": "~5.8.3",
-    "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.3",
+    "typescript-eslint": "^8.36.0",
+    "vite": "^7.0.4",
     "wait-on": "^8.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `buildDir` usage with `layout.buildDirectory` across services
- upgrade web-client dev dependencies

## Testing
- `npm install` in `web-client`
- `npm outdated`
- `pre-commit run --all-files` *(fails: interrupted)*
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_6871f4f9d52c8330b92ea97c788c638e