### PR TITLE
Enable gRPC TLS hot‑reloading

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -10,7 +10,7 @@ The architecture section describes the platform infrastructure and each microser
 
 ## Directories & Responsibilities
 
- - [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
+- [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 - [**repository-structure.md**](./repository-structure.md) – Layout of Gradle modules and repository files.

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/TlsCertificateWatcher.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/TlsCertificateWatcher.java
@@ -1,0 +1,93 @@
+package net.firedevops.firemud.common.grpc;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.firedevops.firemud.common.LoggingUtil;
+import org.slf4j.Logger;
+
+/**
+ * Watches a set of certificate files for modifications and invokes a callback when any of them
+ * changes. This is used to hot reload gRPC TLS credentials when cert-manager rotates Kubernetes
+ * secrets.
+ */
+public class TlsCertificateWatcher implements AutoCloseable {
+  private static final Logger logger = LoggingUtil.getLogger(TlsCertificateWatcher.class);
+
+  private final WatchService watchService;
+  private final Map<WatchKey, Path> keys = new HashMap<>();
+  private final Set<Path> files;
+  private final Runnable onChange;
+  private final AtomicBoolean running = new AtomicBoolean(true);
+  private final Thread thread;
+
+  public TlsCertificateWatcher(List<Path> files, Runnable onChange) throws IOException {
+    this.files = Set.copyOf(files.stream().map(Path::toAbsolutePath).toList());
+    this.onChange = onChange;
+    this.watchService = FileSystems.getDefault().newWatchService();
+    for (Path file : this.files) {
+      Path dir = file.getParent();
+      WatchKey key =
+          dir.register(
+              watchService,
+              StandardWatchEventKinds.ENTRY_MODIFY,
+              StandardWatchEventKinds.ENTRY_CREATE);
+      keys.put(key, dir);
+    }
+    thread = new Thread(this::processEvents, "tls-cert-watcher");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  private void processEvents() {
+    while (running.get()) {
+      WatchKey key;
+      try {
+        key = watchService.take();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      Path dir = keys.get(key);
+      boolean changed = false;
+      if (dir != null) {
+        for (WatchEvent<?> event : key.pollEvents()) {
+          Path changedPath = dir.resolve((Path) event.context()).toAbsolutePath();
+          if (files.contains(changedPath)) {
+            changed = true;
+            break;
+          }
+        }
+      }
+      boolean valid = key.reset();
+      if (!valid) {
+        keys.remove(key);
+      }
+      if (changed) {
+        logger.info("TLS certificate change detected; reloading channel");
+        onChange.run();
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    running.set(false);
+    try {
+      watchService.close();
+    } finally {
+      if (thread.isAlive()) {
+        thread.interrupt();
+      }
+    }
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
@@ -3,10 +3,15 @@ package net.firedevops.firemud.client;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
-import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import net.firedevops.firemud.gamelogic.v1.GameLogicServiceGrpc;
 import net.firedevops.firemud.gamelogic.v1.PingRequest;
@@ -20,6 +25,7 @@ public class GameLogicClient implements AutoCloseable {
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;
   private GameLogicServiceGrpc.GameLogicServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public GameLogicClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -27,7 +33,28 @@ public class GameLogicClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      // Log but continue using the existing channel if reload fails
+      net.firedevops.firemud.common.LoggingUtil.getLogger(GameLogicClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getGameLogicService();
     String host = target.split(":")[0];
     int port = Integer.parseInt(target.split(":")[1]);
@@ -36,7 +63,12 @@ public class GameLogicClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = GameLogicServiceGrpc.newBlockingStub(channel);
   }
 
@@ -45,8 +77,12 @@ public class GameLogicClient implements AutoCloseable {
     return stub.ping(PingRequest.newBuilder().build());
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -21,6 +21,6 @@ firemud:
   services:
     game-logic-service: game-logic-service:6565
   grpc:
-    cert-chain: classpath:certs/client.crt
-    private-key: classpath:certs/client.key
-    ca-cert: classpath:certs/ca.crt
+    cert-chain: ${GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -4,7 +4,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import net.firedevops.firemud.loggingadmin.v1.CreateReportRequest;
 import net.firedevops.firemud.loggingadmin.v1.ReportServiceGrpc;
@@ -18,6 +25,7 @@ public class LoggingAdminClient implements AutoCloseable {
 
   private ManagedChannel channel;
   private ReportServiceGrpc.ReportServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public LoggingAdminClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -25,7 +33,27 @@ public class LoggingAdminClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws javax.net.ssl.SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(LoggingAdminClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getLoggingAdminService();
     if (target == null || target.isEmpty()) {
       target = "logging-admin-service:6565";
@@ -40,7 +68,12 @@ public class LoggingAdminClient implements AutoCloseable {
                 new java.io.File(tlsProps.getCertChain()),
                 new java.io.File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = ReportServiceGrpc.newBlockingStub(channel);
   }
 
@@ -63,8 +96,12 @@ public class LoggingAdminClient implements AutoCloseable {
     stub.createReport(request);
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/social-groups-service/src/main/resources/application.yml
+++ b/services/social-groups-service/src/main/resources/application.yml
@@ -24,9 +24,9 @@ firemud:
   services:
     logging-admin-service: "logging-admin-service:6565"
   grpc:
-    cert-chain: classpath:certs/client.crt
-    private-key: classpath:certs/client.key
-    ca-cert: classpath:certs/ca.crt
+    cert-chain: ${GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-secret: changemechangemechangeme123456
     jwt-expiration-ms: 3600000


### PR DESCRIPTION
## Summary
- add properties for mTLS certificate paths
- watch cert files and reload gRPC channels when they change
- support hot‑reload for GameSessionService and SocialGroupsService clients
- fix markdown lint issues

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6871ffdc44208330a1104639141ff621