### PR TITLE
Align room cache TTL property

### DIFF
--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
@@ -10,6 +10,16 @@ public class WorldProperties {
   /** Identifier of the shard this service instance hosts. */
   private int localShardId = 0;
 
-  /** TTL in seconds for room cache entries. */
-  private long roomCacheTtlSeconds = 60;
+  /** Properties related to room behaviour. */
+  private Room room = new Room();
+
+  @Data
+  public static class Room {
+    /** TTL in seconds for room cache entries. */
+    private long cacheTtlSeconds = 60;
+  }
+
+  public Room getRoom() {
+    return room;
+  }
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RoomServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RoomServiceImpl.java
@@ -36,7 +36,7 @@ public class RoomServiceImpl implements RoomService {
   void initMetrics() {
     cacheHitCounter = meterRegistry.counter("room_cache_hits_total");
     cacheMissCounter = meterRegistry.counter("room_cache_misses_total");
-    cacheTtlSeconds = worldProperties.getRoomCacheTtlSeconds();
+    cacheTtlSeconds = worldProperties.getRoom().getCacheTtlSeconds();
   }
 
   @Override

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/RoomServiceImplTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/RoomServiceImplTest.java
@@ -32,10 +32,10 @@ class RoomServiceImplTest {
     valueOps = mock(ValueOperations.class);
     when(redisTemplate.opsForValue()).thenReturn(valueOps);
     props = new WorldProperties();
+    props.getRoom().setCacheTtlSeconds(1);
     service =
         new RoomServiceImpl(repository, mapper, redisTemplate, new SimpleMeterRegistry(), props);
     service.initMetrics();
-    service.setCacheTtlSeconds(1);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- fix WorldProperties to load nested `world.room.cache-ttl-seconds` property
- adjust RoomServiceImpl and its test to use new nested property

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6873427ca6a083308d6e8e5ca3513249