### PR TITLE
Implement pagination on list endpoints

### DIFF
--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -9,8 +9,8 @@ These notes summarize typical optimizations applied across FireMUD services.
   asset tables). Additional indexes should be added where missing.
 - Avoid N+1 queries using JPA entity graphs or join fetches. The Entity
   Management service uses `@EntityGraph` for inventory lookups.
-- Prefer pagination for large result sets. **TODO:** current endpoints generally
-  return full lists.
+- Prefer pagination for large result sets. Most REST controllers now accept
+  `Pageable` parameters and return `Page<Dto>` responses.
 
 - Use Spring Cache backed by Redis for expensive queries. The Entity Management
   service caches character inventory graphs and the World Management service

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
@@ -1,12 +1,13 @@
 package net.firedevops.firemud.controller;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AddFriendRequest;
 import net.firedevops.firemud.dto.CharacterFriendDto;
 import net.firedevops.firemud.service.FriendService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,9 +19,9 @@ public class FriendController {
   private final FriendService friendService;
 
   @GetMapping
-  public ResponseEntity<ApiResponse<List<CharacterFriendDto>>> list(
-      @PathVariable Long characterId) {
-    List<CharacterFriendDto> list = friendService.listFriends(characterId);
+  public ResponseEntity<ApiResponse<Page<CharacterFriendDto>>> list(
+      @PathVariable Long characterId, Pageable pageable) {
+    Page<CharacterFriendDto> list = friendService.listFriends(characterId, pageable);
     return ResponseEntity.ok(ApiResponse.success(list));
   }
 

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/CharacterFriendRepository.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/repository/CharacterFriendRepository.java
@@ -1,13 +1,14 @@
 package net.firedevops.firemud.repository;
 
-import java.util.List;
 import net.firedevops.firemud.entity.CharacterFriend;
 import net.firedevops.firemud.entity.CharacterFriendKey;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CharacterFriendRepository
     extends JpaRepository<CharacterFriend, CharacterFriendKey> {
-  List<CharacterFriend> findByIdCharacterId(Long characterId);
+  Page<CharacterFriend> findByIdCharacterId(Long characterId, Pageable pageable);
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/FriendService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/FriendService.java
@@ -1,10 +1,11 @@
 package net.firedevops.firemud.service;
 
-import java.util.List;
 import net.firedevops.firemud.dto.CharacterFriendDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface FriendService {
-  List<CharacterFriendDto> listFriends(Long characterId);
+  Page<CharacterFriendDto> listFriends(Long characterId, Pageable pageable);
 
   CharacterFriendDto addFriend(Long characterId, Long friendId);
 

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
@@ -1,7 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
 import java.time.Instant;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.dto.CharacterFriendDto;
 import net.firedevops.firemud.entity.Character;
@@ -11,6 +10,8 @@ import net.firedevops.firemud.mapper.CharacterFriendMapper;
 import net.firedevops.firemud.repository.CharacterFriendRepository;
 import net.firedevops.firemud.repository.CharacterRepository;
 import net.firedevops.firemud.service.FriendService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,8 +24,8 @@ public class FriendServiceImpl implements FriendService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<CharacterFriendDto> listFriends(Long characterId) {
-    return repository.findByIdCharacterId(characterId).stream().map(mapper::toDto).toList();
+  public Page<CharacterFriendDto> listFriends(Long characterId, Pageable pageable) {
+    return repository.findByIdCharacterId(characterId, pageable).map(mapper::toDto);
   }
 
   @Override

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/controller/GameTemplateController.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/controller/GameTemplateController.java
@@ -1,11 +1,12 @@
 package net.firedevops.firemud.controller;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.GameTemplateDto;
 import net.firedevops.firemud.service.GameTemplateService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,8 +29,9 @@ public class GameTemplateController {
   }
 
   @GetMapping
-  public ResponseEntity<ApiResponse<List<GameTemplateDto>>> list(@RequestParam Long tenantId) {
-    List<GameTemplateDto> templates = templateService.listTemplates(tenantId);
+  public ResponseEntity<ApiResponse<Page<GameTemplateDto>>> list(
+      @RequestParam Long tenantId, Pageable pageable) {
+    Page<GameTemplateDto> templates = templateService.listTemplates(tenantId, pageable);
     return ResponseEntity.ok(ApiResponse.success(templates));
   }
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameTemplateRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/repository/GameTemplateRepository.java
@@ -1,8 +1,12 @@
 package net.firedevops.firemud.repository;
 
 import net.firedevops.firemud.entity.GameTemplate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GameTemplateRepository extends JpaRepository<GameTemplate, Long> {}
+public interface GameTemplateRepository extends JpaRepository<GameTemplate, Long> {
+  Page<GameTemplate> findByTenantId(Long tenantId, Pageable pageable);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/GameTemplateService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/GameTemplateService.java
@@ -1,10 +1,11 @@
 package net.firedevops.firemud.service;
 
-import java.util.List;
 import net.firedevops.firemud.dto.GameTemplateDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface GameTemplateService {
   GameTemplateDto createTemplate(GameTemplateDto dto);
 
-  List<GameTemplateDto> listTemplates(Long tenantId);
+  Page<GameTemplateDto> listTemplates(Long tenantId, Pageable pageable);
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameTemplateServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameTemplateServiceImpl.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.service.impl;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.dto.GameTemplateDto;
@@ -9,6 +8,8 @@ import net.firedevops.firemud.mapper.GameTemplateMapper;
 import net.firedevops.firemud.repository.GameTemplateRepository;
 import net.firedevops.firemud.service.GameTemplateService;
 import org.slf4j.Logger;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,10 +32,7 @@ public class GameTemplateServiceImpl implements GameTemplateService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<GameTemplateDto> listTemplates(Long tenantId) {
-    return repository.findAll().stream()
-        .filter(t -> t.getTenantId().equals(tenantId))
-        .map(mapper::toDto)
-        .toList();
+  public Page<GameTemplateDto> listTemplates(Long tenantId, Pageable pageable) {
+    return repository.findByTenantId(tenantId, pageable).map(mapper::toDto);
   }
 }

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
@@ -10,6 +10,9 @@ import net.firedevops.firemud.entity.GameTemplate;
 import net.firedevops.firemud.mapper.GameTemplateMapper;
 import net.firedevops.firemud.repository.GameTemplateRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 class GameTemplateServiceImplTest {
   @Test
@@ -34,9 +37,10 @@ class GameTemplateServiceImplTest {
     GameTemplate template = new GameTemplate();
     template.setId(1L);
     template.setTenantId(1L);
-    when(repo.findAll()).thenReturn(List.of(template));
+    Page<GameTemplate> page = new PageImpl<>(List.of(template));
+    when(repo.findByTenantId(1L, PageRequest.of(0, 20))).thenReturn(page);
     when(mapper.toDto(template)).thenReturn(new GameTemplateDto(1L, 1L, "name", null, "{}", null));
-    List<GameTemplateDto> result = service.listTemplates(1L);
-    assertEquals(1, result.size());
+    Page<GameTemplateDto> result = service.listTemplates(1L, PageRequest.of(0, 20));
+    assertEquals(1, result.getTotalElements());
   }
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/controller/GenerationRuleController.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/controller/GenerationRuleController.java
@@ -1,10 +1,11 @@
 package net.firedevops.firemud.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.GenerationRuleDto;
 import net.firedevops.firemud.service.GenerationRuleService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,8 +27,9 @@ public class GenerationRuleController {
   }
 
   @GetMapping
-  public ResponseEntity<ApiResponse<List<GenerationRuleDto>>> list(@RequestParam Long tenantId) {
-    List<GenerationRuleDto> list = generationRuleService.listRules(tenantId);
+  public ResponseEntity<ApiResponse<Page<GenerationRuleDto>>> list(
+      @RequestParam Long tenantId, Pageable pageable) {
+    Page<GenerationRuleDto> list = generationRuleService.listRules(tenantId, pageable);
     return ResponseEntity.ok(ApiResponse.success(list));
   }
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/repository/GenerationRuleRepository.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/repository/GenerationRuleRepository.java
@@ -1,11 +1,12 @@
 package net.firedevops.firemud.repository;
 
-import java.util.List;
 import net.firedevops.firemud.entity.GenerationRule;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GenerationRuleRepository extends JpaRepository<GenerationRule, Long> {
-  List<GenerationRule> findByTenantId(Long tenantId);
+  Page<GenerationRule> findByTenantId(Long tenantId, Pageable pageable);
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/GenerationRuleService.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/GenerationRuleService.java
@@ -1,10 +1,11 @@
 package net.firedevops.firemud.service;
 
-import java.util.List;
 import net.firedevops.firemud.dto.GenerationRuleDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface GenerationRuleService {
   GenerationRuleDto saveRule(GenerationRuleDto dto);
 
-  List<GenerationRuleDto> listRules(Long tenantId);
+  Page<GenerationRuleDto> listRules(Long tenantId, Pageable pageable);
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/GenerationRuleServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/GenerationRuleServiceImpl.java
@@ -1,12 +1,13 @@
 package net.firedevops.firemud.service.impl;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.dto.GenerationRuleDto;
 import net.firedevops.firemud.entity.GenerationRule;
 import net.firedevops.firemud.mapper.GenerationRuleMapper;
 import net.firedevops.firemud.repository.GenerationRuleRepository;
 import net.firedevops.firemud.service.GenerationRuleService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +27,7 @@ public class GenerationRuleServiceImpl implements GenerationRuleService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<GenerationRuleDto> listRules(Long tenantId) {
-    return repository.findByTenantId(tenantId).stream().map(mapper::toDto).toList();
+  public Page<GenerationRuleDto> listRules(Long tenantId, Pageable pageable) {
+    return repository.findByTenantId(tenantId, pageable).map(mapper::toDto);
   }
 }

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/GenerationRuleServiceImplTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/GenerationRuleServiceImplTest.java
@@ -11,6 +11,9 @@ import net.firedevops.firemud.repository.GenerationRuleRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 class GenerationRuleServiceImplTest {
   private GenerationRuleRepository repository;
@@ -44,9 +47,10 @@ class GenerationRuleServiceImplTest {
     rule.setTenantId(1L);
     rule.setName("max_rooms");
     rule.setValue("10");
-    when(repository.findByTenantId(1L)).thenReturn(List.of(rule));
-    List<GenerationRuleDto> result = service.listRules(1L);
-    assertEquals(1, result.size());
-    assertEquals("max_rooms", result.get(0).name());
+    Page<GenerationRule> page = new PageImpl<>(List.of(rule));
+    when(repository.findByTenantId(1L, PageRequest.of(0, 20))).thenReturn(page);
+    Page<GenerationRuleDto> result = service.listRules(1L, PageRequest.of(0, 20));
+    assertEquals(1, result.getTotalElements());
+    assertEquals("max_rooms", result.getContent().get(0).name());
   }
 }


### PR DESCRIPTION
## Summary
- enable pageable results on friend, game template, and generation rule listings
- update tests for pagination
- clarify pagination guidance in performance docs

## Testing
- `./gradlew test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68732e3101d883308e302412b472bc95