### PR TITLE
Improve user journeys doc

### DIFF
--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -3,6 +3,12 @@
 This document outlines common flows for creators and players when interacting with the platform. Each step references the microservice responsible for that portion of the journey.
 For step-by-step tooling instructions see the [Game Creator Guide](../user-guides/game-creator-guide.md).
 
+## 🎯 Goals
+
+- Provide a quick reference for how a user moves through the system.
+- Map each step to the microservice that owns the logic or data.
+- Link back to deeper design docs for anyone who needs additional context.
+
 ---
 
 ## 1. Sign Up
@@ -126,7 +132,7 @@ The service also exposes moderation tools such as bans and runtime feature toggl
 Game Design Service (publish) → Game Session Service (restart)
 ```
 
-Example user-journey DSL entry for a hotfix:
+### Example Hotfix DSL
 
 ```yaml
 - action: hotfix_script


### PR DESCRIPTION
## Summary
- add goals section to user journeys doc
- standardize example hotfix snippet heading

## Testing
- `pre-commit run markdownlint --files design/architecture/user-journeys.md` *(fails: Process 'npx' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_6871ff96084483308916ac18bc575076