### PR TITLE
Standardize service docs layout

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -85,7 +85,7 @@ Service issues temporary WebRTC tokens and records basic session metadata so the
 Logging & Admin Service can audit voice activity. Voice chat is disabled by
 default and can be enabled per tenant through configuration.
 
-### gRPC/REST APIs
+### gRPC APIs
 
 - `SendMessage` – publishes a chat message to an in-game channel or player.
 - `SendAccountMessage` – delivers a direct message between account holders.

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -104,7 +104,7 @@ Additional variables control the proxy runtime behaviour:
 | `TCP_PROXY_MAX_CONNECTIONS_PER_IP` | Maximum concurrent connections per client IP | `5` |
 | `TCP_PROXY_MAX_MSGS_PER_SEC` | Allowed messages per second per client | `5` |
 
-## Metrics & Tracing
+### Metrics & Tracing
 
 Metrics are exposed at `/actuator/prometheus` and scraped by Prometheus. The
 service exports OpenTelemetry spans to the collector defined by the


### PR DESCRIPTION
## Summary
- reformat Social & Groups Service heading for gRPC API list
- adjust TCP Proxy Service metrics heading hierarchy

## Testing
- `pre-commit run --files design/architecture/microservices/social-groups-service/README.md design/architecture/microservices/tcp-proxy-service/README.md` *(fails: Buf Lint missing proto fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68735407e44c8330a085d842c8eafd7e