### PR TITLE
Implement procedural generation metadata and solo tick handling

### DIFF
--- a/design/grpc-docs/grpc-api.md
+++ b/design/grpc-docs/grpc-api.md
@@ -523,6 +523,7 @@
 | ----- | ---- | ----- | ----------- |
 | session_id | [string](#string) |  |  |
 | command | [string](#string) |  |  |
+| requires_solo_tick | [bool](#bool) |  |  |
 
 <a name="game_session-v1-EnqueueCommandResponse"></a>
 

--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -49,6 +49,7 @@ message RestartSessionResponse {
 message EnqueueCommandRequest {
   string session_id = 1;
   string command = 2;
+  bool requires_solo_tick = 3;
 }
 
 message EnqueueCommandResponse {

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
@@ -12,12 +12,17 @@ public class DungeonGenerator implements Generator {
 
   @Override
   public GenerationResult generate(GenerationParams params) {
+    List<String> errors = validateParams(params);
+    if (!errors.isEmpty()) {
+      return new GenerationResult(
+          List.of(), new GenerationErrorDetail("VALIDATION_FAILED", String.join(";", errors)));
+    }
     Random rnd = new SecureRandom();
     rnd.setSeed(params.seed());
     int rooms = params.rooms();
     List<GeneratedRoom> result = new ArrayList<>();
     if (rooms <= 0) {
-      return new GenerationResult(result);
+      return new GenerationResult(result, null);
     }
     // first room has no connection
     result.add(new GeneratedRoom(1, 0));
@@ -25,7 +30,7 @@ public class DungeonGenerator implements Generator {
       long connectTo = result.get(rnd.nextInt(result.size())).id();
       result.add(new GeneratedRoom(i, connectTo));
     }
-    return new GenerationResult(result);
+    return new GenerationResult(result, null);
   }
 
   @Override

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationErrorDetail.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationErrorDetail.java
@@ -1,0 +1,4 @@
+package net.firedevops.firemud.service.generator;
+
+/** Structured error returned when generation fails. */
+public record GenerationErrorDetail(String code, String message) {}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationResult.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationResult.java
@@ -3,4 +3,4 @@ package net.firedevops.firemud.service.generator;
 import java.util.List;
 
 /** Result of procedural generation. */
-public record GenerationResult(List<GeneratedRoom> rooms) {}
+public record GenerationResult(List<GeneratedRoom> rooms, GenerationErrorDetail error) {}

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/generator/DungeonGeneratorTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/generator/DungeonGeneratorTest.java
@@ -17,4 +17,13 @@ class DungeonGeneratorTest {
     assertEquals(5, rooms.size());
     assertFalse(rooms.stream().skip(1).anyMatch(r -> r.connectedTo() == 0));
   }
+
+  @Test
+  void invalidParamsReturnError() {
+    Generator gen = new DungeonGenerator();
+    GenerationParams params = new GenerationParams(42L, 0, Map.of());
+    GenerationResult result = gen.generate(params);
+    assertEquals(0, result.rooms().size());
+    assertEquals("VALIDATION_FAILED", result.error().code());
+  }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/TickService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/TickService.java
@@ -3,7 +3,7 @@ package net.firedevops.firemud.service;
 /** Coordinates tick execution and command queues using Redis. */
 public interface TickService {
   /** Add a command to the queue for the next tick. */
-  void enqueueCommand(Long sessionId, String command);
+  void enqueueCommand(Long sessionId, String command, boolean requiresSoloTick);
 
   /** Execute a single tick if the lock is acquired. */
   void processTick(Long sessionId);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -135,7 +135,10 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
   public void enqueueCommand(
       EnqueueCommandRequest request, StreamObserver<EnqueueCommandResponse> responseObserver) {
     try {
-      tickService.enqueueCommand(Long.valueOf(request.getSessionId()), request.getCommand());
+      tickService.enqueueCommand(
+          Long.valueOf(request.getSessionId()),
+          request.getCommand(),
+          request.getRequiresSoloTick());
       EnqueueCommandResponse response =
           EnqueueCommandResponse.newBuilder().setAccepted(true).build();
       responseObserver.onNext(response);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -36,6 +36,9 @@ public class TickServiceImpl implements TickService {
   @Value("${game.tick-budget-ms:100}")
   private long tickBudgetMs;
 
+  @Value("${game.solo-tick-budget-ms:500}")
+  private long soloTickBudgetMs;
+
   @Value("${game.tick-max-commands:50}")
   private int tickMaxCommands;
 
@@ -113,8 +116,9 @@ public class TickServiceImpl implements TickService {
 
   @Override
   @Timed(value = "gamesession.command.enqueue")
-  public void enqueueCommand(Long sessionId, String command) {
-    redisTemplate.opsForList().rightPush(queueKey(sessionId), command);
+  public void enqueueCommand(Long sessionId, String command, boolean requiresSoloTick) {
+    String value = (requiresSoloTick ? "S|" : "N|") + command;
+    redisTemplate.opsForList().rightPush(queueKey(sessionId), value);
     enqueueCounter.increment();
     logger.debug("Queued command for {}", sessionId);
   }
@@ -132,6 +136,8 @@ public class TickServiceImpl implements TickService {
       logger.debug("Could not acquire tick lock {}", lockKey);
       return;
     }
+    String head = null;
+    boolean solo = false;
     try {
       Long pending = redisTemplate.opsForList().size(pendingKey(sessionId));
       retryQueueDepth.set(pending != null ? pending.intValue() : 0);
@@ -143,14 +149,16 @@ public class TickServiceImpl implements TickService {
                     () -> executeScriptWithRetry(commitScript, List.of(pendingKey(sessionId)))));
         awaitReplication();
       }
+      Object headObj = redisTemplate.opsForList().index(queueKey(sessionId), 0);
+      head = headObj != null ? headObj.toString() : null;
+      solo = head != null && head.startsWith("S|");
+      int max = solo ? 1 : tickMaxCommands;
       tickTimer.record(
           () ->
               luaTimer.record(
                   () ->
                       executeScriptWithRetry(
-                          stageScript,
-                          List.of(queueKey(sessionId), pendingKey(sessionId)),
-                          tickMaxCommands)));
+                          stageScript, List.of(queueKey(sessionId), pendingKey(sessionId)), max)));
       tickTimer.record(
           () ->
               luaTimer.record(
@@ -165,7 +173,8 @@ public class TickServiceImpl implements TickService {
       awaitReplication();
     } finally {
       long elapsed = (System.nanoTime() - start) / 1_000_000;
-      if (elapsed > tickBudgetMs) {
+      long budget = solo ? soloTickBudgetMs : tickBudgetMs;
+      if (elapsed > budget) {
         budgetExceededCounter.increment();
         logger.debug("Tick budget exceeded: {} ms", elapsed);
       }

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -35,7 +35,7 @@ class TickServiceImplTest {
 
   @Test
   void enqueueCommandPushesToQueue() {
-    service.enqueueCommand(2L, "look");
+    service.enqueueCommand(2L, "look", false);
     verify(listOps).rightPush(any(String.class), any());
   }
 

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/dto/RegionDto.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/dto/RegionDto.java
@@ -8,4 +8,7 @@ public record RegionDto(
     @NotNull Long tenantId,
     @NotNull @Size(max = 100) String name,
     String weather,
-    Integer shardId) {}
+    Integer shardId,
+    Long generationSeed,
+    String generatorType,
+    String generatorParams) {}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Region.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Region.java
@@ -27,5 +27,17 @@ public class Region {
   @Column(length = 50)
   private String weather;
 
+  /** Seed used for procedural generation of this region. */
+  @Column(name = "generation_seed", nullable = false)
+  private Long generationSeed = 0L;
+
+  /** Generator type used to create this region. */
+  @Column(name = "generator_type", length = 50)
+  private String generatorType;
+
+  /** Raw generator parameters serialized as JSON. */
+  @Column(name = "generator_params")
+  private String generatorParams;
+
   @Version private int version;
 }

--- a/services/world-management-service/src/main/resources/db/migration/V8__region_generation_metadata.sql
+++ b/services/world-management-service/src/main/resources/db/migration/V8__region_generation_metadata.sql
@@ -1,0 +1,4 @@
+ALTER TABLE region \
+    ADD COLUMN generation_seed BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN generator_type VARCHAR(50),
+    ADD COLUMN generator_params TEXT;


### PR DESCRIPTION
## Summary
- add generation metadata fields to Region entity and DTO
- create migration for region generation metadata
- enhance DungeonGenerator to return structured error details
- extend generation result to include errors
- add GenerationErrorDetail record
- add tests for dungeon generator validation
- wire requiresSoloTick flag through gRPC to tick service
- support solo tick budget in TickServiceImpl
- document `requires_solo_tick` field in gRPC docs

## Testing
- `./gradlew spotlessApply`
- `./gradlew check` *(failed: Task ':automation-scripting-service:spotlessJavaCheck' due to formatting issues, corrected with spotlessApply but build subsequently interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6874b7f12c78833086b54e91f6beea37