### PR TITLE
Align gRPC TLS usage with environment design

### DIFF
--- a/dev-tools/generate-dev-certs.sh
+++ b/dev-tools/generate-dev-certs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate self-signed CA and client/server certificates for local dev
+CERT_DIR="certs"
+mkdir -p "$CERT_DIR"
+
+# CA
+openssl genrsa -out "$CERT_DIR/ca.key" 2048
+openssl req -x509 -new -nodes -key "$CERT_DIR/ca.key" -sha256 -days 365 \
+  -subj "/CN=FireMUD-CA" -out "$CERT_DIR/ca.crt"
+
+# Server cert
+openssl genrsa -out "$CERT_DIR/server.key" 2048
+openssl req -new -key "$CERT_DIR/server.key" -subj "/CN=localhost" \
+  -out "$CERT_DIR/server.csr"
+openssl x509 -req -in "$CERT_DIR/server.csr" -CA "$CERT_DIR/ca.crt" -CAkey "$CERT_DIR/ca.key" \
+  -CAcreateserial -out "$CERT_DIR/server.crt" -days 365 -sha256
+
+# Client cert
+openssl genrsa -out "$CERT_DIR/client.key" 2048
+openssl req -new -key "$CERT_DIR/client.key" -subj "/CN=firemud-client" \
+  -out "$CERT_DIR/client.csr"
+openssl x509 -req -in "$CERT_DIR/client.csr" -CA "$CERT_DIR/ca.crt" -CAkey "$CERT_DIR/ca.key" \
+  -CAcreateserial -out "$CERT_DIR/client.crt" -days 365 -sha256
+
+rm "$CERT_DIR"/*.csr "$CERT_DIR"/*.srl
+
+echo "Certificates generated in $CERT_DIR" 

--- a/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -4,9 +4,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import net.firedevops.firemud.loggingadmin.v1.ApplyModerationActionRequest;
 import net.firedevops.firemud.loggingadmin.v1.LoggingAdminServiceGrpc;
@@ -20,6 +25,7 @@ public class LoggingAdminClient implements AutoCloseable {
 
   private ManagedChannel channel;
   private LoggingAdminServiceGrpc.LoggingAdminServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public LoggingAdminClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -27,7 +33,27 @@ public class LoggingAdminClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(LoggingAdminClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getLoggingAdminService();
     if (target == null || target.isEmpty()) {
       target = "logging-admin-service:6565";
@@ -40,7 +66,12 @@ public class LoggingAdminClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = LoggingAdminServiceGrpc.newBlockingStub(channel);
   }
 
@@ -56,8 +87,12 @@ public class LoggingAdminClient implements AutoCloseable {
     stub.applyModerationAction(request);
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/account-service/src/main/resources/application-prod.yml
+++ b/services/account-service/src/main/resources/application-prod.yml
@@ -12,8 +12,18 @@ spring:
 grpc:
   server:
     port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
 
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
     jwt-expiration-ms: ${FIREMUD_AUTH_JWT_EXPIRATION_MS:3600000}

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -13,8 +13,18 @@ spring:
 grpc:
   server:
     port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
 
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-expiration-ms: 3600000
     session-expiration-ms: 3600000

--- a/services/automation-scripting-service/src/main/resources/application-prod.yml
+++ b/services/automation-scripting-service/src/main/resources/application-prod.yml
@@ -19,3 +19,19 @@ script:
   quota:
     limit: ${SCRIPT_QUOTA_LIMIT:50}
     windowSeconds: ${SCRIPT_QUOTA_WINDOWSECONDS:60}
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -20,3 +20,19 @@ script:
   quota:
     limit: 50
     windowSeconds: 60
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/entity-management-service/src/main/resources/application-prod.yml
+++ b/services/entity-management-service/src/main/resources/application-prod.yml
@@ -14,3 +14,19 @@ management:
     health:
       probes:
         enabled: true
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/entity-management-service/src/main/resources/application.yml
+++ b/services/entity-management-service/src/main/resources/application.yml
@@ -16,3 +16,19 @@ management:
       probes:
         enabled: true
 
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/client/AutomationScriptingClient.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/client/AutomationScriptingClient.java
@@ -4,12 +4,16 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.automationscripting.v1.AutomationScriptingServiceGrpc;
 import net.firedevops.firemud.automationscripting.v1.NotifyScriptVersionUpdateRequest;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +24,7 @@ public class AutomationScriptingClient implements AutoCloseable {
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;
   private AutomationScriptingServiceGrpc.AutomationScriptingServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public AutomationScriptingClient(
       ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
@@ -28,7 +33,27 @@ public class AutomationScriptingClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(AutomationScriptingClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getAutomationScriptingService();
     if (target == null || target.isEmpty()) {
       target = "automation-scripting-service:6565";
@@ -41,7 +66,12 @@ public class AutomationScriptingClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = AutomationScriptingServiceGrpc.newBlockingStub(channel);
   }
 
@@ -56,8 +86,12 @@ public class AutomationScriptingClient implements AutoCloseable {
     stub.notifyScriptVersionUpdate(request);
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/game-design-service/src/main/resources/application-prod.yml
+++ b/services/game-design-service/src/main/resources/application-prod.yml
@@ -14,3 +14,19 @@ management:
     health:
       probes:
         enabled: true
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/game-design-service/src/main/resources/application.yml
+++ b/services/game-design-service/src/main/resources/application.yml
@@ -15,3 +15,19 @@ management:
     health:
       probes:
         enabled: true
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/game-logic-service/src/main/resources/application-prod.yml
+++ b/services/game-logic-service/src/main/resources/application-prod.yml
@@ -15,7 +15,21 @@ management:
       probes:
         enabled: true
 
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
     jwt-expiration-ms: ${FIREMUD_AUTH_JWT_EXPIRATION_MS:3600000}

--- a/services/game-logic-service/src/main/resources/application.yml
+++ b/services/game-logic-service/src/main/resources/application.yml
@@ -16,7 +16,21 @@ management:
       probes:
         enabled: true
 
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-secret: changemechangemechangeme123456
     jwt-expiration-ms: 3600000

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
@@ -4,12 +4,17 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.account.v1.AccountServiceGrpc;
 import net.firedevops.firemud.account.v1.DeleteAccountRequest;
 import net.firedevops.firemud.account.v1.DeleteAccountResponse;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +25,7 @@ public class AccountClient implements AutoCloseable {
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;
   private AccountServiceGrpc.AccountServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public AccountClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -27,7 +33,27 @@ public class AccountClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(AccountClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getAccountService();
     if (target == null || target.isEmpty()) {
       target = "account-service:6565";
@@ -40,7 +66,12 @@ public class AccountClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = AccountServiceGrpc.newBlockingStub(channel);
   }
 
@@ -54,8 +85,12 @@ public class AccountClient implements AutoCloseable {
     return stub.deleteAccount(request);
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -4,9 +4,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import net.firedevops.firemud.gamesession.v1.GameSessionServiceGrpc;
 import net.firedevops.firemud.gamesession.v1.PingRequest;
@@ -22,6 +27,7 @@ public class GameSessionClient implements AutoCloseable {
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;
   private GameSessionServiceGrpc.GameSessionServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -29,7 +35,27 @@ public class GameSessionClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(GameSessionClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getGameSessionService();
     if (target == null || target.isEmpty()) {
       target = "game-session-service:6565";
@@ -42,7 +68,12 @@ public class GameSessionClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = GameSessionServiceGrpc.newBlockingStub(channel);
   }
 
@@ -58,8 +89,12 @@ public class GameSessionClient implements AutoCloseable {
     return stub.stopSession(request);
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/logging-admin-service/src/main/resources/application-prod.yml
+++ b/services/logging-admin-service/src/main/resources/application-prod.yml
@@ -14,3 +14,19 @@ management:
     health:
       probes:
         enabled: true
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/logging-admin-service/src/main/resources/application.yml
+++ b/services/logging-admin-service/src/main/resources/application.yml
@@ -15,3 +15,19 @@ management:
     health:
       probes:
         enabled: true
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -10,8 +10,18 @@ spring:
 grpc:
   server:
     port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
 
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-expiration-ms: 3600000
 
@@ -45,6 +55,10 @@ spring:
             redis-rate-limiter.burstCapacity: 40
 
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-secret: changeit-changeit-changeit-changeit
 
@@ -67,5 +81,9 @@ spring:
             redis-rate-limiter.replenishRate: 20
             redis-rate-limiter.burstCapacity: 40
 firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}

--- a/services/tcp-proxy-service/src/main/resources/application.yml
+++ b/services/tcp-proxy-service/src/main/resources/application.yml
@@ -15,3 +15,19 @@ management:
     health:
       probes:
         enabled: true
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
@@ -4,9 +4,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import net.firedevops.firemud.gamedesign.v1.GameDesignServiceGrpc;
 import net.firedevops.firemud.gamedesign.v1.ListVersionsRequest;
@@ -20,6 +25,7 @@ public class GameDesignClient implements AutoCloseable {
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;
   private GameDesignServiceGrpc.GameDesignServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public GameDesignClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -27,7 +33,27 @@ public class GameDesignClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(GameDesignClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getGameDesignService();
     if (target == null || target.isEmpty()) {
       target = "game-design-service:6565";
@@ -40,7 +66,12 @@ public class GameDesignClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = GameDesignServiceGrpc.newBlockingStub(channel);
   }
 
@@ -50,8 +81,12 @@ public class GameDesignClient implements AutoCloseable {
     return stub.listVersions(request);
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -4,9 +4,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
 import net.firedevops.firemud.config.GrpcClientProperties;
 import net.firedevops.firemud.gamesession.v1.GameSessionServiceGrpc;
 import net.firedevops.firemud.gamesession.v1.PingRequest;
@@ -20,6 +25,7 @@ public class GameSessionClient implements AutoCloseable {
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;
   private GameSessionServiceGrpc.GameSessionServiceBlockingStub stub;
+  private TlsCertificateWatcher watcher;
 
   public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
@@ -27,7 +33,27 @@ public class GameSessionClient implements AutoCloseable {
   }
 
   @PostConstruct
-  void init() throws SSLException {
+  void init() throws SSLException, IOException {
+    reloadChannel();
+    watcher =
+        new TlsCertificateWatcher(
+            List.of(
+                Path.of(tlsProps.getCertChain()),
+                Path.of(tlsProps.getPrivateKey()),
+                Path.of(tlsProps.getCaCert())),
+            this::safeReload);
+  }
+
+  private synchronized void safeReload() {
+    try {
+      reloadChannel();
+    } catch (SSLException e) {
+      net.firedevops.firemud.common.LoggingUtil.getLogger(GameSessionClient.class)
+          .error("Failed to reload gRPC channel", e);
+    }
+  }
+
+  private void reloadChannel() throws SSLException {
     String target = endpoints.getGameSessionService();
     if (target == null || target.isEmpty()) {
       target = "game-session-service:6565";
@@ -40,7 +66,12 @@ public class GameSessionClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    ManagedChannel newChannel =
+        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    if (channel != null) {
+      channel.shutdown();
+    }
+    channel = newChannel;
     stub = GameSessionServiceGrpc.newBlockingStub(channel);
   }
 
@@ -49,8 +80,12 @@ public class GameSessionClient implements AutoCloseable {
     return stub.ping(PingRequest.newBuilder().build());
   }
 
+  @PreDestroy
   @Override
-  public void close() {
+  public void close() throws IOException {
+    if (watcher != null) {
+      watcher.close();
+    }
     if (channel != null) {
       channel.shutdown();
     }

--- a/services/world-management-service/src/main/resources/application-prod.yml
+++ b/services/world-management-service/src/main/resources/application-prod.yml
@@ -21,3 +21,19 @@ world:
     cache-ttl-seconds: ${WORLD_ROOM_CACHE_TTL_SECONDS:60}
   instance:
     expiration-hours: ${WORLD_INSTANCE_EXPIRATION_HOURS:24}
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}

--- a/services/world-management-service/src/main/resources/application.yml
+++ b/services/world-management-service/src/main/resources/application.yml
@@ -22,3 +22,19 @@ world:
     cache-ttl-seconds: 60
   instance:
     expiration-hours: 24
+
+grpc:
+  server:
+    port: 6565
+    security:
+      enabled: true
+      certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+      privateKeyPath: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+      trustCertCollectionPath: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
+      clientAuth: REQUIRE
+
+firemud:
+  grpc:
+    cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
+    private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
+    ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}


### PR DESCRIPTION
## Summary
- add TLS configuration placeholders to all services
- reload gRPC clients when cert files change
- generate local dev certificates with `generate-dev-certs.sh`

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687280a0d6148330b3d5db8956caeb94