### PR TITLE
Update user journey documentation

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -120,6 +120,7 @@ The gRPC schemas for this service live in
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys – Sign Up](../user-journeys.md#1-sign-up)
 - [User Journeys](../user-journeys.md#10-purchases-and-subscriptions) – payment and subscription workflow.
+- [User Journeys – Account Data Export & Deletion](../user-journeys.md#17-account-data-export--deletion)
 - [Redis Architecture](../system-architecture-redis.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -218,6 +218,19 @@ Before launch or after major updates, creators invite testers to staged environm
 GitHub → CI Workflow → Container Registry → Kubernetes
 ```
 
+## 17. Account Data Export & Deletion
+
+Players may request a full data export or permanently delete an account through
+the [Account Service](./microservices/account-service/README.md). Exported data
+is provided in JSON format for portability. Deletions require confirmation and
+are recorded by the
+[Logging & Admin Service](./microservices/logging-admin-service/README.md) for
+audit purposes.
+
+```plaintext
+Player → Account Service → Logging & Admin Service (audit)
+```
+
 ---
 
 These flows complement the architecture diagrams in [System Architecture Overview](./system-architecture-overview.md).


### PR DESCRIPTION
## Summary
- expand User Journeys with account data export and deletion flow
- cross-link Account Service docs to the new journey

## Testing
- `./gradlew check` *(fails: :social-groups-service:spotlessJavaCheck FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68720851c09c83309511ffbd951413f7