### PR TITLE
Update user journeys doc

### DIFF
--- a/design/architecture/README.md
+++ b/design/architecture/README.md
@@ -23,6 +23,7 @@ The architecture section describes the platform infrastructure and each microser
 - [**system-architecture-redis.md**](./system-architecture-redis.md) – Redis deployment topology and usage patterns.
 - [**system-architecture-gateway.md**](./system-architecture-gateway.md) – Spring Cloud Gateway routing and WebSocket support.
 - [**system-architecture-protocol-bridging.md**](./system-architecture-protocol-bridging.md) – Bridging Telnet and WebSocket clients.
+- [**system-architecture-mcp-support.md**](./system-architecture-mcp-support.md) – Mud Client Protocol integration for external editors.
 - [**system-architecture-reconnection.md**](./system-architecture-reconnection.md) – Client reconnect flow across services.
 - [**system-architecture-ticks.md**](./system-architecture-ticks.md) – Tick system and runtime design.
 - [**system-architecture-scripting.md**](./system-architecture-scripting.md) – Automation and scripting framework.

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -41,6 +41,7 @@ For step-by-step tooling instructions see the [Game Creator Guide](../user-guide
 ## 1. Sign Up
 
 Players register for an account through the [Account Service](./microservices/account-service/README.md). Email verification and login flows are outlined in [Authentication & Authorization](./system-architecture-authentication.md).
+Admins and moderators can enable **two-factor authentication** (TOTP) as described in the [Security Architecture](./system-architecture-security.md).
 
 ```plaintext
 Player → Account Service
@@ -211,6 +212,7 @@ through the [Account Service](./microservices/account-service/README.md),
 which issues password reset emails and temporary login tokens. Suspicious
 attempts are logged by the
 [Logging & Admin Service](./microservices/logging-admin-service/README.md).
+If two-factor authentication was enabled, the service validates the TOTP code before issuing a new password.
 
 ```plaintext
 Player → Account Service → Logging & Admin Service (audit)
@@ -289,6 +291,7 @@ FireMUD can be deployed locally using **Docker Compose** or to production via **
 
 1. **Local Development** – Run `./gradlew devUp` to start all services with Docker Compose. Configuration values are loaded from an `.env` file. See [Deployment Environments](./infrastructure/deployment-environments.md).
 2. **Production** – Kubernetes manifests load configuration through `ConfigMap` and `Secret` objects. Refer to [Environment & Secrets Management](./infrastructure/environment-and-secrets.md) for details.
+3. **Infrastructure Overview** – Shared networking and deployment patterns are summarized in [Infrastructure Overview](./infrastructure/README.md).
 
 ```plaintext
 Developer → Docker Compose / Kubernetes → Running Services


### PR DESCRIPTION
## Summary
- document optional two-factor authentication
- reference infrastructure overview
- link Mud Client Protocol doc in architecture README

## Testing
- `pre-commit run --files design/architecture/README.md design/architecture/user-journeys.md` *(fails: cannot find symbol Jwts.parserBuilder)*

------
https://chatgpt.com/codex/tasks/task_e_687317c6b128833099a1439bb9d8ec3d