### PR TITLE
Update user journeys and fix links

### DIFF
--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -112,7 +112,7 @@ the generated code with `./gradlew generateProto` after making changes.
 - [Logging & Monitoring](../system-architecture-logging-monitoring.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#6-player-login-and-gameplay)
+- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
 - [Testing Strategy](../system-architecture-testing.md)
 - [CI/CD Pipeline](../system-architecture-cicd.md)
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -191,7 +191,7 @@ Session state needed for reconnect recovery is stored under `session:{tenantId}:
 - [System Architecture Overview](../system-architecture-overview.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
 - [User Journeys – Publish and Start a Game Instance](../user-journeys.md#5-publish-and-start-a-game-instance)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#6-player-login-and-gameplay)
+- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
 
 - [System Architecture Diagram](../system-architecture-diagram.md)
 - [System Context Diagram](../system-context-diagram.md)

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -104,7 +104,7 @@ adding or removing routes at runtime.
 - [Security Architecture](../system-architecture-security.md)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#6-player-login-and-gameplay)
+- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)
 - [Testing Strategy](../system-architecture-testing.md)

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -110,7 +110,7 @@ regenerated via `./gradlew generateProto` when the proto files change.
 - [Reconnection Strategy](../system-architecture-reconnection.md)
 - [Security Architecture](../system-architecture-security.md)
 - [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#6-player-login-and-gameplay)
+- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
 - [Multi-Tenancy](../system-architecture-multi-tenancy.md)
 - [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
 - [Shared Libraries Overview](../system-architecture-shared-libraries.md)

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -153,4 +153,4 @@ These can be added as separate workflows or additional jobs in the main pipeline
 - [Infrastructure Overview](./infrastructure/README.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)
 - [Testing Strategy](./system-architecture-testing.md)
-- [User Journeys – Testing & Continuous Delivery](./user-journeys.md#16-testing--continuous-delivery)
+- [User Journeys – Testing & Continuous Delivery](./user-journeys.md#17-testing--continuous-delivery)

--- a/design/architecture/system-architecture-testing.md
+++ b/design/architecture/system-architecture-testing.md
@@ -73,4 +73,4 @@ OWASP ZAP crawls the web client and Gateway endpoints during CI. Penetration tes
 
 - [CI/CD Pipeline](./system-architecture-cicd.md)
 - [System Architecture Overview](./system-architecture-overview.md)
-- [User Journeys – Testing & Continuous Delivery](./user-journeys.md#16-testing--continuous-delivery)
+- [User Journeys – Testing & Continuous Delivery](./user-journeys.md#17-testing--continuous-delivery)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -12,6 +12,32 @@ For step-by-step tooling instructions see the [Game Creator Guide](../user-guide
 
 ---
 
+## 📑 Quick Reference
+
+1. [Sign Up](#1-sign-up)
+2. [Game Creation](#2-game-creation)
+3. [World and Entity Design](#3-world-and-entity-design)
+4. [Add Automation & Scripting](#4-add-automation--scripting)
+5. [Publish and Start a Game Instance](#5-publish-and-start-a-game-instance)
+6. [Character Creation & Selection](#6-character-creation--selection)
+7. [Player Login and Gameplay](#7-player-login-and-gameplay)
+8. [Social Interaction](#8-social-interaction)
+9. [Monitoring and Moderation](#9-monitoring-and-moderation)
+10. [Patch and Update a Live Game](#10-patch-and-update-a-live-game)
+11. [Purchases and Subscriptions](#11-purchases-and-subscriptions)
+12. [Password Resets & Account Recovery](#12-password-resets--account-recovery)
+13. [Switch Games or Manage Multiple Games](#13-switch-games-or-manage-multiple-games)
+14. [Operational Recovery](#14-operational-recovery)
+15. [Branding and Customization](#15-branding-and-customization)
+16. [Playtesting & Analytics](#16-playtesting--analytics)
+17. [Testing & Continuous Delivery](#17-testing--continuous-delivery)
+18. [Account Data Export & Deletion](#18-account-data-export--deletion)
+19. [Deployment & Environment Configuration](#19-deployment--environment-configuration)
+20. [Observability & Debugging](#20-observability--debugging)
+21. [Extensibility & External Tools](#21-extensibility--external-tools)
+
+---
+
 ## 1. Sign Up
 
 Players register for an account through the [Account Service](./microservices/account-service/README.md). Email verification and login flows are outlined in [Authentication & Authorization](./system-architecture-authentication.md).
@@ -96,6 +122,7 @@ Players connect through the networking layer:
 3. **Authentication** – Login credentials are validated by the [Game Session Service](./microservices/game-session-service/README.md).
    See [Authentication & Authorization](./system-architecture-authentication.md)
    for supported `LOGIN` commands and token handling.
+4. **Frontend** – The React client connects through the Gateway using the same WebSocket flow. Component structure and state management are detailed in the [Frontend Architecture](./system-architecture-frontend.md).
 
 ```plaintext
 Client → Proxy/Gateway → Game Session Service → Game Logic Service / Entity & World services


### PR DESCRIPTION
## Summary
- add quick reference section to `user-journeys.md`
- mention frontend architecture in gameplay flow
- fix incorrect anchors in microservice docs
- update references to testing & CI/CD sections

## Testing
- `npx markdownlint-cli2 design/architecture/user-journeys.md design/architecture/system-architecture-testing.md design/architecture/system-architecture-cicd.md design/architecture/microservices/game-logic-service/README.md design/architecture/microservices/game-session-service/README.md design/architecture/microservices/spring-cloud-gateway/README.md design/architecture/microservices/tcp-proxy-service/README.md`
- `./gradlew -q lintMarkdown`
- `./gradlew -q check` *(failed: terminated after long output)*

------
https://chatgpt.com/codex/tasks/task_e_6873123a32408330a1843f305257e223