### PR TITLE
Update Velero configuration docs

### DIFF
--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -48,10 +48,10 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      restart containers with `docker compose restart`.
    - Scheduled backups are created automatically by the Terraform modules using
      `k8s/velero/schedule.yaml`.
-    - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
-    - A manual workflow `manual-backup-restore.yml` can verify backups and
-      perform an optional restore test in a temporary namespace. Trigger it
-      from the GitHub Actions UI when needed.
+   - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
+   - A manual workflow `manual-backup-restore.yml` can verify backups and
+     perform an optional restore test in a temporary namespace. Trigger it
+     from the GitHub Actions UI when needed.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/k8s/terraform-production/README.md
+++ b/k8s/terraform-production/README.md
@@ -21,3 +21,18 @@ The module exposes variables to configure Velero:
 - `velero_bucket` – Backup bucket name.
 - `velero_bucket_prefix` – Prefix inside the bucket for backups.
 - `velero_credentials_secret` – Name of the Kubernetes secret containing credentials.
+
+Create a `terraform.tfvars` file (or pass variables via the CLI) with values for
+these settings. An example `terraform.tfvars.example` is provided:
+
+```tfvars
+kubeconfig               = "~/.kube/config"
+namespace                = "firemud"
+velero_provider          = "aws"
+velero_bucket            = "firemud-backups"
+velero_bucket_prefix     = "postgres"
+velero_credentials_secret = "velero-creds"
+```
+
+Replace the bucket name and credentials secret with your production object
+storage details to prevent failed backups.

--- a/k8s/terraform-production/terraform.tfvars.example
+++ b/k8s/terraform-production/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Example values for deploying FireMUD with Velero backups
+# Copy to terraform.tfvars and replace with your production settings
+
+kubeconfig               = "~/.kube/config"
+namespace                = "firemud"
+velero_provider          = "aws"
+velero_bucket            = "firemud-backups"
+velero_bucket_prefix     = "postgres"
+velero_credentials_secret = "velero-creds"


### PR DESCRIPTION
## Summary
- add `terraform.tfvars.example` with Velero bucket and credential settings
- document using a `terraform.tfvars` file in Terraform production README
- fix markdown list indentation

## Testing
- `./gradlew lintMarkdown`

------
https://chatgpt.com/codex/tasks/task_e_6874ab88b73c833087a201090ed2dcbf