### PR TITLE
Fix tenantId term in JWT docs

### DIFF
--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -52,15 +52,15 @@ Internal JWTs are issued by the Account Service and used for backend gRPC author
 |---------------|-------------------------------------------------------------------------|
 | `accountId`   | Identity of the authenticated account                                   |
 | `globalRoles` | Cross-game privileges (e.g., `platformAdmin`, `moderator`)              |
-| `scopedRoles` | Map of `gameId` → roles (e.g., `"game-abc": ["admin", "designer"]`)     |
+| `scopedRoles` | Map of `tenantId` (game ID) → roles (e.g., `"tenant-abc": ["admin", "designer"]`)     |
 
 ### 🧾 Example JWT Payload
 
 - `accountId`: `"user-123"`
 - `globalRoles`: `["moderator"]`
 - `scopedRoles`:
-  - `"game-abc"` → `["admin", "designer"]`
-  - `"game-def"` → `["moderator"]`
+  - `"tenant-abc"` → `["admin", "designer"]`
+  - `"tenant-def"` → `["moderator"]`
 
 > Tokens are short-lived and internal only. Gameplay context (e.g., `playerId`, `worldId`) is stored in Redis and sent via command envelopes.
 


### PR DESCRIPTION
## Summary
- fix inconsistent term for scoped roles in `system-architecture-authentication.md`

## Testing
- `./gradlew check` *(fails: spotlessJavaCheck formatting violations)*

------
https://chatgpt.com/codex/tasks/task_e_68732216bc0c8330bb5591d7eaa88c60