### PR TITLE
Resolve env/secrets mismatches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Logs and temporary files
 *.log
 .DS_Store
+certs/
 
 # Gradle Wrapper
 **/build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,8 +155,13 @@ tasks.register("buildDockerImages") {
     )
 }
 
+tasks.register<Exec>("generateDevCerts") {
+    workingDir("dev-tools")
+    commandLine("bash", "generate-dev-certs.sh")
+}
+
 tasks.register<Exec>("devUp") {
-    dependsOn("buildDockerImages")
+    dependsOn("generateDevCerts", "buildDockerImages")
     commandLine("docker", "compose", "up", "--build")
 }
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import net.firedevops.firemud.security.GrpcJwtAuthInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,6 +37,9 @@ public class GrpcConfig {
     return new TracingInterceptor(tracer);
   }
 
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
+
   @Bean
   @GRpcGlobalInterceptor
   public GrpcJwtAuthInterceptor grpcJwtAuthInterceptor(
@@ -46,7 +50,7 @@ public class GrpcConfig {
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -11,12 +11,16 @@ import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /** Registers global gRPC interceptors for logging, metrics and tracing. */
 @Configuration
 public class GrpcConfig {
+
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
 
   @Bean
   @GRpcGlobalInterceptor
@@ -39,7 +43,7 @@ public class GrpcConfig {
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -13,6 +13,7 @@ import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import net.firedevops.firemud.common.security.AuthTokenInterceptor;
 import net.firedevops.firemud.common.security.JwtUtil;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,6 +39,9 @@ public class GrpcConfig {
     return new TracingInterceptor(tracer);
   }
 
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
+
   @Bean
   @GRpcGlobalInterceptor
   public AuthTokenInterceptor authTokenInterceptor(JwtUtil jwtUtil) {
@@ -47,7 +51,7 @@ public class GrpcConfig {
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();

--- a/services/game-logic-service/src/main/resources/application.yml
+++ b/services/game-logic-service/src/main/resources/application.yml
@@ -32,7 +32,6 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
-    jwt-secret: changemechangemechangeme123456
     jwt-expiration-ms: 3600000
 
 server:

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -11,12 +11,16 @@ import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /** Configuration for gRPC interceptors and OpenTelemetry. */
 @Configuration
 public class GrpcConfig {
+
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
 
   @Bean
   @GRpcGlobalInterceptor
@@ -39,7 +43,7 @@ public class GrpcConfig {
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -13,11 +13,15 @@ import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import net.firedevops.firemud.common.security.AuthTokenInterceptor;
 import net.firedevops.firemud.common.security.JwtUtil;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class GrpcConfig {
+
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
 
   @Bean
   @GRpcGlobalInterceptor
@@ -46,7 +50,7 @@ public class GrpcConfig {
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -11,6 +11,7 @@ import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -35,10 +36,13 @@ public class GrpcConfig {
     return new TracingInterceptor(tracer);
   }
 
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
+
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();

--- a/services/social-groups-service/src/main/resources/application.yml
+++ b/services/social-groups-service/src/main/resources/application.yml
@@ -24,7 +24,6 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
-    jwt-secret: changemechangemechangeme123456
     jwt-expiration-ms: 3600000
   voice:
     token-expiration-ms: 300000

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -71,8 +71,7 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:classpath:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:classpath:certs/ca.crt}
   auth:
-    jwt-secret: changeit-changeit-changeit-changeit
-
+    # Leave secret empty in dev so AuthConfig generates a random value
 ---
 
 spring:

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -11,12 +11,16 @@ import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /** Configuration for gRPC interceptors and OpenTelemetry tracing. */
 @Configuration
 public class GrpcConfig {
+
+  @Value("${otel.endpoint:http://otel-collector:4317}")
+  private String otelEndpoint;
 
   @Bean
   @GRpcGlobalInterceptor
@@ -39,7 +43,7 @@ public class GrpcConfig {
   @Bean
   public OpenTelemetry openTelemetry() {
     OtlpGrpcSpanExporter exporter =
-        OtlpGrpcSpanExporter.builder().setEndpoint("http://otel-collector:4317").build();
+        OtlpGrpcSpanExporter.builder().setEndpoint(otelEndpoint).build();
     SdkTracerProvider provider =
         SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
     return OpenTelemetrySdk.builder().setTracerProvider(provider).build();


### PR DESCRIPTION
## Summary
- generate dev certs automatically when running `./gradlew devUp`
- ignore generated certs
- remove hard-coded JWT secrets from dev configs
- allow overriding OTEL collector endpoint in remaining services

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68731ef741948330a2650881a6a6b5ba