### PR TITLE
Implement external account linking

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -59,6 +59,10 @@ Manages user accounts and authentication for the platform. It stores profile dat
 - `session` keys in Redis map temporary session tokens to account IDs for quick
   reconnects.
 
+External accounts allow players to log in via Google, Discord, or Steam. Each
+link stores the provider name and external ID so the platform account can be
+resolved during authentication.
+
 ### gRPC APIs
 
 - `CreateAccount` – registers a new user and establishes a session for internal

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -117,7 +117,7 @@ The service also exposes moderation tools such as bans or runtime feature toggle
    to load the new `version_id` when a full update is required. Script-only
    patches are applied live without restarting.
 
-4. **Verify Performance** – Check metrics after deployment; see [Performance Optimization Guidelines](./performance-optimization.md).
+5. **Verify Performance** – Check metrics after deployment; see [Performance Optimization Guidelines](./performance-optimization.md).
 
 ```plaintext
 Game Design Service (publish) → Game Session Service (restart)

--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -4,7 +4,7 @@
   - [ ] Implement user registration and authentication (OAuth2, JWT)
   - [x] Implement session management and persistent logins
   - [x] Implement role-based access control (RBAC) for admins, moderators, and players
-  - [ ] Enable external account linking (Google, Discord, Steam)
+  - [x] Enable external account linking (Google, Discord, Steam)
   - [x] Implement profile system with achievements, game history, and social features
   - [x] Implement player data export & deletion (GDPR compliance)
   - [x] Expose JWKS endpoint for token verification

--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -17,6 +17,7 @@ service AccountService {
   rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse);
   rpc RequestPasswordReset(RequestPasswordResetRequest) returns (RequestPasswordResetResponse);
   rpc CompletePasswordReset(CompletePasswordResetRequest) returns (CompletePasswordResetResponse);
+  rpc LinkExternalAccount(LinkExternalAccountRequest) returns (LinkExternalAccountResponse);
 }
 
 message PingRequest {}
@@ -109,6 +110,18 @@ message CompletePasswordResetRequest {
 }
 
 message CompletePasswordResetResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message LinkExternalAccountRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+  string provider = 3;
+  string external_id = 4;
+}
+
+message LinkExternalAccountResponse {
   bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
@@ -6,6 +6,7 @@ import net.firedevops.firemud.common.security.RequireAdminRole;
 import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
+import net.firedevops.firemud.dto.LinkExternalAccountRequest;
 import net.firedevops.firemud.service.AccountService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,6 +45,15 @@ public class AccountController {
   public ResponseEntity<ApiResponse<Void>> deleteAccount(
       @PathVariable Long accountId, Long tenantId) {
     accountService.deleteAccount(tenantId, accountId);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  @PostMapping("/{accountId}/external")
+  public ResponseEntity<ApiResponse<Void>> linkExternalAccount(
+      @PathVariable Long accountId, @Valid @RequestBody LinkExternalAccountRequest request) {
+    accountService.linkExternalAccount(
+        new LinkExternalAccountRequest(
+            request.tenantId(), accountId, request.provider(), request.externalId()));
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/LinkExternalAccountRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/LinkExternalAccountRequest.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record LinkExternalAccountRequest(
+    @NotNull Long tenantId,
+    @NotNull Long accountId,
+    @NotBlank String provider,
+    @NotBlank String externalId) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/ExternalAccount.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/ExternalAccount.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(
+    name = "external_account",
+    uniqueConstraints = {@UniqueConstraint(columnNames = {"provider", "external_id"})})
+public class ExternalAccount {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "account_id", nullable = false)
+  private Account account;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  @Column(nullable = false, length = 20)
+  private String provider;
+
+  @Column(name = "external_id", nullable = false, length = 100)
+  private String externalId;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/ExternalAccountRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/ExternalAccountRepository.java
@@ -1,0 +1,14 @@
+package net.firedevops.firemud.repository;
+
+import java.util.Optional;
+import net.firedevops.firemud.entity.ExternalAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ExternalAccountRepository extends JpaRepository<ExternalAccount, Long> {
+  Optional<ExternalAccount> findByTenantIdAndProviderAndExternalId(
+      Long tenantId, String provider, String externalId);
+
+  boolean existsByTenantIdAndAccountIdAndProvider(Long tenantId, Long accountId, String provider);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
@@ -24,4 +24,6 @@ public interface AccountService {
   void requestPasswordReset(PasswordResetRequest request);
 
   void completePasswordReset(CompletePasswordResetRequest request);
+
+  void linkExternalAccount(net.firedevops.firemud.dto.LinkExternalAccountRequest request);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -276,4 +276,37 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
       responseObserver.onCompleted();
     }
   }
+
+  @Override
+  public void linkExternalAccount(
+      net.firedevops.firemud.account.v1.LinkExternalAccountRequest request,
+      StreamObserver<net.firedevops.firemud.account.v1.LinkExternalAccountResponse>
+          responseObserver) {
+    try {
+      accountService.linkExternalAccount(
+          new net.firedevops.firemud.dto.LinkExternalAccountRequest(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getAccountId()),
+              request.getProvider(),
+              request.getExternalId()));
+      var response =
+          net.firedevops.firemud.account.v1.LinkExternalAccountResponse.newBuilder()
+              .setSuccess(true)
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      var response =
+          net.firedevops.firemud.account.v1.LinkExternalAccountResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -24,6 +24,7 @@ import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.ExternalAccountRepository;
 import net.firedevops.firemud.repository.PasswordResetTokenRepository;
 import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
@@ -44,6 +45,7 @@ public class AccountServiceImpl implements AccountService {
   private final ProfileMapper profileMapper;
   private final PaymentTransactionRepository paymentTransactionRepository;
   private final SubscriptionRepository subscriptionRepository;
+  private final ExternalAccountRepository externalAccountRepository;
   private final PasswordResetTokenRepository passwordResetTokenRepository;
   private final NotificationService notificationService;
   private final LoggingAdminClient loggingAdminClient;
@@ -57,6 +59,7 @@ public class AccountServiceImpl implements AccountService {
       ProfileMapper profileMapper,
       PaymentTransactionRepository paymentTransactionRepository,
       SubscriptionRepository subscriptionRepository,
+      ExternalAccountRepository externalAccountRepository,
       PasswordResetTokenRepository passwordResetTokenRepository,
       NotificationService notificationService,
       LoggingAdminClient loggingAdminClient,
@@ -68,6 +71,7 @@ public class AccountServiceImpl implements AccountService {
     this.profileMapper = profileMapper;
     this.paymentTransactionRepository = paymentTransactionRepository;
     this.subscriptionRepository = subscriptionRepository;
+    this.externalAccountRepository = externalAccountRepository;
     this.passwordResetTokenRepository = passwordResetTokenRepository;
     this.notificationService = notificationService;
     this.loggingAdminClient = loggingAdminClient;
@@ -237,6 +241,30 @@ public class AccountServiceImpl implements AccountService {
     account.setPasswordHash(hashPassword(request.newPassword()));
     accountRepository.save(account);
     passwordResetTokenRepository.delete(token);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.link_external")
+  public void linkExternalAccount(net.firedevops.firemud.dto.LinkExternalAccountRequest request) {
+    Account account =
+        accountRepository
+            .findById(request.accountId())
+            .filter(a -> a.getTenantId().equals(request.tenantId()))
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+
+    if (externalAccountRepository.existsByTenantIdAndAccountIdAndProvider(
+        request.tenantId(), request.accountId(), request.provider())) {
+      throw new IllegalArgumentException("Account already linked");
+    }
+
+    net.firedevops.firemud.entity.ExternalAccount entity =
+        new net.firedevops.firemud.entity.ExternalAccount();
+    entity.setAccount(account);
+    entity.setTenantId(request.tenantId());
+    entity.setProvider(request.provider());
+    entity.setExternalId(request.externalId());
+    externalAccountRepository.save(entity);
   }
 
   private String hashPassword(String password) {

--- a/services/account-service/src/main/resources/db/migration/V7__external_account.sql
+++ b/services/account-service/src/main/resources/db/migration/V7__external_account.sql
@@ -1,0 +1,8 @@
+CREATE TABLE external_account (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id),
+    tenant_id BIGINT NOT NULL,
+    provider VARCHAR(20) NOT NULL,
+    external_id VARCHAR(100) NOT NULL,
+    UNIQUE(provider, external_id)
+);

--- a/services/account-service/src/main/resources/openapi.yaml
+++ b/services/account-service/src/main/resources/openapi.yaml
@@ -101,6 +101,16 @@ components:
         newPassword:
           type: string
       required: [tenantId, token, newPassword]
+    LinkExternalAccountRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        provider:
+          type: string
+        externalId:
+          type: string
+      required: [tenantId, provider, externalId]
 paths:
   /ping:
     get:
@@ -196,6 +206,25 @@ paths:
       responses:
         '200':
           description: Exported data
+  /accounts/{accountId}/external:
+    post:
+      summary: Link external account
+      operationId: linkExternalAccount
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LinkExternalAccountRequest'
+      responses:
+        '200':
+          description: Linked
   /accounts/{accountId}:
     delete:
       summary: Delete account

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountGrpcServiceTest.java
@@ -238,4 +238,36 @@ class AccountGrpcServiceTest {
     assertNotNull(ref.get());
     assertTrue(ref.get().getSuccess());
   }
+
+  @Test
+  void linkExternalAccountSuccess() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<net.firedevops.firemud.account.v1.LinkExternalAccountResponse> ref =
+        new AtomicReference<>();
+    service.linkExternalAccount(
+        net.firedevops.firemud.account.v1.LinkExternalAccountRequest.newBuilder()
+            .setTenantId("1")
+            .setAccountId("2")
+            .setProvider("google")
+            .setExternalId("abc")
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(net.firedevops.firemud.account.v1.LinkExternalAccountResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertTrue(ref.get().getSuccess());
+  }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -16,6 +16,7 @@ import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.ExternalAccountRepository;
 import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
 import net.firedevops.firemud.repository.SubscriptionRepository;
@@ -36,6 +37,7 @@ class AccountServiceImplTest {
   @Mock private SessionService sessionService;
   @Mock private PaymentTransactionRepository paymentTransactionRepository;
   @Mock private SubscriptionRepository subscriptionRepository;
+  @Mock private ExternalAccountRepository externalAccountRepository;
 
   @Mock
   private net.firedevops.firemud.repository.PasswordResetTokenRepository
@@ -56,6 +58,7 @@ class AccountServiceImplTest {
             profileMapper,
             paymentTransactionRepository,
             subscriptionRepository,
+            externalAccountRepository,
             passwordResetTokenRepository,
             notificationService,
             loggingAdminClient,
@@ -146,6 +149,24 @@ class AccountServiceImplTest {
         .save(org.mockito.ArgumentMatchers.any());
     org.mockito.Mockito.verify(notificationService)
         .sendNotification(1L, 1L, "Password reset requested");
+  }
+
+  @Test
+  void linkExternalAccountSavesEntity() {
+    Account account = new Account();
+    account.setId(5L);
+    account.setTenantId(1L);
+    when(accountRepository.findById(5L)).thenReturn(Optional.of(account));
+    when(externalAccountRepository.existsByTenantIdAndAccountIdAndProvider(1L, 5L, "google"))
+        .thenReturn(false);
+
+    service.linkExternalAccount(
+        new net.firedevops.firemud.dto.LinkExternalAccountRequest(1L, 5L, "google", "abc"));
+
+    org.mockito.ArgumentCaptor<net.firedevops.firemud.entity.ExternalAccount> captor =
+        org.mockito.ArgumentCaptor.forClass(net.firedevops.firemud.entity.ExternalAccount.class);
+    org.mockito.Mockito.verify(externalAccountRepository).save(captor.capture());
+    assertEquals("abc", captor.getValue().getExternalId());
   }
 
   private static String hash(String password) {


### PR DESCRIPTION
## Summary
- enable external account linking in account service
- add ExternalAccount entity, repo, service method
- expose REST and gRPC endpoints for linking
- document external account table in design docs
- update task list and user journey numbering

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6871f63febdc8330b0a02713f91bcbd8