### PR TITLE
Update WebSocket documentation

### DIFF
--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -41,7 +41,7 @@ Despite their differences, both protocols are normalized into the same internal 
 - The service:
   - Accepts and parses Telnet line-based input.
   - Normalizes the connection.
-  - **Creates a WebSocket connection to Spring Cloud Gateway** (where all WebSocket connections terminate) on behalf of the TCP client.
+  - Creates a WebSocket connection to Spring Cloud Gateway on behalf of the TCP client.
   - Proxies I/O between the TCP client and Spring Cloud Gateway.
   - Buffers active input while the client remains connected and discards it if
     the TCP connection drops.

--- a/design/architecture/infrastructure/protocol-bridging.md
+++ b/design/architecture/infrastructure/protocol-bridging.md
@@ -41,7 +41,7 @@ Despite their differences, both protocols are normalized into the same internal 
 - The service:
   - Accepts and parses Telnet line-based input.
   - Normalizes the connection.
-  - **Creates a WebSocket connection to the backend** on behalf of the TCP client.
+  - **Creates a WebSocket connection to Spring Cloud Gateway** (where all WebSocket connections terminate) on behalf of the TCP client.
   - Proxies I/O between the TCP client and Spring Cloud Gateway.
   - Buffers active input while the client remains connected and discards it if
     the TCP connection drops.

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -117,7 +117,7 @@ The service also exposes moderation tools such as bans or runtime feature toggle
    to load the new `version_id` when a full update is required. Script-only
    patches are applied live without restarting.
 
-4. **Verify Performance** – Check metrics after deployment; see [Performance Optimization Guidelines](./performance-optimization.md).
+5. **Verify Performance** – Check metrics after deployment; see [Performance Optimization Guidelines](./performance-optimization.md).
 
 ```plaintext
 Game Design Service (publish) → Game Session Service (restart)


### PR DESCRIPTION
## Summary
- clarify that the TCP proxy service opens a WebSocket connection to Spring Cloud Gateway
- fix a numbering issue in the user journey docs

## Testing
- `./gradlew lintMarkdown`
- `pre-commit run --all-files` *(fails: `buf` not found and proto lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871f7f11a6c833095dc5463ee93fdb1