### PR TITLE
Update CI/CD docs

### DIFF
--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -14,7 +14,7 @@ This document describes the basic continuous integration and deployment strategy
 - **Perform code scanning** with CodeQL and open source **license checks** on every pull request.
 - **Publish documentation** to GitHub Pages after successful builds.
 - **Create release PRs automatically** using the `release-please` workflow.
-- **Generate database ERD diagrams** as build artifacts after each run.
+- **Generate database ERD diagrams** as build artifacts after each run. The diagrams are stored in `design/erd-diagrams/` and uploaded as workflow artifacts.
 
 The CI job first performs a **Buf breaking change check** to ensure protobuf APIs remain compatible. It then runs formatting and lint steps followed by a matrix of Gradle `check` tasks—one per microservice—which compile and test each module while running Spotless, Checkstyle, and SpotBugs. Coverage reports are generated with JaCoCo and a Trivy security scan runs on the workspace. Node 20 is also configured so the pipeline can lint OpenAPI definitions, run the React client’s linters, and execute an accessibility audit using headless Chrome. After the scan, the job executes `dev-tools/generate-erd.sh` to build ERD diagrams from the service migrations and uploads them as artifacts. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
 
@@ -47,6 +47,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
       - name: Format Code
         run: ./gradlew spotlessApply
       - name: Lint Markdown


### PR DESCRIPTION
## Summary
- clarify location of ERD diagrams in CI documentation
- mention Node setup step in workflow example

## Testing
- `./gradlew --no-daemon spotlessApply lintMarkdownFix`


------
https://chatgpt.com/codex/tasks/task_e_68734e933a5c8330b9ef1a217ec5ef49