### PR TITLE
Enable Redis AOF and add restore helper

### DIFF
--- a/dev-tools/restore-cluster.sh
+++ b/dev-tools/restore-cluster.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Restore a FireMUD Kubernetes cluster from a Velero backup and restart services.
+set -euo pipefail
+
+BACKUP_NAME=${1:?"Usage: restore-cluster.sh <backup-name>"}
+NAMESPACE=${FIREMUD_K8S_NAMESPACE:-firemud}
+
+# Restore the backup and wait for completion
+velero restore create --from-backup "$BACKUP_NAME" --wait
+
+# Restart all deployments and statefulsets to ensure they pick up restored volumes
+kubectl rollout restart deployment -n "$NAMESPACE"
+kubectl rollout restart statefulset -n "$NAMESPACE"
+
+echo "Cluster restored from $BACKUP_NAME and services restarted"

--- a/k8s/terraform-production/redis-values.yaml
+++ b/k8s/terraform-production/redis-values.yaml
@@ -7,3 +7,12 @@ replica:
   persistence:
     enabled: true
     size: 8Gi
+commonConfiguration: |-
+  # Enable AOF persistence for crash recovery
+  appendonly yes
+  appendfsync everysec
+  # Disable RDB snapshots as only AOF is required
+  save ""
+  # Manage AOF growth via automatic rewrite
+  auto-aof-rewrite-percentage 100
+  auto-aof-rewrite-min-size 64mb


### PR DESCRIPTION
## Summary
- enable AOF persistence in Kubernetes Redis values
- add `restore-cluster.sh` for Velero restore automation

## Testing
- `pre-commit run --files dev-tools/restore-cluster.sh k8s/terraform-production/redis-values.yaml` *(failed: command not found)*
- `pip install pre-commit`
- `pre-commit run --files dev-tools/restore-cluster.sh k8s/terraform-production/redis-values.yaml` *(interrupted)*
- `./gradlew check` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6873434bb4e883309ed2e18497da4e43