### PR TITLE
Add Velero backup verification example

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -14,13 +14,15 @@ This document defines the backup schedule and disaster recovery procedures for F
 - Velero backup schedules are installed automatically by the
   production Terraform modules using `k8s/velero/schedule.yaml`.
   Operators must configure Velero with access to an object storage bucket
-    (AWS S3, GCS, etc.). Example `values.yaml` snippet:
+    (AWS S3, GCS, etc.). Copy `k8s/velero/values.example.yaml` to `values.yaml`
+    and adjust the provider and bucket. Example `values.yaml` snippet:
 
     ```yaml
     configuration:
       provider: aws
       backupStorageLocation:
         bucket: firemud-backups
+        prefix: postgres
     ```
 
   - If the database service fails completely:
@@ -50,6 +52,17 @@ This document defines the backup schedule and disaster recovery procedures for F
 - Create ad hoc snapshots with `dev-tools/backup-db.sh` before restoring.
 - Services are restarted with **Docker Compose**.
 - Redis starts empty and repopulates when services access the database.
+
+---
+
+## ✅ Backup Verification & Restoration Testing
+
+- The `k8s/velero/verify-backups-cronjob.yaml` CronJob runs
+  `dev-tools/verify-backups.sh` daily to ensure recent snapshots are present in
+  the object store.
+- Operators should periodically test recovery by restoring a snapshot into a
+  throwaway namespace with `dev-tools/restore-cluster.sh <backup-name>` and
+  verifying services start successfully.
 
 ---
 

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -46,6 +46,7 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      restart containers with `docker compose restart`.
    - Scheduled backups are created automatically by the Terraform modules using
      `k8s/velero/schedule.yaml`.
+   - Apply `k8s/velero/verify-backups-cronjob.yaml` to run daily checks that backups exist.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/dev-tools/verify-backups.sh
+++ b/dev-tools/verify-backups.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Verify that Velero backups exist and the object store is reachable.
+# Intended for periodic checks via CI or a Kubernetes CronJob.
+set -euo pipefail
+
+NAMESPACE=${FIREMUD_K8S_NAMESPACE:-firemud}
+
+# Ensure Velero CLI is available
+command -v velero >/dev/null 2>&1 || {
+  echo "Velero CLI not found" >&2
+  exit 1
+}
+
+# List backups and ensure at least one exists
+BACKUP_COUNT=$(velero backup get -n "$NAMESPACE" --no-headers | wc -l || true)
+if [ "$BACKUP_COUNT" -eq 0 ]; then
+  echo "No Velero backups found in namespace $NAMESPACE" >&2
+  exit 1
+fi
+
+echo "Found $BACKUP_COUNT Velero backups in $NAMESPACE"

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -10,7 +10,7 @@ Apply the manifests with:
 kubectl apply -f schedule.yaml -n velero
 ```
 
-Ensure Velero is installed and configured with access to your object storage bucket prior to applying the schedule.
+Ensure Velero is installed and configured with access to your object storage bucket prior to applying the schedule. A starter [values.example.yaml](./values.example.yaml) file is included. Copy it to `values.yaml` and edit the provider and bucket for your environment.
 
 Example `values.yaml` snippet when using AWS S3:
 
@@ -19,6 +19,15 @@ configuration:
   provider: aws
   backupStorageLocation:
     bucket: firemud-backups
+    prefix: postgres
 ```
 
 For Google Cloud Storage set `provider: gcp` and adjust the bucket name accordingly.
+
+To automatically verify that backups continue to run, apply the optional
+`verify-backups-cronjob.yaml` which executes a daily check using the included
+script:
+
+```bash
+kubectl apply -f verify-backups-cronjob.yaml -n velero
+```

--- a/k8s/velero/values.example.yaml
+++ b/k8s/velero/values.example.yaml
@@ -1,0 +1,7 @@
+# Example Velero Helm values for FireMUD
+# Customize the provider and bucket name for your environment.
+configuration:
+  provider: aws
+  backupStorageLocation:
+    bucket: firemud-backups
+    prefix: postgres

--- a/k8s/velero/verify-backups-cronjob.yaml
+++ b/k8s/velero/verify-backups-cronjob.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: verify-velero-backups
+  namespace: firemud
+spec:
+  schedule: "0 4 * * *" # daily at 04:00
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: check
+            image: velero/velero:latest
+            command: ["/bin/sh", "-c", "/scripts/verify-backups.sh"]
+            volumeMounts:
+            - name: script
+              mountPath: /scripts
+          restartPolicy: OnFailure
+          volumes:
+          - name: script
+            configMap:
+              name: verify-backups-script
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: verify-backups-script
+  namespace: firemud
+data:
+  verify-backups.sh: |
+    #!/usr/bin/env bash
+    # Verify that Velero backups exist and the object store is reachable.
+    # Intended for periodic checks via CI or a Kubernetes CronJob.
+    set -euo pipefail
+    
+    NAMESPACE=${FIREMUD_K8S_NAMESPACE:-firemud}
+    
+    # Ensure Velero CLI is available
+    command -v velero >/dev/null 2>&1 || {
+      echo "Velero CLI not found" >&2
+      exit 1
+    }
+    
+    # List backups and ensure at least one exists
+    BACKUP_COUNT=$(velero backup get -n "$NAMESPACE" --no-headers | wc -l || true)
+    if [ "$BACKUP_COUNT" -eq 0 ]; then
+      echo "No Velero backups found in namespace $NAMESPACE" >&2
+      exit 1
+    fi
+    
+    echo "Found $BACKUP_COUNT Velero backups in $NAMESPACE"
+


### PR DESCRIPTION
## Summary
- include a sample `values.example.yaml` for Velero Helm chart
- add a CronJob and script for verifying backups
- document backup verification steps and example values in the architecture docs

## Testing
- `pre-commit run --files design/architecture/system-architecture-backup-recovery.md design/architecture/system-architecture-runbooks.md k8s/velero/README.md dev-tools/verify-backups.sh k8s/velero/values.example.yaml k8s/velero/verify-backups-cronjob.yaml` *(fails: Spotless check, Gradle build interruption)*
- `./gradlew check` *(fails: SpotlessJavaCheck FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6873588c9cd48330bb676c63fd82f866