### PR TITLE
Update frontend docs for RTK Query

### DIFF
--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -30,6 +30,7 @@ frontend/
 Application state is handled by **Redux Toolkit**, with **RTK Query** used for data fetching and mutations. RTK Query auto-generates hooks for API access and manages caching, invalidation, and loading/error states declaratively.
 
 - The global store is created in `src/store.ts` and provided via `<Provider>`.
+- `setupListeners(store.dispatch)` enables automatic refetching on focus and reconnects.
 - Components dispatch actions and select state using hooks (`useAppDispatch`, `useAppSelector`).
 - RTK Query hooks expose typed endpoints that components call directly.
 

--- a/web-client/src/store.ts
+++ b/web-client/src/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { setupListeners } from '@reduxjs/toolkit/query';
 import { firemudApi } from './api/firemudApi';
 
 export const store = configureStore({
@@ -8,6 +9,8 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(firemudApi.middleware),
 });
+
+setupListeners(store.dispatch);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
- document RTK Query listener setup in architecture
- enable setupListeners in frontend store

## Testing
- `pre-commit run --all-files` *(fails: Spotless violations, buf/ESLint deps missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873692932d08330ada7798a3384243b