### PR TITLE
Automate local Velero setup

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -44,21 +44,8 @@ This document defines the backup schedule and disaster recovery procedures for F
         existingSecret: velero-minio-creds
       ```
 
-      Create the `firemud-backups` bucket in MinIO prior to installing Velero. Example using the MinIO client:
-
-      ```bash
-      mc alias set local http://minio.minio.svc.cluster.local:9000 myaccesskey mysecretkey
-
-      mc mb local/firemud-backups
-      ```
-
-      Then install Velero using the local values file:
-
-      ```bash
-      helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
-      helm install velero vmware-tanzu/velero \
-        -n velero --create-namespace -f k8s/velero/values-minio.yaml
-      ```
+      Run `dev-tools/setup-local-backup.sh` to deploy MinIO, create the
+      `firemud-backups` bucket, and install Velero automatically.
 
   - If the database service fails completely:
   1. Restore the latest snapshot.

--- a/dev-tools/setup-local-backup.sh
+++ b/dev-tools/setup-local-backup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Setup MinIO and Velero for local FireMUD backups.
+# Deploys MinIO, creates the backup bucket, and installs Velero using
+# the provided Helm values.
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+
+MINIO_MANIFEST="$ROOT_DIR/k8s/velero/minio.yaml"
+VALUES_FILE="$ROOT_DIR/k8s/velero/values-minio.yaml"
+BUCKET="firemud-backups"
+
+# Apply MinIO manifest
+kubectl apply -f "$MINIO_MANIFEST"
+
+# Wait for MinIO deployment to be ready
+kubectl wait --for=condition=available --timeout=120s deployment/minio -n minio
+
+# Read credentials from secret
+ACCESS_KEY=$(kubectl get secret minio-creds -n minio -o jsonpath='{.data.accesskey}' | base64 -d)
+SECRET_KEY=$(kubectl get secret minio-creds -n minio -o jsonpath='{.data.secretkey}' | base64 -d)
+
+# Configure MinIO client and create bucket
+mc alias set local http://minio.minio.svc.cluster.local:9000 "$ACCESS_KEY" "$SECRET_KEY" >/dev/null
+mc mb local/$BUCKET || true
+
+# Create or update Velero credentials secret
+kubectl create secret generic velero-minio-creds -n velero \
+  --from-literal=cloud="[default]\naws_access_key_id=$ACCESS_KEY\naws_secret_access_key=$SECRET_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Install or upgrade Velero
+helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts >/dev/null
+helm upgrade --install velero vmware-tanzu/velero -n velero --create-namespace -f "$VALUES_FILE"
+
+echo "Local backup setup complete."

--- a/k8s/terraform-production/README.md
+++ b/k8s/terraform-production/README.md
@@ -5,3 +5,12 @@ It installs PostgreSQL and Redis using Bitnami Helm charts with replication enab
 
 These modules assume an existing Kubernetes cluster and `kubectl` access via a kubeconfig file.
 The configuration is intentionally minimal and should be customized for real deployments.
+
+## Variables
+
+The module exposes variables to configure Velero:
+
+- `velero_provider` – Object storage provider (e.g. `aws`, `gcp`).
+- `velero_bucket` – Backup bucket name.
+- `velero_bucket_prefix` – Prefix inside the bucket for backups.
+- `velero_credentials_secret` – Name of the Kubernetes secret containing credentials.

--- a/k8s/terraform-production/main.tf
+++ b/k8s/terraform-production/main.tf
@@ -47,8 +47,16 @@ resource "helm_release" "velero" {
     value = var.velero_provider
   }
   set {
-    name  = "configuration.backupStorageLocation.name"
+    name  = "configuration.backupStorageLocation.bucket"
     value = var.velero_bucket
+  }
+  set {
+    name  = "configuration.backupStorageLocation.prefix"
+    value = var.velero_bucket_prefix
+  }
+  set {
+    name  = "credentials.existingSecret"
+    value = var.velero_credentials_secret
   }
 }
 

--- a/k8s/terraform-production/variables.tf
+++ b/k8s/terraform-production/variables.tf
@@ -18,3 +18,15 @@ variable "velero_bucket" {
   description = "Velero backup bucket name"
   type        = string
 }
+
+variable "velero_bucket_prefix" {
+  description = "Prefix inside the backup bucket"
+  type        = string
+  default     = "postgres"
+}
+
+variable "velero_credentials_secret" {
+  description = "Existing Kubernetes secret containing Velero credentials"
+  type        = string
+  default     = "velero-creds"
+}

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -69,17 +69,8 @@ aws_access_key_id=myaccesskey
 aws_secret_access_key=mysecretkey'
 ```
 
-Create the backup bucket using the MinIO client or web UI before installing Velero. Example with the `mc` CLI:
+Run the helper script to deploy MinIO, create the bucket, and install Velero:
 
 ```bash
-mc alias set local http://minio.minio.svc.cluster.local:9000 myaccesskey mysecretkey
-mc mb local/firemud-backups
-```
-
-Install Velero with these values after the MinIO bucket has been created:
-
-```bash
-helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
-helm install velero vmware-tanzu/velero \
-  -n velero --create-namespace -f values-minio.yaml
+dev-tools/setup-local-backup.sh
 ```


### PR DESCRIPTION
## Summary
- automate creation of MinIO bucket and Velero install with a new script
- wire velero bucket, prefix and credentials through Terraform variables
- document new script and Terraform variables in backup docs

## Testing
- `pre-commit run --all-files` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687395223bfc833089a69c97ba77e600