### PR TITLE
Implement donation flow in Account Service

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -151,6 +151,7 @@ The gRPC schemas for this service live in
 ### Monetization Design
 
 The Account Service also manages billing records for purchases and subscriptions. Payment processing is handled through **Stripe** as outlined in the [Core Requirements](../../../design/project-management/core-requirements.md#2.8-moderation-administration--monetization). Planned entities include `payment_transaction` and `subscription` tables with Flyway migrations. gRPC endpoints and REST controllers expose operations for creating payment intents and managing subscriptions. The proto definitions live in [`payment_service.proto`](../../../protos/account/v1/payment_service.proto).
+Donations are stored as one-time `payment_transaction` records with the `donation` flag set to `true`. A dedicated `CreateDonation` gRPC method issues a Stripe payment intent for these cases.
 
 ### Email & Notification Design
 

--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -19,7 +19,7 @@
   - [x] Add asynchronous NotificationService components with gRPC endpoints
 - [ ] **Develop Monetization & Payment Module**
   - [x] Integrate Stripe or similar for in-game purchases
-  - [ ] Support subscriptions, one-time purchases, and donations
+  - [x] Support subscriptions, one-time purchases, and donations
   - [x] Enforce platform fee on transactions
   - [ ] Implement refund & chargeback handling
   - [ ] Use saga orchestrator for cross-service purchase workflows

--- a/protos/account/v1/payment_service.proto
+++ b/protos/account/v1/payment_service.proto
@@ -10,6 +10,7 @@ option java_multiple_files = true;
 service PaymentService {
   rpc CreatePaymentIntent(CreatePaymentIntentRequest) returns (CreatePaymentIntentResponse);
   rpc CreateSubscription(CreateSubscriptionRequest) returns (CreateSubscriptionResponse);
+  rpc CreateDonation(CreateDonationRequest) returns (CreateDonationResponse);
   rpc RefundPayment(RefundPaymentRequest) returns (RefundPaymentResponse);
 }
 
@@ -34,6 +35,18 @@ message CreateSubscriptionRequest {
 message CreateSubscriptionResponse {
   string subscription_id = 1;
   shared.v1.ErrorDetail error = 2;
+}
+
+message CreateDonationRequest {
+  string tenant_id = 1;
+  string account_id = 2;
+  int64 amount_cents = 3;
+}
+
+message CreateDonationResponse {
+  string intent_id = 1;
+  string client_secret = 2;
+  shared.v1.ErrorDetail error = 3;
 }
 
 message RefundPaymentRequest {

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/PaymentIntentDto.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/PaymentIntentDto.java
@@ -7,4 +7,5 @@ public record PaymentIntentDto(
     Long amountCents,
     Long platformFeeCents,
     String currency,
-    String clientSecret) {}
+    String clientSecret,
+    boolean donation) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -30,6 +30,9 @@ public class PaymentTransaction {
   @Column(name = "provider_id", length = 50)
   private String providerId;
 
+  @Column(nullable = false)
+  private boolean donation;
+
   @Column(name = "tenant_id", nullable = false)
   private Long tenantId;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/PaymentService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/PaymentService.java
@@ -6,6 +6,8 @@ import net.firedevops.firemud.dto.SubscriptionDto;
 public interface PaymentService {
   PaymentIntentDto createPaymentIntent(Long tenantId, Long accountId, Long amountCents);
 
+  PaymentIntentDto createDonation(Long tenantId, Long accountId, Long amountCents);
+
   SubscriptionDto createSubscription(Long tenantId, Long accountId, String planId);
 
   void refundPayment(Long tenantId, Long paymentId);

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentGrpcService.java
@@ -1,6 +1,8 @@
 package net.firedevops.firemud.service.impl;
 
 import io.grpc.stub.StreamObserver;
+import net.firedevops.firemud.account.v1.CreateDonationRequest;
+import net.firedevops.firemud.account.v1.CreateDonationResponse;
 import net.firedevops.firemud.account.v1.CreatePaymentIntentRequest;
 import net.firedevops.firemud.account.v1.CreatePaymentIntentResponse;
 import net.firedevops.firemud.account.v1.CreateSubscriptionRequest;
@@ -69,6 +71,36 @@ public class PaymentGrpcService extends PaymentServiceGrpc.PaymentServiceImplBas
     } catch (IllegalArgumentException ex) {
       CreateSubscriptionResponse response =
           CreateSubscriptionResponse.newBuilder()
+              .setError(
+                  net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
+                      .setCode("INVALID_ARGUMENT")
+                      .setMessage(ex.getMessage())
+                      .build())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  @Override
+  public void createDonation(
+      CreateDonationRequest request, StreamObserver<CreateDonationResponse> responseObserver) {
+    try {
+      PaymentIntentDto dto =
+          paymentService.createDonation(
+              Long.valueOf(request.getTenantId()),
+              Long.valueOf(request.getAccountId()),
+              request.getAmountCents());
+      CreateDonationResponse response =
+          CreateDonationResponse.newBuilder()
+              .setIntentId(dto.id().toString())
+              .setClientSecret(dto.clientSecret())
+              .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (IllegalArgumentException ex) {
+      CreateDonationResponse response =
+          CreateDonationResponse.newBuilder()
               .setError(
                   net.firedevops.firemud.shared.v1.ErrorDetail.newBuilder()
                       .setCode("INVALID_ARGUMENT")

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
@@ -62,6 +62,7 @@ public class PaymentServiceImpl implements PaymentService {
     tx.setPlatformFeeCents(platformFee);
     tx.setProviderId(intent.id());
     tx.setStatus(intent.status());
+    tx.setDonation(false);
     tx.setTenantId(tenantId);
     tx = paymentTransactionRepository.save(tx);
     return new PaymentIntentDto(
@@ -71,7 +72,47 @@ public class PaymentServiceImpl implements PaymentService {
         tx.getAmountCents(),
         tx.getPlatformFeeCents(),
         tx.getCurrency(),
-        intent.clientSecret());
+        intent.clientSecret(),
+        false);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "payment.create_donation")
+  public PaymentIntentDto createDonation(Long tenantId, Long accountId, Long amountCents) {
+    logger.info("Create donation {} cents for account {}", amountCents, accountId);
+    Account account =
+        accountRepository
+            .findById(accountId)
+            .filter(a -> a.getTenantId().equals(tenantId))
+            .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+    long platformFee = stripeClient.calculatePlatformFee(amountCents);
+    StripeClient.IntentResult intent;
+    try {
+      intent = stripeClient.createPaymentIntent(amountCents, "usd");
+    } catch (com.stripe.exception.StripeException e) {
+      throw new IllegalStateException("Stripe error", e);
+    }
+
+    PaymentTransaction tx = new PaymentTransaction();
+    tx.setAccount(account);
+    tx.setAmountCents(amountCents);
+    tx.setCurrency("USD");
+    tx.setPlatformFeeCents(platformFee);
+    tx.setProviderId(intent.id());
+    tx.setStatus(intent.status());
+    tx.setDonation(true);
+    tx.setTenantId(tenantId);
+    tx = paymentTransactionRepository.save(tx);
+    return new PaymentIntentDto(
+        tx.getId(),
+        tenantId,
+        accountId,
+        tx.getAmountCents(),
+        tx.getPlatformFeeCents(),
+        tx.getCurrency(),
+        intent.clientSecret(),
+        true);
   }
 
   @Override

--- a/services/account-service/src/main/resources/db/migration/V11__donation_flag.sql
+++ b/services/account-service/src/main/resources/db/migration/V11__donation_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_transaction ADD COLUMN donation BOOLEAN NOT NULL DEFAULT FALSE;

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentGrpcServiceTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.account.v1.CreateDonationRequest;
+import net.firedevops.firemud.account.v1.CreateDonationResponse;
 import net.firedevops.firemud.account.v1.CreatePaymentIntentRequest;
 import net.firedevops.firemud.account.v1.CreatePaymentIntentResponse;
 import net.firedevops.firemud.account.v1.CreateSubscriptionRequest;
@@ -19,7 +21,7 @@ class PaymentGrpcServiceTest {
   void createPaymentIntentReturnsResponse() {
     PaymentService paymentService = Mockito.mock(PaymentService.class);
     Mockito.when(paymentService.createPaymentIntent(1L, 2L, 500L))
-        .thenReturn(new PaymentIntentDto(10L, 1L, 2L, 500L, 25L, "USD", "secret"));
+        .thenReturn(new PaymentIntentDto(10L, 1L, 2L, 500L, 25L, "USD", "secret", false));
     PaymentGrpcService service = new PaymentGrpcService(paymentService);
 
     AtomicReference<CreatePaymentIntentResponse> ref = new AtomicReference<>();
@@ -75,5 +77,36 @@ class PaymentGrpcServiceTest {
 
     assertNotNull(ref.get());
     assertEquals("INVALID_ARGUMENT", ref.get().getError().getCode());
+  }
+
+  @Test
+  void createDonationReturnsResponse() {
+    PaymentService paymentService = Mockito.mock(PaymentService.class);
+    Mockito.when(paymentService.createDonation(1L, 2L, 100L))
+        .thenReturn(new PaymentIntentDto(11L, 1L, 2L, 100L, 5L, "USD", "donate", true));
+    PaymentGrpcService service = new PaymentGrpcService(paymentService);
+
+    AtomicReference<CreateDonationResponse> ref = new AtomicReference<>();
+    service.createDonation(
+        CreateDonationRequest.newBuilder()
+            .setTenantId("1")
+            .setAccountId("2")
+            .setAmountCents(100)
+            .build(),
+        new StreamObserver<>() {
+          @Override
+          public void onNext(CreateDonationResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals("11", ref.get().getIntentId());
+    assertEquals("donate", ref.get().getClientSecret());
   }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PaymentServiceImplTest.java
@@ -57,6 +57,7 @@ class PaymentServiceImplTest {
     verify(txRepo).save(captor.capture());
     assertEquals(2L, captor.getValue().getTenantId());
     assertEquals(25L, captor.getValue().getPlatformFeeCents());
+    assertFalse(dto.donation());
   }
 
   @Test
@@ -82,5 +83,30 @@ class PaymentServiceImplTest {
     verify(stripeClient).createRefund("pi_123");
     verify(txRepo).save(tx);
     assertEquals("refunded", tx.getStatus());
+  }
+
+  @Test
+  void createDonationSetsFlag() throws Exception {
+    Account account = new Account();
+    account.setId(1L);
+    account.setTenantId(2L);
+    when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+    when(txRepo.save(any()))
+        .thenAnswer(
+            invocation -> {
+              PaymentTransaction tx = invocation.getArgument(0);
+              tx.setId(11L);
+              return tx;
+            });
+    when(stripeClient.calculatePlatformFee(100L)).thenReturn(5L);
+    when(stripeClient.createPaymentIntent(100L, "usd"))
+        .thenReturn(new StripeClient.IntentResult("pi2", "donate", "pending"));
+
+    PaymentIntentDto dto = service.createDonation(2L, 1L, 100L);
+
+    assertTrue(dto.donation());
+    ArgumentCaptor<PaymentTransaction> captor = ArgumentCaptor.forClass(PaymentTransaction.class);
+    verify(txRepo).save(captor.capture());
+    assertTrue(captor.getValue().isDonation());
   }
 }


### PR DESCRIPTION
## Summary
- add `donation` flag for `PaymentTransaction`
- support donations via `CreateDonation` gRPC method
- include migration and update service/test logic
- note new donations in account service design
- mark donations task complete

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6873059fa3788330aa05c41e88e8643b