### PR TITLE
Fix failing lint and spotbugs checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "markdownlint-cli2": "^0.18.1"
   },
   "scripts": {
-    "openapi:lint": "npx @redocly/cli lint \"services/**/openapi.yaml\""
+    "openapi:lint": "npx @redocly/cli lint \"services/**/src/main/resources/openapi.yaml\""
   }
 }

--- a/services/account-service/src/main/resources/openapi.yaml
+++ b/services/account-service/src/main/resources/openapi.yaml
@@ -116,8 +116,10 @@ paths:
                 properties:
                   data:
                     type: string
-                example:
-                  data: pong
+              example:
+                data: pong
+        '400':
+          description: Bad request
   /auth/login:
     post:
       summary: Authenticate and return JWT
@@ -132,9 +134,11 @@ paths:
         '200':
           description: Auth token
           content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthTokenDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenDto'
+        '400':
+          description: Invalid credentials
   /auth/request-password-reset:
     post:
       summary: Request password reset
@@ -148,6 +152,8 @@ paths:
       responses:
         '200':
           description: Request accepted
+        '400':
+          description: Invalid request
   /auth/complete-password-reset:
     post:
       summary: Complete password reset
@@ -161,6 +167,8 @@ paths:
       responses:
         '200':
           description: Password updated
+        '400':
+          description: Invalid token
   /accounts:
     post:
       summary: Create a new account
@@ -178,6 +186,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccountDto'
+        '400':
+          description: Invalid account data
   /accounts/{accountId}/export:
     get:
       summary: Export account data
@@ -196,6 +206,8 @@ paths:
       responses:
         '200':
           description: Exported data
+        '400':
+          description: Invalid account ID
   /accounts/{accountId}:
     delete:
       summary: Delete account
@@ -214,6 +226,8 @@ paths:
       responses:
         '200':
           description: Deletion success
+        '400':
+          description: Invalid account ID
   /profiles/{accountId}:
     get:
       summary: Get profile
@@ -236,6 +250,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProfileDto'
+        '400':
+          description: Account not found
     put:
       summary: Update profile
       operationId: updateProfile
@@ -258,6 +274,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProfileDto'
+        '400':
+          description: Invalid profile data
   /.well-known/jwks.json:
     get:
       summary: JWKS public keys
@@ -269,3 +287,5 @@ paths:
             application/json:
               schema:
                 type: object
+        '400':
+          description: Bad request

--- a/services/common-library/build.gradle.kts
+++ b/services/common-library/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.8.4")
+
     api("org.springframework.boot:spring-boot-starter-web:3.5.3")
     api("org.springframework.boot:spring-boot-starter-validation:3.5.3")
 }

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
@@ -7,8 +7,8 @@ import io.lettuce.core.resource.DefaultClientResources;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Objects;
 import javax.sql.DataSource;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -20,10 +20,14 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 @EnableConfigurationProperties({PostgresProperties.class, RedisProperties.class})
-@RequiredArgsConstructor
 public class DatabaseAutoConfiguration {
   private final PostgresProperties postgres;
   private final RedisProperties redis;
+
+  public DatabaseAutoConfiguration(PostgresProperties postgres, RedisProperties redis) {
+    this.postgres = Objects.requireNonNull(postgres);
+    this.redis = Objects.requireNonNull(redis);
+  }
 
   @Bean
   public DataSource dataSource() {

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/MetricsInterceptor.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/MetricsInterceptor.java
@@ -3,13 +3,14 @@ package net.firedevops.firemud.common.grpc;
 import io.grpc.*;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.Objects;
 
 /** Records gRPC call metrics using Micrometer. */
 public class MetricsInterceptor implements ServerInterceptor {
   private final MeterRegistry registry;
 
   public MetricsInterceptor(MeterRegistry registry) {
-    this.registry = registry;
+    this.registry = Objects.requireNonNull(registry);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- add 400 responses in account-service openapi
- lint openapi specs in src directories only
- ensure MetricsInterceptor and DatabaseAutoConfiguration validate constructor args
- add spotbugs annotations dependency

## Testing
- `./gradlew check`
- `npm run openapi:lint`


------
https://chatgpt.com/codex/tasks/task_e_6871f8b0f4f88330844cf40a2f1a82cb