### PR TITLE
Add Velero backups

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -162,6 +162,16 @@ Run `dev-tools/firemud-cli.sh` for shortcuts:
 ./dev-tools/firemud-cli.sh ping # test a running service
 ```
 
+### Backing Up the Local Database
+
+Use `dev-tools/backup-db.sh` to create a snapshot and
+`dev-tools/restore-db.sh` to restore one:
+
+```bash
+./dev-tools/backup-db.sh             # writes to ./backups
+./dev-tools/restore-db.sh backups/<file>
+```
+
 ## Manual Testing Tools
 
 ### Insomnia for REST and WebSocket

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -11,6 +11,7 @@ This document defines the backup schedule and disaster recovery procedures for F
   - **24 hours** of 15‑minute snapshots
   - **3 weekly** snapshots
   - **3 monthly** snapshots
+- Example Velero schedules are provided in `k8s/velero/schedule.yaml`.
 - If the database service fails completely:
   1. Restore the latest snapshot.
   2. Restart services to resume operation.
@@ -32,7 +33,7 @@ This document defines the backup schedule and disaster recovery procedures for F
 
 ## 🐳 Local Development
 
-- Backups are restored manually using `pg_restore` from local snapshot files.
+- Backups are restored using `dev-tools/restore-db.sh` with a snapshot file.
 - Services are restarted with **Docker Compose**.
 - Redis starts empty and repopulates when services access the database.
 
@@ -43,7 +44,7 @@ This document defines the backup schedule and disaster recovery procedures for F
 | Environment      | Steps |
 |------------------|-------------------------------------------------------------|
 | **Kubernetes**   | Restore PostgreSQL via Velero → restore other resources → restart pods → allow Redis to repopulate |
-| **Docker Compose** | `pg_restore` local backup → restart containers → Redis repopulates automatically |
+| **Docker Compose** | `dev-tools/restore-db.sh` snapshot → restart containers → Redis repopulates automatically |
 
 Redis always uses AOF for crash recovery during runtime but is **never** restored from backup images. Gameplay resumes after services restart and Redis repopulates from PostgreSQL.
 

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -40,6 +40,9 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      ```
 
    - Restart dependent services with `kubectl rollout restart`.
+   - For local development, run `dev-tools/restore-db.sh <backup-file>` and then
+     restart containers with `docker compose restart`.
+   - Scheduled backups are defined in `k8s/velero/schedule.yaml`.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/dev-tools/backup-db.sh
+++ b/dev-tools/backup-db.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Creates a PostgreSQL backup using pg_dump.
+set -euo pipefail
+
+BACKUP_DIR=${1:-backups}
+mkdir -p "$BACKUP_DIR"
+
+FILE="$BACKUP_DIR/firemud_$(date +%Y%m%d%H%M%S).dump"
+
+pg_dump -h "${FIREMUD_POSTGRES_HOST:-localhost}" \
+        -U "${FIREMUD_POSTGRES_USER:-firemud}" \
+        -d "${FIREMUD_POSTGRES_DB:-firemud}" \
+        -Fc -f "$FILE"
+
+echo "Backup saved to $FILE"

--- a/dev-tools/restore-db.sh
+++ b/dev-tools/restore-db.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Restores a PostgreSQL backup created by backup-db.sh.
+set -euo pipefail
+
+FILE=${1:?"Usage: restore-db.sh <backup-file>"}
+
+pg_restore -h "${FIREMUD_POSTGRES_HOST:-localhost}" \
+           -U "${FIREMUD_POSTGRES_USER:-firemud}" \
+           -d "${FIREMUD_POSTGRES_DB:-firemud}" \
+           --clean "$FILE"
+
+echo "Database restored from $FILE"

--- a/k8s/terraform-production/main.tf
+++ b/k8s/terraform-production/main.tf
@@ -36,3 +36,18 @@ resource "helm_release" "redis" {
   namespace  = var.namespace
   values     = [file("${path.module}/redis-values.yaml")]
 }
+
+resource "helm_release" "velero" {
+  name       = "velero"
+  repository = "https://vmware-tanzu.github.io/helm-charts"
+  chart      = "velero"
+  namespace  = var.namespace
+  set {
+    name  = "configuration.provider"
+    value = var.velero_provider
+  }
+  set {
+    name  = "configuration.backupStorageLocation.name"
+    value = var.velero_bucket
+  }
+}

--- a/k8s/terraform-production/variables.tf
+++ b/k8s/terraform-production/variables.tf
@@ -8,3 +8,13 @@ variable "namespace" {
   type        = string
   default     = "firemud"
 }
+
+variable "velero_provider" {
+  description = "Velero object storage provider (e.g., aws, gcp)"
+  type        = string
+}
+
+variable "velero_bucket" {
+  description = "Velero backup bucket name"
+  type        = string
+}

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -1,0 +1,13 @@
+# Velero Backups
+
+This directory contains Kubernetes manifests for installing Velero and scheduling PostgreSQL backups for the FireMUD cluster.
+
+The `schedule.yaml` file defines three backup schedules matching the retention policy described in the architecture docs.
+
+Apply the manifests with:
+
+```bash
+kubectl apply -f schedule.yaml -n velero
+```
+
+Ensure Velero is installed and configured with access to your object storage bucket prior to applying the schedule.

--- a/k8s/velero/schedule.yaml
+++ b/k8s/velero/schedule.yaml
@@ -1,0 +1,32 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: firemud-postgres-15m
+spec:
+  schedule: "*/15 * * * *"
+  template:
+    includedNamespaces:
+    - firemud
+    ttl: 24h
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: firemud-postgres-weekly
+spec:
+  schedule: "0 2 * * 0"
+  template:
+    includedNamespaces:
+    - firemud
+    ttl: 504h # 21 days
+---
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: firemud-postgres-monthly
+spec:
+  schedule: "0 3 1 * *"
+  template:
+    includedNamespaces:
+    - firemud
+    ttl: 2160h # 90 days

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameTemplateServiceImplTest.java
@@ -11,8 +11,8 @@ import net.firedevops.firemud.repository.GameTemplateRepository;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 
 class GameTemplateServiceImplTest {


### PR DESCRIPTION
## Summary
- document backup scripts in developer docs
- add Velero schedule manifests and Terraform release
- include helper scripts for backing up/restoring Postgres
- note Velero schedules and local restore steps in docs
- fix missing import in GameTemplateServiceImplTest

## Testing
- `./gradlew :game-design-service:compileTestJava`
- `./gradlew check` *(failed: spotbugs warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6873325114508330af6f779bb4a469aa