### PR TITLE
Fix Logging Admin design doc layout

### DIFF
--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -114,15 +114,6 @@ Additional variables specific to this service:
 | -------- | ------- | ------- |
 | *(none)* | This service relies only on the shared configuration variables. | *(none)* |
 
-## Saga Dashboard
-
-The service exposes `/sagas` and `/sagas/{id}/steps` endpoints for operators to inspect
-long-running workflows coordinated via the shared Saga library. The dashboard reads from
-the `saga_instance` and `saga_step` tables and publishes a `sagas.active` Prometheus gauge.
-
-See [Transaction Strategies](../system-architecture-transactions.md) for an overview of
-Saga usage across FireMUD.
-
 ## Proto Files
 
 API schemas are kept in
@@ -147,6 +138,17 @@ See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for 
 
 - [System Architecture Diagram](../system-architecture-diagram.md)
 - [System Context Diagram](../system-context-diagram.md)
+
+## Additional Details
+
+### Saga Dashboard
+
+The service exposes `/sagas` and `/sagas/{id}/steps` endpoints for operators to inspect
+long-running workflows coordinated via the shared Saga library. The dashboard reads from
+the `saga_instance` and `saga_step` tables and publishes a `sagas.active` Prometheus gauge.
+
+See [Transaction Strategies](../system-architecture-transactions.md) for an overview of
+Saga usage across FireMUD.
 
 ## Future Enhancements
 


### PR DESCRIPTION
## Summary
- move saga dashboard notes under Additional Details in Logging Admin design doc

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68734db161a483309b1d798cac10e0e8