### PR TITLE
Add smoke test for account service

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -118,7 +118,7 @@ participate in CI.
 
 - [x] Add unit tests for gRPC, REST (if present), and startup behaviour
 - [x] Use Spring Boot Test and Testcontainers for integration tests
-- [ ] Validate contracts with smoke tests (gRPC and REST)
+- [x] Validate contracts with smoke tests (gRPC and REST)
 - [x] Seed minimal test data for local workflows
 - [x] Run `./gradlew check` in CI to execute all tests
 - [ ] *(When workflows span services)* add cross-service integration tests

--- a/services/account-service/smoke-test.sh
+++ b/services/account-service/smoke-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Simple smoke test for Account Service REST and gRPC endpoints
+set -euo pipefail
+
+HTTP_URL=${HTTP_URL:-http://localhost:8080}
+GRPC_ADDR=${GRPC_ADDR:-localhost:6565}
+
+function require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo >&2 "Required command '$1' not found"; exit 1; }
+}
+
+require_cmd curl
+require_cmd grpcurl
+
+echo "Checking REST /ping"
+resp=$(curl -fsSL "$HTTP_URL/ping")
+if ! echo "$resp" | grep -q '"SUCCESS"'; then
+  echo "REST ping failed" >&2
+  exit 1
+fi
+
+echo "Checking gRPC Ping"
+resp=$(grpcurl -plaintext "$GRPC_ADDR" account.v1.AccountService/Ping)
+if ! echo "$resp" | grep -q 'pong'; then
+  echo "gRPC ping failed" >&2
+  exit 1
+fi
+
+echo "Smoke tests passed"


### PR DESCRIPTION
## Summary
- add `smoke-test.sh` to Account Service for REST and gRPC contract validation
- mark smoke test item as complete in Account Service task list

## Testing
- `./gradlew check` *(fails: SpotBugs errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68721b1047d083308f3b9b24628ed513