### PR TITLE
Add manual backup verification workflow

### DIFF
--- a/.github/workflows/manual-backup-restore.yml
+++ b/.github/workflows/manual-backup-restore.yml
@@ -1,0 +1,54 @@
+name: Manual Backup Verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      restore:
+        description: 'Run restore test as well'
+        required: false
+        default: 'false'
+      namespace:
+        description: 'Namespace for restore test'
+        required: false
+        default: 'restore-test'
+      backup_name:
+        description: 'Backup name to restore (defaults to latest)'
+        required: false
+        default: ''
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Install Velero CLI
+        run: |
+          VELERO_VERSION=v1.12.3
+          curl -L https://github.com/vmware-tanzu/velero/releases/download/$VELERO_VERSION/velero-$VELERO_VERSION-linux-amd64.tar.gz -o velero.tar.gz
+          tar -xzf velero.tar.gz
+          sudo mv velero-$VELERO_VERSION-linux-amd64/velero /usr/local/bin/velero
+
+      - name: Verify backups
+        run: dev-tools/verify-backups.sh
+
+      - name: Create restore namespace
+        if: ${{ inputs.restore == 'true' }}
+        run: |
+          kubectl create namespace "${{ inputs.namespace }}" --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Run restore test
+        if: ${{ inputs.restore == 'true' }}
+        env:
+          FIREMUD_K8S_NAMESPACE: ${{ inputs.namespace }}
+        run: |
+          BACKUP="${{ inputs.backup_name }}"
+          if [ -z "$BACKUP" ]; then
+            BACKUP=$(velero backup get -n ${{ inputs.namespace }} --no-headers | awk 'END{print $1}')
+          fi
+          dev-tools/restore-cluster.sh "$BACKUP"
+

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -97,8 +97,11 @@ Because Redis is not a source of truth, this strategy guarantees a clean, determ
   the object store. This CronJob is installed automatically by the production
   Terraform modules.
 - Operators should periodically test recovery by restoring a snapshot into a
-  throwaway namespace with `dev-tools/restore-cluster.sh <backup-name>` and
-  verifying services start successfully.
+  throwaway namespace with `dev-tools/restore-cluster.sh <backup-name>
+  <namespace>` (or by setting `FIREMUD_K8S_NAMESPACE`) and verifying
+  services start successfully. A manual workflow
+  `.github/workflows/manual-backup-restore.yml` can run these checks on
+  demand from the GitHub Actions UI.
 
 ---
 

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -47,7 +47,10 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      restart containers with `docker compose restart`.
    - Scheduled backups are created automatically by the Terraform modules using
      `k8s/velero/schedule.yaml`.
-   - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
+    - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
+    - A manual workflow `manual-backup-restore.yml` can verify backups and
+      perform an optional restore test in a temporary namespace. Trigger it
+      from the GitHub Actions UI when needed.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**


### PR DESCRIPTION
## Summary
- add workflow for manual backup verification and restore testing
- document manual workflow in backup recovery and runbooks

## Testing
- `pre-commit run --files design/architecture/system-architecture-backup-recovery.md design/architecture/system-architecture-runbooks.md .github/workflows/manual-backup-restore.yml` *(failed: Execution failed for task ':lintMarkdown')*

------
https://chatgpt.com/codex/tasks/task_e_68749f52e2b483309509eaf9c81ba7df