### PR TITLE
Implement pg_dump retention and bucket upload

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -174,7 +174,11 @@ Use `dev-tools/backup-db.sh` to create a snapshot and
 
 ### Automatic Kubernetes Backups
 
-Production clusters run a `firemud-pg-dump` CronJob that writes compressed dumps to a `firemud-pg-dumps` volume (or MinIO bucket). Retrieve a dump with `kubectl cp` and restore it with `psql` as shown in the runbooks. Velero schedules back up only Kubernetes manifests.
+Production clusters run a `firemud-pg-dump` CronJob that writes compressed dumps
+to a `firemud-pg-dumps` volume. A helper script rotates these files and can
+upload them to an object bucket when `PG_DUMP_BUCKET` is configured. Retrieve a
+dump with `kubectl cp` or `aws s3 cp` and restore it with `psql` as shown in the
+runbooks. Velero schedules back up only Kubernetes manifests.
 
 ### Optional Redis Persistence
 

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -11,7 +11,10 @@ This document defines the backup schedule and disaster recovery procedures for F
   - **24 hours** of 15‑minute dumps
   - **3 weekly** dumps
   - **3 monthly** dumps
-- The CronJob writes to a persistent volume claim `firemud-pg-dumps` or uploads to MinIO if configured.
+- The CronJob writes to a persistent volume claim `firemud-pg-dumps` and runs
+  a script (`pg-dump.sh`) that enforces the retention policy. When the
+  environment variable `PG_DUMP_BUCKET` is set, the script also uploads each
+  dump to the specified S3/MinIO bucket.
 - Velero schedules defined in `k8s/velero/schedule.yaml` back up only Kubernetes manifests.
 - Copy `k8s/velero/values.example.yaml` to `values.yaml` and configure your object storage bucket. Example snippet:
 

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -37,21 +37,25 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      Set `FIREMUD_K8S_NAMESPACE` to restore into a custom namespace.
    - Alternatively, restore manually:
 
-     ```bash
-     kubectl cp <namespace>/<pg-pod>:/backups/latest.sql.gz ./latest.sql.gz
-     gunzip -c latest.sql.gz | kubectl exec -i <postgres-pod> -- psql -U "$FIREMUD_POSTGRES_USER" "$FIREMUD_POSTGRES_DB"
-     kubectl rollout restart deployment -n firemud
-     kubectl rollout restart statefulset -n firemud
-     ```
+   ```bash
+   kubectl cp <namespace>/<pg-pod>:/backups/latest.sql.gz ./latest.sql.gz
+   gunzip -c latest.sql.gz | kubectl exec -i <postgres-pod> -- psql -U "$FIREMUD_POSTGRES_USER" "$FIREMUD_POSTGRES_DB"
+   kubectl rollout restart deployment -n firemud
+   kubectl rollout restart statefulset -n firemud
+   ```
+
+   - If dumps are stored in an object bucket set via `PG_DUMP_BUCKET`, download
+      the desired file with `aws s3 cp s3://$PG_DUMP_BUCKET/<path> ./dump.sql.gz`
+      (add `--endpoint-url` for MinIO) before running the above restore steps.
 
    - For local development, run `dev-tools/restore-db.sh <backup-file>` and then
      restart containers with `docker compose restart`.
    - Scheduled backups are created automatically by the Terraform modules using
      `k8s/velero/schedule.yaml`.
-    - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
-    - A manual workflow `manual-backup-restore.yml` can verify backups and
-      perform an optional restore test in a temporary namespace. Trigger it
-      from the GitHub Actions UI when needed.
+   - Daily backup checks are handled by the `verify-backups` CronJob deployed by Terraform.
+   - A manual workflow `manual-backup-restore.yml` can verify backups and
+     perform an optional restore test in a temporary namespace. Trigger it
+     from the GitHub Actions UI when needed.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/dev-tools/pg-dump-rotate.sh
+++ b/dev-tools/pg-dump-rotate.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Create a pg_dump, enforce retention, and optionally upload to S3/MinIO
+set -euo pipefail
+
+BACKUP_DIR=${BACKUP_DIR:-/backups}
+BUCKET=${PG_DUMP_BUCKET:-}
+ENDPOINT=${PG_DUMP_ENDPOINT:-}
+PREFIX=firemud
+
+mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
+TS=$(date +%Y%m%d%H%M%S)
+DUMP="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"
+
+# Install awscli if bucket upload is enabled and aws command missing
+if [ -n "$BUCKET" ] && ! command -v aws >/dev/null 2>&1; then
+  apt-get update -y >/dev/null && apt-get install -y awscli >/dev/null
+fi
+
+pg_dump -h "$FIREMUD_POSTGRES_HOST" -U "$FIREMUD_POSTGRES_USER" -d "$FIREMUD_POSTGRES_DB" | gzip > "$DUMP"
+
+# keep last 96 daily dumps
+cd "$BACKUP_DIR/daily"
+ls -1t ${PREFIX}_*.sql.gz | tail -n +97 | xargs -r rm --
+
+DOW=$(date +%u) # 1-7 (Mon-Sun)
+DOM=$(date +%d)
+
+if [ "$DOW" = "7" ]; then
+  WEEKLY_DEST="$BACKUP_DIR/weekly/${PREFIX}_${TS}.sql.gz"
+  cp "$DUMP" "$WEEKLY_DEST"
+  cd "$BACKUP_DIR/weekly"
+  ls -1t ${PREFIX}_*.sql.gz | tail -n +4 | xargs -r rm --
+fi
+
+if [ "$DOM" = "01" ]; then
+  MONTHLY_DEST="$BACKUP_DIR/monthly/${PREFIX}_${TS}.sql.gz"
+  cp "$DUMP" "$MONTHLY_DEST"
+  cd "$BACKUP_DIR/monthly"
+  ls -1t ${PREFIX}_*.sql.gz | tail -n +4 | xargs -r rm --
+fi
+
+if [ -n "$BUCKET" ]; then
+  AWS_ARGS=""
+  if [ -n "$ENDPOINT" ]; then
+    AWS_ARGS="--endpoint-url $ENDPOINT"
+  fi
+  aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS
+  if [ "$DOW" = "7" ]; then
+    aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS
+  fi
+  if [ "$DOM" = "01" ]; then
+    aws s3 cp "$DUMP" "s3://$BUCKET/monthly/" $AWS_ARGS
+  fi
+fi

