### PR TITLE
Run module tests and fix NPE in certificate watcher

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/TlsCertificateWatcher.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/TlsCertificateWatcher.java
@@ -36,6 +36,9 @@ public class TlsCertificateWatcher implements AutoCloseable {
     this.watchService = FileSystems.getDefault().newWatchService();
     for (Path file : this.files) {
       Path dir = file.getParent();
+      if (dir == null) {
+        throw new IOException("File path has no parent: " + file);
+      }
       WatchKey key =
           dir.register(
               watchService,


### PR DESCRIPTION
## Summary
- run sample tests for account-service, entity-management-service, and common-library
- address SpotBugs NPE warning in `TlsCertificateWatcher`

## Testing
- `./gradlew :account-service:test`
- `./gradlew :entity-management-service:test`
- `./gradlew :common-library:test`


------
https://chatgpt.com/codex/tasks/task_e_6872a0bd2ce48330aea382b9a991ed98