### PR TITLE
Update CI/CD doc ERD path

### DIFF
--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -14,7 +14,7 @@ This document describes the basic continuous integration and deployment strategy
 - **Perform code scanning** with CodeQL and open source **license checks** on every pull request.
 - **Publish documentation** to GitHub Pages after successful builds.
 - **Create release PRs automatically** using the `release-please` workflow.
-- **Generate database ERD diagrams** as build artifacts after each run. The diagrams are stored in `design/erd-diagrams/` and uploaded as workflow artifacts.
+- **Generate database ERD diagrams** as build artifacts after each run. The diagrams are stored in `design/erd/` and uploaded as workflow artifacts.
 
 The CI job first performs a **Buf breaking change check** to ensure protobuf APIs remain compatible. It then runs formatting and lint steps followed by a matrix of Gradle `check` tasks—one per microservice—which compile and test each module while running Spotless, Checkstyle, and SpotBugs. Coverage reports are generated with JaCoCo and a Trivy security scan runs on the workspace. Node 20 is also configured so the pipeline can lint OpenAPI definitions, run the React client’s linters, and execute an accessibility audit using headless Chrome. After the scan, the job executes `dev-tools/generate-erd.sh` to build ERD diagrams from the service migrations and uploads them as artifacts. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
 


### PR DESCRIPTION
## Summary
- fix ERD diagram path in CI/CD design doc

## Testing
- `./gradlew check` *(fails: some tasks didn't finish)*

------
https://chatgpt.com/codex/tasks/task_e_6873507fc7808330b6ef63d4f39824ef