### PR TITLE
Standardize microservice doc headings

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -71,7 +71,7 @@ resolved during authentication.
 - `GetProfile` – retrieves profile information for the current account.
 - `UpdateProfile` – modifies profile fields and triggers notification emails.
 
-### REST Endpoints
+### REST APIs
 
 | Method | Path       | Description               |
 | ------ | ---------- | ------------------------- |

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -85,7 +85,7 @@ Service issues temporary WebRTC tokens and records basic session metadata so the
 Logging & Admin Service can audit voice activity. Voice chat is disabled by
 default and can be enabled per tenant through configuration.
 
-### gRPC/REST APIs
+### gRPC APIs
 
 - `SendMessage` – publishes a chat message to an in-game channel or player.
 - `SendAccountMessage` – delivers a direct message between account holders.


### PR DESCRIPTION
## Summary
- fix inconsistent REST section heading in account service doc
- standardize gRPC section heading in social groups service doc

## Testing
- `pre-commit run --files design/architecture/microservices/account-service/README.md design/architecture/microservices/social-groups-service/README.md` *(fails: SpotBugs interrupted)*
- `./gradlew check` *(fails: SpotBugs warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68735407e44c8330a085d842c8eafd7e