### PR TITLE
Handle missing JWT secrets in dev mode

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -10,7 +10,7 @@ The architecture section describes the platform infrastructure and each microser
 
 ## Directories & Responsibilities
 
- - [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
+- [**infrastructure/**](./infrastructure/) – Deployment environments and secrets management.
 - [**microservices/**](./microservices/) – Individual service responsibilities and APIs.
 - [**service-responsibility-matrix.md**](./service-responsibility-matrix.md) – Summary of which service handles what.
 - [**repository-structure.md**](./repository-structure.md) – Layout of Gradle modules and repository files.

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,15 +1,40 @@
 package net.firedevops.firemud.config;
 
+import java.util.Arrays;
+import java.util.UUID;
+import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.security.JwtUtil;
+import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
 public class AuthConfig {
+  private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
+  private final Environment environment;
+
+  public AuthConfig(Environment environment) {
+    this.environment = environment;
+  }
+
   @Bean
   public JwtUtil jwtUtil(AuthProperties props) {
-    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+    String secret = props.getJwtSecret();
+    if (secret == null || secret.isBlank()) {
+      boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+      if (dev) {
+        secret =
+            UUID.randomUUID().toString().replace("-", "")
+                + UUID.randomUUID().toString().replace("-", "");
+        logger.info("Generated random JWT secret for development profile");
+        props.setJwtSecret(secret);
+      } else {
+        throw new IllegalStateException("firemud.auth.jwt-secret must be set");
+      }
+    }
+    return new JwtUtil(secret, props.getJwtExpirationMs());
   }
 }

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -11,7 +11,6 @@ grpc:
 
 firemud:
   auth:
-    jwt-secret: changeit-changeit-changeit-changeit
     jwt-expiration-ms: 3600000
     session-expiration-ms: 3600000
 

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/config/AuthConfigTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/config/AuthConfigTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import net.firedevops.firemud.common.security.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+class AuthConfigTest {
+  @Test
+  void generatesSecretWhenMissingInDev() {
+    AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+    StandardEnvironment env = new StandardEnvironment();
+    env.setActiveProfiles("dev");
+    env.getPropertySources()
+        .addFirst(
+            new MapPropertySource("test", Map.of("firemud.auth.jwt-expiration-ms", "3600000")));
+    ctx.setEnvironment(env);
+    ctx.register(AuthConfig.class);
+    ctx.refresh();
+
+    AuthProperties props = ctx.getBean(AuthProperties.class);
+
+    assertThat(props.getJwtSecret()).isNotBlank();
+    assertThat(ctx.getBean(JwtUtil.class)).isNotNull();
+
+    ctx.close();
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,15 +1,40 @@
 package net.firedevops.firemud.config;
 
+import java.util.Arrays;
+import java.util.UUID;
+import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.security.JwtUtil;
+import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
 public class AuthConfig {
+  private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
+  private final Environment environment;
+
+  public AuthConfig(Environment environment) {
+    this.environment = environment;
+  }
+
   @Bean
   public JwtUtil jwtUtil(AuthProperties props) {
-    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+    String secret = props.getJwtSecret();
+    if (secret == null || secret.isBlank()) {
+      boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+      if (dev) {
+        secret =
+            UUID.randomUUID().toString().replace("-", "")
+                + UUID.randomUUID().toString().replace("-", "");
+        logger.info("Generated random JWT secret for development profile");
+        props.setJwtSecret(secret);
+      } else {
+        throw new IllegalStateException("firemud.auth.jwt-secret must be set");
+      }
+    }
+    return new JwtUtil(secret, props.getJwtExpirationMs());
   }
 }

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,15 +1,40 @@
 package net.firedevops.firemud.config;
 
+import java.util.Arrays;
+import java.util.UUID;
+import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.security.JwtUtil;
+import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
 public class AuthConfig {
+  private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
+  private final Environment environment;
+
+  public AuthConfig(Environment environment) {
+    this.environment = environment;
+  }
+
   @Bean
   public JwtUtil jwtUtil(AuthProperties props) {
-    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+    String secret = props.getJwtSecret();
+    if (secret == null || secret.isBlank()) {
+      boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+      if (dev) {
+        secret =
+            UUID.randomUUID().toString().replace("-", "")
+                + UUID.randomUUID().toString().replace("-", "");
+        logger.info("Generated random JWT secret for development profile");
+        props.setJwtSecret(secret);
+      } else {
+        throw new IllegalStateException("firemud.auth.jwt-secret must be set");
+      }
+    }
+    return new JwtUtil(secret, props.getJwtExpirationMs());
   }
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,15 +1,40 @@
 package net.firedevops.firemud.config;
 
+import java.util.Arrays;
+import java.util.UUID;
+import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.security.JwtUtil;
+import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
 public class AuthConfig {
+  private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
+  private final Environment environment;
+
+  public AuthConfig(Environment environment) {
+    this.environment = environment;
+  }
+
   @Bean
   public JwtUtil jwtUtil(AuthProperties props) {
-    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+    String secret = props.getJwtSecret();
+    if (secret == null || secret.isBlank()) {
+      boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+      if (dev) {
+        secret =
+            UUID.randomUUID().toString().replace("-", "")
+                + UUID.randomUUID().toString().replace("-", "");
+        logger.info("Generated random JWT secret for development profile");
+        props.setJwtSecret(secret);
+      } else {
+        throw new IllegalStateException("firemud.auth.jwt-secret must be set");
+      }
+    }
+    return new JwtUtil(secret, props.getJwtExpirationMs());
   }
 }

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,15 +1,40 @@
 package net.firedevops.firemud.config;
 
+import java.util.Arrays;
+import java.util.UUID;
+import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.security.JwtUtil;
+import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableConfigurationProperties(AuthProperties.class)
 public class AuthConfig {
+  private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
+  private final Environment environment;
+
+  public AuthConfig(Environment environment) {
+    this.environment = environment;
+  }
+
   @Bean
   public JwtUtil jwtUtil(AuthProperties props) {
-    return new JwtUtil(props.getJwtSecret(), props.getJwtExpirationMs());
+    String secret = props.getJwtSecret();
+    if (secret == null || secret.isBlank()) {
+      boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
+      if (dev) {
+        secret =
+            UUID.randomUUID().toString().replace("-", "")
+                + UUID.randomUUID().toString().replace("-", "");
+        logger.info("Generated random JWT secret for development profile");
+        props.setJwtSecret(secret);
+      } else {
+        throw new IllegalStateException("firemud.auth.jwt-secret must be set");
+      }
+    }
+    return new JwtUtil(secret, props.getJwtExpirationMs());
   }
 }

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -13,7 +13,6 @@ grpc:
 
 firemud:
   auth:
-    jwt-secret: changeit-changeit-changeit-changeit
     jwt-expiration-ms: 3600000
 
 management:


### PR DESCRIPTION
## Summary
- generate random JWT secret when `firemud.auth.jwt-secret` is absent
- log generation of the secret
- drop hardcoded secrets from gateway and account service configs
- add a unit test for secret generation logic

## Testing
- `pre-commit run --all-files` *(fails: buf lint missing packages)*
- `./gradlew check` *(fails: 1 failing test in account-service before fix; passes after spotless but some tasks fail due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6871ffd5cea88330bb82c491f2c133b1