### PR TITLE
Document service-specific env vars

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -123,6 +123,14 @@ and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-con
 variables to access its databases.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables tune the scripting engine:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `SCRIPT_QUOTA_LIMIT` | Number of events a script may process per window | `50` |
+| `SCRIPT_QUOTA_WINDOWSECONDS` | Length of the quota window in seconds | `60` |
+| `AUTOMATION_TICK_DURATION_MS` | Duration of a processing tick in milliseconds | `1000` |
+
 ## Proto Files
 
 API definitions are located in

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -92,6 +92,18 @@ so the standard `FIREMUD_POSTGRES_*` and `FIREMUD_REDIS_*` variables may be pres
 but are ignored.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables control the proxy runtime behaviour:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `TCP_PROXY_PORT` | TCP port the proxy listens on | `2323` |
+| `GATEWAY_WS_URL` | WebSocket URL for forwarding to the gateway | `ws://spring-cloud-gateway:8080/ws` |
+| `TCP_PROXY_TLS_ENABLED` | Enable Telnet-over-TLS termination | `false` |
+| `TCP_PROXY_TLS_CERT` | Path to the TLS certificate | *(empty)* |
+| `TCP_PROXY_TLS_KEY` | Path to the TLS private key | *(empty)* |
+| `TCP_PROXY_MAX_CONNECTIONS_PER_IP` | Maximum concurrent connections per client IP | `5` |
+| `TCP_PROXY_MAX_MSGS_PER_SEC` | Allowed messages per second per client | `5` |
+
 ## Metrics & Tracing
 
 Metrics are exposed at `/actuator/prometheus` and scraped by Prometheus. The

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -104,6 +104,14 @@ It depends on the [PostgreSQL credentials](../../infrastructure/environment-and-
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables configure world data caching and sharding:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| `WORLD_LOCAL_SHARD_ID` | Numeric identifier for this shard instance | `0` |
+| `WORLD_ROOM_CACHE_TTL_SECONDS` | Seconds to retain room data in the cache | `60` |
+| `WORLD_INSTANCE_EXPIRATION_HOURS` | Hours before a transient instance expires | `24` |
+
 ## Proto Files
 
 The gRPC contract for world operations is located in


### PR DESCRIPTION
## Summary
- document TCP Proxy service variables
- document Automation Scripting service variables
- document World Management service variables

## Testing
- `./gradlew check` *(fails: spotlessJavaCheck)*

------
https://chatgpt.com/codex/tasks/task_e_687327ebfc4083308767d8c78ced28ce