### PR TITLE
Implement email verification in account service

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -10,7 +10,7 @@ The architecture section describes the platform infrastructure and each microser
 
 ## Directories & Responsibilities
 
- - [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
+- [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 - [**repository-structure.md**](./repository-structure.md) – Layout of Gradle modules and repository files.

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -160,6 +160,8 @@ Admin and moderator accounts can enable a TOTP secret for additional protection.
 - `DELETE /accounts/{accountId}` – remove an account permanently.
 - `POST /auth/login` – authenticate and establish a session. The JWT returned is for internal service calls.
 - `GET /.well-known/jwks.json` – JWKS for verifying issued JWT tokens.
+- `POST /auth/request-email-verification` – send a verification email for the account.
+- `POST /auth/verify-email` – confirm the verification token.
 
 Example account creation request:
 
@@ -206,6 +208,8 @@ Example login response:
 - `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`account_service.proto`](../../../protos/account/v1/account_service.proto).
 - `CreateAccount(CreateAccountRequest) returns (CreateAccountResponse)` – registers a new user.
 - `SendNotification(SendNotificationRequest) returns (SendNotificationResponse)` – deliver account notifications asynchronously.
+- `RequestEmailVerification(RequestEmailVerificationRequest) returns (RequestEmailVerificationResponse)` – send a verification email for the account.
+- `VerifyEmail(VerifyEmailRequest) returns (VerifyEmailResponse)` – confirm the email token.
 
 Call the gRPC method with:
 

--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -12,7 +12,7 @@
   - [ ] Implement self-service account recovery
   - [x] Add optional 2FA for admin and moderator roles
 - [ ] **Develop Email & Notification System**
-  - [ ] Implement email verification & password resets
+  - [x] Implement email verification & password resets
   - [ ] Implement in-game notification system for events & messages
   - [ ] Configure SMTP provider and test templates
   - [x] Document email and notification design in `account-service/design/README.md`

--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -18,6 +18,8 @@ service AccountService {
   rpc RequestPasswordReset(RequestPasswordResetRequest) returns (RequestPasswordResetResponse);
   rpc CompletePasswordReset(CompletePasswordResetRequest) returns (CompletePasswordResetResponse);
   rpc LinkExternalAccount(LinkExternalAccountRequest) returns (LinkExternalAccountResponse);
+  rpc RequestEmailVerification(RequestEmailVerificationRequest) returns (RequestEmailVerificationResponse);
+  rpc VerifyEmail(VerifyEmailRequest) returns (VerifyEmailResponse);
 }
 
 message PingRequest {}
@@ -122,6 +124,26 @@ message LinkExternalAccountRequest {
 }
 
 message LinkExternalAccountResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message RequestEmailVerificationRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+}
+
+message RequestEmailVerificationResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message VerifyEmailRequest {
+  string tenant_id = 1;
+  string token = 2;
+}
+
+message VerifyEmailResponse {
   bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
@@ -24,6 +24,8 @@ public class WebConfig implements WebMvcConfigurer {
             "/auth/login",
             "/auth/request-password-reset",
             "/auth/complete-password-reset",
+            "/auth/request-email-verification",
+            "/auth/verify-email",
             "/accounts",
             "/ping",
             "/.well-known/**");

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -2,10 +2,12 @@ package net.firedevops.firemud.controller;
 
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.AccountRefRequest;
 import net.firedevops.firemud.dto.AuthTokenDto;
 import net.firedevops.firemud.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.dto.LoginRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
+import net.firedevops.firemud.dto.VerifyEmailRequest;
 import net.firedevops.firemud.service.AccountService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,6 +43,20 @@ public class AuthController {
   public ResponseEntity<ApiResponse<Void>> completePasswordReset(
       @Valid @RequestBody CompletePasswordResetRequest request) {
     accountService.completePasswordReset(request);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  @PostMapping("/request-email-verification")
+  public ResponseEntity<ApiResponse<Void>> requestEmailVerification(
+      @Valid @RequestBody AccountRefRequest request) {
+    accountService.requestEmailVerification(request.tenantId(), request.accountId());
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  @PostMapping("/verify-email")
+  public ResponseEntity<ApiResponse<Void>> verifyEmail(
+      @Valid @RequestBody VerifyEmailRequest request) {
+    accountService.verifyEmail(request);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/AccountDto.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/AccountDto.java
@@ -9,4 +9,5 @@ public record AccountDto(
     @NotNull Long tenantId,
     @NotNull @Size(max = 50) String username,
     @NotNull @Email @Size(max = 100) String email,
-    @NotNull @Size(max = 20) String role) {}
+    @NotNull @Size(max = 20) String role,
+    boolean emailVerified) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/AccountRefRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/AccountRefRequest.java
@@ -1,0 +1,5 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AccountRefRequest(@NotNull Long tenantId, @NotNull Long accountId) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/VerifyEmailRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/VerifyEmailRequest.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record VerifyEmailRequest(@NotNull Long tenantId, @NotBlank String token) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/Account.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/Account.java
@@ -28,4 +28,7 @@ public class Account {
 
   @Column(name = "two_factor_secret", length = 64)
   private String twoFactorSecret;
+
+  @Column(name = "email_verified", nullable = false)
+  private boolean emailVerified = false;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/EmailVerificationToken.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/EmailVerificationToken.java
@@ -1,0 +1,27 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "email_verification_token")
+public class EmailVerificationToken {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "account_id", nullable = false)
+  private Account account;
+
+  @Column(nullable = false, length = 64)
+  private String token;
+
+  @Column(name = "expires_at", nullable = false)
+  private LocalDateTime expiresAt;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/repository/EmailVerificationTokenRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/repository/EmailVerificationTokenRepository.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.repository;
+
+import java.util.Optional;
+import net.firedevops.firemud.entity.EmailVerificationToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailVerificationTokenRepository
+    extends JpaRepository<EmailVerificationToken, Long> {
+  Optional<EmailVerificationToken> findByTokenAndTenantId(String token, Long tenantId);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
@@ -26,4 +26,8 @@ public interface AccountService {
   void completePasswordReset(CompletePasswordResetRequest request);
 
   void linkExternalAccount(net.firedevops.firemud.dto.LinkExternalAccountRequest request);
+
+  void requestEmailVerification(Long tenantId, Long accountId);
+
+  void verifyEmail(net.firedevops.firemud.dto.VerifyEmailRequest request);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -309,4 +309,62 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
       responseObserver.onCompleted();
     }
   }
+
+  @Override
+  public void requestEmailVerification(
+      net.firedevops.firemud.account.v1.RequestEmailVerificationRequest request,
+      StreamObserver<net.firedevops.firemud.account.v1.RequestEmailVerificationResponse>
+          responseObserver) {
+    try {
+      accountService.requestEmailVerification(
+          Long.valueOf(request.getTenantId()), Long.valueOf(request.getAccountId()));
+      var response =
+          net.firedevops.firemud.account.v1.RequestEmailVerificationResponse.newBuilder()
+              .setSuccess(true)
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      var response =
+          net.firedevops.firemud.account.v1.RequestEmailVerificationResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void verifyEmail(
+      net.firedevops.firemud.account.v1.VerifyEmailRequest request,
+      StreamObserver<net.firedevops.firemud.account.v1.VerifyEmailResponse> responseObserver) {
+    try {
+      accountService.verifyEmail(
+          new net.firedevops.firemud.dto.VerifyEmailRequest(
+              Long.valueOf(request.getTenantId()), request.getToken()));
+      var response =
+          net.firedevops.firemud.account.v1.VerifyEmailResponse.newBuilder()
+              .setSuccess(true)
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (Exception ex) {
+      var response =
+          net.firedevops.firemud.account.v1.VerifyEmailResponse.newBuilder()
+              .setSuccess(false)
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -19,11 +19,14 @@ import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.dto.ProfileDto;
 import net.firedevops.firemud.dto.UpdateProfileRequest;
+import net.firedevops.firemud.dto.VerifyEmailRequest;
 import net.firedevops.firemud.entity.Account;
+import net.firedevops.firemud.entity.EmailVerificationToken;
 import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.EmailVerificationTokenRepository;
 import net.firedevops.firemud.repository.ExternalAccountRepository;
 import net.firedevops.firemud.repository.PasswordResetTokenRepository;
 import net.firedevops.firemud.repository.PaymentTransactionRepository;
@@ -47,6 +50,7 @@ public class AccountServiceImpl implements AccountService {
   private final SubscriptionRepository subscriptionRepository;
   private final ExternalAccountRepository externalAccountRepository;
   private final PasswordResetTokenRepository passwordResetTokenRepository;
+  private final EmailVerificationTokenRepository emailVerificationTokenRepository;
   private final NotificationService notificationService;
   private final LoggingAdminClient loggingAdminClient;
   private final JwtUtil jwtUtil;
@@ -61,6 +65,7 @@ public class AccountServiceImpl implements AccountService {
       SubscriptionRepository subscriptionRepository,
       ExternalAccountRepository externalAccountRepository,
       PasswordResetTokenRepository passwordResetTokenRepository,
+      EmailVerificationTokenRepository emailVerificationTokenRepository,
       NotificationService notificationService,
       LoggingAdminClient loggingAdminClient,
       JwtUtil jwtUtil,
@@ -73,6 +78,7 @@ public class AccountServiceImpl implements AccountService {
     this.subscriptionRepository = subscriptionRepository;
     this.externalAccountRepository = externalAccountRepository;
     this.passwordResetTokenRepository = passwordResetTokenRepository;
+    this.emailVerificationTokenRepository = emailVerificationTokenRepository;
     this.notificationService = notificationService;
     this.loggingAdminClient = loggingAdminClient;
     this.jwtUtil = jwtUtil;
@@ -241,6 +247,41 @@ public class AccountServiceImpl implements AccountService {
     account.setPasswordHash(hashPassword(request.newPassword()));
     accountRepository.save(account);
     passwordResetTokenRepository.delete(token);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.request_email_verification")
+  public void requestEmailVerification(Long tenantId, Long accountId) {
+    Account account =
+        accountRepository
+            .findById(accountId)
+            .filter(a -> a.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    EmailVerificationToken token = new EmailVerificationToken();
+    token.setAccount(account);
+    token.setTenantId(tenantId);
+    token.setToken(java.util.UUID.randomUUID().toString());
+    token.setExpiresAt(java.time.LocalDateTime.now().plusHours(24));
+    emailVerificationTokenRepository.save(token);
+    notificationService.sendNotification(tenantId, accountId, "Email verification requested");
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.verify_email")
+  public void verifyEmail(VerifyEmailRequest request) {
+    EmailVerificationToken token =
+        emailVerificationTokenRepository
+            .findByTokenAndTenantId(request.token(), request.tenantId())
+            .orElseThrow(() -> new IllegalArgumentException("Invalid token"));
+    if (token.getExpiresAt().isBefore(java.time.LocalDateTime.now())) {
+      throw new IllegalArgumentException("Token expired");
+    }
+    Account account = token.getAccount();
+    account.setEmailVerified(true);
+    accountRepository.save(account);
+    emailVerificationTokenRepository.delete(token);
   }
 
   @Override

--- a/services/account-service/src/main/resources/db/migration/V8__email_verification.sql
+++ b/services/account-service/src/main/resources/db/migration/V8__email_verification.sql
@@ -1,0 +1,9 @@
+ALTER TABLE accounts ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE email_verification_token (
+    id SERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL REFERENCES accounts(id),
+    token VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    tenant_id BIGINT NOT NULL
+);

--- a/services/account-service/src/main/resources/openapi.yaml
+++ b/services/account-service/src/main/resources/openapi.yaml
@@ -111,6 +111,22 @@ components:
         externalId:
           type: string
       required: [tenantId, provider, externalId]
+    AccountRefRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        accountId:
+          type: integer
+      required: [tenantId, accountId]
+    VerifyEmailRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        token:
+          type: string
+      required: [tenantId, token]
 paths:
   /ping:
     get:
@@ -171,6 +187,32 @@ paths:
       responses:
         '200':
           description: Password updated
+  /auth/request-email-verification:
+    post:
+      summary: Request email verification
+      operationId: requestEmailVerification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountRefRequest'
+      responses:
+        '200':
+          description: Request accepted
+  /auth/verify-email:
+    post:
+      summary: Verify email token
+      operationId: verifyEmail
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerifyEmailRequest'
+      responses:
+        '200':
+          description: Email verified
   /accounts:
     post:
       summary: Create a new account

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AccountControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AccountControllerTest.java
@@ -28,7 +28,7 @@ class AccountControllerTest {
   void createAccountReturnsDto() throws Exception {
     CreateAccountRequest request =
         new CreateAccountRequest(1L, "demo", "demo@example.com", "password");
-    AccountDto response = new AccountDto(1L, 1L, "demo", "demo@example.com", "player");
+    AccountDto response = new AccountDto(1L, 1L, "demo", "demo@example.com", "player", true);
     when(accountService.createAccount(request)).thenReturn(response);
 
     mockMvc

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
@@ -51,4 +51,32 @@ class AuthControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"));
   }
+
+  @Test
+  void requestEmailVerificationReturnsSuccess() throws Exception {
+    net.firedevops.firemud.dto.AccountRefRequest req =
+        new net.firedevops.firemud.dto.AccountRefRequest(1L, 2L);
+
+    mockMvc
+        .perform(
+            post("/auth/request-email-verification")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"));
+  }
+
+  @Test
+  void verifyEmailReturnsSuccess() throws Exception {
+    net.firedevops.firemud.dto.VerifyEmailRequest req =
+        new net.firedevops.firemud.dto.VerifyEmailRequest(1L, "tok");
+
+    mockMvc
+        .perform(
+            post("/auth/verify-email")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("SUCCESS"));
+  }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -12,10 +13,12 @@ import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.entity.Account;
+import net.firedevops.firemud.entity.EmailVerificationToken;
 import net.firedevops.firemud.entity.Profile;
 import net.firedevops.firemud.mapper.AccountMapper;
 import net.firedevops.firemud.mapper.ProfileMapper;
 import net.firedevops.firemud.repository.AccountRepository;
+import net.firedevops.firemud.repository.EmailVerificationTokenRepository;
 import net.firedevops.firemud.repository.ExternalAccountRepository;
 import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
@@ -39,6 +42,8 @@ class AccountServiceImplTest {
   @Mock private SubscriptionRepository subscriptionRepository;
   @Mock private ExternalAccountRepository externalAccountRepository;
 
+  @Mock private EmailVerificationTokenRepository emailVerificationTokenRepository;
+
   @Mock
   private net.firedevops.firemud.repository.PasswordResetTokenRepository
       passwordResetTokenRepository;
@@ -60,6 +65,7 @@ class AccountServiceImplTest {
             subscriptionRepository,
             externalAccountRepository,
             passwordResetTokenRepository,
+            emailVerificationTokenRepository,
             notificationService,
             loggingAdminClient,
             jwtUtil,
@@ -167,6 +173,38 @@ class AccountServiceImplTest {
         org.mockito.ArgumentCaptor.forClass(net.firedevops.firemud.entity.ExternalAccount.class);
     org.mockito.Mockito.verify(externalAccountRepository).save(captor.capture());
     assertEquals("abc", captor.getValue().getExternalId());
+  }
+
+  @Test
+  void requestEmailVerificationCreatesToken() {
+    Account account = new Account();
+    account.setId(6L);
+    account.setTenantId(1L);
+    when(accountRepository.findById(6L)).thenReturn(Optional.of(account));
+
+    service.requestEmailVerification(1L, 6L);
+
+    org.mockito.Mockito.verify(emailVerificationTokenRepository)
+        .save(org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.verify(notificationService)
+        .sendNotification(1L, 6L, "Email verification requested");
+  }
+
+  @Test
+  void verifyEmailSetsFlag() {
+    Account account = new Account();
+    account.setTenantId(1L);
+    EmailVerificationToken token = new EmailVerificationToken();
+    token.setAccount(account);
+    token.setTenantId(1L);
+    token.setExpiresAt(java.time.LocalDateTime.now().plusHours(1));
+    when(emailVerificationTokenRepository.findByTokenAndTenantId("tok", 1L))
+        .thenReturn(Optional.of(token));
+
+    service.verifyEmail(new net.firedevops.firemud.dto.VerifyEmailRequest(1L, "tok"));
+
+    assertTrue(account.isEmailVerified());
+    org.mockito.Mockito.verify(emailVerificationTokenRepository).delete(token);
   }
 
   private static String hash(String password) {


### PR DESCRIPTION
## Summary
- add email verification token entity, repository, DTOs, and service logic
- expose request/verify endpoints in REST, gRPC, and OpenAPI specs
- update WebConfig paths and design docs
- mark task-list item as complete

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871fd5fc4a08330a091928d168b4438