### PR TITLE
Automate backup verification job

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -76,6 +76,7 @@ Because Redis is not a source of truth, this strategy guarantees a clean, determ
     2. Restore other resources (StatefulSets, ConfigMaps, Secrets).
     3. Restart the affected pods; Redis starts empty and fills itself from PostgreSQL.
     4. Operators can run `dev-tools/restore-cluster.sh <backup-name>` to automate these steps in production.
+       Set `FIREMUD_K8S_NAMESPACE` if restoring to a different namespace.
 
 ## 🐳 Local Development
 
@@ -90,7 +91,8 @@ Because Redis is not a source of truth, this strategy guarantees a clean, determ
 
 - The `k8s/velero/verify-backups-cronjob.yaml` CronJob runs
   `dev-tools/verify-backups.sh` daily to ensure recent snapshots are present in
-  the object store.
+  the object store. This CronJob is installed automatically by the production
+  Terraform modules.
 - Operators should periodically test recovery by restoring a snapshot into a
   throwaway namespace with `dev-tools/restore-cluster.sh <backup-name>` and
   verifying services start successfully.

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -34,6 +34,7 @@ For local development, use `./gradlew devUp` to start Docker Compose.
 
 1. **Database Failure**
    - Run `dev-tools/restore-cluster.sh <backup-name>` to restore from the latest Velero snapshot and restart services.
+     Set `FIREMUD_K8S_NAMESPACE` to restore into a custom namespace.
    - Alternatively, restore manually:
 
      ```bash
@@ -46,7 +47,7 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      restart containers with `docker compose restart`.
    - Scheduled backups are created automatically by the Terraform modules using
      `k8s/velero/schedule.yaml`.
-   - Apply `k8s/velero/verify-backups-cronjob.yaml` to run daily checks that backups exist.
+   - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/k8s/terraform-production/main.tf
+++ b/k8s/terraform-production/main.tf
@@ -61,3 +61,13 @@ resource "kubernetes_manifest" "velero_schedule" {
   manifest  = each.value
   depends_on = [helm_release.velero]
 }
+
+locals {
+  velero_verify_docs = split("\n---\n", file("${path.module}/../velero/verify-backups-cronjob.yaml"))
+}
+
+resource "kubernetes_manifest" "velero_verify" {
+  for_each  = { for idx, doc in local.velero_verify_docs : idx => yamldecode(doc) }
+  manifest  = each.value
+  depends_on = [helm_release.velero]
+}

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -24,9 +24,9 @@ configuration:
 
 For Google Cloud Storage set `provider: gcp` and adjust the bucket name accordingly.
 
-To automatically verify that backups continue to run, apply the optional
-`verify-backups-cronjob.yaml` which executes a daily check using the included
-script:
+The repository includes a `verify-backups-cronjob.yaml` manifest that runs
+`dev-tools/verify-backups.sh` daily. Production Terraform modules deploy this
+CronJob automatically, but you can apply it manually in other environments:
 
 ```bash
 kubectl apply -f verify-backups-cronjob.yaml -n velero


### PR DESCRIPTION
## Summary
- deploy verify-backups CronJob via Terraform
- note FIREMUD_K8S_NAMESPACE in backup recovery docs and runbooks
- document automatic CronJob install in Velero README

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6873686d1b0c8330bc5acc3794e98944