### PR TITLE
Fix build failures

### DIFF
--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -48,10 +48,11 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      restart containers with `docker compose restart`.
    - Scheduled backups are created automatically by the Terraform modules using
      `k8s/velero/schedule.yaml`.
-    - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
-    - A manual workflow `manual-backup-restore.yml` can verify backups and
-      perform an optional restore test in a temporary namespace. Trigger it
-      from the GitHub Actions UI when needed.
+   - Daily backup checks are handled by the `verify-backups` CronJob deployed by
+     Terraform.
+   - A manual workflow `manual-backup-restore.yml` can verify backups and
+     perform an optional restore test in a temporary namespace. Trigger it
+     from the GitHub Actions UI when needed.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/services/account-service/src/main/java/net/firedevops/firemud/client/StripeClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/StripeClient.java
@@ -13,13 +13,14 @@ public class StripeClient {
   public StripeClient(String apiKey, double platformFeePercent) {
     this.apiKey = apiKey;
     this.platformFeePercent = platformFeePercent;
+    // Set once during construction to avoid repeated writes to static field
+    Stripe.apiKey = apiKey;
   }
 
   public record IntentResult(String id, String clientSecret, String status) {}
 
   public IntentResult createPaymentIntent(long amountCents, String currency)
       throws StripeException {
-    Stripe.apiKey = apiKey;
     long fee = calculatePlatformFee(amountCents);
     PaymentIntentCreateParams params =
         PaymentIntentCreateParams.builder()
@@ -40,7 +41,6 @@ public class StripeClient {
   }
 
   public void createRefund(String paymentIntentId) throws StripeException {
-    Stripe.apiKey = apiKey;
     RefundCreateParams params =
         RefundCreateParams.builder().setPaymentIntent(paymentIntentId).build();
     com.stripe.model.Refund.create(params);


### PR DESCRIPTION
## Summary
- fix markdown indentation
- set Stripe API key once in constructor to avoid SpotBugs ST_WRITE_TO_STATIC

## Testing
- `./gradlew :account-service:spotbugsMain --no-daemon`
- `./gradlew check --no-daemon` *(fails: SpotBugs output and process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6874ad93c75883309cf16ba0927d3b44