### PR TITLE
Add budget metric test

### DIFF
--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -57,4 +57,18 @@ class TickServiceImplTest {
     org.junit.jupiter.api.Assertions.assertEquals(
         1.0, meterRegistry.get("game_session_lock_contention_total").counter().count(), 0.001);
   }
+
+  @Test
+  void slowTickIncrementsBudgetMetric() {
+    when(valueOps.setIfAbsent(any(), any(), any())).thenReturn(true);
+    when(redisTemplate.execute(any(RedisScript.class), any(List.class))).thenReturn(1L);
+    when(listOps.size(any())).thenReturn(0L);
+
+    org.springframework.test.util.ReflectionTestUtils.setField(service, "tickBudgetMs", 0L);
+
+    service.processTick(2L);
+
+    org.junit.jupiter.api.Assertions.assertEquals(
+        1.0, meterRegistry.get("game_session_tick_budget_exceeded_total").counter().count(), 0.001);
+  }
 }


### PR DESCRIPTION
## Summary
- add unit test verifying tick budget metric increments when tick is slow

## Testing
- `./gradlew :game-session-service:test --no-daemon`
- `pre-commit run --all-files` *(fails: lintMarkdown - npx exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68739b9249648330b0c76110b07522a7