### PR TITLE
Move Gatling load testing module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Hooks automatically format code, lint Markdown, and run static analysis before e
 
 - All functionality must be covered by unit tests.
 - Use **JUnit** with **Mockito** for backend unit tests and **Jest** for frontend components.
-- Integration tests rely on **Spring Test**, and we use **Gatling** for load testing.
+- Integration tests rely on **Spring Test**, and we use **Gatling** (see `dev-tools/load-testing`) for load testing.
 - Tests should run successfully with `./gradlew test`.
 - Ensure new tests pass and existing tests are not broken before submitting a PR.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This repository serves as the **central mono-repo** for the FireMUD Game Platfor
 
 - **Unit Testing**: JUnit, Mockito
 - **Integration Testing**: Spring Test
-- **Load Testing**: Gatling
+- **Load Testing**: Gatling (see `dev-tools/load-testing` module)
 - **Accessibility Audit**: axe-core CLI (requires Google Chrome).
   To run the audit locally, install Chrome as described in
   [Developer Setup](DEVELOPER_SETUP.md#frontend-lint--accessibility)

--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -82,8 +82,7 @@ These notes summarize typical optimizations applied across FireMUD services.
   - **Guild/City:** 48 hours or 50 messages per guild or city
   - **Account messages:** 48 hours or 50 messages
   Older messages are persisted in PostgreSQL for long-term retrieval.
-- High concurrency load tests with Gatling help determine scaling limits and
-  guide database indexing improvements.
+- High concurrency load tests with Gatling, located under `dev-tools/load-testing`, help determine scaling limits and guide database indexing improvements.
 
 Following these patterns keeps resource usage low even as player counts grow.
 

--- a/design/architecture/system-architecture-testing.md
+++ b/design/architecture/system-architecture-testing.md
@@ -6,12 +6,12 @@ FireMUD employs a layered testing approach to keep services reliable while avoid
 
 ## 📝 Testing Scope
 
-Each microservice has its own unit and integration tests. Cross‑service scenarios are also covered in a dedicated suite. Load tests run independently using Gatling.
+Each microservice has its own unit and integration tests. Cross‑service scenarios are also covered in a dedicated suite. Load tests run independently using Gatling in a separate `load-testing` module.
 
 - **Unit tests** live under each service in `src/test/java/unit/`.
 - **Integration tests** for that service live in `src/test/java/integration/` and may start Redis, Postgres, or other dependencies on demand.
 - **Cross-service integration tests** exercise workflows that span multiple services. They are triggered via separate Gradle tasks and can orchestrate several services with Docker or Testcontainers.
-- **Load tests** reside in `src/gatling` and simulate real usage patterns. These tests are run manually when preparing a major release.
+- **Load tests** reside in `dev-tools/load-testing/src/gatling` and simulate real usage patterns. These tests are run manually when preparing a major release.
 
 Test data seeding strategies are still under discussion. For now, tests set up their own minimal fixtures programmatically.
 

--- a/design/project-management/design-assumptions.md
+++ b/design/project-management/design-assumptions.md
@@ -58,4 +58,4 @@ This document outlines high-level design and technology assumptions for the Fire
 
 - **Unit Testing**: JUnit, Mockito
 - **Integration Testing**: Spring Test
-- **Load Testing**: Gatling
+- **Load Testing**: Gatling (module `dev-tools/load-testing`)

--- a/dev-tools/load-testing/build.gradle.kts
+++ b/dev-tools/load-testing/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("io.gatling.gradle") version "3.10.5"
+}
+
+dependencies {
+    implementation("io.gatling:gatling-core:3.10.5")
+    implementation("io.gatling:gatling-http:3.10.5")
+}
+
+// keep simulations under src/gatling

--- a/dev-tools/load-testing/src/gatling/kotlin/BasicSimulation.kt
+++ b/dev-tools/load-testing/src/gatling/kotlin/BasicSimulation.kt
@@ -1,0 +1,18 @@
+import io.gatling.javaapi.core.CoreDsl.*
+import io.gatling.javaapi.http.HttpDsl.*
+import io.gatling.javaapi.core.Simulation
+
+class BasicSimulation : Simulation() {
+    private val httpProtocol = http
+        .baseUrl("http://localhost:8080")
+        .acceptHeader("application/json")
+
+    private val scn = scenario("Ping Load")
+        .exec(http("ping").get("/ping"))
+
+    init {
+        setUp(
+            scn.injectOpen(constantUsersPerSec(10.0).during(10))
+        ).protocols(httpProtocol)
+    }
+}

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
@@ -71,28 +71,20 @@ class ChatServiceImplTest {
     assertEquals(1L, dto.id());
     verify(listOps).leftPush("say:1:1", "hello");
     verify(redisTemplate)
-        .expire(
-            "say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
+        .expire("say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
     verify(listOps).trim("say:1:1", 0, props.getSays().getMaxMessages() - 1);
-    assertEquals(
-        1.0,
-        meterRegistry.get("chat_messages_published_total").counter().count(),
-        0.001);
-    assertEquals(
-        0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
+    assertEquals(1.0, meterRegistry.get("chat_messages_published_total").counter().count(), 0.001);
+    assertEquals(0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }
 
   @Test
   void redisFailureIncrementsErrorMetric() {
-    doThrow(new RuntimeException("fail"))
-        .when(listOps)
-        .leftPush(any(), any());
+    doThrow(new RuntimeException("fail")).when(listOps).leftPush(any(), any());
 
     SendMessageRequestDto req =
         new SendMessageRequestDto(1L, 2L, ChatType.SAY, null, 1L, null, null, "hi");
     service.sendMessage(req);
 
-    assertEquals(
-        1.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
+    assertEquals(1.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,3 +35,6 @@ project(":tcp-proxy-service").projectDir = File("services/tcp-proxy-service")
 
 include("world-management-service")
 project(":world-management-service").projectDir = File("services/world-management-service")
+
+include("load-testing")
+project(":load-testing").projectDir = File("dev-tools/load-testing")

--- a/web-client/src/ScriptEditor.tsx
+++ b/web-client/src/ScriptEditor.tsx
@@ -37,7 +37,12 @@ export default function ScriptEditor() {
         minRows={4}
         fullWidth
       />
-      <Button variant="contained" sx={{ mt: 1 }} onClick={handleTest} disabled={isLoading}>
+      <Button
+        variant="contained"
+        sx={{ mt: 1 }}
+        onClick={handleTest}
+        disabled={isLoading}
+      >
         {isLoading ? 'Running...' : 'Test Run'}
       </Button>
     </Box>


### PR DESCRIPTION
## Summary
- relocate `load-testing` module to `dev-tools/`
- document new location in testing docs

## Testing
- `pre-commit run --files CONTRIBUTING.md README.md design/architecture/performance-optimization.md design/architecture/system-architecture-testing.md design/project-management/design-assumptions.md dev-tools/load-testing/build.gradle.kts dev-tools/load-testing/src/gatling/kotlin/BasicSimulation.kt settings.gradle.kts` *(fails: SpotBugs step interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68736a2062808330a2b6bb0279a0c3f1