### PR TITLE
Update env docs

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -17,8 +17,7 @@ This document explains how configuration values and sensitive secrets are suppli
 - Sensitive values (database passwords, JWT keys, TLS certificates) are stored in Kubernetes `Secret` objects.
 - The manifests in `k8s/base/` demonstrate loading these via `envFrom` so that services receive the same variables as in development.
 - Secrets are provisioned by **cert-manager** and rotated automatically. The
-  sample `firemud-secret` manifest in `k8s/base/` contains placeholder values
-  only for local demos; production deployments must supply real credentials.
+  sample `firemud-secret` Secret is defined in `k8s/base/firemud-db-env.yaml` and contains placeholder values only for local demos; production deployments must supply real credentials.
 - **Kubernetes Secrets** is the chosen mechanism for storing all sensitive
   credentials. External secret stores like Vault are not planned at this
   stage.
@@ -132,6 +131,10 @@ Service design documents reference this table for the OpenTelemetry endpoint con
 Service-specific settings such as SMTP credentials for the Account Service or
 `GAME_TICK_DURATION_MS` for the Game Session Service are documented in each
 service's design file. This document covers only shared configuration keys.
+
+Operational scripts like `dev-tools/restore-cluster.sh` use an optional
+`FIREMUD_K8S_NAMESPACE` variable to target the Kubernetes namespace. It defaults
+to `firemud` when unset.
 
 ## 📚 Related Documentation
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -18,6 +18,9 @@ kubectl apply -f base/world-management-service.yaml
 kubectl apply -f base/spring-cloud-gateway.yaml
 ```
 
+The file `base/firemud-db-env.yaml` defines the shared `firemud-config`
+`ConfigMap` and `firemud-secret` `Secret` used by these deployments.
+
 After the services are running, apply the default network policies found in
 `network-policies/` to restrict traffic to internal pods only:
 

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
@@ -71,28 +71,20 @@ class ChatServiceImplTest {
     assertEquals(1L, dto.id());
     verify(listOps).leftPush("say:1:1", "hello");
     verify(redisTemplate)
-        .expire(
-            "say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
+        .expire("say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
     verify(listOps).trim("say:1:1", 0, props.getSays().getMaxMessages() - 1);
-    assertEquals(
-        1.0,
-        meterRegistry.get("chat_messages_published_total").counter().count(),
-        0.001);
-    assertEquals(
-        0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
+    assertEquals(1.0, meterRegistry.get("chat_messages_published_total").counter().count(), 0.001);
+    assertEquals(0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }
 
   @Test
   void redisFailureIncrementsErrorMetric() {
-    doThrow(new RuntimeException("fail"))
-        .when(listOps)
-        .leftPush(any(), any());
+    doThrow(new RuntimeException("fail")).when(listOps).leftPush(any(), any());
 
     SendMessageRequestDto req =
         new SendMessageRequestDto(1L, 2L, ChatType.SAY, null, 1L, null, null, "hi");
     service.sendMessage(req);
 
-    assertEquals(
-        1.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
+    assertEquals(1.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }
 }


### PR DESCRIPTION
## Summary
- clarify location of firemud-secret sample in environment docs
- document FIREMUD_K8S_NAMESPACE variable
- mention shared env manifest in Kubernetes README
- format ChatServiceImplTest with spotless

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6873674d107883309863ae18544dfb2d