### PR TITLE
Improve user journeys docs

### DIFF
--- a/design/architecture/microservices/game-design-service/modding-framework.md
+++ b/design/architecture/microservices/game-design-service/modding-framework.md
@@ -2,7 +2,7 @@
 
 This document sketches the planned modding system that allows administrators to extend a published game without republishing a full version.
 
-## Goals
+## 🎯 Goals
 
 - Enable runtime loading of approved plugins written in the same scripting DSL used for automation.
 - Provide a secure sandbox so plugins cannot access unauthorized data or system resources.
@@ -19,3 +19,4 @@ This document sketches the planned modding system that allows administrators to 
 
 - [Automation & Scripting Service](../automation-scripting-service/README.md)
 - [Game Design Service Architecture](README.md)
+- [User Journeys – Extensibility & External Tools](../user-journeys.md#21-extensibility--external-tools)

--- a/design/architecture/system-architecture-mcp-support.md
+++ b/design/architecture/system-architecture-mcp-support.md
@@ -2,7 +2,7 @@
 
 This document outlines how FireMUD will incorporate the Mud Client Protocol (MCP) to enable richer tooling for AI-assisted game creation.
 
-## Goals
+## 🎯 Goals
 
 - Allow editors and automated tools to communicate with the server using structured MCP messages.
 - Enable scripted workflows where the AI can create rooms, items, and NPCs via standardized commands.
@@ -26,3 +26,4 @@ Future enhancements will include bulk import and transaction support for batch c
 - [Game Design Service](./microservices/game-design-service/README.md)
 - [TCP Proxy Service](./microservices/tcp-proxy-service/README.md)
 - [Modding Framework](./microservices/game-design-service/modding-framework.md)
+- [User Journeys – Extensibility & External Tools](./user-journeys.md#21-extensibility--external-tools)

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -1,9 +1,9 @@
 # 🔄 FireMUD User Journeys
 
-This document outlines common flows for creators and players when interacting with the platform. Each step references the microservice responsible for that portion of the journey.
-It complements the [System Architecture Overview](./system-architecture-overview.md) and [System Context Diagram](./system-context-diagram.md) to show how users traverse the overall platform.
+This guide summarizes typical workflows for creators and players. Each numbered step links to the microservice or design document that manages that portion of the flow.
+Use it alongside the [System Architecture Overview](./system-architecture-overview.md) and [System Context Diagram](./system-context-diagram.md) to understand how users traverse the platform.
 For a breakdown of every service see the [Microservices Overview](./microservices/README.md) and the [Service Responsibility Matrix](./service-responsibility-matrix.md).
-For step-by-step tooling instructions see the [Game Creator Guide](../user-guides/game-creator-guide.md).
+Detailed tooling instructions live in the [Game Creator Guide](../user-guides/game-creator-guide.md).
 
 ## 🎯 Goals
 


### PR DESCRIPTION
## Summary
- enhance intro for `user-journeys.md`
- standardize Goals headings with emoji
- link modding framework and MCP docs back to user journeys

## Testing
- `pre-commit run --files design/architecture/user-journeys.md design/architecture/microservices/game-design-service/modding-framework.md design/architecture/system-architecture-mcp-support.md` *(fails: markdownlint line length)*

------
https://chatgpt.com/codex/tasks/task_e_6873332d4be48330aa31e093b5aeb36e