### PR TITLE
Document TLS and discovery env vars

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -66,6 +66,31 @@ these variables.
 | `FIREMUD_REDIS_HOST` | Redis host | `redis` |
 | `FIREMUD_REDIS_PORT` | Redis port | `6379` |
 
+### gRPC TLS Certificates
+
+Mutual TLS protects all gRPC calls between services. Certificates are normally
+provisioned by **cert-manager** and mounted from Kubernetes Secrets.
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `FIREMUD_GRPC_CERT_CHAIN` | PEM encoded certificate chain for this service | _(none)_ |
+| `FIREMUD_GRPC_PRIVATE_KEY` | Private key matching the certificate chain | _(none)_ |
+| `FIREMUD_GRPC_CA_CERT` | CA bundle used to verify peer services | _(none)_ |
+
+During local development these values are generated automatically, so the
+variables may be omitted.
+
+### Service Discovery
+
+The shared configuration library resolves other services using environment
+variables prefixed with `FIREMUD_SERVICES_`. Each variable holds a `host:port`
+pair for a target service. When undefined, Kubernetes DNS is used instead.
+
+```bash
+FIREMUD_SERVICES_ACCOUNT=account-service:6565
+FIREMUD_SERVICES_GAME_LOGIC=game-logic-service:6565
+```
+
 ## 📚 Related Docs
 
 - [Deployment Environments](./deployment-environments.md)

--- a/services/account-service/README.md
+++ b/services/account-service/README.md
@@ -4,3 +4,7 @@ The complete design for this service is documented in the central repository:
 [📄 Account Service Design](../../design/architecture/microservices/account-service/README.md)
 
 This README is only a stub linking to that document. **Do not add design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -5,3 +5,7 @@ Design documentation lives at:
 
 This README is a stub that only links to the real design document.
 **Do not place design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/common-library/README.md
+++ b/services/common-library/README.md
@@ -4,3 +4,7 @@ Design and usage notes are documented under:
 [📄 Shared Libraries Overview](../../design/architecture/system-architecture-shared-libraries.md)
 
 This README is only a stub linking to the design guide. **Do not add design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -4,3 +4,7 @@ The service design is located in the central docs:
 [📄 Entity Management Service Design](../../design/architecture/microservices/entity-management-service/README.md)
 
 This README is a stub only. **Please do not add design information here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -4,3 +4,7 @@ Architecture details are documented at:
 [📄 Game Design Service Design](../../design/architecture/microservices/game-design-service/README.md)
 
 This README remains a stub. **Do not add design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -4,3 +4,7 @@ Full design documentation lives in:
 [📄 Game Logic Service Design](../../design/architecture/microservices/game-logic-service/README.md)
 
 This README is a stub. **Keep design information in the linked document only.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -4,3 +4,7 @@ Design details are kept in the architecture docs:
 [📄 Game Session Service Design](../../design/architecture/microservices/game-session-service/README.md)
 
 This README is only a stub. **Do not place design information here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -4,3 +4,7 @@ Central design documentation:
 [📄 Logging Admin Service Design](../../design/architecture/microservices/logging-admin-service/README.md)
 
 This README serves only as a stub. **Do not add design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/social-groups-service/README.md
+++ b/services/social-groups-service/README.md
@@ -4,3 +4,7 @@ Design documentation is maintained here:
 [📄 Social Groups Service Design](../../design/architecture/microservices/social-groups-service/README.md)
 
 This README is a stub. **Keep all design info in the linked document.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/spring-cloud-gateway/README.md
+++ b/services/spring-cloud-gateway/README.md
@@ -4,3 +4,7 @@ The gateway's design documentation lives at:
 [📄 Spring Cloud Gateway Design](../../design/architecture/microservices/spring-cloud-gateway/README.md)
 
 This README is a stub. **Do not add design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/tcp-proxy-service/README.md
+++ b/services/tcp-proxy-service/README.md
@@ -4,3 +4,7 @@ The complete design can be found in:
 [📄 TCP Proxy Service Design](../../design/architecture/microservices/tcp-proxy-service/README.md)
 
 This README is only a stub for reference. **Do not include design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/world-management-service/README.md
+++ b/services/world-management-service/README.md
@@ -4,3 +4,7 @@ See the design documentation at:
 [📄 World Management Service Design](../../design/architecture/microservices/world-management-service/README.md)
 
 This README is a stub only. **Do not add design details here.**
+
+See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.


### PR DESCRIPTION
## Summary
- document TLS certificate variables and service discovery in the environment docs
- link these environment docs from every microservice README

## Testing
- `pre-commit run --files design/architecture/infrastructure/environment-and-secrets.md services/account-service/README.md services/automation-scripting-service/README.md services/common-library/README.md services/entity-management-service/README.md services/game-design-service/README.md services/game-logic-service/README.md services/game-session-service/README.md services/logging-admin-service/README.md services/social-groups-service/README.md services/spring-cloud-gateway/README.md services/tcp-proxy-service/README.md services/world-management-service/README.md` *(fails: Process 'npx' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_6871ffeaf610833084f68d949c5bf3fb