### PR TITLE
Update frontend architecture doc and add websocket helper

### DIFF
--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -27,7 +27,7 @@ web-client/
 
 ## ⚛️ State Management
 
-Application state is handled by **Redux Toolkit**, with **RTK Query** used for data fetching and mutations. This replaced the previous thunk-based approach and greatly simplifies asynchronous logic. RTK Query auto-generates hooks for API access and manages caching, invalidation, and loading/error states declaratively.
+Application state is handled by **Redux Toolkit**, with **RTK Query** used for data fetching and mutations. RTK Query auto-generates hooks for API access and manages caching, invalidation, and loading/error states declaratively.
 
 - The global store is created in `src/store.ts` and provided via `<Provider>`.
 - `setupListeners(store.dispatch)` enables automatic refetching on focus and reconnects.

--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -27,7 +27,7 @@ web-client/
 
 ## ⚛️ State Management
 
-Application state is handled by **Redux Toolkit**, with **RTK Query** used for data fetching and mutations. RTK Query auto-generates hooks for API access and manages caching, invalidation, and loading/error states declaratively.
+Application state is handled by **Redux Toolkit**, with **RTK Query** used for data fetching and mutations. This replaced the previous thunk-based approach and greatly simplifies asynchronous logic. RTK Query auto-generates hooks for API access and manages caching, invalidation, and loading/error states declaratively.
 
 - The global store is created in `src/store.ts` and provided via `<Provider>`.
 - `setupListeners(store.dispatch)` enables automatic refetching on focus and reconnects.

--- a/web-client/src/hooks.ts
+++ b/web-client/src/hooks.ts
@@ -1,4 +1,5 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import type { AppDispatch, RootState } from './store';
 
 export const useAppDispatch: () => AppDispatch = useDispatch;

--- a/web-client/src/websocket.ts
+++ b/web-client/src/websocket.ts
@@ -1,0 +1,50 @@
+export type MessageHandler = (data: unknown) => void;
+
+class WebSocketClient {
+  private socket: WebSocket | null = null;
+  private handlers = new Set<MessageHandler>();
+
+  connect(path = '/ws'): void {
+    if (this.socket) {
+      return;
+    }
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const url = `${protocol}://${window.location.host}${path}`;
+    this.socket = new WebSocket(url);
+
+    this.socket.onmessage = (event) => {
+      let payload: unknown = event.data;
+      try {
+        payload = JSON.parse(event.data);
+      } catch {
+        // non-JSON payloads are allowed
+      }
+      this.handlers.forEach((h) => h(payload));
+    };
+
+    this.socket.onclose = () => {
+      this.socket = null;
+    };
+  }
+
+  send(data: unknown): void {
+    if (!this.socket) return;
+    const payload = typeof data === 'string' ? data : JSON.stringify(data);
+    this.socket.send(payload);
+  }
+
+  addMessageHandler(handler: MessageHandler): void {
+    this.handlers.add(handler);
+  }
+
+  removeMessageHandler(handler: MessageHandler): void {
+    this.handlers.delete(handler);
+  }
+
+  disconnect(): void {
+    this.socket?.close();
+    this.socket = null;
+  }
+}
+
+export const websocketClient = new WebSocketClient();


### PR DESCRIPTION
## Summary
- document migration from thunks to RTK Query
- adjust hooks import to satisfy TypeScript with `verbatimModuleSyntax`
- add `websocketClient` helper used by frontend

## Testing
- `npm run format`
- `npm run build`
- `npm run lint`
- ❌ `pre-commit run --all-files` *(failed: KeyboardInterrupt / memory issues)*
- ❌ `./gradlew check` *(failed: JVM garbage collector thrashing)*

------
https://chatgpt.com/codex/tasks/task_e_687393223ba4833086068fc573b29e26