### PR TITLE
Implement missing performance instrumentation

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -33,6 +33,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
 
   private Counter enqueueCounter;
   private Counter redisErrorCounter;
+  private Counter lockContentionCounter;
   private Timer tickTimer;
   private Timer luaTimer;
   private java.util.concurrent.atomic.AtomicInteger retryQueueDepth =
@@ -45,6 +46,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   void init() {
     enqueueCounter = meterRegistry.counter("automation_tick_events_enqueued_total");
     redisErrorCounter = meterRegistry.counter("automation_tick_redis_errors_total");
+    lockContentionCounter = meterRegistry.counter("automation_tick_lock_contention_total");
     tickTimer = meterRegistry.timer("automation_tick_duration_ms");
     luaTimer = meterRegistry.timer("automation_lua_latency_ms");
     Gauge.builder(
@@ -80,6 +82,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
     Boolean acquired =
         redisTemplate.opsForValue().setIfAbsent(lockKey, "1", Duration.ofMillis(tickDurationMs));
     if (Boolean.FALSE.equals(acquired)) {
+      lockContentionCounter.increment();
       logger.debug("Could not acquire tick lock {}", lockKey);
       return;
     }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.service.FeatureFlagService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
   private final FeatureFlagMapper mapper;
 
   @Override
+  @Timed(value = "gamesession.feature.toggle")
   @Transactional
   public FeatureFlagDto toggleFlag(ToggleFeatureFlagRequest request) {
     logger.info("Toggling feature flag {} for tenant {}", request.name(), request.tenantId());

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -18,6 +18,7 @@ import net.firedevops.firemud.service.SessionStateService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import io.micrometer.core.annotation.Timed;
 
 /** Default implementation of {@link GameInstanceService}. */
 @Service
@@ -69,6 +70,7 @@ public class GameInstanceServiceImpl implements GameInstanceService {
   }
 
   @Override
+  @Timed(value = "gamesession.start")
   @Transactional
   public GameInstanceDto startSession(StartSessionRequest request) {
     logger.info(
@@ -126,6 +128,7 @@ public class GameInstanceServiceImpl implements GameInstanceService {
   }
 
   @Override
+  @Timed(value = "gamesession.stop")
   @Transactional
   public GameInstanceDto stopSession(long sessionId) {
     GameInstance instance =
@@ -158,6 +161,7 @@ public class GameInstanceServiceImpl implements GameInstanceService {
   }
 
   @Override
+  @Timed(value = "gamesession.restart")
   @Transactional
   public GameInstanceDto restartSession(long sessionId) {
     GameInstance instance =

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameManifestServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameManifestServiceImpl.java
@@ -9,6 +9,7 @@ import net.firedevops.firemud.service.GameManifestService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 public class GameManifestServiceImpl implements GameManifestService {
@@ -22,6 +23,7 @@ public class GameManifestServiceImpl implements GameManifestService {
   }
 
   @Override
+  @Timed(value = "gamesession.manifest.create")
   @Transactional
   public GameManifestDto createManifest(GameManifestDto dto) {
     logger.info("Creating game manifest for version {}", dto.versionId());

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRoleServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRoleServiceImpl.java
@@ -4,12 +4,14 @@ import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.service.SessionRoleService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 public class SessionRoleServiceImpl implements SessionRoleService {
   private static final Logger logger = LoggingUtil.getLogger(SessionRoleServiceImpl.class);
 
   @Override
+  @Timed(value = "gamesession.roles.refresh")
   public String refreshRoles(long sessionId) {
     logger.info("Refreshing roles for session {}", sessionId);
     return "refreshed";

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
@@ -7,6 +7,7 @@ import net.firedevops.firemud.service.SessionStateService;
 import org.slf4j.Logger;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import io.micrometer.core.annotation.Timed;
 
 /** Default Redis-backed implementation of {@link SessionStateService}. */
 @Service
@@ -17,6 +18,7 @@ public class SessionStateServiceImpl implements SessionStateService {
   private final RedisTemplate<String, Object> redisTemplate;
 
   @Override
+  @Timed(value = "gamesession.state.save")
   public void saveState(GameInstanceDto dto) {
     String key = key(dto.tenantId(), dto.id());
     redisTemplate.opsForValue().set(key, dto);
@@ -24,6 +26,7 @@ public class SessionStateServiceImpl implements SessionStateService {
   }
 
   @Override
+  @Timed(value = "gamesession.state.delete")
   public void deleteState(Long tenantId, Long sessionId) {
     String key = key(tenantId, sessionId);
     redisTemplate.delete(key);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.annotation.Timed;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.PostConstruct;
@@ -70,6 +71,7 @@ public class TickServiceImpl implements TickService {
   }
 
   @Override
+  @Timed(value = "gamesession.command.enqueue")
   public void enqueueCommand(Long sessionId, String command) {
     redisTemplate.opsForList().rightPush(queueKey(sessionId), command);
     enqueueCounter.increment();
@@ -77,6 +79,7 @@ public class TickServiceImpl implements TickService {
   }
 
   @Override
+  @Timed(value = "gamesession.tick.process")
   public void processTick(Long sessionId) {
     long start = System.nanoTime();
     String lockKey = lockKey(sessionId);
@@ -125,6 +128,7 @@ public class TickServiceImpl implements TickService {
   }
 
   @Override
+  @Timed(value = "gamesession.state.query")
   public String queryState(Long sessionId) {
     Object state = redisTemplate.opsForValue().get(stateKey(sessionId));
     return state != null ? state.toString() : "{}";

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +45,7 @@ public class ChatServiceImpl implements ChatService {
   }
 
   @Override
+  @Timed(value = "chat.send")
   @Transactional
   public ChatMessageDto sendMessage(SendMessageRequestDto request) {
     logger.info("Chat message from {}", request.senderAccountId());
@@ -95,6 +97,7 @@ public class ChatServiceImpl implements ChatService {
   }
 
   @Override
+  @Timed(value = "chat.tells")
   public java.util.List<String> getRecentTells(Long tenantId, Long accountId) {
     String key = String.format("tell:%d:%d", tenantId, accountId);
     try {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/MailServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/MailServiceImpl.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.service.MailService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import io.micrometer.core.annotation.Timed;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class MailServiceImpl implements MailService {
   private final MailMessageMapper mapper;
 
   @Override
+  @Timed(value = "mail.send")
   @Transactional
   public MailMessageDto sendMail(SendMailRequest request) {
     logger.info("Mail from {} to {}", request.senderAccountId(), request.recipientAccountId());


### PR DESCRIPTION
## Summary
- instrument chat and mail services with `@Timed`
- track script tick lock contention
- add timing metrics for game session services

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68734f4ca5148330ba13579dc358cba9