### PR TITLE
Implement wait-for-it startup coordination

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -27,6 +27,10 @@ FireMUD uses Docker Compose for local development and testing:
   - See [Reconnection Strategy](../system-architecture-reconnection.md) for how sessions survive service restarts in Docker Compose.
 
 💡 **Tip**: For more reliable startup coordination, use **Gateway retry filters** or utilities like `wait-for-it.sh`.
+The gateway now includes a default *Retry* filter in `application.yml` so failed
+requests to services are retried automatically during startup. Each service's
+Dockerfile runs `docker/start-service.sh`, which invokes `wait-for-it.sh` to
+pause startup until PostgreSQL and Redis are reachable.
 
 ---
 

--- a/dev-tools/wait-for-it.sh
+++ b/dev-tools/wait-for-it.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# wait-for-it.sh -- wait for a host and port to be available
+# Usage: wait-for-it.sh host port [cmd...]
+set -e
+HOST="$1"
+PORT="$2"
+shift 2
+TIMEOUT=${WAITFORIT_TIMEOUT:-30}
+
+for i in $(seq $TIMEOUT); do
+  if bash -c "</dev/tcp/$HOST/$PORT" >/dev/null 2>&1; then
+    if [ "$#" -gt 0 ]; then
+      exec "$@"
+    fi
+    exit 0
+  fi
+  sleep 1
+  echo "Waiting for $HOST:$PORT... $((TIMEOUT - i))s remaining" >&2
+
+done
+echo "Timeout waiting for $HOST:$PORT" >&2
+exit 1
+

--- a/docker/start-service.sh
+++ b/docker/start-service.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+/usr/local/bin/wait-for-it.sh "${FIREMUD_POSTGRES_HOST:-postgres}" "${FIREMUD_POSTGRES_PORT:-5432}"
+/usr/local/bin/wait-for-it.sh "${FIREMUD_REDIS_HOST:-redis}" "${FIREMUD_REDIS_PORT:-6379}"
+exec java -jar /app/app.jar
+

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/automation-scripting-service/Dockerfile
+++ b/services/automation-scripting-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/entity-management-service/Dockerfile
+++ b/services/entity-management-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/game-design-service/Dockerfile
+++ b/services/game-design-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/game-logic-service/Dockerfile
+++ b/services/game-logic-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/game-session-service/Dockerfile
+++ b/services/game-session-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/logging-admin-service/Dockerfile
+++ b/services/logging-admin-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/social-groups-service/Dockerfile
+++ b/services/social-groups-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/spring-cloud-gateway/Dockerfile
+++ b/services/spring-cloud-gateway/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -43,6 +43,17 @@ spring:
           args:
             redis-rate-limiter.replenishRate: 20
             redis-rate-limiter.burstCapacity: 40
+        - name: Retry
+          args:
+            retries: 3
+            statuses: BAD_GATEWAY,GATEWAY_TIMEOUT
+            series: SERVER_ERROR
+            methods: GET,POST
+            backoff:
+              firstBackoff: 50ms
+              maxBackoff: 500ms
+              factor: 2
+              basedOnPreviousValue: false
 
 firemud:
   auth:
@@ -66,6 +77,17 @@ spring:
           args:
             redis-rate-limiter.replenishRate: 20
             redis-rate-limiter.burstCapacity: 40
+        - name: Retry
+          args:
+            retries: 3
+            statuses: BAD_GATEWAY,GATEWAY_TIMEOUT
+            series: SERVER_ERROR
+            methods: GET,POST
+            backoff:
+              firstBackoff: 50ms
+              maxBackoff: 500ms
+              factor: 2
+              basedOnPreviousValue: false
 firemud:
   auth:
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}

--- a/services/tcp-proxy-service/Dockerfile
+++ b/services/tcp-proxy-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]

--- a/services/world-management-service/Dockerfile
+++ b/services/world-management-service/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY build/libs/*.jar app.jar
-ENTRYPOINT ["java","-jar","/app/app.jar"]
+COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+COPY ../../docker/start-service.sh /usr/local/bin/start-service.sh
+RUN chmod +x /usr/local/bin/wait-for-it.sh /usr/local/bin/start-service.sh
+ENTRYPOINT ["/usr/local/bin/start-service.sh"]


### PR DESCRIPTION
## Summary
- add wait-for-it script and start-service.sh helper
- update all service Dockerfiles to delay startup until Redis and Postgres are available
- document the new startup coordination mechanism

## Testing
- `./gradlew check` *(failed: log truncated)*

------
https://chatgpt.com/codex/tasks/task_e_68728133b9d88330b4920cbbc9ab8367