### PR TITLE
Add Redis performance metrics

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.service.impl;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
@@ -33,6 +34,9 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   private Counter enqueueCounter;
   private Counter redisErrorCounter;
   private Timer tickTimer;
+  private Timer luaTimer;
+  private java.util.concurrent.atomic.AtomicInteger retryQueueDepth =
+      new java.util.concurrent.atomic.AtomicInteger();
   private RedisScript<Long> stageScript;
   private RedisScript<Long> commitScript;
   private RedisScript<Long> rollbackScript;
@@ -42,6 +46,12 @@ public class ScriptTickServiceImpl implements ScriptTickService {
     enqueueCounter = meterRegistry.counter("automation_tick_events_enqueued_total");
     redisErrorCounter = meterRegistry.counter("automation_tick_redis_errors_total");
     tickTimer = meterRegistry.timer("automation_tick_duration_ms");
+    luaTimer = meterRegistry.timer("automation_lua_latency_ms");
+    Gauge.builder(
+            "automation_retry_queue_depth",
+            retryQueueDepth,
+            java.util.concurrent.atomic.AtomicInteger::get)
+        .register(meterRegistry);
     ResourceScriptSource commitSrc =
         new ResourceScriptSource(new ClassPathResource("redis/tick_commit.lua"));
     ResourceScriptSource stageSrc =
@@ -75,23 +85,37 @@ public class ScriptTickServiceImpl implements ScriptTickService {
     }
     try {
       Long pending = redisTemplate.opsForList().size(pendingKey(tenantId, scriptId));
+      retryQueueDepth.set(pending != null ? pending.intValue() : 0);
       if (pending != null && pending > 0) {
         logger.info("Replaying {} pending events for {}:{}", pending, tenantId, scriptId);
         tickTimer.record(
-            () -> redisTemplate.execute(commitScript, List.of(pendingKey(tenantId, scriptId))));
+            () ->
+                luaTimer.record(
+                    () ->
+                        redisTemplate.execute(
+                            commitScript, List.of(pendingKey(tenantId, scriptId)))));
       }
       tickTimer.record(
           () ->
-              redisTemplate.execute(
-                  stageScript,
-                  List.of(queueKey(tenantId, scriptId), pendingKey(tenantId, scriptId))));
+              luaTimer.record(
+                  () ->
+                      redisTemplate.execute(
+                          stageScript,
+                          List.of(queueKey(tenantId, scriptId), pendingKey(tenantId, scriptId)))));
       tickTimer.record(
-          () -> redisTemplate.execute(commitScript, List.of(pendingKey(tenantId, scriptId))));
+          () ->
+              luaTimer.record(
+                  () ->
+                      redisTemplate.execute(
+                          commitScript, List.of(pendingKey(tenantId, scriptId)))));
     } catch (Exception ex) {
       redisErrorCounter.increment();
       logger.error("Script tick failed, rolling back", ex);
-      redisTemplate.execute(
-          rollbackScript, List.of(pendingKey(tenantId, scriptId), queueKey(tenantId, scriptId)));
+      luaTimer.record(
+          () ->
+              redisTemplate.execute(
+                  rollbackScript,
+                  List.of(pendingKey(tenantId, scriptId), queueKey(tenantId, scriptId))));
     } finally {
       redisTemplate.delete(lockKey);
     }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