--- a/k8s/postgres/pg-dump-cronjob.yaml
+++ b/k8s/postgres/pg-dump-cronjob.yaml
@@ -30,16 +30,78 @@ spec:
                     name: firemud-config
                 - secretRef:
                     name: firemud-secret
-              command: ["/bin/sh", "-c"]
-              args:
-                - |
-                  ts=$(date +%Y%m%d%H%M%S)
-                  pg_dump -h "$FIREMUD_POSTGRES_HOST" -U "$FIREMUD_POSTGRES_USER" -d "$FIREMUD_POSTGRES_DB" \
-                    | gzip > /backups/firemud_${ts}.sql.gz
+              command: ["/bin/bash", "/scripts/pg-dump.sh"]
               volumeMounts:
                 - name: backups
                   mountPath: /backups
+                - name: script
+                  mountPath: /scripts
           volumes:
             - name: backups
               persistentVolumeClaim:
                 claimName: firemud-pg-dumps
+            - name: script
+              configMap:
+                name: pg-dump-script
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pg-dump-script
+  namespace: firemud
+data:
+  pg-dump.sh: |
+    #!/usr/bin/env bash
+    # Create a pg_dump, enforce retention, and optionally upload to S3/MinIO
+    set -euo pipefail
+
+    BACKUP_DIR=${BACKUP_DIR:-/backups}
+    BUCKET=${PG_DUMP_BUCKET:-}
+    ENDPOINT=${PG_DUMP_ENDPOINT:-}
+    PREFIX=firemud
+
+    mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
+    TS=$(date +%Y%m%d%H%M%S)
+    DUMP="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"
+
+    # Install awscli if bucket upload is enabled and aws command missing
+    if [ -n "$BUCKET" ] && ! command -v aws >/dev/null 2>&1; then
+      apt-get update -y >/dev/null && apt-get install -y awscli >/dev/null
+    fi
+
+    pg_dump -h "$FIREMUD_POSTGRES_HOST" -U "$FIREMUD_POSTGRES_USER" -d "$FIREMUD_POSTGRES_DB" | gzip > "$DUMP"
+
+    # keep last 96 daily dumps
+    cd "$BACKUP_DIR/daily"
+    ls -1t ${PREFIX}_*.sql.gz | tail -n +97 | xargs -r rm --
+
+    DOW=$(date +%u) # 1-7 (Mon-Sun)
+    DOM=$(date +%d)
+
+    if [ "$DOW" = "7" ]; then
+      WEEKLY_DEST="$BACKUP_DIR/weekly/${PREFIX}_${TS}.sql.gz"
+      cp "$DUMP" "$WEEKLY_DEST"
+      cd "$BACKUP_DIR/weekly"
+      ls -1t ${PREFIX}_*.sql.gz | tail -n +4 | xargs -r rm --
+    fi
+
+    if [ "$DOM" = "01" ]; then
+      MONTHLY_DEST="$BACKUP_DIR/monthly/${PREFIX}_${TS}.sql.gz"
+      cp "$DUMP" "$MONTHLY_DEST"
+      cd "$BACKUP_DIR/monthly"
+      ls -1t ${PREFIX}_*.sql.gz | tail -n +4 | xargs -r rm --
+    fi
+
+    if [ -n "$BUCKET" ]; then
+      AWS_ARGS=""
+      if [ -n "$ENDPOINT" ]; then
+        AWS_ARGS="--endpoint-url $ENDPOINT"
+      fi
+      aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS
+      if [ "$DOW" = "7" ]; then
+        aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS
+      fi
+      if [ "$DOM" = "01" ]; then
+        aws s3 cp "$DUMP" "s3://$BUCKET/monthly/" $AWS_ARGS
+      fi
+    fi

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -76,4 +76,8 @@ Run the helper script to deploy MinIO, create the bucket, and install Velero:
 dev-tools/setup-local-backup.sh
 ```
 
-Velero backups exclude PostgreSQL and Redis data. PostgreSQL dumps are created by the `firemud-pg-dump` CronJob defined under `k8s/postgres/pg-dump-cronjob.yaml`. Redis is intentionally ephemeral and repopulates from the database on startup.
+Velero backups exclude PostgreSQL and Redis data. PostgreSQL dumps are created by
+the `firemud-pg-dump` CronJob defined under `k8s/postgres/pg-dump-cronjob.yaml`.
+The CronJob's script rotates daily/weekly/monthly dumps and can upload them to a
+bucket when `PG_DUMP_BUCKET` is set. Redis is intentionally ephemeral and
+repopulates from the database on startup.


### PR DESCRIPTION
## Summary
- rotate and optionally upload PostgreSQL dumps with `pg-dump.sh`
- mount the new script in the `firemud-pg-dump` CronJob
- document retention script and bucket upload configuration
- update runbook with object bucket restore instructions
- update developer setup and Velero README

## Testing
- `./gradlew check` *(fails: Gradle build daemon stopped due to GC thrashing)*

------
https://chatgpt.com/codex/tasks/task_e_6874ab7ef39c8330a943a978f2046376