### PR TITLE
Implement SMTP email support in account service

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -142,7 +142,7 @@ The Account Service also manages billing records for purchases and subscriptions
 
 ### Email & Notification Design
 
-This service sends verification and password reset emails using a configured SMTP provider. Notifications for suspicious logins or account events are queued for asynchronous delivery via a gRPC `NotificationService`. Sample templates live under `resources/templates/` and environment variables specify SMTP credentials. The gRPC API is defined in [`notification_service.proto`](../../../protos/account/v1/notification_service.proto).
+This service sends verification and password reset emails using a configured SMTP provider. Notifications for suspicious logins or account events are queued for asynchronous delivery via a gRPC `NotificationService`. Sample templates live under `resources/templates/` and environment variables configure `spring.mail.*` along with `firemud.mail.from`, `firemud.mail.verification-url`, and `firemud.mail.reset-url`. The gRPC API is defined in [`notification_service.proto`](../../../protos/account/v1/notification_service.proto).
 
 ### Session Management
 

--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -14,7 +14,7 @@
 - [ ] **Develop Email & Notification System**
   - [x] Implement email verification & password resets
   - [ ] Implement in-game notification system for events & messages
-  - [ ] Configure SMTP provider and test templates
+  - [x] Configure SMTP provider and test templates
   - [x] Document email and notification design in `account-service/design/README.md`
   - [x] Add asynchronous NotificationService components with gRPC endpoints
 - [ ] **Develop Monetization & Payment Module**

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis:3.5.3")
     implementation(project(":common-library"))
     implementation("org.springframework.boot:spring-boot-starter-aop:3.5.3")
+    implementation("org.springframework.boot:spring-boot-starter-mail:3.5.3")
     implementation("io.github.lognet:grpc-spring-boot-starter:5.2.0")
     implementation("io.micrometer:micrometer-core:1.15.1")
     implementation("io.micrometer:micrometer-registry-prometheus:1.15.1")

--- a/services/account-service/src/main/java/net/firedevops/firemud/AccountServiceApplication.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/AccountServiceApplication.java
@@ -4,6 +4,7 @@ import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.config.AuthConfig;
 import net.firedevops.firemud.config.GrpcClientProperties;
