### PR TITLE
Fix JWT parser builder API usage

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
@@ -30,9 +30,6 @@ public class JwtUtil {
   }
 
   public Jws<Claims> parseToken(String token) {
-    return Jwts.parserBuilder()
-        .setSigningKey(Keys.hmacShaKeyFor(key))
-        .build()
-        .parseClaimsJws(token);
+    return Jwts.parser().setSigningKey(Keys.hmacShaKeyFor(key)).build().parseClaimsJws(token);
   }
 }


### PR DESCRIPTION
## Summary
- fix JwtUtil to use Jwts.parser() with build() before parsing JWTs

## Testing
- `./gradlew :common-library:check`
- `./gradlew :account-service:check`

------
https://chatgpt.com/codex/tasks/task_e_6873189975cc83309e97b26037bb3ab5