### PR TITLE
Improve user journeys and standardize docs

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -121,7 +121,7 @@ Service-specific settings such as SMTP credentials for the Account Service or
 `GAME_TICK_DURATION_MS` for the Game Session Service are documented in each
 service's design file. This document covers only shared configuration keys.
 
-## 📚 Related Docs
+## 📚 Related Documentation
 
 - [Deployment Environments](./deployment-environments.md)
 - [System Architecture: Security](../system-architecture-security.md)

--- a/design/architecture/microservices/game-design-service/modding-framework.md
+++ b/design/architecture/microservices/game-design-service/modding-framework.md
@@ -15,7 +15,7 @@ This document sketches the planned modding system that allows administrators to 
 3. A registry tracks which plugins are active for each game instance and exposes toggle APIs via the Logging & Admin Service.
 4. Plugins can subscribe to events such as `onEnterRoom` or `onItemUse` to inject custom behavior.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Automation & Scripting Service](../automation-scripting-service/README.md)
 - [Game Design Service Architecture](README.md)

--- a/design/architecture/system-architecture-diagram.md
+++ b/design/architecture/system-architecture-diagram.md
@@ -44,3 +44,8 @@ Game Design         Account Service              Entity Management     World Man
                        | Game Design Service (Passive Editor) |
                        +--------------------------------------+
 ```
+
+## 📚 Related Documentation
+
+- [System Context Diagram](./system-context-diagram.md)
+- [Gateway Architecture](./system-architecture-gateway.md)

--- a/design/architecture/system-architecture-mcp-support.md
+++ b/design/architecture/system-architecture-mcp-support.md
@@ -20,3 +20,9 @@ The TCP Proxy Service will negotiate MCP with connecting clients. When enabled, 
 4. A confirmation package containing the new room ID is returned.
 
 Future enhancements will include bulk import and transaction support for batch creation.
+
+## 📚 Related Documentation
+
+- [Game Design Service](./microservices/game-design-service/README.md)
+- [TCP Proxy Service](./microservices/tcp-proxy-service/README.md)
+- [Modding Framework](./microservices/game-design-service/modding-framework.md)

--- a/design/architecture/system-architecture-procedural-generation.md
+++ b/design/architecture/system-architecture-procedural-generation.md
@@ -16,3 +16,8 @@ This document describes the basic approach for procedurally generating simple du
 - Designed for extensibility so terrain features can be added later.
 
 The generator is intentionally lightweight to keep early worlds simple while providing a template for future expansion.
+
+## 📚 Related Documentation
+
+- [Automation & Scripting Service](./microservices/automation-scripting-service/README.md)
+- [World Management Service](./microservices/world-management-service/README.md)

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -196,7 +196,7 @@ Redis in FireMUD is:
 
 ---
 
-📚 **Related Documentation**
+## 📚 Related Documentation
 
 - [Tick System and Runtime Design](./system-architecture-ticks.md)
 - [System Architecture Overview](./system-architecture-overview.md)

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -58,3 +58,9 @@ See [Backup & Disaster Recovery](./system-architecture-backup-recovery.md) for s
 ---
 
 These runbooks provide a starting point for operators. Update them as new tooling or workflows evolve.
+
+## 📚 Related Documentation
+
+- [Logging & Monitoring Overview](./system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](./system-architecture-backup-recovery.md)
+- [CI/CD Pipeline](./system-architecture-cicd.md)

--- a/design/architecture/system-architecture-shared-libraries.md
+++ b/design/architecture/system-architecture-shared-libraries.md
@@ -90,3 +90,8 @@ new SagaBuilder()
 ```
 
 Saga state is stored in the bundled `saga_instance` and `saga_step` tables.
+
+## 📚 Related Documentation
+
+- [gRPC API Style & Versioning Guidelines](./system-architecture-grpc.md)
+- [Transaction Strategies](./system-architecture-transactions.md)

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -215,7 +215,7 @@ This supports **idempotent, replayable** ticks — without risk of duplicate eff
 
 ---
 