+import net.firedevops.firemud.config.MailConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -11,7 +12,12 @@ import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @EnableConfigurationProperties(GrpcClientProperties.class)
-@Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, AuthConfig.class})
+@Import({
+  DatabaseAutoConfiguration.class,
+  CommonAutoConfiguration.class,
+  AuthConfig.class,
+  MailConfig.class
+})
 public class AccountServiceApplication {
   public static void main(String[] args) {
     SpringApplication.run(AccountServiceApplication.class, args);

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/MailConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/MailConfig.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(MailProperties.class)
+public class MailConfig {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/MailProperties.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/MailProperties.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "firemud.mail")
+public class MailProperties {
+  private String from;
+  private String verificationUrl;
+  private String resetUrl;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/EmailService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/EmailService.java
@@ -1,0 +1,5 @@
+package net.firedevops.firemud.service;
+
+public interface EmailService {
+  void sendEmail(String to, String subject, String body);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
 import net.firedevops.firemud.common.saga.SagaException;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.MailProperties;
 import net.firedevops.firemud.dto.AccountDataExportDto;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CompletePasswordResetRequest;
@@ -33,6 +34,7 @@ import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
 import net.firedevops.firemud.repository.SubscriptionRepository;
 import net.firedevops.firemud.service.AccountService;
+import net.firedevops.firemud.service.EmailService;
 import net.firedevops.firemud.service.NotificationService;
 import net.firedevops.firemud.service.SagaRunner;
 import org.slf4j.Logger;
@@ -53,6 +55,8 @@ public class AccountServiceImpl implements AccountService {
   private final PasswordResetTokenRepository passwordResetTokenRepository;
   private final EmailVerificationTokenRepository emailVerificationTokenRepository;
   private final NotificationService notificationService;
+  private final EmailService emailService;
+  private final MailProperties mailProperties;
   private final LoggingAdminClient loggingAdminClient;
   private final JwtUtil jwtUtil;
   private final net.firedevops.firemud.service.session.SessionService sessionService;
@@ -69,6 +73,8 @@ public class AccountServiceImpl implements AccountService {
       PasswordResetTokenRepository passwordResetTokenRepository,
       EmailVerificationTokenRepository emailVerificationTokenRepository,
       NotificationService notificationService,
+      EmailService emailService,
+      MailProperties mailProperties,
       LoggingAdminClient loggingAdminClient,
       JwtUtil jwtUtil,
       net.firedevops.firemud.service.session.SessionService sessionService,
@@ -83,6 +89,8 @@ public class AccountServiceImpl implements AccountService {
     this.passwordResetTokenRepository = passwordResetTokenRepository;
     this.emailVerificationTokenRepository = emailVerificationTokenRepository;
     this.notificationService = notificationService;
+    this.emailService = emailService;
+    this.mailProperties = mailProperties;
     this.loggingAdminClient = loggingAdminClient;
     this.jwtUtil = jwtUtil;
     this.sessionService = sessionService;
@@ -232,6 +240,11 @@ public class AccountServiceImpl implements AccountService {
     token.setToken(java.util.UUID.randomUUID().toString());
     token.setExpiresAt(java.time.LocalDateTime.now().plusHours(1));
     passwordResetTokenRepository.save(token);
+    String url = String.format(mailProperties.getResetUrl(), token.getToken());
+    emailService.sendEmail(
+        account.getEmail(),
+        "Password Reset",
+        String.format(readTemplate("password-reset.txt"), url));
     notificationService.sendNotification(
         request.tenantId(), account.getId(), "Password reset requested");
   }
@@ -268,6 +281,11 @@ public class AccountServiceImpl implements AccountService {
     token.setToken(java.util.UUID.randomUUID().toString());
     token.setExpiresAt(java.time.LocalDateTime.now().plusHours(24));
     emailVerificationTokenRepository.save(token);
+    String url = String.format(mailProperties.getVerificationUrl(), token.getToken());
+    emailService.sendEmail(
+        account.getEmail(),
+        "Email Verification",
+        String.format(readTemplate("email-verification.txt"), url));
     notificationService.sendNotification(tenantId, accountId, "Email verification requested");
   }
 
@@ -323,6 +341,17 @@ public class AccountServiceImpl implements AccountService {
       return sb.toString();
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+
+  private String readTemplate(String name) {
+    try (var in = getClass().getClassLoader().getResourceAsStream("templates/" + name)) {
+      if (in == null) {
+        throw new IllegalStateException("Missing template: " + name);
+      }
+      return new String(in.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+    } catch (java.io.IOException e) {
+      throw new IllegalStateException("Failed to read template", e);
     }
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/EmailServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/EmailServiceImpl.java
@@ -1,0 +1,35 @@
+package net.firedevops.firemud.service.impl;
+
+import io.micrometer.core.annotation.Timed;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.config.MailProperties;
+import net.firedevops.firemud.service.EmailService;
+import org.slf4j.Logger;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+  private static final Logger logger = LoggingUtil.getLogger(EmailServiceImpl.class);
+
+  private final JavaMailSender mailSender;
+  private final MailProperties mailProperties;
+
+  public EmailServiceImpl(JavaMailSender mailSender, MailProperties mailProperties) {
+    this.mailSender = mailSender;
+    this.mailProperties = mailProperties;
+  }
+
+  @Override
+  @Timed(value = "email.send")
+  public void sendEmail(String to, String subject, String body) {
+    SimpleMailMessage message = new SimpleMailMessage();
+    message.setFrom(mailProperties.getFrom());
+    message.setTo(to);
+    message.setSubject(subject);
+    message.setText(body);
+    logger.info("Sending email '{}' to {}", subject, to);
+    mailSender.send(message);
+  }
+}

--- a/services/account-service/src/main/resources/application-prod.yml
+++ b/services/account-service/src/main/resources/application-prod.yml
@@ -4,6 +4,11 @@ spring:
     name: account-service
   flyway:
     enabled: true
+  mail:
+    host: ${SMTP_HOST}
+    port: ${SMTP_PORT:587}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
 grpc:
   server:
     port: 6565
@@ -13,6 +18,10 @@ firemud:
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
     jwt-expiration-ms: ${FIREMUD_AUTH_JWT_EXPIRATION_MS:3600000}
     session-expiration-ms: ${FIREMUD_AUTH_SESSION_EXPIRATION_MS:3600000}
+  mail:
+    from: ${SMTP_FROM:no-reply@firemud.com}
+    verification-url: ${FIREMUD_MAIL_VERIFICATION_URL:https://firemud.com/auth/verify-email?token=%s}
+    reset-url: ${FIREMUD_MAIL_RESET_URL:https://firemud.com/reset-password?token=%s}
 
 management:
   endpoints:

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
     name: account-service
   flyway:
     enabled: true
+  mail:
+    host: localhost
+    port: 1025
+    username: ''
+    password: ''
 grpc:
   server:
     port: 6565
@@ -13,6 +18,10 @@ firemud:
   auth:
     jwt-expiration-ms: 3600000
     session-expiration-ms: 3600000
+  mail:
+    from: no-reply@firemud.local
+    verification-url: http://localhost:8080/auth/verify-email?token=%s
+    reset-url: http://localhost:8080/reset-password?token=%s
 
 management:
   endpoints:

--- a/services/account-service/src/main/resources/templates/email-verification.txt
+++ b/services/account-service/src/main/resources/templates/email-verification.txt
@@ -1,0 +1,6 @@
+Hello,
+
+Please verify your email address by visiting the link below:
+%s
+
+Thank you for joining FireMUD!

--- a/services/account-service/src/main/resources/templates/password-reset.txt
+++ b/services/account-service/src/main/resources/templates/password-reset.txt
@@ -1,0 +1,8 @@
+Hello,
+
+You requested a password reset. Use the following link to set a new password:
+%s
+
+If you did not request this, please ignore this message.
+
+-- FireMUD Team

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.config.MailProperties;
 import net.firedevops.firemud.dto.AccountDto;
 import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
@@ -23,6 +24,7 @@ import net.firedevops.firemud.repository.ExternalAccountRepository;
 import net.firedevops.firemud.repository.PaymentTransactionRepository;
 import net.firedevops.firemud.repository.ProfileRepository;
 import net.firedevops.firemud.repository.SubscriptionRepository;
+import net.firedevops.firemud.service.EmailService;
 import net.firedevops.firemud.service.NotificationService;
 import net.firedevops.firemud.service.SagaRunner;
 import net.firedevops.firemud.service.session.SessionService;
@@ -37,6 +39,8 @@ class AccountServiceImplTest {
   @Mock private ProfileRepository profileRepository;
   @Mock private ProfileMapper profileMapper;
   @Mock private NotificationService notificationService;
+  @Mock private EmailService emailService;
+  @Mock private MailProperties mailProperties;
   @Mock private LoggingAdminClient loggingAdminClient;
   @Mock private SessionService sessionService;
   @Mock private SagaRunner sagaRunner;
@@ -57,6 +61,8 @@ class AccountServiceImplTest {
     MockitoAnnotations.openMocks(this);
     AccountMapper mapper = Mappers.getMapper(AccountMapper.class);
     JwtUtil jwtUtil = new JwtUtil("mysecretkey123456789012345678901", 3600000L);
+    when(mailProperties.getResetUrl()).thenReturn("http://reset/%s");
+    when(mailProperties.getVerificationUrl()).thenReturn("http://verify/%s");
     service =
         new AccountServiceImpl(
             accountRepository,
@@ -69,6 +75,8 @@ class AccountServiceImplTest {
             passwordResetTokenRepository,
             emailVerificationTokenRepository,
             notificationService,
+            emailService,
+            mailProperties,
             loggingAdminClient,
             jwtUtil,
             sessionService,
@@ -157,6 +165,7 @@ class AccountServiceImplTest {
   void requestPasswordResetCreatesToken() {
     Account account = new Account();
     account.setId(1L);
+    account.setEmail("demo@example.com");
     when(accountRepository.findByTenantIdAndEmail(1L, "demo@example.com"))
         .thenReturn(Optional.of(account));
 
@@ -164,6 +173,11 @@ class AccountServiceImplTest {
 
     org.mockito.Mockito.verify(passwordResetTokenRepository)
         .save(org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.verify(emailService)
+        .sendEmail(
+            org.mockito.ArgumentMatchers.eq("demo@example.com"),
+            org.mockito.ArgumentMatchers.eq("Password Reset"),
+            org.mockito.ArgumentMatchers.anyString());
     org.mockito.Mockito.verify(notificationService)
         .sendNotification(1L, 1L, "Password reset requested");
   }
@@ -191,12 +205,18 @@ class AccountServiceImplTest {
     Account account = new Account();
     account.setId(6L);
     account.setTenantId(1L);
+    account.setEmail("demo@example.com");
     when(accountRepository.findById(6L)).thenReturn(Optional.of(account));
 
     service.requestEmailVerification(1L, 6L);
 
     org.mockito.Mockito.verify(emailVerificationTokenRepository)
         .save(org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.verify(emailService)
+        .sendEmail(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.eq("Email Verification"),
+            org.mockito.ArgumentMatchers.anyString());
     org.mockito.Mockito.verify(notificationService)
         .sendNotification(1L, 6L, "Email verification requested");
   }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/EmailServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/EmailServiceImplTest.java
@@ -1,0 +1,33 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.mockito.Mockito.verify;
+
+import net.firedevops.firemud.config.MailProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+class EmailServiceImplTest {
+  @Mock private JavaMailSender sender;
+
+  private MailProperties props;
+  private EmailServiceImpl service;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+    props = new MailProperties();
+    props.setFrom("test@example.com");
+    service = new EmailServiceImpl(sender, props);
+  }
+
+  @Test
+  void sendEmailUsesJavaMailSender() {
+    service.sendEmail("to@example.com", "Sub", "Body");
+
+    verify(sender).send(org.mockito.ArgumentMatchers.any(SimpleMailMessage.class));
+  }
+}


### PR DESCRIPTION
## Summary
- create MailProperties and MailConfig for SMTP settings
- add EmailService with EmailServiceImpl
- send verification and password reset emails
- provide email templates
- document new env vars and mark SMTP task complete
- update unit tests

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68720d57f3f88330a2537bea3f94d778