### PR TITLE
Update Kubernetes configs and helm docs

### DIFF
--- a/charts/firemud/Chart.yaml
+++ b/charts/firemud/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: firemud
+version: 0.1.0
+appVersion: "1.0"
+description: Example umbrella chart for FireMUD

--- a/charts/firemud/values.yaml
+++ b/charts/firemud/values.yaml
@@ -1,0 +1,50 @@
+accountService:
+  image:
+    repository: ghcr.io/example/account-service
+    tag: latest
+gameSessionService:
+  image:
+    repository: ghcr.io/example/game-session-service
+    tag: latest
+automationScriptingService:
+  image:
+    repository: ghcr.io/example/automation-scripting-service
+    tag: latest
+entityManagementService:
+  image:
+    repository: ghcr.io/example/entity-management-service
+    tag: latest
+gameDesignService:
+  image:
+    repository: ghcr.io/example/game-design-service
+    tag: latest
+gameLogicService:
+  image:
+    repository: ghcr.io/example/game-logic-service
+    tag: latest
+loggingAdminService:
+  image:
+    repository: ghcr.io/example/logging-admin-service
+    tag: latest
+socialGroupsService:
+  image:
+    repository: ghcr.io/example/social-groups-service
+    tag: latest
+springCloudGateway:
+  image:
+    repository: ghcr.io/example/spring-cloud-gateway
+    tag: latest
+tcpProxyService:
+  image:
+    repository: ghcr.io/example/tcp-proxy-service
+    tag: latest
+worldManagementService:
+  image:
+    repository: ghcr.io/example/world-management-service
+    tag: latest
+redis:
+  persistence:
+    size: 8Gi
+postgresql:
+  persistence:
+    size: 10Gi

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -10,7 +10,7 @@ This document summarizes routine procedures for deploying, scaling, and recoveri
 2. **Helm Charts** deploy each microservice. Install with:
 
    ```bash
-   helm install firemud ./k8s/charts/firemud -f k8s/charts/firemud/values-prod.yaml
+   helm install firemud ./k8s/helm/firemud -f k8s/helm/values-dev.yaml
    ```
 
 3. Verify pods are running with `kubectl get pods -n firemud`.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -57,6 +57,10 @@ and the Spring Cloud Gateway is published on port `80`.
 
 A sample Terraform module is available in [`terraform/`](./terraform) to spin up a local Kind cluster with a `firemud` namespace and admin RBAC. It can optionally install Redis via Helm.
 
+## Persistent Storage
+
+The production Terraform modules provision persistent volumes for PostgreSQL and Redis. Default sizes are defined in `terraform-production/postgres-values.yaml` and `terraform-production/redis-values.yaml` as **10Gi** and **8Gi** respectively. Update these values to match your capacity planning when deploying to a real cluster.
+
 ## Helm Charts
 
 The [`helm/`](./helm) folder contains example charts. Use `values-local.yaml` or `values-dev.yaml` to override connection details and feature flags when deploying locally:

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: account-service
           image: account-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,6 +35,11 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: automation-scripting-service
           image: automation-scripting-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: entity-management-service
           image: entity-management-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: game-design-service
           image: game-design-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: game-logic-service
           image: game-logic-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: game-session-service
           image: game-session-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:
@@ -55,10 +61,6 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
-      volumes:
-        - name: grpc-tls
-          secret:
-            secretName: firemud-grpc-tls
       volumes:
         - name: grpc-tls
           secret:

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: logging-admin-service
           image: logging-admin-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:
@@ -57,6 +63,7 @@ spec:
             periodSeconds: 20
         - name: fluent-bit
           image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: IfNotPresent
           args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
           volumeMounts:
             - name: varlog
@@ -64,6 +71,11 @@ spec:
             - name: containers
               mountPath: /var/lib/docker/containers
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: social-groups-service
           image: social-groups-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
         - name: spring-cloud-gateway
           image: spring-cloud-gateway:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -30,13 +31,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -16,13 +16,19 @@ spec:
       containers:
         - name: tcp-proxy-service
           image: tcp-proxy-service:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 2323
           readinessProbe:

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: world-management-service
           image: world-management-service:latest
+          imagePullPolicy: IfNotPresent
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -34,13 +35,18 @@ spec:
             - name: grpc-tls
               mountPath: /tls
               readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
           resources:
             requests:
-              cpu: "100m"
-              memory: "128Mi"
-            limits:
               cpu: "200m"
               memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/k8s/helm/firemud/values.yaml
+++ b/k8s/helm/firemud/values.yaml
@@ -4,3 +4,30 @@ account-service:
 game-session-service:
   image:
     tag: latest
+automation-scripting-service:
+  image:
+    tag: latest
+entity-management-service:
+  image:
+    tag: latest
+game-design-service:
+  image:
+    tag: latest
+game-logic-service:
+  image:
+    tag: latest
+logging-admin-service:
+  image:
+    tag: latest
+social-groups-service:
+  image:
+    tag: latest
+spring-cloud-gateway:
+  image:
+    tag: latest
+tcp-proxy-service:
+  image:
+    tag: latest
+world-management-service:
+  image:
+    tag: latest

--- a/k8s/terraform-production/README.md
+++ b/k8s/terraform-production/README.md
@@ -5,3 +5,9 @@ It installs PostgreSQL and Redis using Bitnami Helm charts with replication enab
 
 These modules assume an existing Kubernetes cluster and `kubectl` access via a kubeconfig file.
 The configuration is intentionally minimal and should be customized for real deployments.
+Persistent volumes are configured via the included Helm values files:
+
+- `postgres-values.yaml` provisions a **10Gi** volume for the PostgreSQL primary and each replica.
+- `redis-values.yaml` provisions **8Gi** volumes for Redis master and replicas with AOF enabled.
+
+Adjust these sizes to fit your production retention policy before applying the module.


### PR DESCRIPTION
## Summary
- add missing Chart and example values for FireMUD Helm chart
- expand K8s resource requests and limits
- add `imagePullPolicy` and security contexts
- fix duplicate volumes in game session manifest
- document persistent volumes in k8s README and Terraform README
- include all services in sample Helm charts

## Testing
- `pre-commit run --all-files` *(failed: interrupted at Checkstyle)*
- `./gradlew check` *(failed: spotbugs warnings and other output)*
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_68739039b5ac8330b1bf6e3bc997ef7d