### PR TITLE
Ensure session saga checks all services

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
@@ -1,0 +1,58 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import net.firedevops.firemud.entitymanagement.v1.EntityManagementServiceGrpc;
+import net.firedevops.firemud.entitymanagement.v1.PingRequest;
+import net.firedevops.firemud.entitymanagement.v1.PingResponse;
+import org.springframework.stereotype.Component;
+
+/** gRPC client for the Entity Management Service. */
+@Component
+public class EntityManagementClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+  private ManagedChannel channel;
+  private EntityManagementServiceGrpc.EntityManagementServiceBlockingStub stub;
+
+  public EntityManagementClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getEntityManagementService();
+    if (target == null || target.isEmpty()) {
+      target = "entity-management-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = EntityManagementServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Simple ping to verify connectivity. */
+  public PingResponse ping() {
+    return stub.ping(PingRequest.newBuilder().build());
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
@@ -1,0 +1,58 @@
+package net.firedevops.firemud.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import javax.net.ssl.SSLException;
+import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
+import net.firedevops.firemud.config.GrpcClientProperties;
+import net.firedevops.firemud.worldmanagement.v1.WorldManagementServiceGrpc;
+import net.firedevops.firemud.worldmanagement.v1.PingRequest;
+import net.firedevops.firemud.worldmanagement.v1.PingResponse;
+import org.springframework.stereotype.Component;
+
+/** gRPC client for the World Management Service. */
+@Component
+public class WorldManagementClient implements AutoCloseable {
+  private final ServiceEndpointsProperties endpoints;
+  private final GrpcClientProperties tlsProps;
+  private ManagedChannel channel;
+  private WorldManagementServiceGrpc.WorldManagementServiceBlockingStub stub;
+
+  public WorldManagementClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+    this.endpoints = endpoints;
+    this.tlsProps = tlsProps;
+  }
+
+  @PostConstruct
+  void init() throws SSLException {
+    String target = endpoints.getWorldManagementService();
+    if (target == null || target.isEmpty()) {
+      target = "world-management-service:6565";
+    }
+    String[] parts = target.split(":");
+    String host = parts[0];
+    int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 6565;
+    var sslContext =
+        GrpcSslContexts.forClient()
+            .trustManager(new File(tlsProps.getCaCert()))
+            .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
+            .build();
+    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+    stub = WorldManagementServiceGrpc.newBlockingStub(channel);
+  }
+
+  /** Simple ping to verify connectivity. */
+  public PingResponse ping() {
+    return stub.ping(PingRequest.newBuilder().build());
+  }
+
+  @Override
+  public void close() {
+    if (channel != null) {
+      channel.shutdown();
+    }
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/config/GrpcClientConfig.java
@@ -2,6 +2,8 @@ package net.firedevops.firemud.config;
 
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.client.GameLogicClient;
+import net.firedevops.firemud.client.WorldManagementClient;
+import net.firedevops.firemud.client.EntityManagementClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,5 +17,21 @@ public class GrpcClientConfig {
       GrpcClientProperties properties)
       throws SSLException {
     return new GameLogicClient(endpoints, properties);
+  }
+
+  @Bean
+  public WorldManagementClient worldManagementClient(
+      net.firedevops.firemud.common.config.ServiceEndpointsProperties endpoints,
+      GrpcClientProperties properties)
+      throws SSLException {
+    return new WorldManagementClient(endpoints, properties);
+  }
+
+  @Bean
+  public EntityManagementClient entityManagementClient(
+      net.firedevops.firemud.common.config.ServiceEndpointsProperties endpoints,
+      GrpcClientProperties properties)
+      throws SSLException {
+    return new EntityManagementClient(endpoints, properties);
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -2,6 +2,8 @@ package net.firedevops.firemud.service.impl;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.client.GameLogicClient;
+import net.firedevops.firemud.client.WorldManagementClient;
+import net.firedevops.firemud.client.EntityManagementClient;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
 import net.firedevops.firemud.common.saga.SagaException;
@@ -26,6 +28,8 @@ public class GameInstanceServiceImpl implements GameInstanceService {
   private final GameInstanceMapper mapper;
   private final SessionStateService sessionStateService;
   private final GameLogicClient gameLogicClient;
+  private final WorldManagementClient worldManagementClient;
+  private final EntityManagementClient entityManagementClient;
   private final SagaRunner sagaRunner;
   private final MeterRegistry meterRegistry;
 
@@ -34,12 +38,16 @@ public class GameInstanceServiceImpl implements GameInstanceService {
       GameInstanceMapper mapper,
       SessionStateService sessionStateService,
       GameLogicClient gameLogicClient,
+      WorldManagementClient worldManagementClient,
+      EntityManagementClient entityManagementClient,
       SagaRunner sagaRunner,
       MeterRegistry meterRegistry) {
     this.repository = repository;
     this.mapper = mapper;
     this.sessionStateService = sessionStateService;
     this.gameLogicClient = gameLogicClient;
+    this.worldManagementClient = worldManagementClient;
+    this.entityManagementClient = entityManagementClient;
     this.sagaRunner = sagaRunner;
     this.meterRegistry = meterRegistry;
   }
@@ -53,6 +61,8 @@ public class GameInstanceServiceImpl implements GameInstanceService {
         repository,
         mapper,
         sessionStateService,
+        null,
+        null,
         null,
         null,
         new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
@@ -93,9 +103,14 @@ public class GameInstanceServiceImpl implements GameInstanceService {
             request.scriptPatchVersion() == null ? "none" : request.scriptPatchVersion())
         .increment();
 
-    if (gameLogicClient != null && sagaRunner != null) {
+    if (gameLogicClient != null
+        && worldManagementClient != null
+        && entityManagementClient != null
+        && sagaRunner != null) {
       var saga =
           new SagaBuilder("startSession")
+              .step("checkWorldService", () -> worldManagementClient.ping())
+              .step("checkEntityService", () -> entityManagementClient.ping())
               .step("notifyGameLogic", () -> gameLogicClient.ping())
               .build();
       try {
@@ -121,10 +136,15 @@ public class GameInstanceServiceImpl implements GameInstanceService {
     GameInstance saved = repository.save(instance);
     sessionStateService.deleteState(instance.getTenantId(), instance.getId());
 
-    if (gameLogicClient != null && sagaRunner != null) {
+    if (gameLogicClient != null
+        && worldManagementClient != null
+        && entityManagementClient != null
+        && sagaRunner != null) {
       var saga =
           new SagaBuilder("stopSession")
               .step("notifyGameLogic", () -> gameLogicClient.ping())
+              .step("flushWorldService", () -> worldManagementClient.ping())
+              .step("flushEntityService", () -> entityManagementClient.ping())
               .build();
       try {
         sagaRunner.run(saga);

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
@@ -30,7 +30,15 @@ class GameInstanceServiceImplTest {
     stateService = mock(SessionStateService.class);
     meterRegistry = new SimpleMeterRegistry();
     service =
-        new GameInstanceServiceImpl(repository, mapper, stateService, null, null, meterRegistry);
+        new GameInstanceServiceImpl(
+            repository,
+            mapper,
+            stateService,
+            null,
+            null,
+            null,
+            null,
+            meterRegistry);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- implement `WorldManagementClient` and `EntityManagementClient`
- expose new gRPC client beans
- extend `GameInstanceServiceImpl` saga to ping world and entity services
- update unit tests

## Testing
- `./gradlew test classes`

------
https://chatgpt.com/codex/tasks/task_e_687303058e508330a9c5a22517cfcc83