### PR TITLE
docs: fix frontend directory path

### DIFF
--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -9,7 +9,7 @@ This document describes the structure and tooling for FireMUD's browser-based us
 FireMUD uses React components with a **feature-first** organization. Each feature folder contains its own components, tests, and styling:
 
 ```text
-frontend/
+web-client/
   src/
     features/
       account/


### PR DESCRIPTION
## Summary
- fix doc example path in frontend architecture doc

## Testing
- `./gradlew check` *(fails: :social-groups-service:spotlessJavaCheck)*

------
https://chatgpt.com/codex/tasks/task_e_68738e7a24348330bea4a3659c2b1a93