### PR TITLE
Update OTEL env var docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,4 +11,4 @@ FIREMUD_GRPC_PRIVATE_KEY_PATH=certs/client.key
 FIREMUD_GRPC_CA_CERT_PATH=certs/ca.crt
 
 SPRING_PROFILES_ACTIVE=dev
-otel.endpoint=http://otel-collector:4317
+OTEL_ENDPOINT=http://otel-collector:4317

--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -113,11 +113,13 @@ FIREMUD_SERVICES_LOGGING_ADMIN_SERVICE=logging-admin-service:6565
 
 ### Observability
 
-All services export OpenTelemetry spans. The collector endpoint can be overridden with:
+All services export OpenTelemetry spans. The collector endpoint can be
+overridden with the `OTEL_ENDPOINT` environment variable (mapped to the
+Spring property `otel.endpoint`):
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `otel.endpoint` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
+| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 
 ### Additional Notes
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -108,7 +108,8 @@ Additional variables control the proxy runtime behaviour:
 
 Metrics are exposed at `/actuator/prometheus` and scraped by Prometheus. The
 service exports OpenTelemetry spans to the collector defined by the
-`otel.endpoint` property so traces appear in Jaeger.
+`OTEL_ENDPOINT` environment variable (Spring property `otel.endpoint`) so
+traces appear in Jaeger.
 
 ## Proto Files
 


### PR DESCRIPTION
## Summary
- use `OTEL_ENDPOINT` environment variable in the env/secrets guide
- adjust tcp-proxy service docs for `OTEL_ENDPOINT`
- update `.env.sample`

## Testing
- `./gradlew check` *(fails: JVM garbage collector thrashing)*

------
https://chatgpt.com/codex/tasks/task_e_68733d1852448330a1d068913dc87657