### PR TITLE
Clarify service design stubs

### DIFF
--- a/services/game-design-service/design/asset-storage.md
+++ b/services/game-design-service/design/asset-storage.md
@@ -3,3 +3,5 @@
 The authoritative design document is located at [../../design/architecture/microservices/game-design-service/asset-storage.md](../../../design/architecture/microservices/game-design-service/asset-storage.md).
 
 This stub exists for convenience. Please see the linked file for details about asset upload and storage configuration.
+
+**This file is only a stub. Do not add design details here.**

--- a/services/game-design-service/design/game-templates.md
+++ b/services/game-design-service/design/game-templates.md
@@ -3,3 +3,5 @@
 The authoritative design document is located at [../../design/architecture/microservices/game-design-service/game-templates.md](../../../design/architecture/microservices/game-design-service/game-templates.md).
 
 This stub exists for convenience. Please see the linked file for details about template management and configuration.
+
+**This file is only a stub. Do not add design details here.**


### PR DESCRIPTION
## Summary
- clarify documentation for game design service stubs

## Testing
- `./gradlew check` *(fails: cannot find symbol method parserBuilder)*

------
https://chatgpt.com/codex/tasks/task_e_6873137fa2248330a4259a337b16569b