### PR TITLE
Clean up service design stubs

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -104,6 +104,7 @@ This service follows the standard scheme described in
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -121,6 +121,7 @@ This service follows the common scheme in
 It uses the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables to access its databases.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -90,6 +90,7 @@ This service uses the shared configuration described in
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -94,6 +94,7 @@ Configuration uses the conventions defined in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 This service relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials).
 Redis variables are not used.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -92,6 +92,7 @@ This service follows the conventions in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -95,6 +95,7 @@ This service follows the configuration scheme from
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -106,6 +106,7 @@ The service uses the configuration approach from
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials).
 Redis variables are not required.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Saga Dashboard
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -106,6 +106,7 @@ The service follows the conventions from
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -81,6 +81,7 @@ The database variables
 ([PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection))
 may be present for consistency but are ignored by this service.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 Important variables include:
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -90,6 +90,7 @@ The proxy uses minimal configuration. It still follows the scheme in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
 so the standard `FIREMUD_POSTGRES_*` and `FIREMUD_REDIS_*` variables may be present
 but are ignored.
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Metrics & Tracing
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -102,6 +102,7 @@ World Management Service uses the configuration scheme defined in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
+TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/services/account-service/README.md
+++ b/services/account-service/README.md
@@ -4,7 +4,3 @@ The complete design for this service is documented in the central repository:
 [📄 Account Service Design](../../design/architecture/microservices/account-service/README.md)
 
 This README is only a stub linking to that document. **Do not add design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -5,7 +5,3 @@ Design documentation lives at:
 
 This README is a stub that only links to the real design document.
 **Do not place design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/common-library/README.md
+++ b/services/common-library/README.md
@@ -4,7 +4,3 @@ Design and usage notes are documented under:
 [📄 Shared Libraries Overview](../../design/architecture/system-architecture-shared-libraries.md)
 
 This README is only a stub linking to the design guide. **Do not add design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/entity-management-service/README.md
+++ b/services/entity-management-service/README.md
@@ -4,7 +4,3 @@ The service design is located in the central docs:
 [📄 Entity Management Service Design](../../design/architecture/microservices/entity-management-service/README.md)
 
 This README is a stub only. **Please do not add design information here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-design-service/README.md
+++ b/services/game-design-service/README.md
@@ -4,7 +4,3 @@ Architecture details are documented at:
 [📄 Game Design Service Design](../../design/architecture/microservices/game-design-service/README.md)
 
 This README remains a stub. **Do not add design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-logic-service/README.md
+++ b/services/game-logic-service/README.md
@@ -4,7 +4,3 @@ Full design documentation lives in:
 [📄 Game Logic Service Design](../../design/architecture/microservices/game-logic-service/README.md)
 
 This README is a stub. **Keep design information in the linked document only.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -4,7 +4,3 @@ Design details are kept in the architecture docs:
 [📄 Game Session Service Design](../../design/architecture/microservices/game-session-service/README.md)
 
 This README is only a stub. **Do not place design information here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/logging-admin-service/README.md
+++ b/services/logging-admin-service/README.md
@@ -4,7 +4,3 @@ Central design documentation:
 [📄 Logging Admin Service Design](../../design/architecture/microservices/logging-admin-service/README.md)
 
 This README serves only as a stub. **Do not add design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/social-groups-service/README.md
+++ b/services/social-groups-service/README.md
@@ -4,7 +4,3 @@ Design documentation is maintained here:
 [📄 Social Groups Service Design](../../design/architecture/microservices/social-groups-service/README.md)
 
 This README is a stub. **Keep all design info in the linked document.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/spring-cloud-gateway/README.md
+++ b/services/spring-cloud-gateway/README.md
@@ -4,7 +4,3 @@ The gateway's design documentation lives at:
 [📄 Spring Cloud Gateway Design](../../design/architecture/microservices/spring-cloud-gateway/README.md)
 
 This README is a stub. **Do not add design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/tcp-proxy-service/README.md
+++ b/services/tcp-proxy-service/README.md
@@ -4,7 +4,3 @@ The complete design can be found in:
 [📄 TCP Proxy Service Design](../../design/architecture/microservices/tcp-proxy-service/README.md)
 
 This README is only a stub for reference. **Do not include design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.

--- a/services/world-management-service/README.md
+++ b/services/world-management-service/README.md
@@ -4,7 +4,3 @@ See the design documentation at:
 [📄 World Management Service Design](../../design/architecture/microservices/world-management-service/README.md)
 
 This README is a stub only. **Do not add design details here.**
-
-See [Environment Variables & Secrets Management](../../design/architecture/infrastructure/environment-and-secrets.md)
-for TLS variables `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, `FIREMUD_GRPC_CA_CERT`
-and the `FIREMUD_SERVICES_*` service discovery settings.


### PR DESCRIPTION
## Summary
- remove environment variable notes from service README stubs
- document TLS and service discovery variables in each service design doc

## Testing
- `pre-commit run --all-files` *(fails: Buf Lint complaints about proto file layout)*

------
https://chatgpt.com/codex/tasks/task_e_6872045b366c8330a27ff41ac2a5538e