### PR TITLE
Add PG_DUMP var validation

### DIFF
--- a/dev-tools/pg-dump-rotate.sh
+++ b/dev-tools/pg-dump-rotate.sh
@@ -5,6 +5,14 @@ set -euo pipefail
 BACKUP_DIR=${BACKUP_DIR:-/backups}
 BUCKET=${PG_DUMP_BUCKET:-}
 ENDPOINT=${PG_DUMP_ENDPOINT:-}
+
+# Validate upload configuration
+if [[ -n "$BUCKET" || -n "$ENDPOINT" ]]; then
+  if [[ -z "$BUCKET" || -z "$ENDPOINT" ]]; then
+    echo "Both PG_DUMP_BUCKET and PG_DUMP_ENDPOINT must be set to upload backups" >&2
+    exit 1
+  fi
+fi
 PREFIX=firemud
 
 mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"

--- a/dev-tools/setup-local-backup.sh
+++ b/dev-tools/setup-local-backup.sh
@@ -10,6 +10,15 @@ MINIO_MANIFEST="$ROOT_DIR/k8s/velero/minio.yaml"
 VALUES_FILE="$ROOT_DIR/k8s/velero/values-minio.yaml"
 BUCKET="firemud-backups"
 
+# Validate required environment variables for uploads
+if [[ -z "${PG_DUMP_BUCKET:-}" || -z "${PG_DUMP_ENDPOINT:-}" ]]; then
+  echo "PG_DUMP_BUCKET and PG_DUMP_ENDPOINT must be set before running this script" >&2
+  echo "Example:" >&2
+  echo "  export PG_DUMP_BUCKET=$BUCKET" >&2
+  echo "  export PG_DUMP_ENDPOINT=http://minio.minio.svc.cluster.local:9000" >&2
+  exit 1
+fi
+
 # Apply MinIO manifest
 kubectl apply -f "$MINIO_MANIFEST"
 

--- a/k8s/postgres/pg-dump-cronjob.yaml
+++ b/k8s/postgres/pg-dump-cronjob.yaml
@@ -60,6 +60,14 @@ data:
     ENDPOINT=${PG_DUMP_ENDPOINT:-}
     PREFIX=firemud
 
+    # Validate upload configuration
+    if [[ -n "$BUCKET" || -n "$ENDPOINT" ]]; then
+      if [[ -z "$BUCKET" || -z "$ENDPOINT" ]]; then
+        echo "Both PG_DUMP_BUCKET and PG_DUMP_ENDPOINT must be set to upload backups" >&2
+        exit 1
+      fi
+    fi
+
     mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
     TS=$(date +%Y%m%d%H%M%S)
     DUMP="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"


### PR DESCRIPTION
## Summary
- check that `PG_DUMP_BUCKET` and `PG_DUMP_ENDPOINT` are set in setup-local-backup
- guard `pg-dump.sh` against partial upload config
- add same validation to CronJob ConfigMap script

## Testing
- `./gradlew check` *(fails: JVM garbage collector thrashing)*

------
https://chatgpt.com/codex/tasks/task_e_6874b2c61b6c833095e84d83615b3855