### PR TITLE
Align environment variable docs

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -16,7 +16,9 @@ This document explains how configuration values and sensitive secrets are suppli
 - Kubernetes `ConfigMap` objects store non‑secret configuration values like host names or feature flags.
 - Sensitive values (database passwords, JWT keys, TLS certificates) are stored in Kubernetes `Secret` objects.
 - The manifests in `k8s/base/` demonstrate loading these via `envFrom` so that services receive the same variables as in development.
-- Secrets are provisioned by **cert-manager** and rotated automatically.
+- Secrets are provisioned by **cert-manager** and rotated automatically. The
+  sample `firemud-secret` manifest in `k8s/base/` contains placeholder values
+  only for local demos; production deployments must supply real credentials.
 - **Kubernetes Secrets** is the chosen mechanism for storing all sensitive
   credentials. External secret stores like Vault are not planned at this
   stage.
@@ -80,16 +82,40 @@ provisioned by **cert-manager** and mounted from Kubernetes Secrets.
 During local development these values are generated automatically, so the
 variables may be omitted.
 
+### Authentication
+
+JWT tokens secure internal service calls. Production keys are provided via
+environment variables while development instances generate random secrets.
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `FIREMUD_AUTH_JWT_SECRET` | HMAC signing key for JWTs | *(none)* |
+| `FIREMUD_AUTH_JWT_EXPIRATION_MS` | Lifetime of issued JWTs in milliseconds | `3600000` |
+| `FIREMUD_AUTH_SESSION_EXPIRATION_MS` | Server-side session TTL in milliseconds | `3600000` |
+
 ### Service Discovery
 
 The shared configuration library resolves other services using environment
 variables prefixed with `FIREMUD_SERVICES_`. Each variable holds a `host:port`
 pair for a target service. When undefined, Kubernetes DNS is used instead.
 
+Each variable is suffixed with `_SERVICE` to match the Spring configuration
+keys. Examples:
+
 ```bash
-FIREMUD_SERVICES_ACCOUNT=account-service:6565
-FIREMUD_SERVICES_GAME_LOGIC=game-logic-service:6565
+FIREMUD_SERVICES_GAME_LOGIC_SERVICE=game-logic-service:6565
+FIREMUD_SERVICES_LOGGING_ADMIN_SERVICE=logging-admin-service:6565
 ```
+
+### Additional Service Settings
+
+Some configuration values apply only to specific services:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `FIREMUD_LOGGINGADMIN_HOST` | Hostname for the Logging Admin service | `logging-admin-service` |
+| `FIREMUD_LOGGINGADMIN_PORT` | gRPC port for the Logging Admin service | `6565` |
+| `FIREMUD_VOICE_TOKEN_EXPIRATION_MS` | Expiration of voice chat tokens | `300000` |
 
 ## 📚 Related Docs
 

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -104,7 +104,7 @@ This service follows the standard scheme described in
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -121,7 +121,7 @@ This service follows the common scheme in
 It uses the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables to access its databases.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -90,7 +90,7 @@ This service uses the shared configuration described in
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -97,7 +97,7 @@ Configuration uses the conventions defined in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 This service relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials).
 Redis variables are not used.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -92,7 +92,7 @@ This service follows the conventions in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -95,7 +95,7 @@ This service follows the configuration scheme from
 It requires the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection)
 variables.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -106,7 +106,7 @@ The service uses the configuration approach from
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials).
 Redis variables are not required.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Saga Dashboard
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -106,7 +106,7 @@ The service follows the conventions from
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -81,7 +81,7 @@ The database variables
 ([PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection))
 may be present for consistency but are ignored by this service.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 Important variables include:
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -90,7 +90,7 @@ The proxy uses minimal configuration. It still follows the scheme in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)
 so the standard `FIREMUD_POSTGRES_*` and `FIREMUD_REDIS_*` variables may be present
 but are ignored.
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Metrics & Tracing
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -102,7 +102,7 @@ World Management Service uses the configuration scheme defined in
 [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md).
 It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-secrets.md#postgresql-credentials)
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
-TLS certificates are supplied via `FIREMUD_GRPC_CERT_CHAIN`, `FIREMUD_GRPC_PRIVATE_KEY`, and `FIREMUD_GRPC_CA_CERT`. Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
+TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
 ## Proto Files
 


### PR DESCRIPTION
## Summary
- document prod `firemud-secret` placeholders
- add auth and service-specific variables
- clarify service discovery env names
- update TLS variable names in service docs

## Testing
- `./gradlew check`
- `pre-commit run --all-files` *(fails: buf lint errors in proto files)*

------
https://chatgpt.com/codex/tasks/task_e_68720e8be3288330b7ff5358c3ee777d