### PR TITLE
Improve microservices doc consistency

### DIFF
--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -39,6 +39,8 @@ For cross-service systems (e.g., networking, infrastructure), refer to:
 
 > See [**Infrastructure Overview**](../infrastructure/README.md) for shared architecture, deployment environments, and networking patterns.
 
+For new services, start from the [Service Template](./service-template.md) so documentation follows the same layout.
+
 All gRPC schema files are organized under the top-level
 [`protos/`](../../protos) directory. Individual service documents link to their
 corresponding versioned proto folders.


### PR DESCRIPTION
## Summary
- clarify usage of the service template in the microservices design README
- verify service docs with markdownlint

## Testing
- `npx markdownlint-cli2 "design/architecture/microservices/**/*.md"`

------
https://chatgpt.com/codex/tasks/task_e_687363e9314083308dc36576d543150e