### PR TITLE
Update JWT validation docs

### DIFF
--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -46,13 +46,13 @@ environments work out of the box.
 ### Filter Chain
 
 - Authentication, rate limiting, and logging filters run before routing.
-- `JwtAuthFilter` validates admin JWTs using `JwtUtil` from the common library.
+- `JwtAuthFilter` passes any provided JWT to backend admin services; validation occurs in those services.
 - WebSocket upgrades are handled with heartbeat and idle timeout logic.
 
 ### Key Routes
 
 - `/api/session/**` → Game Session Service (WebSocket and REST endpoints).
-- `/api/admin/**` → Logging & Admin Service with JWT authentication.
+- `/api/admin/**` → Logging & Admin Service (tokens are verified by the service).
 - `/api/design/**` → Game Design Service for content management.
 
 ## Dependencies

--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -44,7 +44,7 @@ This enables:
 
 ## 🧾 JWT Format and Role Claims
 
-Internal JWTs are issued by the Account Service and used for backend gRPC authorization. Gameplay clients **never** store or transmit tokens. Admin UIs may supply JWTs for optional validation at the Spring Cloud Gateway.
+Internal JWTs are issued by the Account Service and used for backend gRPC authorization. Gameplay clients **never** store or transmit tokens. Admin UIs may supply JWTs, which are validated by the Logging & Admin Service or other admin consumers. The Gateway and Game Session Service simply forward tokens without validation.
 
 ### 🧠 Claims
 

--- a/design/architecture/system-architecture-gateway.md
+++ b/design/architecture/system-architecture-gateway.md
@@ -10,7 +10,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 
 - Built as a Spring Boot microservice
 - Handles **client** request routing, filtering, CORS, rate limiting, retries, and monitoring
-- May validate JWTs for admin APIs (see [Authentication & Authorization](../system-architecture-authentication.md)). Gameplay login is processed by the **Game Session Service**; see [Authentication & Authorization](../system-architecture-authentication.md#-login-and-session-flow) for the detailed flow.
+- For admin APIs the Gateway forwards JWTs to backend services without validating them. Gameplay login is processed by the **Game Session Service**; see [Authentication & Authorization](../system-architecture-authentication.md#-login-and-session-flow) for the detailed flow.
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
@@ -68,8 +68,7 @@ This pattern ensures all real-time gameplay is unified through WebSocket on the 
 
 Spring Cloud Gateway provides centralized management of client traffic, offering:
 
-- Optional JWT validation for admin or REST endpoints (gameplay clients do not
-  provide JWTs)
+- JWTs presented on admin or REST endpoints are validated by the consuming service. Gameplay clients do not provide tokens.
 - Cross-cutting filters (e.g., rate limiting, logging, CORS)
 - Service isolation through route-based access control
 - Easy expansion of routes for new microservices

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -11,7 +11,7 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 - **TCP Proxy Service** accepts Telnet connections and upgrades them to WebSocket for the Gateway
 - **Consistent end-to-end WebSocket flow**: Telnet (TCP) → TCP Proxy Service (WebSocket upgrade) → Spring Cloud Gateway → Game Session Service
 - **All client traffic is routed through the Spring Cloud Gateway**, ensuring centralized **traffic routing, monitoring, and observability**. See [Gateway Architecture](./system-architecture-gateway.md) for deployment details and stateless behavior.
-   > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway may validate JWTs for admin endpoints, but gameplay clients connect without tokens. See [Authentication & Authorization](./system-architecture-authentication.md#-login-and-session-flow) for the full login flow.
+   > 🛑 **Gameplay login is handled by the Game Session Service** — the Gateway simply forwards any admin tokens. JWTs are validated by the admin or logging services themselves; gameplay clients connect without tokens. See [Authentication & Authorization](./system-architecture-authentication.md#-login-and-session-flow) for the full login flow.
 - **Telnet clients maintain sticky TCP connections only to the TCP Proxy Service**, which buffers **active input**, but **discards it across reconnects**
 - **Reconnection logic is handled in layers** to preserve gameplay continuity
 - **All internal service-to-service communication from the Game Session Service onward uses gRPC**, with strict schema enforcement and low latency

--- a/design/project-management/core-requirements.md
+++ b/design/project-management/core-requirements.md
@@ -127,7 +127,7 @@ This document outlines the **core functional and non-functional requirements** f
 - **WebSocket/TCP-based real-time networking** for low-latency gameplay.
 - **TCP Proxy Service** bridges legacy **Telnet** clients to WebSockets before reaching the Gateway.
 - **API Gateway** manages requests between microservices and handles external integrations.
-- **Gameplay login is handled by the Game Session Service**; the Gateway may validate JWTs for admin or REST endpoints, but gameplay clients connect without tokens.
+- **Gameplay login is handled by the Game Session Service**; any JWT on admin or REST endpoints is validated by the consuming service. The Gateway and Game Session Service do not validate tokens for gameplay.
 - **Internal microservices communicate over gRPC**, secured by **mTLS** certificates issued via Kubernetes.
 - **Cert-manager** provisions and rotates these certificates as **Kubernetes Secrets**.
 - Multi-server support enables **scaling hosted games separately**.


### PR DESCRIPTION
## Summary
- clarify that JWT validation occurs only in admin services
- remove references to gateway validation in architecture docs
- document token forwarding in gateway docs

## Testing
- `pre-commit run --files design/architecture/system-architecture-overview.md design/architecture/system-architecture-authentication.md design/architecture/system-architecture-gateway.md design/architecture/microservices/spring-cloud-gateway/README.md design/project-management/core-requirements.md` *(fails: Spotless build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68731969fd108330848080d819d8be13