### PR TITLE
Implement tick command limits

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -59,6 +59,9 @@ random when the Game Session Service requests a PvE interaction.
 - `automation_queue` keys in Redis buffer triggered events until a script runs.
 - `automation_queue_enqueued_total` and `automation_queue_drained_total` metrics
   track Redis queue activity.
+- The staging Lua script processes only a limited number of events each tick
+  (controlled by `AUTOMATION_TICK_MAX_EVENTS`) to keep automation work
+  predictable.
 - Player reputation data is stored in the Social & Groups Service; see its
   [data model](../social-groups-service/README.md#data-model) for the
   `faction` and `faction_standing` tables.
@@ -131,6 +134,7 @@ Additional variables tune the scripting engine:
 | `SCRIPT_QUOTA_LIMIT` | Number of events a script may process per window | `50` |
 | `SCRIPT_QUOTA_WINDOWSECONDS` | Length of the quota window in seconds | `60` |
 | `AUTOMATION_TICK_DURATION_MS` | Duration of a processing tick in milliseconds | `1000` |
+| `AUTOMATION_TICK_MAX_EVENTS` | Max events staged from the automation queue each tick | `50` |
 
 ## Proto Files
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -63,6 +63,8 @@ Orchestrates live game sessions, including tick execution, player input validati
 
 - Each session advances in fixed-length ticks controlled by a Redis-based timer.
 - Commands are collected during a tick and executed in deterministic order.
+- The staging Lua script only moves a limited number of commands each tick
+  (`GAME_TICK_MAX_COMMANDS`) so one player cannot starve others.
 - After execution, results are persisted and broadcast to connected clients.
 
 ### gRPC APIs
@@ -101,6 +103,8 @@ The OpenTelemetry collector endpoint can be overridden via `OTEL_ENDPOINT` (see 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
 | `GAME_TICK_DURATION_MS` | Length of a single game tick in milliseconds | `1000` |
+| `GAME_TICK_BUDGET_MS` | Soft execution budget for a tick in milliseconds | `100` |
+| `GAME_TICK_MAX_COMMANDS` | Max commands staged from the queue each tick | `50` |
 | `FIREMUD_SERVICES_GAME_LOGIC_SERVICE` | gRPC endpoint (host:port) for the Game Logic Service | *(none)* |
 
 ## Proto Files

--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -54,6 +54,9 @@ These notes summarize typical optimizations applied across FireMUD services.
   deferred to follow-up ticks so long-running commands never block the game
   loop. Conflict metadata collected during retries highlights hotspots for
   operators.
+- Lua staging scripts move only a limited number of commands or events per tick
+  (configurable via `game.tick-max-commands` and `automation.tick-max-events`).
+  This prevents runaway loops and keeps work evenly distributed across ticks.
 - The TCP Proxy Service limits connections per IP and throttles messages per
   client to shield the gateway from abuse.
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -131,6 +131,10 @@ Each tick enforces a **soft execution budget** (e.g., 100ms):
 - **Oldest actions win** in conflict scenarios
 - Newer submissions are backlogged until resolved
 - Conflict metadata enables **hotspot detection** and livelock prevention
+- Lua staging scripts limit how many commands or events move from queue to
+  pending lists per tick. The defaults (`game.tick-max-commands` and
+  `automation.tick-max-events`) spread heavy workloads across ticks so one
+  player or script cannot monopolize the loop.
 
 ---
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -33,6 +33,9 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   @Value("${automation.tick-duration-ms:1000}")
   private long tickDurationMs;
 
+  @Value("${automation.tick-max-events:50}")
+  private int tickMaxEvents;
+
   private Counter enqueueCounter;
   private Counter redisErrorCounter;
   private Counter lockContentionCounter;
@@ -44,11 +47,11 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   private RedisScript<Long> commitScript;
   private RedisScript<Long> rollbackScript;
 
-  private Long executeScriptWithRetry(RedisScript<Long> script, List<String> keys) {
+  private Long executeScriptWithRetry(RedisScript<Long> script, List<String> keys, Object... args) {
     int attempts = 0;
     while (true) {
       try {
-        return redisTemplate.execute(script, keys);
+        return redisTemplate.execute(script, keys, args);
       } catch (Exception ex) {
         attempts++;
         redisErrorCounter.increment();
@@ -145,7 +148,8 @@ public class ScriptTickServiceImpl implements ScriptTickService {
                   () ->
                       executeScriptWithRetry(
                           stageScript,
-                          List.of(queueKey(tenantId, scriptId), pendingKey(tenantId, scriptId)))));
+                          List.of(queueKey(tenantId, scriptId), pendingKey(tenantId, scriptId)),
+                          tickMaxEvents)));
       tickTimer.record(
           () ->
               luaTimer.record(

--- a/services/automation-scripting-service/src/main/resources/application-prod.yml
+++ b/services/automation-scripting-service/src/main/resources/application-prod.yml
@@ -19,6 +19,9 @@ script:
   quota:
     limit: ${SCRIPT_QUOTA_LIMIT:50}
     windowSeconds: ${SCRIPT_QUOTA_WINDOWSECONDS:60}
+automation:
+  tick-duration-ms: ${AUTOMATION_TICK_DURATION_MS:1000}
+  tick-max-events: ${AUTOMATION_TICK_MAX_EVENTS:50}
 
 server:
   compression:

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -20,6 +20,9 @@ script:
   quota:
     limit: 50
     windowSeconds: 60
+automation:
+  tick-duration-ms: 1000
+  tick-max-events: 50
 
 server:
   compression:

--- a/services/automation-scripting-service/src/main/resources/redis/tick_stage.lua
+++ b/services/automation-scripting-service/src/main/resources/redis/tick_stage.lua
@@ -1,7 +1,8 @@
 local queue = KEYS[1]
 local pending = KEYS[2]
+local max = tonumber(ARGV[1])
 local moved = 0
-while true do
+while moved < max do
   local cmd = redis.call('LPOP', queue)
   if not cmd then
     break

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -36,6 +36,9 @@ public class TickServiceImpl implements TickService {
   @Value("${game.tick-budget-ms:100}")
   private long tickBudgetMs;
 
+  @Value("${game.tick-max-commands:50}")
+  private int tickMaxCommands;
+
   private Counter enqueueCounter;
   private Counter redisErrorCounter;
   private Counter lockContentionCounter;
@@ -48,11 +51,11 @@ public class TickServiceImpl implements TickService {
   private RedisScript<Long> commitScript;
   private RedisScript<Long> rollbackScript;
 
-  private Long executeScriptWithRetry(RedisScript<Long> script, List<String> keys) {
+  private Long executeScriptWithRetry(RedisScript<Long> script, List<String> keys, Object... args) {
     int attempts = 0;
     while (true) {
       try {
-        return redisTemplate.execute(script, keys);
+        return redisTemplate.execute(script, keys, args);
       } catch (Exception ex) {
         attempts++;
         redisErrorCounter.increment();
@@ -145,7 +148,9 @@ public class TickServiceImpl implements TickService {
               luaTimer.record(
                   () ->
                       executeScriptWithRetry(
-                          stageScript, List.of(queueKey(sessionId), pendingKey(sessionId)))));
+                          stageScript,
+                          List.of(queueKey(sessionId), pendingKey(sessionId)),
+                          tickMaxCommands)));
       tickTimer.record(
           () ->
               luaTimer.record(

--- a/services/game-session-service/src/main/resources/application-prod.yml
+++ b/services/game-session-service/src/main/resources/application-prod.yml
@@ -17,6 +17,8 @@ management:
 
 game:
   tick-duration-ms: ${GAME_TICK_DURATION_MS:1000}
+  tick-budget-ms: ${GAME_TICK_BUDGET_MS:100}
+  tick-max-commands: ${GAME_TICK_MAX_COMMANDS:50}
 
 firemud:
   services:

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -17,6 +17,8 @@ management:
         enabled: true
 game:
   tick-duration-ms: 1000
+  tick-budget-ms: 100
+  tick-max-commands: 50
 firemud:
   services:
     game-logic-service: game-logic-service:6565

--- a/services/game-session-service/src/main/resources/redis/tick_stage.lua
+++ b/services/game-session-service/src/main/resources/redis/tick_stage.lua
@@ -1,7 +1,8 @@
 local queue = KEYS[1]
 local pending = KEYS[2]
+local max = tonumber(ARGV[1])
 local moved = 0
-while true do
+while moved < max do
   local cmd = redis.call('LPOP', queue)
   if not cmd then
     break


### PR DESCRIPTION
## Summary
- limit Lua staging scripts to a configurable number of commands
- pass the limit from `TickServiceImpl` and `ScriptTickServiceImpl`
- expose new properties in `application.yml`
- document command and event limits in tick architecture and service docs

## Testing
- `./gradlew check` *(failed: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68749ee14df88330a10a59ba7376ded8