### PR TITLE
Fix doc heading for social groups service

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -85,7 +85,7 @@ Service issues temporary WebRTC tokens and records basic session metadata so the
 Logging & Admin Service can audit voice activity. Voice chat is disabled by
 default and can be enabled per tenant through configuration.
 
-### gRPC/REST APIs
+### gRPC APIs
 
 - `SendMessage` – publishes a chat message to an in-game channel or player.
 - `SendAccountMessage` – delivers a direct message between account holders.


### PR DESCRIPTION
## Summary
- standardize the gRPC API section heading in the Social & Groups service design doc

## Testing
- `pre-commit run --files design/architecture/microservices/social-groups-service/README.md` *(fails: SpotBugs interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68735407e44c8330a085d842c8eafd7e