### PR TITLE
Standardize microservice docs

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -39,9 +39,9 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 
 ## Key Features
 
-- Scriptable quests and event triggers  
-- Persistent NPC memory and dynamic reactions  
-- Timers and delayed actions for asynchronous events  
+- Scriptable quests and event triggers
+- Persistent NPC memory and dynamic reactions
+- Timers and delayed actions for asynchronous events
 - Tick-based AI execution for efficient CPU usage and fair scheduling — AI logic runs during tick cycles only when triggered by events, avoiding constant background processing
 - Faction reputation influences NPC aggression states. NPCs may become **FLEEING** or **SURRENDERED** when low on health or morale, allowing players to resolve encounters non-lethally.
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -55,7 +55,7 @@ All admin APIs are secured via role-based access control integrated with the Acc
 - Events are forwarded to the Account Service for enforcement and stored for
   compliance purposes.
 
-### REST & gRPC APIs
+### REST & gRPC Endpoints
 
 #### REST
 


### PR DESCRIPTION
## Summary
- fix whitespace issues in automation-scripting-service docs
- rename Logging & Admin Service heading to `REST & gRPC Endpoints`

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68734db161a483309b1d798cac10e0e8