### PR TITLE
Update multi-tenancy doc with quota link

### DIFF
--- a/design/architecture/system-architecture-multi-tenancy.md
+++ b/design/architecture/system-architecture-multi-tenancy.md
@@ -23,7 +23,7 @@ This document explains how FireMUD hosts many independent games on shared infras
 - Game-specific settings—such as world size, tick intervals, and feature flags—are stored in configuration tables keyed by `tenantId`.
   Runtime flag behavior is described in [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md).
 - All microservices run as shared deployments; there is **no tenant-specific infrastructure** or dedicated clusters.
-- Game Session Service instances scale horizontally based on overall load. Future improvements may add per-game quotas or scaling limits.
+- Game Session Service instances scale horizontally based on overall load. Per-game resource quotas may be enforced so one tenant cannot exhaust cluster capacity. See [Game Session Service design notes](./microservices/game-session-service/README.md#architecture--design-notes) for details.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify possibility of per-game resource quotas
- link to Game Session Service notes for more details

## Testing
- `pre-commit run --files design/architecture/system-architecture-multi-tenancy.md` *(fails: Gradle daemon GC thrash)*
- `./gradlew check` *(fails: manually interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687394cc9ab88330be8b1cfa7ed69a59