### PR TITLE
Update environment variables documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,4 @@ FIREMUD_GRPC_PRIVATE_KEY_PATH=certs/client.key
 FIREMUD_GRPC_CA_CERT_PATH=certs/ca.crt
 
 SPRING_PROFILES_ACTIVE=dev
+otel.endpoint=http://otel-collector:4317

--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -107,15 +107,19 @@ FIREMUD_SERVICES_GAME_LOGIC_SERVICE=game-logic-service:6565
 FIREMUD_SERVICES_LOGGING_ADMIN_SERVICE=logging-admin-service:6565
 ```
 
-### Additional Service Settings
+### Observability
 
-Some configuration values apply only to specific services:
+All services export OpenTelemetry spans. The collector endpoint can be overridden with:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `FIREMUD_LOGGINGADMIN_HOST` | Hostname for the Logging Admin service | `logging-admin-service` |
-| `FIREMUD_LOGGINGADMIN_PORT` | gRPC port for the Logging Admin service | `6565` |
-| `FIREMUD_VOICE_TOKEN_EXPIRATION_MS` | Expiration of voice chat tokens | `300000` |
+| `otel.endpoint` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
+
+### Additional Notes
+
+Service-specific settings such as SMTP credentials for the Account Service or
+`GAME_TICK_DURATION_MS` for the Game Session Service are documented in each
+service's design file. This document covers only shared configuration keys.
 
 ## 📚 Related Docs
 

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -106,6 +106,18 @@ and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-con
 variables.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables configure outbound email delivery:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `SMTP_HOST` | SMTP server hostname | `localhost` |
+| `SMTP_PORT` | SMTP server port | `1025` |
+| `SMTP_USERNAME` | Username for SMTP auth | *(empty)* |
+| `SMTP_PASSWORD` | Password for SMTP auth | *(empty)* |
+| `SMTP_FROM` | From address for transactional emails | `no-reply@firemud.local` |
+| `FIREMUD_MAIL_VERIFICATION_URL` | Public URL for email verification links | `http://localhost:8080/auth/verify-email?token=%s` |
+| `FIREMUD_MAIL_RESET_URL` | Public URL for password reset links | `http://localhost:8080/reset-password?token=%s` |
+
 ## Proto Files
 
 The gRPC schemas for this service live in

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -97,6 +97,10 @@ and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-con
 variables.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `GAME_TICK_DURATION_MS` | Length of a single game tick in milliseconds | `1000` |
+
 ## Proto Files
 
 Service definitions reside in

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -108,6 +108,12 @@ It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-s
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `FIREMUD_LOGGINGADMIN_HOST` | Hostname for the Logging Admin service | `logging-admin-service` |
+| `FIREMUD_LOGGINGADMIN_PORT` | gRPC port for the Logging Admin service | `6565` |
+| `FIREMUD_VOICE_TOKEN_EXPIRATION_MS` | Expiration of voice chat tokens | `300000` |
+
 ## Proto Files
 
 The social APIs are defined in


### PR DESCRIPTION
## Summary
- document the OpenTelemetry collector endpoint
- note that service-specific variables live in the service docs
- add account service SMTP configuration section
- detail game tick duration in Game Session Service docs
- document social groups service variables
- include otel.endpoint in `.env.sample`

## Testing
- `./gradlew --quiet check` *(fails: cleanup output shows warnings but build completed)*

------
https://chatgpt.com/codex/tasks/task_e_687280cc9a208330b219622c711ef84f