### PR TITLE
Improve local Redis persistence and backup docs

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -172,6 +172,19 @@ Use `dev-tools/backup-db.sh` to create a snapshot and
 ./dev-tools/restore-db.sh backups/<file>
 ```
 
+### Optional Redis Persistence
+
+Redis normally starts empty between service restarts. If you want to keep the
+Append-Only File (AOF) across container launches, the compose stack mounts a
+`redis-data` volume. You can manually restore an AOF backup with:
+
+```bash
+./dev-tools/restore-redis-aof.sh backups/appendonly.aof
+```
+
+This helper is intended **only** for local development. Production Redis nodes
+rely on replication and automatically repopulate state from PostgreSQL.
+
 ## Manual Testing Tools
 
 ### Insomnia for REST and WebSocket

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -13,7 +13,17 @@ This document defines the backup schedule and disaster recovery procedures for F
   - **3 monthly** snapshots
 - Velero backup schedules are installed automatically by the
   production Terraform modules using `k8s/velero/schedule.yaml`.
-- If the database service fails completely:
+  Operators must configure Velero with access to an object storage bucket
+    (AWS S3, GCS, etc.). Example `values.yaml` snippet:
+
+    ```yaml
+    configuration:
+      provider: aws
+      backupStorageLocation:
+        bucket: firemud-backups
+    ```
+
+  - If the database service fails completely:
   1. Restore the latest snapshot.
   2. Restart services to resume operation.
   3. Redis repopulates transient state from PostgreSQL on access.
@@ -23,6 +33,7 @@ This document defines the backup schedule and disaster recovery procedures for F
 - Redis stores only **transient gameplay state**.
 - **AOF (Append‑Only File)** is enabled for crash recovery while the cluster is running.
 - Redis is **not restored** from backup during a cold start; it is repopulated from PostgreSQL after recovery.
+  In development a `redis-data` volume can persist the AOF between container restarts. Restore an AOF file with `dev-tools/restore-redis-aof.sh`.
 
 ## ☁️ Kubernetes Production
 
@@ -36,6 +47,7 @@ This document defines the backup schedule and disaster recovery procedures for F
 ## 🐳 Local Development
 
 - Backups are restored using `dev-tools/restore-db.sh` with a snapshot file.
+- Create ad hoc snapshots with `dev-tools/backup-db.sh` before restoring.
 - Services are restarted with **Docker Compose**.
 - Redis starts empty and repopulates when services access the database.
 

--- a/dev-tools/restore-redis-aof.sh
+++ b/dev-tools/restore-redis-aof.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Restores a Redis AOF file for local development.
+# Usage: restore-redis-aof.sh <aof-file>
+# The Redis container must be managed via docker-compose.
+# This script stops the Redis service, copies the provided AOF
+# into the persistent volume, and restarts the container.
+
+set -euo pipefail
+
+FILE=${1:?"Usage: restore-redis-aof.sh <aof-file>"}
+DATA_DIR=${REDIS_DATA_DIR:-redis-data}
+
+# Stop the Redis container if running
+if docker compose ps --status running | grep -q "_redis_"; then
+  docker compose stop redis
+fi
+
+mkdir -p "$DATA_DIR"
+cp "$FILE" "$DATA_DIR/appendonly.aof"
+
+# Start Redis again
+docker compose up -d redis
+
+echo "Redis AOF restored from $FILE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,6 +199,7 @@ services:
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     volumes:
       - ./config/redis.conf:/usr/local/etc/redis/redis.conf:ro
+      - redis-data:/data
     ports:
       - "6379:6379"
     healthcheck:
@@ -209,3 +210,4 @@ services:
 
 volumes:
   postgres-data:
+  redis-data:

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -11,3 +11,14 @@ kubectl apply -f schedule.yaml -n velero
 ```
 
 Ensure Velero is installed and configured with access to your object storage bucket prior to applying the schedule.
+
+Example `values.yaml` snippet when using AWS S3:
+
+```yaml
+configuration:
+  provider: aws
+  backupStorageLocation:
+    bucket: firemud-backups
+```
+
+For Google Cloud Storage set `provider: gcp` and adjust the bucket name accordingly.


### PR DESCRIPTION
## Summary
- add a redis-data volume in docker-compose for optional AOF persistence
- document how to configure Velero object storage
- add helper script for restoring a local Redis AOF
- mention database backup script and optional Redis restore in docs

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68735043424083309c82896de92713b7