### PR TITLE
Fix chat test formatting

### DIFF
--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
@@ -71,28 +71,20 @@ class ChatServiceImplTest {
     assertEquals(1L, dto.id());
     verify(listOps).leftPush("say:1:1", "hello");
     verify(redisTemplate)
-        .expire(
-            "say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
+        .expire("say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
     verify(listOps).trim("say:1:1", 0, props.getSays().getMaxMessages() - 1);
-    assertEquals(
-        1.0,
-        meterRegistry.get("chat_messages_published_total").counter().count(),
-        0.001);
-    assertEquals(
-        0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
+    assertEquals(1.0, meterRegistry.get("chat_messages_published_total").counter().count(), 0.001);
+    assertEquals(0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }
 
   @Test
   void redisFailureIncrementsErrorMetric() {
-    doThrow(new RuntimeException("fail"))
-        .when(listOps)
-        .leftPush(any(), any());
+    doThrow(new RuntimeException("fail")).when(listOps).leftPush(any(), any());
 
     SendMessageRequestDto req =
         new SendMessageRequestDto(1L, 2L, ChatType.SAY, null, 1L, null, null, "hi");
     service.sendMessage(req);
 
-    assertEquals(
-        1.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
+    assertEquals(1.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }
 }


### PR DESCRIPTION
## Summary
- spotless formatting on ChatServiceImplTest

## Testing
- `./gradlew check` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68738e7a24348330bea4a3659c2b1a93