### PR TITLE
Add TCP proxy connection metrics

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -1,6 +1,9 @@
 package net.firedevops.firemud.telnet;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
@@ -33,6 +36,10 @@ public class TelnetServer {
   private final int maxConnectionsPerIp;
   private final int maxMessagesPerSecond;
 
+  private final java.util.concurrent.atomic.AtomicInteger activeConnections =
+      new java.util.concurrent.atomic.AtomicInteger();
+  private final Counter connectionCounter;
+
   private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
   private Channel serverChannel;
@@ -47,7 +54,8 @@ public class TelnetServer {
       @Value("${TCP_PROXY_TLS_CERT:}") String certPath,
       @Value("${TCP_PROXY_TLS_KEY:}") String keyPath,
       @Value("${TCP_PROXY_MAX_CONNECTIONS_PER_IP:5}") int maxConnectionsPerIp,
-      @Value("${TCP_PROXY_MAX_MSGS_PER_SEC:5}") int maxMessagesPerSec)
+      @Value("${TCP_PROXY_MAX_MSGS_PER_SEC:5}") int maxMessagesPerSec,
+      MeterRegistry meterRegistry)
       throws SSLException {
     this.port = port;
     this.gatewayWsUrl = gatewayWsUrl;
@@ -57,6 +65,12 @@ public class TelnetServer {
     this.maxConnectionsPerIp = maxConnectionsPerIp;
     this.maxMessagesPerSecond = maxMessagesPerSec;
     this.connectionThrottler = new ConnectionThrottler(maxConnectionsPerIp);
+    this.connectionCounter = meterRegistry.counter("tcpproxy.connections.total");
+    Gauge.builder(
+            "tcpproxy.connections.active",
+            activeConnections,
+            java.util.concurrent.atomic.AtomicInteger::get)
+        .register(meterRegistry);
     if (tlsEnabled) {
       sslContext = SslContextBuilder.forServer(new File(certPath), new File(keyPath)).build();
     }
@@ -83,7 +97,11 @@ public class TelnetServer {
                     .addLast(new StringDecoder())
                     .addLast(
                         new TelnetServerHandler(
-                            gatewayWsUrl, connectionThrottler, maxMessagesPerSecond));
+                            gatewayWsUrl,
+                            connectionThrottler,
+                            maxMessagesPerSecond,
+                            activeConnections,
+                            connectionCounter));
               }
             });
     serverChannel = b.bind(port).sync().channel();
@@ -110,5 +128,15 @@ public class TelnetServer {
   /** Expose the configured port for testing purposes. */
   public int getPort() {
     return port;
+  }
+
+  /** Current active connection count for metrics testing. */
+  int getActiveConnectionCount() {
+    return activeConnections.get();
+  }
+
+  /** Total connection count for metrics testing. */
+  double getTotalConnections() {
+    return connectionCounter.count();
   }
 }

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -24,15 +24,23 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private final String gatewayWsUrl;
   private final ConnectionThrottler connectionThrottler;
   private final int maxMessagesPerSecond;
+  private final java.util.concurrent.atomic.AtomicInteger activeConnections;
+  private final io.micrometer.core.instrument.Counter connectionCounter;
   private WebSocket webSocket;
   private final Queue<String> buffer = new ConcurrentLinkedQueue<>();
   private final Deque<Long> messageTimes = new ArrayDeque<>();
 
   public TelnetServerHandler(
-      String gatewayWsUrl, ConnectionThrottler connectionThrottler, int maxMessagesPerSecond) {
+      String gatewayWsUrl,
+      ConnectionThrottler connectionThrottler,
+      int maxMessagesPerSecond,
+      java.util.concurrent.atomic.AtomicInteger activeConnections,
+      io.micrometer.core.instrument.Counter connectionCounter) {
     this.gatewayWsUrl = gatewayWsUrl;
     this.connectionThrottler = connectionThrottler;
     this.maxMessagesPerSecond = maxMessagesPerSecond;
+    this.activeConnections = activeConnections;
+    this.connectionCounter = connectionCounter;
   }
 
   void setWebSocket(WebSocket webSocket) {
@@ -62,6 +70,8 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       ctx.close();
       return;
     }
