### PR TITLE
Automate Velero schedule and ensure stateless Redis

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -11,7 +11,8 @@ This document defines the backup schedule and disaster recovery procedures for F
   - **24 hours** of 15‑minute snapshots
   - **3 weekly** snapshots
   - **3 monthly** snapshots
-- Example Velero schedules are provided in `k8s/velero/schedule.yaml`.
+- Velero backup schedules are installed automatically by the
+  production Terraform modules using `k8s/velero/schedule.yaml`.
 - If the database service fails completely:
   1. Restore the latest snapshot.
   2. Restart services to resume operation.

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -42,7 +42,8 @@ For local development, use `./gradlew devUp` to start Docker Compose.
    - Restart dependent services with `kubectl rollout restart`.
    - For local development, run `dev-tools/restore-db.sh <backup-file>` and then
      restart containers with `docker compose restart`.
-   - Scheduled backups are defined in `k8s/velero/schedule.yaml`.
+   - Scheduled backups are created automatically by the Terraform modules using
+     `k8s/velero/schedule.yaml`.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,6 @@ services:
       - .env
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     volumes:
-      - redis-data:/data
       - ./config/redis.conf:/usr/local/etc/redis/redis.conf:ro
     ports:
       - "6379:6379"
@@ -210,4 +209,3 @@ services:
 
 volumes:
   postgres-data:
-  redis-data:

--- a/k8s/terraform-production/main.tf
+++ b/k8s/terraform-production/main.tf
@@ -51,3 +51,13 @@ resource "helm_release" "velero" {
     value = var.velero_bucket
   }
 }
+
+locals {
+  velero_schedule_docs = split("\n---\n", file("${path.module}/../velero/schedule.yaml"))
+}
+
+resource "kubernetes_manifest" "velero_schedule" {
+  for_each  = { for idx, doc in local.velero_schedule_docs : idx => yamldecode(doc) }
+  manifest  = each.value
+  depends_on = [helm_release.velero]
+}


### PR DESCRIPTION
## Summary
- remove redis volume so data is ephemeral
- note that Velero backup schedules are installed by Terraform
- update runbook to mention automatic schedules
- apply Velero schedules via Terraform

## Testing
- `./gradlew check` *(fails: process killed due to resource constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68733d01849483308ae2d66e6e0106eb