### PR TITLE
Implement tick async execution

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/config/AsyncConfig.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package net.firedevops.firemud.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/** Provides the executor used for running tick processing in parallel. */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+  @Bean(name = "tickExecutor")
+  public Executor tickExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    int cores = Runtime.getRuntime().availableProcessors();
+    executor.setCorePoolSize(cores);
+    executor.setMaxPoolSize(cores * 2);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("tick-");
+    executor.initialize();
+    return executor;
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.entity.GameInstance;
@@ -16,6 +17,7 @@ public class TickScheduler {
   private final TickService tickService;
 
   @Scheduled(fixedDelayString = "${game.tick-duration-ms:1000}")
+  @Timed(value = "game_session.tick_scheduler")
   public void runTicks() {
     List<GameInstance> running = repository.findByStatus("RUNNING");
     for (GameInstance instance : running) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scripting.support.ResourceScriptSource;
 import org.springframework.stereotype.Service;
 
@@ -77,6 +78,7 @@ public class TickServiceImpl implements TickService {
   }
 
   @Override
+  @Async("tickExecutor")
   public void processTick(Long sessionId) {
     long start = System.nanoTime();
     String lockKey = lockKey(sessionId);


### PR DESCRIPTION
## Summary
- add `AsyncConfig` to provide tick executor
- execute ticks asynchronously with `@Async`
- record scheduler metrics with `@Timed`

## Testing
- `./gradlew check --no-daemon -q`

------
https://chatgpt.com/codex/tasks/task_e_68734f4ca5148330ba13579dc358cba9