@@ -1,6 +1,9 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.service.TickLockService;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,16 +15,28 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TickLockServiceImpl implements TickLockService {
   private final StringRedisTemplate redisTemplate;
+  private final MeterRegistry meterRegistry;
+
+  private Counter lockContentionCounter;
 
   @Value("${game.tick-duration-ms:1000}")
   private long tickDurationMs;
+
+  @PostConstruct
+  void initMetrics() {
+    lockContentionCounter = meterRegistry.counter("tick_lock_contention_total");
+  }
 
   @Override
   public boolean acquireLock(Long tenantId, Long entityId) {
     String key = lockKey(tenantId, entityId);
     Boolean result =
         redisTemplate.opsForValue().setIfAbsent(key, "1", Duration.ofMillis(tickDurationMs));
-    return Boolean.TRUE.equals(result);
+    boolean acquired = Boolean.TRUE.equals(result);
+    if (!acquired) {
+      lockContentionCounter.increment();
+    }
+    return acquired;
   }
 
   @Override

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickLockServiceImplTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickLockServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class TickLockServiceImplTest {
   private StringRedisTemplate redisTemplate;
   private ValueOperations<String, String> valueOps;
+  private SimpleMeterRegistry meterRegistry;
   private TickLockServiceImpl service;
 
   @BeforeEach
@@ -24,7 +26,9 @@ class TickLockServiceImplTest {
     redisTemplate = mock(StringRedisTemplate.class);
     valueOps = mock(ValueOperations.class);
     when(redisTemplate.opsForValue()).thenReturn(valueOps);
-    service = new TickLockServiceImpl(redisTemplate);
+    meterRegistry = new SimpleMeterRegistry();
+    service = new TickLockServiceImpl(redisTemplate, meterRegistry);
+    service.initMetrics();
     ReflectionTestUtils.setField(service, "tickDurationMs", 1000L);
   }
 
@@ -36,5 +40,15 @@ class TickLockServiceImplTest {
     service.releaseLock(1L, 2L);
 
     verify(redisTemplate).delete("tick:lock:1:2");
+  }
+
+  @Test
+  void lockContentionIncrementsMetric() {
+    when(valueOps.setIfAbsent(eq("tick:lock:1:2"), eq("1"), any(Duration.class))).thenReturn(false);
+
+    service.acquireLock(1L, 2L);
+
+    org.junit.jupiter.api.Assertions.assertEquals(
+        1.0, meterRegistry.get("tick_lock_contention_total").counter().count(), 0.001);
   }
 }

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
@@ -9,17 +9,16 @@ import net.firedevops.firemud.entity.GameTemplate;
 import net.firedevops.firemud.mapper.GameTemplateMapper;
 import net.firedevops.firemud.repository.GameTemplateRepository;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
 import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 
 class GameTemplateServiceImplTest {
   @Test
   void listTemplatesReturnsPage() {
     GameTemplateRepository repo = Mockito.mock(GameTemplateRepository.class);
-    GameTemplateMapper mapper = Mappers.getMapper(GameTemplateMapper.class);
+    GameTemplateMapper mapper = Mockito.mock(GameTemplateMapper.class);
     GameTemplateServiceImpl service = new GameTemplateServiceImpl(repo, mapper);
 
     GameTemplate template = new GameTemplate();

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.service.impl;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
@@ -32,6 +33,9 @@ public class TickServiceImpl implements TickService {
   private Counter enqueueCounter;
   private Counter redisErrorCounter;
   private Timer tickTimer;
+  private Timer luaTimer;
+  private java.util.concurrent.atomic.AtomicInteger retryQueueDepth =
+      new java.util.concurrent.atomic.AtomicInteger();
   private RedisScript<Long> stageScript;
   private RedisScript<Long> commitScript;
   private RedisScript<Long> rollbackScript;
@@ -41,6 +45,12 @@ public class TickServiceImpl implements TickService {
     this.enqueueCounter = meterRegistry.counter("game_session_commands_enqueued_total");
     this.redisErrorCounter = meterRegistry.counter("game_session_redis_errors_total");
     this.tickTimer = meterRegistry.timer("game_session_tick_duration_ms");
+    this.luaTimer = meterRegistry.timer("game_session_lua_latency_ms");
+    Gauge.builder(
+            "game_session_retry_queue_depth",
+            retryQueueDepth,
+            java.util.concurrent.atomic.AtomicInteger::get)
+        .register(meterRegistry);
     ResourceScriptSource commitSrc =
         new ResourceScriptSource(new ClassPathResource("redis/tick_commit.lua"));
     ResourceScriptSource stageSrc =
@@ -70,19 +80,31 @@ public class TickServiceImpl implements TickService {
     }
     try {
       Long pending = redisTemplate.opsForList().size(pendingKey(sessionId));
+      retryQueueDepth.set(pending != null ? pending.intValue() : 0);
       if (pending != null && pending > 0) {
         logger.info("Replaying {} pending commands for {}", pending, sessionId);
-        tickTimer.record(() -> redisTemplate.execute(commitScript, List.of(pendingKey(sessionId))));
+        tickTimer.record(
+            () ->
+                luaTimer.record(
+                    () -> redisTemplate.execute(commitScript, List.of(pendingKey(sessionId)))));
       }
       tickTimer.record(
           () ->
-              redisTemplate.execute(
-                  stageScript, List.of(queueKey(sessionId), pendingKey(sessionId))));
-      tickTimer.record(() -> redisTemplate.execute(commitScript, List.of(pendingKey(sessionId))));
+              luaTimer.record(
+                  () ->
+                      redisTemplate.execute(
+                          stageScript, List.of(queueKey(sessionId), pendingKey(sessionId)))));
+      tickTimer.record(
+          () ->
+              luaTimer.record(
+                  () -> redisTemplate.execute(commitScript, List.of(pendingKey(sessionId)))));
     } catch (Exception ex) {
       redisErrorCounter.increment();
       logger.error("Tick processing failed, rolling back", ex);
-      redisTemplate.execute(rollbackScript, List.of(pendingKey(sessionId), queueKey(sessionId)));
+      luaTimer.record(
+          () ->
+              redisTemplate.execute(
+                  rollbackScript, List.of(pendingKey(sessionId), queueKey(sessionId))));
     } finally {
       redisTemplate.delete(lockKey);
     }


### PR DESCRIPTION
## Summary
- track lock contention via TickLockServiceImpl
- record Lua latency and retry queue depth in tick services
- update tests for metrics and GameTemplateServiceImpl

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68733476f7f8833099586ae302462702