### PR TITLE
Implement JWT secret hot reload

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -94,6 +94,7 @@ environment variables while development instances generate random secrets.
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
 | `FIREMUD_AUTH_JWT_SECRET` | HMAC signing key for JWTs | *(none)* |
+| `FIREMUD_AUTH_JWT_SECRET_PATH` | Path to a file containing the JWT secret; enables hot reload | *(none)* |
 | `FIREMUD_AUTH_JWT_EXPIRATION_MS` | Lifetime of issued JWTs in milliseconds | `3600000` |
 | `FIREMUD_AUTH_SESSION_EXPIRATION_MS` | Server-side session TTL in milliseconds | `3600000` |
 

--- a/design/architecture/system-architecture-security.md
+++ b/design/architecture/system-architecture-security.md
@@ -18,7 +18,7 @@ seamlessly with cert-manager for automatic rotation.
 ### Key and Certificate Rotation
 
 - cert-manager issues both JWT signing keys and mTLS certificates, backed by an internal CA.
-- All services poll their mounted secrets for updates and support **hot reload** of keys and certificates.
+- All services poll their mounted secrets for updates and support **hot reload** of keys and certificates. JWT secrets can be mounted from a file defined by `FIREMUD_AUTH_JWT_SECRET_PATH` so that rotation occurs without restarts.
 - During rotation, services cache both current and previous credentials to allow for **seamless transition**.
 - JWKS is updated automatically to reflect the current public keyset.
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,9 +1,15 @@
 package net.firedevops.firemud.config;
 
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.security.JwtSecretWatcher;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.ReloadableJwtUtil;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -15,13 +21,14 @@ import org.springframework.core.env.Environment;
 public class AuthConfig {
   private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
   private final Environment environment;
+  private JwtSecretWatcher watcher;
 
   public AuthConfig(Environment environment) {
     this.environment = environment;
   }
 
   @Bean
-  public JwtUtil jwtUtil(AuthProperties props) {
+  public JwtUtil jwtUtil(AuthProperties props) throws IOException {
     String secret = props.getJwtSecret();
     if (secret == null || secret.isBlank()) {
       boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
@@ -35,6 +42,29 @@ public class AuthConfig {
         throw new IllegalStateException("firemud.auth.jwt-secret must be set");
       }
     }
-    return new JwtUtil(secret, props.getJwtExpirationMs());
+    ReloadableJwtUtil util = new ReloadableJwtUtil(secret, props.getJwtExpirationMs());
+    String path = props.getJwtSecretPath();
+    if (path != null && !path.isBlank()) {
+      Path p = Path.of(path);
+      Runnable reload =
+          () -> {
+            try {
+              String newSecret = Files.readString(p).trim();
+              util.updateSecret(newSecret);
+            } catch (IOException e) {
+              logger.error("Failed to reload JWT secret", e);
+            }
+          };
+      reload.run();
+      watcher = JwtSecretWatcher.createAndStart(p, reload);
+    }
+    return util;
+  }
+
+  @PreDestroy
+  public void close() throws Exception {
+    if (watcher != null) {
+      watcher.close();
+    }
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "firemud.auth")
 public class AuthProperties {
   private String jwtSecret;
+  private String jwtSecretPath;
   private long jwtExpirationMs;
   private long sessionExpirationMs = 3600000L;
 }

--- a/services/account-service/src/main/resources/application-prod.yml
+++ b/services/account-service/src/main/resources/application-prod.yml
@@ -30,6 +30,7 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
   auth:
+    jwt-secret-path: ${FIREMUD_AUTH_JWT_SECRET_PATH:}
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
     jwt-expiration-ms: ${FIREMUD_AUTH_JWT_EXPIRATION_MS:3600000}
     session-expiration-ms: ${FIREMUD_AUTH_SESSION_EXPIRATION_MS:3600000}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,9 +1,15 @@
 package net.firedevops.firemud.config;
 
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.security.JwtSecretWatcher;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.ReloadableJwtUtil;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -15,13 +21,14 @@ import org.springframework.core.env.Environment;
 public class AuthConfig {
   private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
   private final Environment environment;
+  private JwtSecretWatcher watcher;
 
   public AuthConfig(Environment environment) {
     this.environment = environment;
   }
 
   @Bean
-  public JwtUtil jwtUtil(AuthProperties props) {
+  public JwtUtil jwtUtil(AuthProperties props) throws IOException {
     String secret = props.getJwtSecret();
     if (secret == null || secret.isBlank()) {
       boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
@@ -35,6 +42,29 @@ public class AuthConfig {
         throw new IllegalStateException("firemud.auth.jwt-secret must be set");
       }
     }
-    return new JwtUtil(secret, props.getJwtExpirationMs());
+    ReloadableJwtUtil util = new ReloadableJwtUtil(secret, props.getJwtExpirationMs());
+    String path = props.getJwtSecretPath();
+    if (path != null && !path.isBlank()) {
+      Path p = Path.of(path);
+      Runnable reload =
+          () -> {
+            try {
+              String newSecret = Files.readString(p).trim();
+              util.updateSecret(newSecret);
+            } catch (IOException e) {
+              logger.error("Failed to reload JWT secret", e);
+            }
+          };
+      reload.run();
+      watcher = JwtSecretWatcher.createAndStart(p, reload);
+    }
+    return util;
+  }
+
+  @PreDestroy
+  public void close() throws Exception {
+    if (watcher != null) {
+      watcher.close();
+    }
   }
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -7,5 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "firemud.auth")
 public class AuthProperties {
   private String jwtSecret;
+  private String jwtSecretPath;
   private long jwtExpirationMs;
 }

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtSecretWatcher.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtSecretWatcher.java
@@ -1,0 +1,87 @@
+package net.firedevops.firemud.common.security;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.firedevops.firemud.common.LoggingUtil;
+import org.slf4j.Logger;
+
+/** Watches a JWT secret file and triggers a callback when it changes. */
+public class JwtSecretWatcher implements AutoCloseable {
+  private static final Logger logger = LoggingUtil.getLogger(JwtSecretWatcher.class);
+
+  private final WatchService watchService;
+  private final Path file;
+  private final Runnable onChange;
+  private final AtomicBoolean running = new AtomicBoolean(true);
+  private final Thread thread;
+
+  public static JwtSecretWatcher createAndStart(Path file, Runnable onChange) throws IOException {
+    JwtSecretWatcher watcher = new JwtSecretWatcher(file, onChange);
+    watcher.start();
+    return watcher;
+  }
+
+  @SuppressFBWarnings(value = "CT_CONSTRUCTOR_THROW", justification = "Thread started via start()")
+  public JwtSecretWatcher(Path file, Runnable onChange) throws IOException {
+    this.file = file.toAbsolutePath();
+    this.onChange = onChange;
+    this.watchService = FileSystems.getDefault().newWatchService();
+    Path dir = this.file.getParent();
+    if (dir == null) {
+      throw new IOException("File path has no parent: " + file);
+    }
+    dir.register(
+        watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
+    thread = new Thread(this::processEvents, "jwt-secret-watcher");
+    thread.setDaemon(true);
+  }
+
+  public void start() {
+    thread.start();
+  }
+
+  private void processEvents() {
+    while (running.get()) {
+      WatchKey key;
+      try {
+        key = watchService.take();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      boolean changed = false;
+      Path dir = (Path) key.watchable();
+      for (WatchEvent<?> event : key.pollEvents()) {
+        Path changedPath = dir.resolve((Path) event.context()).toAbsolutePath();
+        if (changedPath.equals(file)) {
+          changed = true;
+          break;
+        }
+      }
+      key.reset();
+      if (changed) {
+        logger.info("JWT secret change detected; reloading");
+        onChange.run();
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    running.set(false);
+    try {
+      watchService.close();
+    } finally {
+      if (thread.isAlive()) {
+        thread.interrupt();
+      }
+    }
+  }
+}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/ReloadableJwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/ReloadableJwtUtil.java
@@ -1,0 +1,39 @@
+package net.firedevops.firemud.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Wrapper around {@link JwtUtil} that allows the signing secret to be updated at runtime. All token
+ * operations delegate to the current instance.
+ */
+public class ReloadableJwtUtil extends JwtUtil {
+  private final long expirationMillis;
+  private final AtomicReference<JwtUtil> delegate;
+
+  public ReloadableJwtUtil(String secret, long expirationMillis) {
+    super(secret, expirationMillis);
+    this.expirationMillis = expirationMillis;
+    this.delegate = new AtomicReference<>(new JwtUtil(secret, expirationMillis));
+  }
+
+  /**
+   * Update the signing secret. Existing tokens signed with the previous secret will no longer parse
+   * successfully.
+   */
+  public synchronized void updateSecret(String secret) {
+    this.delegate.set(new JwtUtil(secret, expirationMillis));
+  }
+
+  @Override
+  public String generateToken(String subject, Map<String, Object> claims) {
+    return delegate.get().generateToken(subject, claims);
+  }
+
+  @Override
+  public Jws<Claims> parseToken(String token) {
+    return delegate.get().parseToken(token);
+  }
+}

--- a/services/common-library/src/test/java/unit/net/firedevops/firemud/common/security/JwtSecretWatcherTest.java
+++ b/services/common-library/src/test/java/unit/net/firedevops/firemud/common/security/JwtSecretWatcherTest.java
@@ -1,0 +1,26 @@
+package net.firedevops.firemud.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class JwtSecretWatcherTest {
+  @Test
+  void triggersCallbackOnFileChange() throws Exception {
+    Path temp = Files.createTempFile("jwt-secret", ".txt");
+    Files.writeString(temp, "one");
+    CountDownLatch latch = new CountDownLatch(1);
+    JwtSecretWatcher watcher = JwtSecretWatcher.createAndStart(temp, latch::countDown);
+    try {
+      Files.writeString(temp, "two");
+      assertTrue(latch.await(5, TimeUnit.SECONDS));
+    } finally {
+      watcher.close();
+      Files.deleteIfExists(temp);
+    }
+  }
+}

--- a/services/common-library/src/test/java/unit/net/firedevops/firemud/common/security/ReloadableJwtUtilTest.java
+++ b/services/common-library/src/test/java/unit/net/firedevops/firemud/common/security/ReloadableJwtUtilTest.java
@@ -1,0 +1,23 @@
+package net.firedevops.firemud.common.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.jsonwebtoken.JwtException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ReloadableJwtUtilTest {
+  @Test
+  void updateSecretReplacesSigningKey() {
+    ReloadableJwtUtil util = new ReloadableJwtUtil("secret1secret1secret1secret1abcd", 3600000L);
+    String token1 = util.generateToken("demo", Map.of());
+
+    util.updateSecret("secret2secret2secret2secret2abcd");
+
+    assertThrows(JwtException.class, () -> util.parseToken(token1));
+
+    String token2 = util.generateToken("demo", Map.of());
+    assertEquals("demo", util.parseToken(token2).getBody().getSubject());
+  }
+}

--- a/services/game-logic-service/src/main/resources/application-prod.yml
+++ b/services/game-logic-service/src/main/resources/application-prod.yml
@@ -36,6 +36,7 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
   auth:
+    jwt-secret-path: ${FIREMUD_AUTH_JWT_SECRET_PATH:}
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
     jwt-expiration-ms: ${FIREMUD_AUTH_JWT_EXPIRATION_MS:3600000}
 

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,9 +1,15 @@
 package net.firedevops.firemud.config;
 
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.security.JwtSecretWatcher;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.ReloadableJwtUtil;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -15,13 +21,14 @@ import org.springframework.core.env.Environment;
 public class AuthConfig {
   private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
   private final Environment environment;
+  private JwtSecretWatcher watcher;
 
   public AuthConfig(Environment environment) {
     this.environment = environment;
   }
 
   @Bean
-  public JwtUtil jwtUtil(AuthProperties props) {
+  public JwtUtil jwtUtil(AuthProperties props) throws IOException {
     String secret = props.getJwtSecret();
     if (secret == null || secret.isBlank()) {
       boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
@@ -35,6 +42,29 @@ public class AuthConfig {
         throw new IllegalStateException("firemud.auth.jwt-secret must be set");
       }
     }
-    return new JwtUtil(secret, props.getJwtExpirationMs());
+    ReloadableJwtUtil util = new ReloadableJwtUtil(secret, props.getJwtExpirationMs());
+    String path = props.getJwtSecretPath();
+    if (path != null && !path.isBlank()) {
+      Path p = Path.of(path);
+      Runnable reload =
+          () -> {
+            try {
+              String newSecret = Files.readString(p).trim();
+              util.updateSecret(newSecret);
+            } catch (IOException e) {
+              logger.error("Failed to reload JWT secret", e);
+            }
+          };
+      reload.run();
+      watcher = JwtSecretWatcher.createAndStart(p, reload);
+    }
+    return util;
+  }
+
+  @PreDestroy
+  public void close() throws Exception {
+    if (watcher != null) {
+      watcher.close();
+    }
   }
 }

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -7,5 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "firemud.auth")
 public class AuthProperties {
   private String jwtSecret;
+  private String jwtSecretPath;
   private long jwtExpirationMs;
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,9 +1,15 @@
 package net.firedevops.firemud.config;
 
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.security.JwtSecretWatcher;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.ReloadableJwtUtil;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -15,13 +21,14 @@ import org.springframework.core.env.Environment;
 public class AuthConfig {
   private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
   private final Environment environment;
+  private JwtSecretWatcher watcher;
 
   public AuthConfig(Environment environment) {
     this.environment = environment;
   }
 
   @Bean
-  public JwtUtil jwtUtil(AuthProperties props) {
+  public JwtUtil jwtUtil(AuthProperties props) throws IOException {
     String secret = props.getJwtSecret();
     if (secret == null || secret.isBlank()) {
       boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
@@ -35,6 +42,29 @@ public class AuthConfig {
         throw new IllegalStateException("firemud.auth.jwt-secret must be set");
       }
     }
-    return new JwtUtil(secret, props.getJwtExpirationMs());
+    ReloadableJwtUtil util = new ReloadableJwtUtil(secret, props.getJwtExpirationMs());
+    String path = props.getJwtSecretPath();
+    if (path != null && !path.isBlank()) {
+      Path p = Path.of(path);
+      Runnable reload =
+          () -> {
+            try {
+              String newSecret = Files.readString(p).trim();
+              util.updateSecret(newSecret);
+            } catch (IOException e) {
+              logger.error("Failed to reload JWT secret", e);
+            }
+          };
+      reload.run();
+      watcher = JwtSecretWatcher.createAndStart(p, reload);
+    }
+    return util;
+  }
+
+  @PreDestroy
+  public void close() throws Exception {
+    if (watcher != null) {
+      watcher.close();
+    }
   }
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -7,5 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "firemud.auth")
 public class AuthProperties {
   private String jwtSecret;
+  private String jwtSecretPath;
   private long jwtExpirationMs;
 }

--- a/services/social-groups-service/src/main/resources/application-prod.yml
+++ b/services/social-groups-service/src/main/resources/application-prod.yml
@@ -23,6 +23,7 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
   auth:
+    jwt-secret-path: ${FIREMUD_AUTH_JWT_SECRET_PATH:}
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
     jwt-expiration-ms: ${FIREMUD_AUTH_JWT_EXPIRATION_MS:3600000}
   voice:

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/AuthConfig.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/AuthConfig.java
@@ -1,9 +1,15 @@
 package net.firedevops.firemud.config;
 
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.security.JwtSecretWatcher;
 import net.firedevops.firemud.common.security.JwtUtil;
+import net.firedevops.firemud.common.security.ReloadableJwtUtil;
 import org.slf4j.Logger;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -15,13 +21,14 @@ import org.springframework.core.env.Environment;
 public class AuthConfig {
   private static final Logger logger = LoggingUtil.getLogger(AuthConfig.class);
   private final Environment environment;
+  private JwtSecretWatcher watcher;
 
   public AuthConfig(Environment environment) {
     this.environment = environment;
   }
 
   @Bean
-  public JwtUtil jwtUtil(AuthProperties props) {
+  public JwtUtil jwtUtil(AuthProperties props) throws IOException {
     String secret = props.getJwtSecret();
     if (secret == null || secret.isBlank()) {
       boolean dev = Arrays.asList(environment.getActiveProfiles()).contains("dev");
@@ -35,6 +42,29 @@ public class AuthConfig {
         throw new IllegalStateException("firemud.auth.jwt-secret must be set");
       }
     }
-    return new JwtUtil(secret, props.getJwtExpirationMs());
+    ReloadableJwtUtil util = new ReloadableJwtUtil(secret, props.getJwtExpirationMs());
+    String path = props.getJwtSecretPath();
+    if (path != null && !path.isBlank()) {
+      Path p = Path.of(path);
+      Runnable reload =
+          () -> {
+            try {
+              String newSecret = Files.readString(p).trim();
+              util.updateSecret(newSecret);
+            } catch (IOException e) {
+              logger.error("Failed to reload JWT secret", e);
+            }
+          };
+      reload.run();
+      watcher = JwtSecretWatcher.createAndStart(p, reload);
+    }
+    return util;
+  }
+
+  @PreDestroy
+  public void close() throws Exception {
+    if (watcher != null) {
+      watcher.close();
+    }
   }
 }

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/AuthProperties.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/AuthProperties.java
@@ -7,5 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "firemud.auth")
 public class AuthProperties {
   private String jwtSecret;
+  private String jwtSecretPath;
   private long jwtExpirationMs;
 }

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -122,6 +122,7 @@ firemud:
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
   auth:
+    jwt-secret-path: ${FIREMUD_AUTH_JWT_SECRET_PATH:}
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
 
 server:

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
@@ -83,8 +83,7 @@ public class GameDesignClient implements AutoCloseable {
 
   /** Returns published versions for the given tenant. */
   public ListVersionsResponse listVersions(long tenantId) {
-    ListVersionsRequest request =
-        ListVersionsRequest.newBuilder().setTenantId(tenantId).build();
+    ListVersionsRequest request = ListVersionsRequest.newBuilder().setTenantId(tenantId).build();
     return stub.listVersions(request);
   }
 


### PR DESCRIPTION
## Summary
- add `FIREMUD_AUTH_JWT_SECRET_PATH` env var to docs
- clarify hot-reload of secrets in security design
- support reloading JWT secrets from file via `ReloadableJwtUtil` and `JwtSecretWatcher`
- wire new hot-reload logic into service auth configs
- update YAML configs with optional `jwt-secret-path`
- add unit tests for new helper classes

## Testing
- `./gradlew check --no-configuration-cache`

------
https://chatgpt.com/codex/tasks/task_e_68734231c8988330950f152a5b76ea75