### PR TITLE
Add username recovery feature

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/WebConfig.java
@@ -26,6 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
             "/auth/complete-password-reset",
             "/auth/request-email-verification",
             "/auth/verify-email",
+            "/auth/recover-username",
             "/accounts",
             "/ping",
             "/.well-known/**");

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -7,6 +7,7 @@ import net.firedevops.firemud.dto.AuthTokenDto;
 import net.firedevops.firemud.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.dto.LoginRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
+import net.firedevops.firemud.dto.UsernameRecoveryRequest;
 import net.firedevops.firemud.dto.VerifyEmailRequest;
 import net.firedevops.firemud.service.AccountService;
 import org.springframework.http.ResponseEntity;
@@ -57,6 +58,13 @@ public class AuthController {
   public ResponseEntity<ApiResponse<Void>> verifyEmail(
       @Valid @RequestBody VerifyEmailRequest request) {
     accountService.verifyEmail(request);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  @PostMapping("/recover-username")
+  public ResponseEntity<ApiResponse<Void>> recoverUsername(
+      @Valid @RequestBody UsernameRecoveryRequest request) {
+    accountService.sendUsernameReminder(request);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/UsernameRecoveryRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/UsernameRecoveryRequest.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/** Request object for username recovery emails. */
+public record UsernameRecoveryRequest(
+    @NotNull Long tenantId, @NotNull @Email @Size(max = 100) String email) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/AccountService.java
@@ -30,4 +30,7 @@ public interface AccountService {
   void requestEmailVerification(Long tenantId, Long accountId);
 
   void verifyEmail(net.firedevops.firemud.dto.VerifyEmailRequest request);
+
+  /** Send the username associated with an email address. */
+  void sendUsernameReminder(net.firedevops.firemud.dto.UsernameRecoveryRequest request);
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -21,6 +21,7 @@ import net.firedevops.firemud.dto.CreateAccountRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
 import net.firedevops.firemud.dto.ProfileDto;
 import net.firedevops.firemud.dto.UpdateProfileRequest;
+import net.firedevops.firemud.dto.UsernameRecoveryRequest;
 import net.firedevops.firemud.dto.VerifyEmailRequest;
 import net.firedevops.firemud.entity.Account;
 import net.firedevops.firemud.entity.EmailVerificationToken;
@@ -328,6 +329,22 @@ public class AccountServiceImpl implements AccountService {
     entity.setProvider(request.provider());
     entity.setExternalId(request.externalId());
     externalAccountRepository.save(entity);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.username_reminder")
+  public void sendUsernameReminder(UsernameRecoveryRequest request) {
+    Account account =
+        accountRepository
+            .findByTenantIdAndEmail(request.tenantId(), request.email())
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    emailService.sendEmail(
+        account.getEmail(),
+        "Username Reminder",
+        String.format(readTemplate("username-reminder.txt"), account.getUsername()));
+    notificationService.sendNotification(
+        request.tenantId(), account.getId(), "Username reminder requested");
   }
 
   private String hashPassword(String password) {

--- a/services/account-service/src/main/resources/openapi.yaml
+++ b/services/account-service/src/main/resources/openapi.yaml
@@ -101,6 +101,14 @@ components:
         newPassword:
           type: string
       required: [tenantId, token, newPassword]
+    UsernameRecoveryRequest:
+      type: object
+      properties:
+        tenantId:
+          type: integer
+        email:
+          type: string
+      required: [tenantId, email]
     LinkExternalAccountRequest:
       type: object
       properties:
@@ -225,6 +233,21 @@ paths:
           description: Email verified
         '400':
           description: Invalid verification token
+  /auth/recover-username:
+    post:
+      summary: Send username reminder
+      operationId: recoverUsername
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsernameRecoveryRequest'
+      responses:
+        '200':
+          description: Email sent
+        '400':
+          description: Invalid request
   /accounts:
     post:
       summary: Create a new account

--- a/services/account-service/src/main/resources/templates/username-reminder.txt
+++ b/services/account-service/src/main/resources/templates/username-reminder.txt
@@ -1,0 +1,9 @@
+Hello,
+
+A username reminder was requested for this email address. Your username is:
+
+%s
+
+If you did not request this, you can safely ignore the message.
+
+-- FireMUD Team

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -183,6 +183,28 @@ class AccountServiceImplTest {
   }
 
   @Test
+  void sendUsernameReminderEmailsUsername() {
+    Account account = new Account();
+    account.setId(1L);
+    account.setTenantId(1L);
+    account.setUsername("demo");
+    account.setEmail("demo@example.com");
+    when(accountRepository.findByTenantIdAndEmail(1L, "demo@example.com"))
+        .thenReturn(Optional.of(account));
+
+    service.sendUsernameReminder(
+        new net.firedevops.firemud.dto.UsernameRecoveryRequest(1L, "demo@example.com"));
+
+    org.mockito.Mockito.verify(emailService)
+        .sendEmail(
+            org.mockito.ArgumentMatchers.eq("demo@example.com"),
+            org.mockito.ArgumentMatchers.eq("Username Reminder"),
+            org.mockito.ArgumentMatchers.anyString());
+    org.mockito.Mockito.verify(notificationService)
+        .sendNotification(1L, 1L, "Username reminder requested");
+  }
+
+  @Test
   void linkExternalAccountSavesEntity() {
     Account account = new Account();
     account.setId(5L);


### PR DESCRIPTION
## Summary
- implement username reminder endpoint for Account Service
- expose UsernameRecoveryRequest DTO
- send reminder emails via EmailService
- exclude endpoint from JWT auth
- document API in OpenAPI spec
- add unit test for new service method

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68728304479c83309c180834b56808c9