### PR TITLE
Update doc for script patch workflow

### DIFF
--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -43,6 +43,9 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Version and patch note management for published games.
 - Supports script-only patch versions that reference a `baseVersionId` and
   generate a new `scriptPatchVersion` without requiring a full publish.
+- Does not track individual script definitions at runtime; only the patch
+  version metadata is recorded. Runtime services manage the active script
+  registry and are notified when a patch version is published.
 - [Item & Equipment Balancing Tools](item-equipment-balancing.md)
 - Import/export of design assets for sharing between game worlds.
 

--- a/services/automation-scripting-service/README.md
+++ b/services/automation-scripting-service/README.md
@@ -4,4 +4,3 @@ Design documentation lives at:
 [📄 Automation Scripting Service Design](../../design/architecture/microservices/automation-scripting-service/README.md)
 
 This README is a stub that only links to the real design document. **Do not place design details here.**
-

--- a/services/common-library/README.md
+++ b/services/common-library/README.md
@@ -4,4 +4,3 @@ Design and usage notes are documented under:
 [📄 Shared Libraries Overview](../../design/architecture/system-architecture-shared-libraries.md)
 
 This README is only a stub linking to the design guide. **Do not add design details here.**
-


### PR DESCRIPTION
## Summary
- clarify that Game Design Service only records script patch metadata and not individual script definitions
- clean up extra blank lines in stub READMEs

## Testing
- `pre-commit run --files services/automation-scripting-service/README.md services/common-library/README.md design/architecture/microservices/game-design-service/README.md` *(passes)*
- `./gradlew check` *(failed: build interrupted due to SpotBugs process)*

------
https://chatgpt.com/codex/tasks/task_e_68720ea3239c83309b885e015d932544