### PR TITLE
Document manual Helm deployment and use base image

### DIFF
--- a/.github/workflows/manual-helm-deploy.yml
+++ b/.github/workflows/manual-helm-deploy.yml
@@ -1,0 +1,18 @@
+name: Manual Helm Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install firemud ./k8s/helm/firemud \
+            -f k8s/helm/values-local.yaml

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -52,7 +52,7 @@ In production, FireMUD is deployed into Kubernetes (e.g., AWS EKS, Google GKE, o
 - The cluster uses **IPVS** (or a similar load-balancing mode) to route service traffic efficiently.
 - Redis runs as a clustered StatefulSet with automatic failover. Details are in [Redis Architecture](../system-architecture-redis.md). Redis persistence uses **AOF**, as described there.
 - PostgreSQL is deployed within the cluster (or provided as a managed database service) to store persistent domain data. See [System Architecture Overview](../system-architecture-overview.md#📦-data-and-state-management). Backup and restore procedures are outlined in [Backup & Disaster Recovery](../system-architecture-backup-recovery.md).
-- Deployments are managed via Helm charts in the CI/CD pipeline. See [CI/CD Pipeline](../system-architecture-cicd.md#🚢-deploying-to-kubernetes) for details.
+- Deployments use Helm charts but are triggered manually. The `manual-helm-deploy.yml` GitHub workflow runs `helm upgrade` against a local cluster when invoked. See [CI/CD Pipeline](../system-architecture-cicd.md#🚢-deploying-to-kubernetes) for details.
 
 A sample Terraform module for a local Kind cluster is provided in [k8s/terraform](../../k8s/terraform). This demo module creates a `firemud` namespace and optional Redis Helm release for quick testing. Use `helm install` with the example charts in [k8s/helm](../../k8s/helm) to deploy services locally.
 

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -1,6 +1,6 @@
 # 🚀 FireMUD System Architecture: CI/CD Pipeline
 
-This document describes the basic continuous integration and deployment strategy for FireMUD using **GitHub Actions**. Every service is built, tested, containerized, and deployed automatically so that changes reach production reliably.
+This document describes the basic continuous integration and deployment strategy for FireMUD using **GitHub Actions**. Every service is built, tested, and containerized. Deployment to Kubernetes is triggered manually using a dedicated workflow until cloud hosting is available.
 
 ---
 
@@ -102,17 +102,18 @@ Images are tagged with the commit SHA and pushed to **GitHub Container Registry 
 
 ### Base Docker Image
 
-The firemud-base image provides a consistent OS and JVM setup across all service containers. It is built using the buildBaseImage Gradle task and reused by all microservice Dockerfiles.
+The firemud-base image provides a consistent OS and JVM setup across all service containers. It is built using the `buildBaseImage` Gradle task and referenced in each microservice Dockerfile as `ghcr.io/firedevops/firemud-base:latest`.
 
 ---
 
 ## 🚢 Deploying to Kubernetes
 
-At the moment FireMUD does not automatically deploy to Kubernetes. Operators
-apply the manifests in [`k8s/`](../../k8s/) or the provided Helm charts to roll
-out new versions. Cluster credentials and registry secrets are managed manually.
-When automated deployment is added, a workflow similar to the example below can
-be introduced.
+FireMUD does not yet deploy automatically to Kubernetes. Operators trigger the
+`manual-helm-deploy.yml` workflow when they want to roll out a new version. That
+job runs `helm upgrade` against a local cluster using the charts in
+[`k8s/helm`](../../k8s/helm). Cluster credentials and registry secrets must be
+configured beforehand. When full automation is added, a workflow similar to the
+example below can be introduced.
 
 ```yaml
 deploy:

--- a/services/account-service/Dockerfile
+++ b/services/account-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/automation-scripting-service/Dockerfile
+++ b/services/automation-scripting-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/entity-management-service/Dockerfile
+++ b/services/entity-management-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/game-design-service/Dockerfile
+++ b/services/game-design-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/game-logic-service/Dockerfile
+++ b/services/game-logic-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/game-session-service/Dockerfile
+++ b/services/game-session-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/logging-admin-service/Dockerfile
+++ b/services/logging-admin-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/social-groups-service/Dockerfile
+++ b/services/social-groups-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/spring-cloud-gateway/Dockerfile
+++ b/services/spring-cloud-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/tcp-proxy-service/Dockerfile
+++ b/services/tcp-proxy-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh

--- a/services/world-management-service/Dockerfile
+++ b/services/world-management-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM ghcr.io/firedevops/firemud-base:latest
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 COPY ../../dev-tools/wait-for-it.sh /usr/local/bin/wait-for-it.sh


### PR DESCRIPTION
## Summary
- note that Helm deployments are triggered manually
- reference the manual-helm-deploy workflow
- introduce a GitHub Action to run Helm when invoked
- inherit the `firemud-base` image in all service Dockerfiles

## Testing
- `pre-commit run --all-files` *(fails: SpotBugs step interrupted)*
- `./gradlew check` *(fails: spotbugs warnings; process killed)*

------
https://chatgpt.com/codex/tasks/task_e_6874a21890548330adbd0962c2186c2b