### PR TITLE
Clarify Chrome requirement for accessibility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 - **Unit Testing**: JUnit, Mockito
 - **Integration Testing**: Spring Test
 - **Load Testing**: Gatling
-- **Accessibility Audit**: axe-core CLI (requires Google Chrome)
+- **Accessibility Audit**: axe-core CLI (requires Google Chrome).
+  To run the audit locally, install Chrome as described in
+  [Developer Setup](DEVELOPER_SETUP.md#frontend-lint--accessibility)
+  before executing `npm run accessibility`.
 
 ### Design Goals
 


### PR DESCRIPTION
## Summary
- add note about installing Chrome before running the accessibility audit

## Testing
- `npm run accessibility`

------
https://chatgpt.com/codex/tasks/task_e_687327d5b9088330b16e4badd822998a