### PR TITLE
Remove ERD section from migrations doc

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -27,10 +27,6 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 
 Migrations are therefore applied consistently in every environment without manual steps.
 
-### ERD Diagrams
-
-CI runs `dev-tools/generate-erd.sh` after tests complete to create database diagrams. The script concatenates each service's migrations, converts them to DBML via `@dbml/cli`, and uploads the output as build artifacts.
-
 ---
 
 ## 📚 Related Documentation


### PR DESCRIPTION
## Summary
- remove ERD diagram info from database migrations guide because it's covered elsewhere

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6873495471d083308dd312aa17907965