### PR TITLE
Add purchase saga workflow

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -256,6 +256,11 @@ so the workflow remains consistent across services. See the
 [Transaction Strategies](../system-architecture-transactions.md) document for
 details on the saga pattern.
 
+Purchase workflows (one-time payments or donations) reuse this same runner. The
+`PurchaseWorkflowService` creates the payment intent and then records the
+transaction with the Logging & Admin Service. Should the log step fail, the
+saga automatically refunds the Stripe payment via a compensation action.
+
 ### Metrics & Tracing
 
 Prometheus scrapes metrics from `/actuator/prometheus`. Service methods expose `account.*`, `payment.*`, `notification.*`, and `session.*` timers via `@Timed` annotations. OpenTelemetry spans are exported to the collector service so traces can be viewed in Jaeger. No additional configuration is required when running via `./gradlew bootRun` as the default properties target `http://otel-collector:4317`.

--- a/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -87,6 +87,18 @@ public class LoggingAdminClient implements AutoCloseable {
     stub.applyModerationAction(request);
   }
 
+  /** Log that a payment transaction occurred. */
+  public void logPayment(long tenantId, long accountId, long transactionId) {
+    ApplyModerationActionRequest request =
+        ApplyModerationActionRequest.newBuilder()
+            .setTenantId(Long.toString(tenantId))
+            .setAccountId(Long.toString(accountId))
+            .setAction("PAYMENT_TXN")
+            .setReason("txId=" + transactionId)
+            .build();
+    stub.applyModerationAction(request);
+  }
+
   @PreDestroy
   @Override
   public void close() throws IOException {

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/PurchaseRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/PurchaseRequest.java
@@ -1,0 +1,4 @@
+package net.firedevops.firemud.dto;
+
+/** Request to process a payment transaction using the saga workflow. */
+public record PurchaseRequest(Long tenantId, Long accountId, Long amountCents) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/PurchaseWorkflowService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/PurchaseWorkflowService.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.PaymentIntentDto;
+import net.firedevops.firemud.dto.PurchaseRequest;
+
+/** Saga-based workflow for processing purchases. */
+public interface PurchaseWorkflowService {
+  PaymentIntentDto processPurchase(PurchaseRequest request);
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PurchaseWorkflowServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PurchaseWorkflowServiceImpl.java
@@ -1,0 +1,64 @@
+package net.firedevops.firemud.service.impl;
+
+import io.micrometer.core.annotation.Timed;
+import net.firedevops.firemud.client.LoggingAdminClient;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.saga.SagaBuilder;
+import net.firedevops.firemud.common.saga.SagaException;
+import net.firedevops.firemud.common.saga.SagaRunner;
+import net.firedevops.firemud.dto.PaymentIntentDto;
+import net.firedevops.firemud.dto.PurchaseRequest;
+import net.firedevops.firemud.service.PaymentService;
+import net.firedevops.firemud.service.PurchaseWorkflowService;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Implements purchase workflows using SagaRunner. */
+@Service
+public class PurchaseWorkflowServiceImpl implements PurchaseWorkflowService {
+  private static final Logger logger = LoggingUtil.getLogger(PurchaseWorkflowServiceImpl.class);
+
+  private final PaymentService paymentService;
+  private final LoggingAdminClient loggingAdminClient;
+  private final SagaRunner sagaRunner;
+
+  public PurchaseWorkflowServiceImpl(
+      PaymentService paymentService, LoggingAdminClient loggingAdminClient, SagaRunner sagaRunner) {
+    this.paymentService = paymentService;
+    this.loggingAdminClient = loggingAdminClient;
+    this.sagaRunner = sagaRunner;
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "payment.purchase")
+  public PaymentIntentDto processPurchase(PurchaseRequest request) {
+    final PaymentIntentDto[] ref = new PaymentIntentDto[1];
+    SagaBuilder builder = new SagaBuilder("purchase");
+    builder
+        .step(
+            "createIntent",
+            () ->
+                ref[0] =
+                    paymentService.createPaymentIntent(
+                        request.tenantId(), request.accountId(), request.amountCents()),
+            () -> {
+              if (ref[0] != null) {
+                paymentService.refundPayment(request.tenantId(), ref[0].id());
+              }
+            })
+        .step(
+            "log",
+            () ->
+                loggingAdminClient.logPayment(
+                    request.tenantId(), request.accountId(), ref[0].id()));
+    try {
+      sagaRunner.run(builder.build());
+    } catch (SagaException e) {
+      logger.warn("Purchase saga failed", e);
+      throw new IllegalStateException("Purchase failed", e);
+    }
+    return ref[0];
+  }
+}

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PurchaseWorkflowServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/PurchaseWorkflowServiceImplTest.java
@@ -1,0 +1,48 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import net.firedevops.firemud.client.LoggingAdminClient;
+import net.firedevops.firemud.common.saga.SagaRunner;
+import net.firedevops.firemud.dto.PaymentIntentDto;
+import net.firedevops.firemud.dto.PurchaseRequest;
+import net.firedevops.firemud.service.PaymentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PurchaseWorkflowServiceImplTest {
+  @Mock private PaymentService paymentService;
+  @Mock private LoggingAdminClient loggingAdminClient;
+  @Mock private SagaRunner sagaRunner;
+
+  private PurchaseWorkflowServiceImpl service;
+
+  @BeforeEach
+  void setup() throws net.firedevops.firemud.common.saga.SagaException {
+    MockitoAnnotations.openMocks(this);
+    service = new PurchaseWorkflowServiceImpl(paymentService, loggingAdminClient, sagaRunner);
+    doAnswer(
+            inv -> {
+              ((net.firedevops.firemud.common.saga.Saga) inv.getArgument(0)).run();
+              return null;
+            })
+        .when(sagaRunner)
+        .run(any());
+  }
+
+  @Test
+  void processPurchaseRunsSaga() throws Exception {
+    when(paymentService.createPaymentIntent(1L, 2L, 100L))
+        .thenReturn(new PaymentIntentDto(5L, 1L, 2L, 100L, 5L, "USD", "secret", false));
+
+    PurchaseRequest req = new PurchaseRequest(1L, 2L, 100L);
+    PaymentIntentDto dto = service.processPurchase(req);
+
+    assertEquals(5L, dto.id());
+    verify(loggingAdminClient).logPayment(1L, 2L, 5L);
+    verify(sagaRunner).run(any());
+  }
+}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
@@ -30,9 +30,6 @@ public class JwtUtil {
   }
 
   public Jws<Claims> parseToken(String token) {
-    return Jwts.parserBuilder()
-        .setSigningKey(Keys.hmacShaKeyFor(key))
-        .build()
-        .parseClaimsJws(token);
+    return Jwts.parser().setSigningKey(Keys.hmacShaKeyFor(key)).build().parseClaimsJws(token);
   }
 }


### PR DESCRIPTION
## Summary
- implement purchase saga using SagaRunner
- log payment transactions via LoggingAdminClient
- update design docs to describe purchase workflow
- adjust JwtUtil for jjwt 0.12 API
- add unit test for purchase saga service

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68731b3de6908330b483e754e90f9957