### PR TITLE
Implement admin saga

### DIFF
--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/LoggingAdminServiceApplication.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/LoggingAdminServiceApplication.java
@@ -5,11 +5,14 @@ import io.swagger.v3.oas.annotations.info.Info;
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.config.AuthConfig;
+import net.firedevops.firemud.config.GrpcClientProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
+@EnableConfigurationProperties(GrpcClientProperties.class)
 @OpenAPIDefinition(info = @Info(title = "Logging Admin Service", version = "v1"))
 @Import({DatabaseAutoConfiguration.class, CommonAutoConfiguration.class, AuthConfig.class})
 public class LoggingAdminServiceApplication {

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
@@ -1,0 +1,63 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.account.v1.AccountServiceGrpc;
+import net.firedevops.firemud.account.v1.DeleteAccountRequest;
+import net.firedevops.firemud.account.v1.DeleteAccountResponse;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import org.springframework.stereotype.Component;
+
+/** gRPC client for communicating with the Account Service. */
+@Component
+public class AccountClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+  private ManagedChannel channel;
+  private AccountServiceGrpc.AccountServiceBlockingStub stub;
+
+  public AccountClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getAccountService();
+    if (target == null || target.isEmpty()) {
+      target = "account-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = AccountServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Permanently delete the account. */
+  public DeleteAccountResponse deleteAccount(long tenantId, long accountId) {
+    DeleteAccountRequest request =
+        DeleteAccountRequest.newBuilder()
+            .setTenantId(Long.toString(tenantId))
+            .setAccountId(Long.toString(accountId))
+            .build();
+    return stub.deleteAccount(request);
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -1,0 +1,67 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import net.firedevops.firemud.gamesession.v1.GameSessionServiceGrpc;
+import net.firedevops.firemud.gamesession.v1.PingRequest;
+import net.firedevops.firemud.gamesession.v1.PingResponse;
+import net.firedevops.firemud.gamesession.v1.StopSessionRequest;
+import net.firedevops.firemud.gamesession.v1.StopSessionResponse;
+import org.springframework.stereotype.Component;
+
+/** gRPC client for communicating with the Game Session Service. */
+@Component
+public class GameSessionClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+  private ManagedChannel channel;
+  private GameSessionServiceGrpc.GameSessionServiceBlockingStub stub;
+
+  public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getGameSessionService();
+    if (target == null || target.isEmpty()) {
+      target = "game-session-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = GameSessionServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Simple ping to verify connectivity. */
+  public PingResponse ping() {
+    return stub.ping(PingRequest.newBuilder().build());
+  }
+
+  /** Stop a running session by ID. */
+  public StopSessionResponse stopSession(long sessionId) {
+    StopSessionRequest request =
+        StopSessionRequest.newBuilder().setSessionId(Long.toString(sessionId)).build();
+    return stub.stopSession(request);
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.config;
+
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.client.AccountClient;
+import net.firedevops.firemud.client.GameSessionClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Bean configuration for outbound gRPC clients. */
+@Configuration
+public class GrpcClientConfig {
+
+  @Bean
+  public AccountClient accountClient(
+      net.firedevops.firemud.common.config.ServiceEndpointsProperties endpoints,
+      GrpcClientProperties properties)
+      throws SSLException {
+    return new AccountClient(endpoints, properties);
+  }
+
+  @Bean
+  public GameSessionClient gameSessionClient(
+      net.firedevops.firemud.common.config.ServiceEndpointsProperties endpoints,
+      GrpcClientProperties properties)
+      throws SSLException {
+    return new GameSessionClient(endpoints, properties);
+  }
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/GrpcClientProperties.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** TLS configuration for outbound gRPC connections. */
+@Data
+@ConfigurationProperties(prefix = "firemud.grpc")
+public class GrpcClientProperties {
+  private String certChain;
+  private String privateKey;
+  private String caCert;
+}

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
@@ -1,7 +1,12 @@
 package net.firedevops.firemud.service.impl;
 
 import java.time.Instant;
+import net.firedevops.firemud.client.AccountClient;
+import net.firedevops.firemud.client.GameSessionClient;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.saga.SagaBuilder;
+import net.firedevops.firemud.common.saga.SagaException;
+import net.firedevops.firemud.common.saga.SagaRunner;
 import net.firedevops.firemud.dto.ApplyModerationActionRequest;
 import net.firedevops.firemud.dto.ModerationActionDto;
 import net.firedevops.firemud.entity.ModerationAction;
@@ -18,11 +23,21 @@ public class ModerationServiceImpl implements ModerationService {
 
   private final ModerationActionRepository repository;
   private final ModerationActionMapper mapper;
+  private final AccountClient accountClient;
+  private final GameSessionClient gameSessionClient;
+  private final SagaRunner sagaRunner;
 
   public ModerationServiceImpl(
-      ModerationActionRepository repository, ModerationActionMapper mapper) {
+      ModerationActionRepository repository,
+      ModerationActionMapper mapper,
+      AccountClient accountClient,
+      GameSessionClient gameSessionClient,
+      SagaRunner sagaRunner) {
     this.repository = repository;
     this.mapper = mapper;
+    this.accountClient = accountClient;
+    this.gameSessionClient = gameSessionClient;
+    this.sagaRunner = sagaRunner;
   }
 
   @Override
@@ -36,7 +51,24 @@ public class ModerationServiceImpl implements ModerationService {
     entity.setAction(request.action());
     entity.setReason(request.reason());
     entity.setCreatedAt(Instant.now());
-    entity = repository.save(entity);
-    return mapper.toDto(entity);
+    final ModerationAction[] ref = new ModerationAction[] {entity};
+
+    SagaBuilder builder = new SagaBuilder("adminBan");
+    builder
+        .step(
+            "recordAction", () -> ref[0] = repository.save(ref[0]), () -> repository.delete(ref[0]))
+        .step(
+            "deleteAccount",
+            () -> accountClient.deleteAccount(request.tenantId(), request.accountId()))
+        .step("stopSession", () -> gameSessionClient.stopSession(request.accountId()));
+
+    try {
+      sagaRunner.run(builder.build());
+    } catch (SagaException e) {
+      logger.warn("Admin operation saga failed", e);
+      throw new IllegalStateException("Moderation action failed", e);
+    }
+
+    return mapper.toDto(ref[0]);
   }
 }

--- a/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/ModerationServiceImplTest.java
+++ b/services/logging-admin-service/src/test/java/unit/net/firedevops/firemud/service/impl/ModerationServiceImplTest.java
@@ -2,10 +2,14 @@ package net.firedevops.firemud.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import net.firedevops.firemud.client.AccountClient;
+import net.firedevops.firemud.client.GameSessionClient;
+import net.firedevops.firemud.common.saga.SagaRunner;
 import net.firedevops.firemud.dto.ApplyModerationActionRequest;
 import net.firedevops.firemud.dto.ModerationActionDto;
 import net.firedevops.firemud.entity.ModerationAction;
@@ -20,6 +24,9 @@ import org.mockito.MockitoAnnotations;
 class ModerationServiceImplTest {
   @Mock ModerationActionRepository repository;
   @Mock ModerationActionMapper mapper;
+  @Mock AccountClient accountClient;
+  @Mock GameSessionClient gameSessionClient;
+  @Mock SagaRunner sagaRunner;
 
   @InjectMocks ModerationServiceImpl service;
 
@@ -29,7 +36,7 @@ class ModerationServiceImplTest {
   }
 
   @Test
-  void applyActionSavesEntity() {
+  void applyActionSavesEntity() throws Exception {
     ApplyModerationActionRequest req = new ApplyModerationActionRequest(1L, 2L, "ban", "test");
     ModerationAction entity = new ModerationAction();
     ModerationAction saved = new ModerationAction();
@@ -39,6 +46,13 @@ class ModerationServiceImplTest {
     ModerationActionDto dto =
         new ModerationActionDto(1L, 1L, 2L, "ban", "test", saved.getCreatedAt(), null);
     when(mapper.toDto(saved)).thenReturn(dto);
+    doAnswer(
+            inv -> {
+              ((net.firedevops.firemud.common.saga.Saga) inv.getArgument(0)).run();
+              return null;
+            })
+        .when(sagaRunner)
+        .run(any());
 
     ModerationActionDto result = service.applyAction(req);
 


### PR DESCRIPTION
## Summary
- implement admin ban saga with SagaBuilder in logging-admin-service
- add gRPC clients for account and session services
- expose gRPC client beans and properties
- adjust ModerationService tests for saga

## Testing
- `./gradlew check --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_687231da814c8330bf305972b400141c