### PR TITLE
Update design docs

### DIFF
--- a/design/architecture/microservices/game-design-service/ability-action-tools.md
+++ b/design/architecture/microservices/game-design-service/ability-action-tools.md
@@ -16,7 +16,7 @@ Game creators can build complex combat systems without modifying the core engine
 2. Designers can group related abilities into categories for organization.
 3. When a version is published, abilities are copied to the Game Logic Service using the `version_id`.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
 - [World Editing & Customization Tools](world-editing-tools.md)

--- a/design/architecture/microservices/game-design-service/game-templates.md
+++ b/design/architecture/microservices/game-design-service/game-templates.md
@@ -30,7 +30,7 @@ curl -X POST http://localhost:8080/templates \
 The service validates the payload and stores it in the `game_templates` table.
 Templates can then be listed per `tenantId` to help bootstrap new games.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Game Design Service Architecture](../../../design/architecture/microservices/game-design-service/README.md)
 - [Multi-Tenancy](../../../design/architecture/system-architecture-multi-tenancy.md)

--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -14,7 +14,7 @@ Game balance relies heavily on item statistics and equipment progression. This d
 2. Balancing views aggregate stats and show graphs for cost vs. power.
 3. Finalized changes are published as part of a game version and copied to the Entity Management Service.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
 - [World Editing & Customization Tools](world-editing-tools.md)

--- a/design/architecture/microservices/game-design-service/version-control.md
+++ b/design/architecture/microservices/game-design-service/version-control.md
@@ -18,7 +18,7 @@ Design assets are versioned to enable rollback and collaborative workflows. This
 - Patch notes are automatically generated from commit messages.
 - Downstream services continue to consume only published versions so runtime stability is preserved.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
 - [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)

--- a/design/architecture/microservices/game-design-service/web-visual-interface.md
+++ b/design/architecture/microservices/game-design-service/web-visual-interface.md
@@ -15,7 +15,7 @@ This document describes the planned **visual editing front end** for the Game De
 3. The visual scripting editor represents nodes and connections in JSON which maps directly to the Automation & Scripting Service DSL.
 4. Authentication relies on credentials exchanged with the Account Service. The resulting JWT is used internally for gRPC calls and is not stored in the browser. Requests include the `tenantId` to isolate data per project.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
 - [Asset Storage Setup](../../../../services/game-design-service/design/asset-storage.md)

--- a/design/architecture/microservices/game-design-service/world-editing-tools.md
+++ b/design/architecture/microservices/game-design-service/world-editing-tools.md
@@ -17,7 +17,7 @@ Game creators use these interfaces to craft rooms, items and NPCs without modify
 3. Revisions are grouped into a **version** and published via the saga workflow described in [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
 4. Downstream services load the data strictly by `version_id` so the design database is never queried at runtime.
 
-## Related Design
+## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
 - [System Architecture – Transactions](../system-architecture-transactions.md)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -70,6 +70,11 @@ Creators refine the world and its inhabitants using several services:
 - **Procedural Generation** – The [Automation & Scripting Service](./microservices/automation-scripting-service/README.md) provides dungeon seeds and templates. See [Procedural Generation](./system-architecture-procedural-generation.md).
 - **MCP Editing** – Connect external tools via the [Mud Client Protocol](./system-architecture-mcp-support.md) to automate room and NPC creation.
 - [Game Customization Options](./game-customization-options.md) covers themes and branding tweaks.
+- **World Editing Tools** – Use the [World Editing & Customization Tools](./microservices/game-design-service/world-editing-tools.md) for room and region editing.
+- **Ability & Action Tools** – Build combat mechanics with the [Ability & Action Design Tools](./microservices/game-design-service/ability-action-tools.md).
+- **Item & Equipment Balancing** – Tune gear progression in the [Item & Equipment Balancing Tools](./microservices/game-design-service/item-equipment-balancing.md).
+- **Visual Interface** – A [web-based visual editor](./microservices/game-design-service/web-visual-interface.md) provides drag-and-drop editing.
+- **Version Control & Templates** – [Version Control](./microservices/game-design-service/version-control.md) and [Game Templates](./microservices/game-design-service/game-templates.md) streamline collaboration and new projects.
 
 ```plaintext
 Game Design ↔ World Management ↔ Entity Management
@@ -353,6 +358,12 @@ These flows complement the architecture diagrams in [System Architecture Overvie
 - [Frontend Architecture](./system-architecture-frontend.md)
 - [Game Creator Guide](../user-guides/game-creator-guide.md)
 - [Game Customization Options](./game-customization-options.md)
+- [World Editing & Customization Tools](./microservices/game-design-service/world-editing-tools.md)
+- [Ability & Action Design Tools](./microservices/game-design-service/ability-action-tools.md)
+- [Item & Equipment Balancing Tools](./microservices/game-design-service/item-equipment-balancing.md)
+- [Web-Based Visual Design Interface](./microservices/game-design-service/web-visual-interface.md)
+- [Version Control](./microservices/game-design-service/version-control.md)
+- [Game Templates](./microservices/game-design-service/game-templates.md)
 - [Gateway Architecture](./system-architecture-gateway.md)
 - [gRPC API Style & Versioning Guidelines](./system-architecture-grpc.md)
 - [Infrastructure Overview](./infrastructure/README.md)


### PR DESCRIPTION
## Summary
- expand user-journeys with links to new design documents
- standardize 'Related Documentation' headers in Game Design Service docs

## Testing
- `pre-commit run --files design/architecture/user-journeys.md design/architecture/microservices/game-design-service/world-editing-tools.md design/architecture/microservices/game-design-service/ability-action-tools.md design/architecture/microservices/game-design-service/item-equipment-balancing.md design/architecture/microservices/game-design-service/version-control.md design/architecture/microservices/game-design-service/web-visual-interface.md design/architecture/microservices/game-design-service/game-templates.md` *(fails: compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_68731b27a9b88330b134b373f3502fdf