### PR TITLE
Add refund handling to AccountService

### DIFF
--- a/protos/account/v1/payment_service.proto
+++ b/protos/account/v1/payment_service.proto
@@ -10,6 +10,7 @@ option java_multiple_files = true;
 service PaymentService {
   rpc CreatePaymentIntent(CreatePaymentIntentRequest) returns (CreatePaymentIntentResponse);
   rpc CreateSubscription(CreateSubscriptionRequest) returns (CreateSubscriptionResponse);
+  rpc RefundPayment(RefundPaymentRequest) returns (RefundPaymentResponse);
 }
 
 message CreatePaymentIntentRequest {
@@ -32,5 +33,15 @@ message CreateSubscriptionRequest {
 
 message CreateSubscriptionResponse {
   string subscription_id = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message RefundPaymentRequest {
+  string tenant_id = 1;
+  string payment_id = 2;
+}
+
+message RefundPaymentResponse {
+  bool success = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/client/StripeClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/StripeClient.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.client;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
 import com.stripe.param.PaymentIntentCreateParams;
+import com.stripe.param.RefundCreateParams;
 
 /** Simple wrapper around Stripe API calls. */
 public class StripeClient {
@@ -32,5 +33,12 @@ public class StripeClient {
             .build();
     com.stripe.model.PaymentIntent intent = com.stripe.model.PaymentIntent.create(params);
     return new IntentResult(intent.getId(), intent.getClientSecret(), intent.getStatus());
+  }
+
+  public void createRefund(String paymentIntentId) throws StripeException {
+    Stripe.apiKey = apiKey;
+    RefundCreateParams params =
+        RefundCreateParams.builder().setPaymentIntent(paymentIntentId).build();
+    com.stripe.model.Refund.create(params);
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -24,6 +24,9 @@ public class PaymentTransaction {
   @Column(nullable = false, length = 20)
   private String status;
 
+  @Column(name = "provider_id", length = 50)
+  private String providerId;
+
   @Column(name = "tenant_id", nullable = false)
   private Long tenantId;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/PaymentService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/PaymentService.java
@@ -7,4 +7,6 @@ public interface PaymentService {
   PaymentIntentDto createPaymentIntent(Long tenantId, Long accountId, Long amountCents);
 
   SubscriptionDto createSubscription(Long tenantId, Long accountId, String planId);
+
+  void refundPayment(Long tenantId, Long paymentId);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
@@ -6,6 +6,8 @@ import net.firedevops.firemud.account.v1.CreatePaymentIntentResponse;
 import net.firedevops.firemud.account.v1.CreateSubscriptionRequest;
 import net.firedevops.firemud.account.v1.CreateSubscriptionResponse;
 import net.firedevops.firemud.account.v1.PaymentServiceGrpc;
+import net.firedevops.firemud.account.v1.RefundPaymentRequest;
+import net.firedevops.firemud.account.v1.RefundPaymentResponse;
 import net.firedevops.firemud.dto.PaymentIntentDto;
 import net.firedevops.firemud.dto.SubscriptionDto;
 import net.firedevops.firemud.service.PaymentService;
@@ -67,6 +69,30 @@ public class PaymentGrpcService extends PaymentServiceGrpc.PaymentServiceImplBas
     } catch (IllegalArgumentException ex) {
       CreateSubscriptionResponse response =
           CreateSubscriptionResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void refundPayment(
+      RefundPaymentRequest request, StreamObserver<RefundPaymentResponse> responseObserver) {
+    try {
+      paymentService.refundPayment(
+          Long.valueOf(request.getTenantId()), Long.valueOf(request.getPaymentId()));
+      RefundPaymentResponse response = RefundPaymentResponse.newBuilder().setSuccess(true).build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      RefundPaymentResponse response =
+          RefundPaymentResponse.newBuilder()
+              .setSuccess(false)
               .setError(
                   net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
                       .setCode("INVALID_ARGUMENT")

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
@@ -58,6 +58,7 @@ public class PaymentServiceImpl implements PaymentService {
     tx.setAccount(account);
     tx.setAmountCents(amountCents);
     tx.setCurrency("USD");
+    tx.setProviderId(intent.id());
     tx.setStatus(intent.status());
     tx.setTenantId(tenantId);
     tx = paymentTransactionRepository.save(tx);
@@ -95,5 +96,25 @@ public class PaymentServiceImpl implements PaymentService {
         sub.getStatus(),
         sub.getStartedAt(),
         sub.getEndedAt());
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "payment.refund")
+  public void refundPayment(Long tenantId, Long paymentId) {
+    PaymentTransaction tx =
+        paymentTransactionRepository
+            .findById(paymentId)
+            .filter(t -> t.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Payment not found"));
+
+    try {
+      stripeClient.createRefund(tx.getProviderId());
+    } catch (com.stripe.exception.StripeException e) {
+      throw new IllegalStateException("Stripe error", e);
+    }
+
+    tx.setStatus("refunded");
+    paymentTransactionRepository.save(tx);
   }
 }

--- a/services/account-service/src/main/resources/db/migration/V9__payment_provider_id.sql
+++ b/services/account-service/src/main/resources/db/migration/V9__payment_provider_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_transaction ADD COLUMN provider_id VARCHAR(50);

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentServiceImplTest.java
@@ -65,4 +65,19 @@ class PaymentServiceImplTest {
 
     assertThrows(IllegalArgumentException.class, () -> service.createSubscription(2L, 1L, "plan"));
   }
+
+  @Test
+  void refundPaymentUpdatesStatus() throws Exception {
+    PaymentTransaction tx = new PaymentTransaction();
+    tx.setId(5L);
+    tx.setTenantId(2L);
+    tx.setProviderId("pi_123");
+    when(txRepo.findById(5L)).thenReturn(Optional.of(tx));
+
+    service.refundPayment(2L, 5L);
+
+    verify(stripeClient).createRefund("pi_123");
+    verify(txRepo).save(tx);
+    assertEquals("refunded", tx.getStatus());
+  }
 }


### PR DESCRIPTION
## Summary
- implement refundPayment RPC in account-service proto and Java
- track provider_id for payments with Flyway migration
- add Stripe refund client helper
- wire up refund logic in service and gRPC layer
- test refund behavior

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68727f30c2fc83309e40e69888a34d93