+    connectionCounter.increment();
+    activeConnections.incrementAndGet();
     HttpClient client = HttpClient.newHttpClient();
     client
         .newWebSocketBuilder()
@@ -119,6 +129,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
     var remote = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
     connectionThrottler.release(remote);
+    activeConnections.decrementAndGet();
     messageTimes.clear();
     buffer.clear();
   }

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -20,7 +20,12 @@ class TelnetServerHandlerTest {
   @Test
   void bufferedInputFlushedOnWebSocketConnect() {
     TelnetServerHandler handler =
-        new TelnetServerHandler("ws://localhost/ws", new ConnectionThrottler(1), 5);
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            new ConnectionThrottler(1),
+            5,
+            new java.util.concurrent.atomic.AtomicInteger(),
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -44,7 +49,12 @@ class TelnetServerHandlerTest {
   @Test
   void bufferClearedOnDisconnect() {
     TelnetServerHandler handler =
-        new TelnetServerHandler("ws://localhost/ws", new ConnectionThrottler(1), 5);
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            new ConnectionThrottler(1),
+            5,
+            new java.util.concurrent.atomic.AtomicInteger(),
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -60,7 +70,12 @@ class TelnetServerHandlerTest {
   @Test
   void rateLimitDropsExcessMessages() {
     TelnetServerHandler handler =
-        new TelnetServerHandler("ws://localhost/ws", new ConnectionThrottler(1), 1);
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            new ConnectionThrottler(1),
+            1,
+            new java.util.concurrent.atomic.AtomicInteger(),
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -79,7 +94,12 @@ class TelnetServerHandlerTest {
   @Test
   void unsupportedTelnetCommandsAreDropped() {
     TelnetServerHandler handler =
-        new TelnetServerHandler("ws://localhost/ws", new ConnectionThrottler(1), 5);
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            new ConnectionThrottler(1),
+            5,
+            new java.util.concurrent.atomic.AtomicInteger(),
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -99,7 +119,12 @@ class TelnetServerHandlerTest {
   @Test
   void controlCharactersAreRemoved() {
     TelnetServerHandler handler =
-        new TelnetServerHandler("ws://localhost/ws", new ConnectionThrottler(1), 5);
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            new ConnectionThrottler(1),
+            5,
+            new java.util.concurrent.atomic.AtomicInteger(),
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -119,7 +144,12 @@ class TelnetServerHandlerTest {
   @Test
   void emptyAfterSanitizeIsIgnored() {
     TelnetServerHandler handler =
-        new TelnetServerHandler("ws://localhost/ws", new ConnectionThrottler(1), 5);
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            new ConnectionThrottler(1),
+            5,
+            new java.util.concurrent.atomic.AtomicInteger(),
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
@@ -17,7 +17,16 @@ class TelnetServerTest {
 
   @Test
   void serverStartsAndStops() throws Exception {
-    server = new TelnetServer(0, "ws://localhost/ws", false, "", "", 5, 5);
+    server =
+        new TelnetServer(
+            0,
+            "ws://localhost/ws",
+            false,
+            "",
+            "",
+            5,
+            5,
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
     server.start();
     server.stop();
     assertTrue(true); // no exception means success


### PR DESCRIPTION
## Summary
- instrument TelnetServer with connection metrics
- track active and total connections in TelnetServerHandler
- update TCP proxy tests for new constructor

## Testing
- `./gradlew :tcp-proxy-service:spotlessApply`
- `./gradlew check` *(failed: SpotBugs warnings cause lengthy output; build attempt interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6874ab2c8404833081bea6c8e7aceb61