### PR TITLE
Implement character cache TTL

### DIFF
--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/config/CacheConfig.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/config/CacheConfig.java
@@ -1,5 +1,7 @@
 package net.firedevops.firemud.config;
 
+import java.time.Duration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,15 +14,19 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 /** Configures Spring Cache to use Redis for entity graph caching. */
 @Configuration
 @EnableCaching
+@EnableConfigurationProperties(EntityCacheProperties.class)
 public class CacheConfig {
 
   @Bean
-  public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
-    RedisCacheConfiguration config =
+  public RedisCacheManager cacheManager(
+      RedisConnectionFactory factory, EntityCacheProperties properties) {
+    RedisCacheConfiguration defaultConfig =
         RedisCacheConfiguration.defaultCacheConfig()
             .serializeValuesWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(
-                    new GenericJackson2JsonRedisSerializer()));
-    return RedisCacheManager.builder(factory).cacheDefaults(config).build();
+                    new GenericJackson2JsonRedisSerializer()))
+            .entryTtl(Duration.ofSeconds(properties.getCharacterGraphTtlSeconds()));
+
+    return RedisCacheManager.builder(factory).cacheDefaults(defaultConfig).build();
   }
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/config/EntityCacheProperties.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/config/EntityCacheProperties.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Configuration for entity cache settings. */
+@Data
+@ConfigurationProperties(prefix = "entity.cache")
+public class EntityCacheProperties {
+  /** TTL in seconds for the characterGraph cache. */
+  private long characterGraphTtlSeconds = 60;
+}

--- a/services/entity-management-service/src/main/resources/application-prod.yml
+++ b/services/entity-management-service/src/main/resources/application-prod.yml
@@ -41,3 +41,6 @@ firemud:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
+entity:
+  cache:
+    character-graph-ttl-seconds: ${FIREMUD_CHARACTER_CACHE_TTL_SECONDS:60}

--- a/services/entity-management-service/src/main/resources/application.yml
+++ b/services/entity-management-service/src/main/resources/application.yml
@@ -42,3 +42,6 @@ firemud:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
+entity:
+  cache:
+    character-graph-ttl-seconds: 60

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/CacheConfigTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/CacheConfigTest.java
@@ -1,0 +1,30 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import net.firedevops.firemud.config.CacheConfig;
+import net.firedevops.firemud.config.EntityCacheProperties;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/** Unit tests for {@link CacheConfig}. */
+class CacheConfigTest {
+  @Test
+  void characterGraphCacheUsesConfiguredTtl() {
+    CacheConfig config = new CacheConfig();
+    EntityCacheProperties props = new EntityCacheProperties();
+    props.setCharacterGraphTtlSeconds(5);
+    RedisConnectionFactory factory = Mockito.mock(RedisConnectionFactory.class);
+
+    RedisCacheManager manager = config.cacheManager(factory, props);
+    // trigger initialization
+    manager.getCache("characterGraph");
+    RedisCacheConfiguration cfg = manager.getCacheConfigurations().get("characterGraph");
+
+    assertEquals(Duration.ofSeconds(5), cfg.getTtl());
+  }
+}


### PR DESCRIPTION
## Summary
- configure TTL for the characterGraph cache in entity-management-service
- expose `EntityCacheProperties` to make TTL configurable
- update `application.yml` and `application-prod.yml`
- add unit test `CacheConfigTest`

## Testing
- `./gradlew :entity-management-service:test --tests CacheConfigTest`
- `./gradlew check --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6873427ca6a083308d6e8e5ca3513249