### PR TITLE
Add Redis AOF wipe job

### DIFF
--- a/charts/firemud/templates/redis-aof-reset-job.yaml
+++ b/charts/firemud/templates/redis-aof-reset-job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redis-wipe-aof
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: redis
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: wipe
+          image: busybox
+          command: ["sh", "-c", "rm -f /mnt/redis/appendonly.aof"]
+          volumeMounts:
+            - name: redis-data
+              mountPath: /mnt/redis
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-data

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -35,6 +35,18 @@ This document defines the backup schedule and disaster recovery procedures for F
 - Redis is **not restored** from backup during a cold start; it is repopulated from PostgreSQL after recovery.
   In development a `redis-data` volume can persist the AOF between container restarts. Restore an AOF file with `dev-tools/restore-redis-aof.sh`.
 
+### Redis AOF Reset on Deployment
+
+FireMUD wipes Redis state on every deployment. Redis is treated as a transient coordination layer and must always start fresh to ensure consistency with authoritative PostgreSQL data.
+
+During each Helm install or upgrade, a Kubernetes Job automatically deletes the Redis Append‑Only File (AOF) before the application starts:
+
+- AOF wipe is triggered via a Helm hook
+- Ensures no stale gameplay state or tick locks remain
+- Does not affect Redis crash recovery during runtime
+
+Because Redis is not a source of truth, this strategy guarantees a clean, deterministic runtime state on every deployment.
+
 ## ☁️ Kubernetes Production
 
 - **Velero** backs up StatefulSets, PersistentVolumeClaims, ConfigMaps, and Secrets.


### PR DESCRIPTION
## Summary
- add helm job to clear Redis AOF on every install or upgrade
- document automatic Redis wipe procedure in backup docs

## Testing
- `pre-commit run --all-files` *(fails: buf lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6873588a20708330aabee14726b7d6c6