### PR TITLE
Integrate Redis AOF wipe job

### DIFF
--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -29,3 +29,8 @@ To deploy all services at once you can use the umbrella chart:
 helm install firemud ./firemud \
   -f values-local.yaml
 ```
+
+The umbrella chart includes a Helm hook job that wipes the Redis Append-Only File on each deployment.
+Set `redis.releaseName` in your values file to match the Redis Helm release name
+(for example `firemud-redis` in production) so the hook can mount the correct
+PersistentVolumeClaim.

--- a/k8s/helm/firemud/templates/redis-aof-reset-job.yaml
+++ b/k8s/helm/firemud/templates/redis-aof-reset-job.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redis-wipe-aof
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: redis
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- $claim := .Values.redis.aofPvc | default (printf "redis-data-%s-master-0" .Values.redis.releaseName) }}
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: wipe
+          image: busybox
+          command: ["sh", "-c", "rm -f /mnt/redis/appendonly.aof"]
+          volumeMounts:
+            - name: redis-data
+              mountPath: /mnt/redis
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: {{ $claim }}

--- a/k8s/helm/firemud/values.yaml
+++ b/k8s/helm/firemud/values.yaml
@@ -4,3 +4,8 @@ account-service:
 game-session-service:
   image:
     tag: latest
+redis:
+  # Helm release name for the Redis chart
+  releaseName: redis
+  # Optional override of the PersistentVolumeClaim used for the AOF file
+  aofPvc: ""


### PR DESCRIPTION
## Summary
- add Redis AOF wipe Job to the umbrella chart
- allow configuring the PVC and Redis release name
- document Redis wipe hook in Helm README

## Testing
- `pre-commit run --files k8s/helm/firemud/templates/redis-aof-reset-job.yaml k8s/helm/firemud/values.yaml k8s/helm/README.md` *(fails: Executable `buf` not found; ESLint module missing)*

------
https://chatgpt.com/codex/tasks/task_e_68738f20a454833081962337c4dcaacd