### PR TITLE
Add MinIO local Velero config

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -14,13 +14,32 @@ This document defines the backup schedule and disaster recovery procedures for F
 - Velero backup schedules are installed automatically by the
   production Terraform modules using `k8s/velero/schedule.yaml`.
   Operators must configure Velero with access to an object storage bucket
-    (AWS S3, GCS, etc.). Example `values.yaml` snippet:
+    (AWS S3, GCS, or MinIO). Example `values.yaml` snippet:
 
     ```yaml
     configuration:
       provider: aws
       backupStorageLocation:
         bucket: firemud-backups
+      ```
+
+    For local clusters without cloud storage, deploy the `k8s/velero/minio.yaml`
+    manifest and configure Velero with a local backup location:
+
+    ```yaml
+    configuration:
+      provider: aws
+      backupStorageLocation:
+        name: local
+        provider: aws
+        bucket: firemud-backups
+        config:
+          region: minio
+          s3Url: http://minio.minio.svc.cluster.local:9000
+          insecureSkipTLSVerify: true
+    credentials:
+      useSecret: true
+      existingSecret: velero-minio-creds
     ```
 
   - If the database service fails completely:

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -22,3 +22,36 @@ configuration:
 ```
 
 For Google Cloud Storage set `provider: gcp` and adjust the bucket name accordingly.
+
+## Local Backup with MinIO
+
+If running backups locally, deploy MinIO on the cluster and configure Velero to use it as the backup storage location. The manifest `minio.yaml` starts a single-node MinIO instance with a `ClusterIP` service.
+
+Example `values-minio.yaml` config:
+
+```yaml
+configuration:
+  provider: aws
+  backupStorageLocation:
+    name: local
+    provider: aws
+    bucket: firemud-backups
+    config:
+      region: minio
+      s3Url: http://minio.minio.svc.cluster.local:9000
+      insecureSkipTLSVerify: true
+credentials:
+  useSecret: true
+  existingSecret: velero-minio-creds
+```
+
+Create the access secret:
+
+```bash
+kubectl create secret generic velero-minio-creds -n velero \
+  --from-literal=cloud='[default]
+aws_access_key_id=myaccesskey
+aws_secret_access_key=mysecretkey'
+```
+
+Install Velero with these values after the MinIO bucket has been created.

--- a/k8s/velero/minio.yaml
+++ b/k8s/velero/minio.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-creds
+  namespace: minio
+type: Opaque
+stringData:
+  accesskey: myaccesskey
+  secretkey: mysecretkey
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  namespace: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:latest
+          args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-creds
+                  key: accesskey
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-creds
+                  key: secretkey
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      targetPort: 9000
+  type: ClusterIP

--- a/k8s/velero/values-minio.yaml
+++ b/k8s/velero/values-minio.yaml
@@ -1,0 +1,13 @@
+configuration:
+  provider: aws
+  backupStorageLocation:
+    name: local
+    provider: aws
+    bucket: firemud-backups
+    config:
+      region: minio
+      s3Url: http://minio.minio.svc.cluster.local:9000
+      insecureSkipTLSVerify: true
+credentials:
+  useSecret: true
+  existingSecret: velero-minio-creds


### PR DESCRIPTION
## Summary
- provide MinIO deployment manifest and Velero values example
- update Velero README to document local MinIO usage
- document MinIO option in backup architecture

## Testing
- `./gradlew check` *(fails: spotlessJavaCheck FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68735893bbfc8330ba8e17f1a4c99c96