### PR TITLE
Clean service design stubs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -105,6 +105,10 @@ It requires the [PostgreSQL credentials](../../infrastructure/environment-and-se
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 The gRPC schemas for this service live in

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -122,6 +122,10 @@ It uses the [PostgreSQL credentials](../../infrastructure/environment-and-secret
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables to access its databases.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 API definitions are located in

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -91,6 +91,10 @@ It requires the [PostgreSQL credentials](../../infrastructure/environment-and-se
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 Service interface definitions are stored in

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -95,6 +95,10 @@ Configuration uses the conventions defined in
 This service relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials).
 Redis variables are not used.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 The service API contract resides in

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -93,6 +93,10 @@ This service follows the conventions in
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 gRPC service definitions can be found in

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -96,6 +96,10 @@ It requires the [PostgreSQL credentials](../../infrastructure/environment-and-se
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 Service definitions reside in

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -107,6 +107,10 @@ The service uses the configuration approach from
 It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials).
 Redis variables are not required.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Saga Dashboard
 
 The service exposes `/sagas` and `/sagas/{id}/steps` endpoints for operators to inspect

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -107,6 +107,10 @@ The service follows the conventions from
 It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 The social APIs are defined in

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -82,6 +82,10 @@ The database variables
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection))
 may be present for consistency but are ignored by this service.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 Important variables include:
 
 | Variable | Purpose | Default |

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -91,6 +91,10 @@ The proxy uses minimal configuration. It still follows the scheme in
 so the standard `FIREMUD_POSTGRES_*` and `FIREMUD_REDIS_*` variables may be present
 but are ignored.
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Metrics & Tracing
 
 Metrics are exposed at `/actuator/prometheus` and scraped by Prometheus. The

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -103,6 +103,10 @@ World Management Service uses the configuration scheme defined in
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 
+See [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.
+
 ## Proto Files
 
 The gRPC contract for world operations is located in

--- a/design/architecture/system-architecture-shared-libraries.md
+++ b/design/architecture/system-architecture-shared-libraries.md
@@ -90,3 +90,9 @@ new SagaBuilder()
 ```
 
 Saga state is stored in the bundled `saga_instance` and `saga_step` tables.
+
+## Environment Variables
+
+See [Environment Variables & Secrets Management](infrastructure/environment-and-secrets.md)
+for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
+and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/account-service/README.md
+++ b/services/account-service/README.md
@@ -5,6 +5,3 @@ The complete design for this service is documented in the central repository:
 
 This README is only a stub linking to that document. **Do not add design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -6,6 +6,3 @@ Design documentation lives at:
 This README is a stub that only links to the real design document.
 **Do not place design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/common-library/README.md
+++ b/services/common-library/README.md
@@ -5,6 +5,3 @@ Design and usage notes are documented under:
 
 This README is only a stub linking to the design guide. **Do not add design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -5,6 +5,3 @@ The service design is located in the central docs:
 
 This README is a stub only. **Please do not add design information here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -5,6 +5,3 @@ Architecture details are documented at:
 
 This README remains a stub. **Do not add design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -5,6 +5,3 @@ Full design documentation lives in:
 
 This README is a stub. **Keep design information in the linked document only.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -5,6 +5,3 @@ Design details are kept in the architecture docs:
 
 This README is only a stub. **Do not place design information here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -5,6 +5,3 @@ Central design documentation:
 
 This README serves only as a stub. **Do not add design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/social-groups-service/README.md
+++ b/services/social-groups-service/README.md
@@ -5,6 +5,3 @@ Design documentation is maintained here:
 
 This README is a stub. **Keep all design info in the linked document.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/spring-cloud-gateway/README.md
+++ b/services/spring-cloud-gateway/README.md
@@ -5,6 +5,3 @@ The gateway's design documentation lives at:
 
 This README is a stub. **Do not add design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/tcp-proxy-service/README.md
+++ b/services/tcp-proxy-service/README.md
@@ -5,6 +5,3 @@ The complete design can be found in:
 
 This README is only a stub for reference. **Do not include design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/world-management-service/README.md
+++ b/services/world-management-service/README.md
@@ -5,6 +5,3 @@ See the design documentation at:
 
 This README is a stub only. **Do not add design details here.**
 
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.


### PR DESCRIPTION
## Summary
- keep service README stubs minimal
- document TLS and service discovery variables in the central design docs

## Testing
- `./gradlew check` *(fails: lintMarkdown errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872045b366c8330a27ff41ac2a5538e