### PR TITLE
Remove per-service OTEL_ENDPOINT doc

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -122,6 +122,8 @@ Spring property `otel.endpoint`):
 | -------- | ------- | ------- |
 | `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 
+Service design documents reference this table for the OpenTelemetry endpoint configuration.
+
 ### Additional Notes
 
 Service-specific settings such as SMTP credentials for the Account Service or

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -110,7 +110,6 @@ Additional variables configure outbound email delivery:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `SMTP_HOST` | SMTP server hostname | `localhost` |
 | `SMTP_PORT` | SMTP server port | `1025` |
 | `SMTP_USERNAME` | Username for SMTP auth | *(empty)* |

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -127,7 +127,6 @@ Additional variables tune the scripting engine:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `SCRIPT_QUOTA_LIMIT` | Number of events a script may process per window | `50` |
 | `SCRIPT_QUOTA_WINDOWSECONDS` | Length of the quota window in seconds | `60` |
 | `AUTOMATION_TICK_DURATION_MS` | Duration of a processing tick in milliseconds | `1000` |

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -96,7 +96,6 @@ Additional variables specific to this service:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `FIREMUD_CHARACTER_CACHE_TTL_SECONDS` | TTL for cached character graphs in Redis (seconds) | `60` |
 
 ## Proto Files

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -103,7 +103,6 @@ Additional variables specific to this service:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | *(none)* | This service relies only on the shared configuration variables. | *(none)* |
 
 ## Proto Files

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -98,7 +98,6 @@ Additional variables specific to this service:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | *(none)* | This service relies only on the shared configuration variables. | *(none)* |
 
 ## Proto Files

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -99,7 +99,6 @@ TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `GAME_TICK_DURATION_MS` | Length of a single game tick in milliseconds | `1000` |
 | `FIREMUD_SERVICES_GAME_LOGIC_SERVICE` | gRPC endpoint (host:port) for the Game Logic Service | *(none)* |
 

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -112,7 +112,6 @@ Additional variables specific to this service:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | *(none)* | This service relies only on the shared configuration variables. | *(none)* |
 
 ## Proto Files

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -115,7 +115,6 @@ TLS certificates are supplied via [`FIREMUD_GRPC_CERT_CHAIN_PATH`, `FIREMUD_GRPC
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `FIREMUD_SERVICES_LOGGING_ADMIN_SERVICE` | `host:port` of the Logging Admin service | `logging-admin-service:6565` |
 | `FIREMUD_VOICE_TOKEN_EXPIRATION_MS` | Expiration of voice chat tokens | `300000` |
 

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -87,7 +87,6 @@ Important variables include:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `SERVER_PORT` | HTTP port exposed by the service | `8080` |
 
 ## Proto Files

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -96,7 +96,6 @@ Additional variables control the proxy runtime behaviour:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `TCP_PROXY_PORT` | TCP port the proxy listens on | `2323` |
 | `GATEWAY_WS_URL` | WebSocket URL for forwarding to the gateway | `ws://spring-cloud-gateway:8080/ws` |
 | `TCP_PROXY_TLS_ENABLED` | Enable Telnet-over-TLS termination | `false` |
@@ -108,9 +107,8 @@ Additional variables control the proxy runtime behaviour:
 ## Metrics & Tracing
 
 Metrics are exposed at `/actuator/prometheus` and scraped by Prometheus. The
-service exports OpenTelemetry spans to the collector defined by the
-`OTEL_ENDPOINT` environment variable (Spring property `otel.endpoint`) so
-traces appear in Jaeger.
+service exports OpenTelemetry spans to the collector defined by
+`OTEL_ENDPOINT` (see [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)) so traces appear in Jaeger.
 
 ## Proto Files
 

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -108,7 +108,6 @@ Additional variables configure world data caching and sharding:
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
-| `OTEL_ENDPOINT` | gRPC endpoint for the OpenTelemetry collector | `http://otel-collector:4317` |
 | `WORLD_LOCAL_SHARD_ID` | Numeric identifier for this shard instance | `0` |
 | `WORLD_ROOM_CACHE_TTL_SECONDS` | Seconds to retain room data in the cache | `60` |
 | `WORLD_INSTANCE_EXPIRATION_HOURS` | Hours before a transient instance expires | `24` |


### PR DESCRIPTION
## Summary
- remove OTEL_ENDPOINT rows from all service docs
- clarify OTEL_ENDPOINT usage in the shared environment docs

## Testing
- `pre-commit run --all-files` *(fails: spotbugs task interrupted)*
- `./gradlew check` *(fails: manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687358fd706c83308a9099873a18155c