-📚 **Related Documentation**
+## 📚 Related Documentation
 
 - [Redis Architecture](./system-architecture-redis.md)
 - [Transaction Strategies](./system-architecture-transactions.md)

--- a/design/architecture/system-architecture-versioning-runtime.md
+++ b/design/architecture/system-architecture-versioning-runtime.md
@@ -69,3 +69,10 @@ flowchart TD
 By decoupling published versions from runtime flags, FireMUD can rapidly iterate on new content while still allowing safe toggles for experimental features during live gameplay.
 
 For API versioning conventions see [gRPC Protocol Guidelines](./system-architecture-grpc.md).
+
+## 📚 Related Documentation
+
+- [System Architecture Overview](./system-architecture-overview.md)
+- [Service Responsibility Matrix](./service-responsibility-matrix.md)
+- [Transaction Strategies](./system-architecture-transactions.md)
+- [Testing Strategy](./system-architecture-testing.md)

--- a/design/architecture/system-context-diagram.md
+++ b/design/architecture/system-context-diagram.md
@@ -36,3 +36,8 @@
                 |  Elasticsearch (logs)                       |
                 +----------------------------------------------+
 ```
+
+## 📚 Related Documentation
+
+- [System Architecture Diagram](./system-architecture-diagram.md)
+- [Gateway Architecture](./system-architecture-gateway.md)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -290,6 +290,19 @@ Service Logs → Elasticsearch → Kibana / Jaeger
 
 ---
 
+## 21. Extensibility & External Tools
+
+Creators extend gameplay using external editors and runtime plugins:
+
+1. **Mud Client Protocol** – The [TCP Proxy Service](./microservices/tcp-proxy-service/README.md) negotiates MCP so tools can create rooms, items, and NPCs programmatically. See [MCP Support](./system-architecture-mcp-support.md).
+2. **Modding Framework** – Plugins packaged through the [Game Design Service](./microservices/game-design-service/modding-framework.md) inject custom logic at runtime. The [Automation & Scripting Service](./microservices/automation-scripting-service/README.md) executes them in a sandbox.
+
+```plaintext
+Editor/Tool → TCP Proxy Service → Game Design Service → Automation & Scripting Service
+```
+
+---
+
 These flows complement the architecture diagrams in [System Architecture Overview](./system-architecture-overview.md).
 
 ## 📚 Related Documentation
@@ -318,6 +331,7 @@ These flows complement the architecture diagrams in [System Architecture Overvie
 - [Reconnection Strategy](./system-architecture-reconnection.md)
 - [Protocol Bridging](./system-architecture-protocol-bridging.md)
 - [MCP Support](./system-architecture-mcp-support.md)
+- [Modding Framework](./microservices/game-design-service/modding-framework.md)
 - [Logging & Monitoring Overview](./system-architecture-logging-monitoring.md)
 - [Tracing](./system-architecture-tracing.md)
 - [Operational Runbooks](./system-architecture-runbooks.md)


### PR DESCRIPTION
## Summary
- extend user journeys with external tooling section
- document related architecture references in multiple design docs
- standardize `Related Documentation` sections across architecture docs

## Testing
- `pre-commit run --files design/architecture/infrastructure/environment-and-secrets.md design/architecture/microservices/game-design-service/modding-framework.md design/architecture/system-architecture-diagram.md design/architecture/system-architecture-mcp-support.md design/architecture/system-architecture-procedural-generation.md design/architecture/system-architecture-redis.md design/architecture/system-architecture-runbooks.md design/architecture/system-architecture-shared-libraries.md design/architecture/system-architecture-ticks.md design/architecture/system-architecture-versioning-runtime.md design/architecture/system-context-diagram.md design/architecture/user-journeys.md` *(failed: Spotless interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68730629f0c08330a9e91ee0660c131a