### PR TITLE
Implement script patch hotfix handling

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -10,7 +10,7 @@ The architecture section describes the platform infrastructure and each microser
 
 ## Directories & Responsibilities
 
- - [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
+- [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 - [**repository-structure.md**](./repository-structure.md) – Layout of Gradle modules and repository files.

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/ScriptDefinitionRepository.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/repository/ScriptDefinitionRepository.java
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ScriptDefinitionRepository extends JpaRepository<ScriptDefinition, Long> {}
+public interface ScriptDefinitionRepository extends JpaRepository<ScriptDefinition, Long> {
+  java.util.List<ScriptDefinition> findByTenantIdAndNameIn(
+      Long tenantId, java.util.List<String> names);
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptVersionServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptVersionServiceImpl.java
@@ -1,8 +1,12 @@
 package net.firedevops.firemud.service.impl;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.entity.ScriptDefinition;
+import net.firedevops.firemud.repository.ScriptDefinitionRepository;
 import net.firedevops.firemud.service.ScriptVersionService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
@@ -16,6 +20,9 @@ import org.springframework.stereotype.Service;
 public class ScriptVersionServiceImpl implements ScriptVersionService {
   private static final Logger logger = LoggingUtil.getLogger(ScriptVersionServiceImpl.class);
 
+  private final ScriptDefinitionRepository repository;
+  private final Map<Long, Map<String, String>> registry = new ConcurrentHashMap<>();
+
   @Override
   public void notifyUpdate(Long gameId, String scriptPatchVersion, List<String> affectedScripts) {
     logger.info(
@@ -23,6 +30,15 @@ public class ScriptVersionServiceImpl implements ScriptVersionService {
         scriptPatchVersion,
         gameId,
         affectedScripts.size());
-    // TODO reload scripts and validate compatibility
+    if (affectedScripts.isEmpty()) {
+      logger.info("No scripts provided for patch {}", scriptPatchVersion);
+      return;
+    }
+    List<ScriptDefinition> defs = repository.findByTenantIdAndNameIn(gameId, affectedScripts);
+    Map<String, String> map = registry.computeIfAbsent(gameId, id -> new ConcurrentHashMap<>());
+    for (ScriptDefinition def : defs) {
+      map.put(def.getName(), def.getDefinition());
+    }
+    logger.info("Reloaded {} scripts for patch {}", defs.size(), scriptPatchVersion);
   }
 }

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptVersionServiceImplTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptVersionServiceImplTest.java
@@ -1,0 +1,33 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import net.firedevops.firemud.entity.ScriptDefinition;
+import net.firedevops.firemud.repository.ScriptDefinitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ScriptVersionServiceImplTest {
+  private ScriptDefinitionRepository repository;
+  private ScriptVersionServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    repository = mock(ScriptDefinitionRepository.class);
+    service = new ScriptVersionServiceImpl(repository);
+  }
+
+  @Test
+  void notifyUpdateReloadsScripts() {
+    ScriptDefinition def = new ScriptDefinition();
+    def.setTenantId(1L);
+    def.setName("npc-barkeep");
+    def.setDefinition("{}");
+    when(repository.findByTenantIdAndNameIn(1L, List.of("npc-barkeep"))).thenReturn(List.of(def));
+
+    service.notifyUpdate(1L, "v1-script.1", List.of("npc-barkeep"));
+
+    verify(repository).findByTenantIdAndNameIn(1L, List.of("npc-barkeep"));
+  }
+}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/ServiceEndpointsProperties.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/ServiceEndpointsProperties.java
@@ -13,4 +13,5 @@ public class ServiceEndpointsProperties {
   private String worldManagementService;
   private String entityManagementService;
   private String loggingAdminService;
+  private String automationScriptingService;
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/GameDesignServiceApplication.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/GameDesignServiceApplication.java
@@ -2,11 +2,14 @@ package net.firedevops.firemud;
 
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
+import net.firedevops.firemud.config.GrpcClientProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@EnableConfigurationProperties(GrpcClientProperties.class)
 @Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class})
 public class GameDesignServiceApplication {
   public static void main(String[] args) {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/client/AutomationScriptingClient.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/client/AutomationScriptingClient.java
@@ -1,0 +1,65 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import java.util.List;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.automationscripting.v1.AutomationScriptingServiceGrpc;
+import net.firedevops.firemud.automationscripting.v1.NotifyScriptVersionUpdateRequest;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import org.springframework.stereotype.Component;
+
+/** gRPC client for Automation & Scripting Service. */
+@Component
+public class AutomationScriptingClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+  private ManagedChannel channel;
+  private AutomationScriptingServiceGrpc.AutomationScriptingServiceBlockingStub stub;
+
+  public AutomationScriptingClient(
+      ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getAutomationScriptingService();
+    if (target == null || target.isEmpty()) {
+      target = "automation-scripting-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = AutomationScriptingServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Notify the Automation service that a new script patch version is active. */
+  public void notifyScriptVersionUpdate(long gameId, String patchVersion, List<String> scripts) {
+    NotifyScriptVersionUpdateRequest request =
+        NotifyScriptVersionUpdateRequest.newBuilder()
+            .setGameId(gameId)
+            .setScriptPatchVersion(patchVersion)
+            .addAllAffectedScripts(scripts)
+            .build();
+    stub.notifyScriptVersionUpdate(request);
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
@@ -1,0 +1,18 @@
+package net.firedevops.firemud.config;
+
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.client.AutomationScriptingClient;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Bean configuration for outbound gRPC clients. */
+@Configuration
+public class GrpcClientConfig {
+
+  @Bean
+  public AutomationScriptingClient automationScriptingClient(
+      ServiceEndpointsProperties endpoints, GrpcClientProperties properties) throws SSLException {
+    return new AutomationScriptingClient(endpoints, properties);
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** TLS configuration for outbound gRPC connections. */
+@Data
+@ConfigurationProperties(prefix = "firemud.grpc")
+public class GrpcClientProperties {
+  private String certChain;
+  private String privateKey;
+  private String caCert;
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.client.AutomationScriptingClient;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
 import net.firedevops.firemud.common.saga.SagaException;
@@ -24,6 +25,7 @@ public class VersionServiceImpl implements VersionService {
   private final VersionRepository versionRepository;
   private final GameRepository gameRepository;
   private final VersionMapper versionMapper;
+  private final AutomationScriptingClient scriptingClient;
 
   @Override
   @Transactional
@@ -84,6 +86,7 @@ public class VersionServiceImpl implements VersionService {
         },
         () -> versionRepository.delete(version));
     builder.run();
+    scriptingClient.notifyScriptVersionUpdate(gameId, scriptPatchVersion, List.of());
     return versionMapper.toDto(version);
   }
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.client.GameLogicClient;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
@@ -26,18 +27,21 @@ public class GameInstanceServiceImpl implements GameInstanceService {
   private final SessionStateService sessionStateService;
   private final GameLogicClient gameLogicClient;
   private final SagaRunner sagaRunner;
+  private final MeterRegistry meterRegistry;
 
   public GameInstanceServiceImpl(
       GameInstanceRepository repository,
       GameInstanceMapper mapper,
       SessionStateService sessionStateService,
       GameLogicClient gameLogicClient,
-      SagaRunner sagaRunner) {
+      SagaRunner sagaRunner,
+      MeterRegistry meterRegistry) {
     this.repository = repository;
     this.mapper = mapper;
     this.sessionStateService = sessionStateService;
     this.gameLogicClient = gameLogicClient;
     this.sagaRunner = sagaRunner;
+    this.meterRegistry = meterRegistry;
   }
 
   // Constructor used in unit tests
@@ -45,7 +49,13 @@ public class GameInstanceServiceImpl implements GameInstanceService {
       GameInstanceRepository repository,
       GameInstanceMapper mapper,
       SessionStateService sessionStateService) {
-    this(repository, mapper, sessionStateService, null, null);
+    this(
+        repository,
+        mapper,
+        sessionStateService,
+        null,
+        null,
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
   }
 
   @Override
@@ -76,6 +86,12 @@ public class GameInstanceServiceImpl implements GameInstanceService {
     instance.setStatus("RUNNING");
     instance = repository.save(instance);
     GameInstanceDto dto = mapper.toDto(instance);
+    meterRegistry
+        .counter(
+            "game_sessions_started_total",
+            "script_patch_version",
+            request.scriptPatchVersion() == null ? "none" : request.scriptPatchVersion())
+        .increment();
 
     if (gameLogicClient != null && sagaRunner != null) {
       var saga = new SagaBuilder().step("notifyGameLogic", () -> gameLogicClient.ping()).build();

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
 import net.firedevops.firemud.dto.GameInstanceDto;
 import net.firedevops.firemud.dto.StartSessionRequest;
@@ -19,6 +20,7 @@ class GameInstanceServiceImplTest {
   private GameInstanceRepository repository;
   private GameInstanceMapper mapper;
   private SessionStateService stateService;
+  private SimpleMeterRegistry meterRegistry;
   private GameInstanceServiceImpl service;
 
   @BeforeEach
@@ -26,7 +28,9 @@ class GameInstanceServiceImplTest {
     repository = mock(GameInstanceRepository.class);
     mapper = mock(GameInstanceMapper.class);
     stateService = mock(SessionStateService.class);
-    service = new GameInstanceServiceImpl(repository, mapper, stateService);
+    meterRegistry = new SimpleMeterRegistry();
+    service =
+        new GameInstanceServiceImpl(repository, mapper, stateService, null, null, meterRegistry);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add automationScriptingService endpoint property
- notify automation service when script patches publish
- add gRPC client for Automation & Scripting Service
- hot reload scripts on patch notification
- tag session metrics with script patch version
- unit tests for new logic
- fix markdown lint

## Testing
- `./gradlew check --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6871fd792ea4833092e20932b4339f51