### PR TITLE
Implement platform fee tracking

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -9,7 +9,7 @@
   - [x] Implement player data export & deletion (GDPR compliance)
   - [x] Expose JWKS endpoint for token verification
   - [x] Use saga orchestrator for account creation workflow
-  - [ ] Implement self-service account recovery
+  - [x] Implement self-service account recovery
   - [x] Add optional 2FA for admin and moderator roles
 - [ ] **Develop Email & Notification System**
   - [x] Implement email verification & password resets
@@ -20,7 +20,7 @@
 - [ ] **Develop Monetization & Payment Module**
   - [x] Integrate Stripe or similar for in-game purchases
   - [ ] Support subscriptions, one-time purchases, and donations
-  - [ ] Enforce platform fee on transactions
+  - [x] Enforce platform fee on transactions
   - [ ] Implement refund & chargeback handling
   - [ ] Use saga orchestrator for cross-service purchase workflows
   - [x] Create `payment_transaction` and `subscription` entities in the Account Service

--- a/services/account-service/src/main/java/net/firedevops/firemud/client/StripeClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/StripeClient.java
@@ -20,7 +20,7 @@ public class StripeClient {
   public IntentResult createPaymentIntent(long amountCents, String currency)
       throws StripeException {
     Stripe.apiKey = apiKey;
-    long fee = Math.round(amountCents * platformFeePercent / 100.0);
+    long fee = calculatePlatformFee(amountCents);
     PaymentIntentCreateParams params =
         PaymentIntentCreateParams.builder()
             .setAmount(amountCents)
@@ -33,6 +33,10 @@ public class StripeClient {
             .build();
     com.stripe.model.PaymentIntent intent = com.stripe.model.PaymentIntent.create(params);
     return new IntentResult(intent.getId(), intent.getClientSecret(), intent.getStatus());
+  }
+
+  public long calculatePlatformFee(long amountCents) {
+    return Math.round(amountCents * platformFeePercent / 100.0);
   }
 
   public void createRefund(String paymentIntentId) throws StripeException {

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/PaymentIntentDto.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/PaymentIntentDto.java
@@ -5,5 +5,6 @@ public record PaymentIntentDto(
     Long tenantId,
     Long accountId,
     Long amountCents,
+    Long platformFeeCents,
     String currency,
     String clientSecret) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -18,6 +18,9 @@ public class PaymentTransaction {
   @Column(name = "amount_cents", nullable = false)
   private Long amountCents;
 
+  @Column(name = "platform_fee_cents", nullable = false)
+  private Long platformFeeCents;
+
   @Column(nullable = false, length = 10)
   private String currency;
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
@@ -47,6 +47,7 @@ public class PaymentServiceImpl implements PaymentService {
             .findById(accountId)
             .filter(a -> a.getTenantId().equals(tenantId))
             .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    long platformFee = stripeClient.calculatePlatformFee(amountCents);
     StripeClient.IntentResult intent;
     try {
       intent = stripeClient.createPaymentIntent(amountCents, "usd");
@@ -58,6 +59,7 @@ public class PaymentServiceImpl implements PaymentService {
     tx.setAccount(account);
     tx.setAmountCents(amountCents);
     tx.setCurrency("USD");
+    tx.setPlatformFeeCents(platformFee);
     tx.setProviderId(intent.id());
     tx.setStatus(intent.status());
     tx.setTenantId(tenantId);
@@ -67,6 +69,7 @@ public class PaymentServiceImpl implements PaymentService {
         tenantId,
         accountId,
         tx.getAmountCents(),
+        tx.getPlatformFeeCents(),
         tx.getCurrency(),
         intent.clientSecret());
   }

--- a/services/account-service/src/main/resources/db/migration/V10__platform_fee.sql
+++ b/services/account-service/src/main/resources/db/migration/V10__platform_fee.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_transaction ADD COLUMN platform_fee_cents BIGINT NOT NULL DEFAULT 0;

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/client/StripeClientTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/client/StripeClientTest.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class StripeClientTest {
+  @Test
+  void calculatesPlatformFeeBasedOnPercent() {
+    StripeClient client = new StripeClient("key", 5.0);
+    assertEquals(50L, client.calculatePlatformFee(1000L));
+  }
+}

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentGrpcServiceTest.java
@@ -19,7 +19,7 @@ class PaymentGrpcServiceTest {
   void createPaymentIntentReturnsResponse() {
     PaymentService paymentService = Mockito.mock(PaymentService.class);
     Mockito.when(paymentService.createPaymentIntent(1L, 2L, 500L))
-        .thenReturn(new PaymentIntentDto(10L, 1L, 2L, 500L, "USD", "secret"));
+        .thenReturn(new PaymentIntentDto(10L, 1L, 2L, 500L, 25L, "USD", "secret"));
     PaymentGrpcService service = new PaymentGrpcService(paymentService);
 
     AtomicReference<CreatePaymentIntentResponse> ref = new AtomicReference<>();

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentServiceImplTest.java
@@ -44,6 +44,7 @@ class PaymentServiceImplTest {
               tx.setId(10L);
               return tx;
             });
+    when(stripeClient.calculatePlatformFee(500L)).thenReturn(25L);
     when(stripeClient.createPaymentIntent(500L, "usd"))
         .thenReturn(new StripeClient.IntentResult("pi", "secret", "pending"));
 
@@ -51,9 +52,11 @@ class PaymentServiceImplTest {
 
     assertEquals(10L, dto.id());
     assertEquals("secret", dto.clientSecret());
+    assertEquals(25L, dto.platformFeeCents());
     ArgumentCaptor<PaymentTransaction> captor = ArgumentCaptor.forClass(PaymentTransaction.class);
     verify(txRepo).save(captor.capture());
     assertEquals(2L, captor.getValue().getTenantId());
+    assertEquals(25L, captor.getValue().getPlatformFeeCents());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- record platform fee on payment transactions
- expose fee in PaymentIntentDto
- compute fee via new method in StripeClient
- cover fee calculation with unit test
- update project task list
- add database migration

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6872a5dd5c348330be70bd28d74e37e0