### PR TITLE
Enable gRPC keepalive and compression

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
@@ -67,12 +68,17 @@ public class LoggingAdminClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = LoggingAdminServiceGrpc.newBlockingStub(channel);
+    stub = LoggingAdminServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Log that a new account was created. */

--- a/services/account-service/src/main/resources/application-prod.yml
+++ b/services/account-service/src/main/resources/application-prod.yml
@@ -12,6 +12,11 @@ spring:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -13,6 +13,11 @@ spring:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/automation-scripting-service/src/main/resources/application-prod.yml
+++ b/services/automation-scripting-service/src/main/resources/application-prod.yml
@@ -29,6 +29,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -30,6 +30,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
@@ -30,9 +30,6 @@ public class JwtUtil {
   }
 
   public Jws<Claims> parseToken(String token) {
-    return Jwts.parserBuilder()
-        .setSigningKey(Keys.hmacShaKeyFor(key))
-        .build()
-        .parseClaimsJws(token);
+    return Jwts.parser().setSigningKey(Keys.hmacShaKeyFor(key)).build().parseClaimsJws(token);
   }
 }

--- a/services/entity-management-service/src/main/resources/application-prod.yml
+++ b/services/entity-management-service/src/main/resources/application-prod.yml
@@ -24,6 +24,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/entity-management-service/src/main/resources/application.yml
+++ b/services/entity-management-service/src/main/resources/application.yml
@@ -25,6 +25,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/client/AutomationScriptingClient.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/client/AutomationScriptingClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.automationscripting.v1.AutomationScriptingServiceGrpc;
 import net.firedevops.firemud.automationscripting.v1.NotifyScriptVersionUpdateRequest;
@@ -67,12 +68,17 @@ public class AutomationScriptingClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = AutomationScriptingServiceGrpc.newBlockingStub(channel);
+    stub = AutomationScriptingServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Notify the Automation service that a new script patch version is active. */

