### PR TITLE
Support runtime script patch versions

### DIFF
--- a/protos/game-design/v1/game_design_service.proto
+++ b/protos/game-design/v1/game_design_service.proto
@@ -61,7 +61,9 @@ message ListVersionsResponse {
 message Version {
   int64 id = 1;
   int32 version_number = 2;
-  string notes = 3;
+  string script_patch_version = 3;
+  bool is_script_only = 4;
+  string notes = 5;
 }
 
 message PingRequest {}

--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -19,7 +19,7 @@ service GameSessionService {
 
 message StartSessionRequest {
   string tenant_id = 1;
-  string version_id = 2;
+  string runtime_version = 2;
   string script_patch_version = 3;
 }
 

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
@@ -111,6 +111,9 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
                   net.firedevops.firemud.gamedesign.v1.Version.newBuilder()
                       .setId(v.id())
                       .setVersionNumber(v.versionNumber())
+                      .setScriptPatchVersion(
+                          v.scriptPatchVersion() == null ? "" : v.scriptPatchVersion())
+                      .setIsScriptOnly(v.scriptOnly())
                       .setNotes(v.notes() == null ? "" : v.notes())
                       .build()));
       responseObserver.onNext(builder.build());

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/data/TestDataSeeder.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/data/TestDataSeeder.java
@@ -43,7 +43,7 @@ public class TestDataSeeder implements ApplicationRunner {
     if (gameInstanceRepository.count() == 0) {
       GameInstance instance = new GameInstance();
       instance.setTenantId(1L);
-      instance.setVersionId("v1.0.0");
+      instance.setRuntimeVersion("v1.0.0");
       instance.setOwnerAccountId(1L);
       instance.setStatus("RUNNING");
       gameInstanceRepository.save(instance);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/GameInstanceDto.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/GameInstanceDto.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 public record GameInstanceDto(
     Long id,
     @NotNull Long tenantId,
-    @NotNull @Size(max = 100) String versionId,
+    @NotNull @Size(max = 100) String runtimeVersion,
     String scriptPatchVersion,
     @NotNull Long ownerAccountId,
     @NotNull @Size(max = 20) String status) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/StartSessionRequest.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/StartSessionRequest.java
@@ -6,6 +6,6 @@ import jakarta.validation.constraints.Size;
 /** Request payload for starting a new game session. */
 public record StartSessionRequest(
     @NotNull Long tenantId,
-    @NotNull @Size(max = 100) String versionId,
+    @NotNull @Size(max = 100) String runtimeVersion,
     String scriptPatchVersion,
     @NotNull Long ownerAccountId) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/entity/GameInstance.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/entity/GameInstance.java
@@ -14,8 +14,8 @@ public class GameInstance {
   @Column(nullable = false)
   private Long tenantId;
 
-  @Column(nullable = false, length = 100)
-  private String versionId;
+  @Column(name = "runtime_version", nullable = false, length = 100)
+  private String runtimeVersion;
 
   @Column(name = "script_patch_version", length = 100)
   private String scriptPatchVersion;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -64,7 +64,7 @@ public class GameInstanceServiceImpl implements GameInstanceService {
     logger.info(
         "Starting game session for tenant {} version {} patch {}",
         request.tenantId(),
-        request.versionId(),
+        request.runtimeVersion(),
         request.scriptPatchVersion());
     repository
         .findFirstByOwnerAccountIdAndStatus(request.ownerAccountId(), "RUNNING")
@@ -80,7 +80,7 @@ public class GameInstanceServiceImpl implements GameInstanceService {
             });
     GameInstance instance = new GameInstance();
     instance.setTenantId(request.tenantId());
-    instance.setVersionId(request.versionId());
+    instance.setRuntimeVersion(request.runtimeVersion());
     instance.setScriptPatchVersion(request.scriptPatchVersion());
     instance.setOwnerAccountId(request.ownerAccountId());
     instance.setStatus("RUNNING");

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -68,7 +68,7 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
       StartSessionRequest dto =
           new StartSessionRequest(
               Long.valueOf(request.getTenantId()),
-              request.getVersionId(),
+              request.getRuntimeVersion(),
               request.getScriptPatchVersion(),
               0L);
       GameInstanceDto instance = gameInstanceService.startSession(dto);

--- a/services/game-session-service/src/main/resources/openapi.yaml
+++ b/services/game-session-service/src/main/resources/openapi.yaml
@@ -21,13 +21,13 @@ components:
       properties:
         tenantId:
           type: integer
-        versionId:
+        runtimeVersion:
           type: string
         ownerAccountId:
           type: integer
       required:
         - tenantId
-        - versionId
+        - runtimeVersion
         - ownerAccountId
     GameInstanceDto:
       type: object
@@ -36,7 +36,7 @@ components:
           type: integer
         tenantId:
           type: integer
-        versionId:
+        runtimeVersion:
           type: string
         ownerAccountId:
           type: integer

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
@@ -39,7 +39,7 @@ class GameInstanceServiceImplTest {
     GameInstance entity = new GameInstance();
     entity.setId(10L);
     entity.setTenantId(1L);
-    entity.setVersionId("v1");
+    entity.setRuntimeVersion("v1");
     entity.setOwnerAccountId(42L);
     entity.setStatus("RUNNING");
 
@@ -57,7 +57,7 @@ class GameInstanceServiceImplTest {
     GameInstance entity = new GameInstance();
     entity.setId(10L);
     entity.setTenantId(1L);
-    entity.setVersionId("v1");
+    entity.setRuntimeVersion("v1");
     entity.setOwnerAccountId(42L);
     entity.setStatus("RUNNING");
 

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
@@ -71,7 +71,7 @@ class GameSessionGrpcServiceTest {
     service.startSession(
         StartSessionRequest.newBuilder()
             .setTenantId("1")
-            .setVersionId("v1")
+            .setRuntimeVersion("v1")
             .setScriptPatchVersion("")
             .build(),
         new StreamObserver<StartSessionResponse>() {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -5,7 +5,6 @@ import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;


### PR DESCRIPTION
## Summary
- rename version fields to runtimeVersion in game session metadata
- update gRPC protos and services for runtimeVersion and scriptPatchVersion
- ensure automation script patch versions are handled in Game Design service
- update OpenAPI spec and tests
- remove baseVersionId from Version proto

## Testing
- `./gradlew --no-daemon check`

------
https://chatgpt.com/codex/tasks/task_e_687204cba0e48330822be635d713adf2