### PR TITLE
Run tests and adjust openapi lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "markdownlint-cli2": "^0.18.1"
   },
   "scripts": {
-    "openapi:lint": "npx @redocly/cli lint \"services/**/src/main/resources/openapi.yaml\""
+    "openapi:lint": "npx -y @redocly/cli lint \"services/**/src/main/resources/openapi.yaml\""
   }
 }


### PR DESCRIPTION
## Summary
- run CICD checks locally
- update openapi lint script to skip interactive prompt

## Testing
- `npm run lint`
- `npm run format -- -c`
- `npm run accessibility`
- `npx -y @redocly/cli lint "services/**/src/main/resources/openapi.yaml"`
- `./gradlew :common-library:check --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687311dd94b483309b9782d4c6978148