### PR TITLE
Standardize env var doc sections

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -92,6 +92,12 @@ and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-con
 variables.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables specific to this service:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| *(none)* | This service relies only on the shared configuration variables. | *(none)* |
+
 ## Proto Files
 
 Service interface definitions are stored in

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -99,6 +99,12 @@ This service relies on the [PostgreSQL credentials](../../infrastructure/environ
 Redis variables are not used.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables specific to this service:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| *(none)* | This service relies only on the shared configuration variables. | *(none)* |
+
 ## Proto Files
 
 The service API contract resides in

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -94,6 +94,12 @@ It requires the [PostgreSQL credentials](../../infrastructure/environment-and-se
 and [Redis connection](../../infrastructure/environment-and-secrets.md#redis-connection).
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables specific to this service:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| *(none)* | This service relies only on the shared configuration variables. | *(none)* |
+
 ## Proto Files
 
 gRPC service definitions can be found in

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -108,6 +108,12 @@ It relies on the [PostgreSQL credentials](../../infrastructure/environment-and-s
 Redis variables are not required.
 TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC_PRIVATE_KEY_PATH`, `FIREMUD_GRPC_CA_CERT_PATH`](../../infrastructure/environment-and-secrets.md#grpc-tls-certificates). Peer services can be discovered using variables prefixed `FIREMUD_SERVICES_`.
 
+Additional variables specific to this service:
+
+| Variable | Purpose | Default |
+| -------- | ------- | ------- |
+| *(none)* | This service relies only on the shared configuration variables. | *(none)* |
+
 ## Saga Dashboard
 
 The service exposes `/sagas` and `/sagas/{id}/steps` endpoints for operators to inspect


### PR DESCRIPTION
## Summary
- standardize environment variable sections across service docs under `design`

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6873422e8a9883308c1484099ba6a5ed