--- a/services/game-design-service/src/main/resources/application-prod.yml
+++ b/services/game-design-service/src/main/resources/application-prod.yml
@@ -24,6 +24,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/game-design-service/src/main/resources/application.yml
+++ b/services/game-design-service/src/main/resources/application.yml
@@ -25,6 +25,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/game-logic-service/src/main/resources/application-prod.yml
+++ b/services/game-logic-service/src/main/resources/application-prod.yml
@@ -18,6 +18,11 @@ management:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/game-logic-service/src/main/resources/application.yml
+++ b/services/game-logic-service/src/main/resources/application.yml
@@ -19,6 +19,11 @@ management:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
@@ -5,6 +5,7 @@ import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.config.GrpcClientProperties;
@@ -21,7 +22,8 @@ public class EntityManagementClient implements AutoCloseable {
   private ManagedChannel channel;
   private EntityManagementServiceGrpc.EntityManagementServiceBlockingStub stub;
 
-  public EntityManagementClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+  public EntityManagementClient(
+      ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
     this.tlsProps = tlsProps;
   }
@@ -40,8 +42,14 @@ public class EntityManagementClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
-    stub = EntityManagementServiceGrpc.newBlockingStub(channel);
+    channel =
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
+    stub = EntityManagementServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Simple ping to verify connectivity. */

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
@@ -64,12 +65,17 @@ public class GameLogicClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = GameLogicServiceGrpc.newBlockingStub(channel);
+    stub = GameLogicServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Simple ping to verify connectivity. */

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
@@ -5,12 +5,13 @@ import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import jakarta.annotation.PostConstruct;
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.config.GrpcClientProperties;
-import net.firedevops.firemud.worldmanagement.v1.WorldManagementServiceGrpc;
 import net.firedevops.firemud.worldmanagement.v1.PingRequest;
 import net.firedevops.firemud.worldmanagement.v1.PingResponse;
+import net.firedevops.firemud.worldmanagement.v1.WorldManagementServiceGrpc;
 import org.springframework.stereotype.Component;
 
 /** gRPC client for the World Management Service. */
@@ -21,7 +22,8 @@ public class WorldManagementClient implements AutoCloseable {
   private ManagedChannel channel;
   private WorldManagementServiceGrpc.WorldManagementServiceBlockingStub stub;
 
-  public WorldManagementClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
+  public WorldManagementClient(
+      ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = endpoints;
     this.tlsProps = tlsProps;
   }
@@ -40,8 +42,14 @@ public class WorldManagementClient implements AutoCloseable {
             .trustManager(new File(tlsProps.getCaCert()))
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
-    channel = NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
-    stub = WorldManagementServiceGrpc.newBlockingStub(channel);
+    channel =
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
+    stub = WorldManagementServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Simple ping to verify connectivity. */

--- a/services/game-session-service/src/main/resources/application-prod.yml
+++ b/services/game-session-service/src/main/resources/application-prod.yml
@@ -31,3 +31,11 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+grpc:
+  server:
+    port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -30,3 +30,11 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+grpc:
+  server:
+    port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.account.v1.AccountServiceGrpc;
 import net.firedevops.firemud.account.v1.DeleteAccountRequest;
@@ -67,12 +68,17 @@ public class AccountClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = AccountServiceGrpc.newBlockingStub(channel);
+    stub = AccountServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Permanently delete the account. */

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
@@ -69,12 +70,17 @@ public class GameSessionClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = GameSessionServiceGrpc.newBlockingStub(channel);
+    stub = GameSessionServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Simple ping to verify connectivity. */

--- a/services/logging-admin-service/src/main/resources/application-prod.yml
+++ b/services/logging-admin-service/src/main/resources/application-prod.yml
@@ -24,6 +24,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/logging-admin-service/src/main/resources/application.yml
+++ b/services/logging-admin-service/src/main/resources/application.yml
@@ -25,6 +25,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -8,6 +8,7 @@ import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
@@ -68,12 +69,17 @@ public class LoggingAdminClient implements AutoCloseable {
                 new java.io.File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = ReportServiceGrpc.newBlockingStub(channel);
+    stub = ReportServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /**

--- a/services/social-groups-service/src/main/resources/application-prod.yml
+++ b/services/social-groups-service/src/main/resources/application-prod.yml
@@ -53,3 +53,11 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+grpc:
+  server:
+    port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip

--- a/services/social-groups-service/src/main/resources/application.yml
+++ b/services/social-groups-service/src/main/resources/application.yml
@@ -54,3 +54,11 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+grpc:
+  server:
+    port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
@@ -64,6 +69,11 @@ spring:
               maxBackoff: 500ms
               factor: 2
               basedOnPreviousValue: false
+      httpclient:
+        pool:
+          type: fixed
+          maxConnections: 500
+          acquireTimeout: 5000
 
 firemud:
   grpc:
@@ -102,6 +112,11 @@ spring:
               maxBackoff: 500ms
               factor: 2
               basedOnPreviousValue: false
+      httpclient:
+        pool:
+          type: fixed
+          maxConnections: 500
+          acquireTimeout: 5000
 firemud:
   grpc:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}
@@ -115,4 +130,9 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+spring:
+  web:
+    resources:
+      cache:
+        period: 3600
 

--- a/services/tcp-proxy-service/src/main/resources/application-prod.yml
+++ b/services/tcp-proxy-service/src/main/resources/application-prod.yml
@@ -20,3 +20,11 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 1024
+grpc:
+  server:
+    port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip

--- a/services/tcp-proxy-service/src/main/resources/application.yml
+++ b/services/tcp-proxy-service/src/main/resources/application.yml
@@ -25,6 +25,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
@@ -67,12 +68,17 @@ public class GameDesignClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = GameDesignServiceGrpc.newBlockingStub(channel);
+    stub = GameDesignServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Returns published versions for the given game. */

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import net.firedevops.firemud.common.config.ServiceEndpointsProperties;
 import net.firedevops.firemud.common.grpc.TlsCertificateWatcher;
@@ -67,12 +68,17 @@ public class GameSessionClient implements AutoCloseable {
             .keyManager(new File(tlsProps.getCertChain()), new File(tlsProps.getPrivateKey()))
             .build();
     ManagedChannel newChannel =
-        NettyChannelBuilder.forAddress(host, port).sslContext(sslContext).build();
+        NettyChannelBuilder.forAddress(host, port)
+            .sslContext(sslContext)
+            .keepAliveTime(30, TimeUnit.SECONDS)
+            .keepAliveTimeout(5, TimeUnit.SECONDS)
+            .keepAliveWithoutCalls(true)
+            .build();
     if (channel != null) {
       channel.shutdown();
     }
     channel = newChannel;
-    stub = GameSessionServiceGrpc.newBlockingStub(channel);
+    stub = GameSessionServiceGrpc.newBlockingStub(channel).withCompression("gzip");
   }
 
   /** Simple ping to verify connectivity. */

--- a/services/world-management-service/src/main/resources/application-prod.yml
+++ b/services/world-management-service/src/main/resources/application-prod.yml
@@ -31,6 +31,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}

--- a/services/world-management-service/src/main/resources/application.yml
+++ b/services/world-management-service/src/main/resources/application.yml
@@ -32,6 +32,11 @@ server:
 grpc:
   server:
     port: 6565
+    enableKeepAlive: true
+    keepAliveTime: 30s
+    keepAliveTimeout: 5s
+    permitKeepAliveWithoutCalls: true
+    compression: gzip
     security:
       enabled: true
       certificateChainPath: ${FIREMUD_GRPC_CERT_CHAIN_PATH:classpath:certs/client.crt}


### PR DESCRIPTION
## Summary
- enable keep-alive and gzip compression on gRPC servers
- compress gRPC clients and set keep-alive
- add HTTP client pooling and static resource caching for the gateway
- fix JwtUtil for jjwt API

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68731ddfd68883309960268dbaf40fad