### PR TITLE
Implement conflict tracking

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.conflict.ConflictTracker;
 import net.firedevops.firemud.service.tick.ScriptTickService;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;
   private final net.firedevops.firemud.service.quota.ScriptQuotaService quotaService;
+  private final ConflictTracker conflictTracker;
 
   @Value("${automation.tick-duration-ms:1000}")
   private long tickDurationMs;
@@ -126,6 +128,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
         redisTemplate.opsForValue().setIfAbsent(lockKey, "1", Duration.ofMillis(tickDurationMs));
     if (Boolean.FALSE.equals(acquired)) {
       lockContentionCounter.increment();
+      conflictTracker.recordConflict("script:" + tenantId + ":" + scriptId);
       logger.debug("Could not acquire tick lock {}", lockKey);
       return;
     }
@@ -159,6 +162,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
       awaitReplication();
     } catch (Exception ex) {
       logger.error("Script tick failed, rolling back", ex);
+      conflictTracker.recordConflict("script:" + tenantId + ":" + scriptId);
       luaTimer.record(
           () ->
               executeScriptWithRetry(

--- a/services/automation-scripting-service/src/main/resources/application-prod.yml
+++ b/services/automation-scripting-service/src/main/resources/application-prod.yml
@@ -50,3 +50,5 @@ firemud:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
+  conflict:
+    ttlSeconds: ${FIREMUD_CONFLICT_TTL_SECONDS:300}

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -51,3 +51,5 @@ firemud:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
+  conflict:
+    ttlSeconds: 300

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptTickServiceImplTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptTickServiceImplTest.java
@@ -21,6 +21,7 @@ class ScriptTickServiceImplTest {
   private org.springframework.data.redis.core.ValueOperations<String, Object> valueOps;
   private SimpleMeterRegistry meterRegistry;
   private ScriptQuotaService quotaService;
+  private net.firedevops.firemud.common.conflict.ConflictTracker conflictTracker;
   private ScriptTickService service;
 
   @BeforeEach
@@ -33,7 +34,9 @@ class ScriptTickServiceImplTest {
     quotaService = mock(ScriptQuotaService.class);
     when(quotaService.tryAcquire(any(), any())).thenReturn(true);
     meterRegistry = new SimpleMeterRegistry();
-    service = new ScriptTickServiceImpl(redisTemplate, meterRegistry, quotaService);
+    conflictTracker = mock(net.firedevops.firemud.common.conflict.ConflictTracker.class);
+    service =
+        new ScriptTickServiceImpl(redisTemplate, meterRegistry, quotaService, conflictTracker);
     ((ScriptTickServiceImpl) service).init();
   }
 
@@ -58,5 +61,14 @@ class ScriptTickServiceImplTest {
     ArgumentCaptor<RedisScript> scriptCaptor = ArgumentCaptor.forClass(RedisScript.class);
     verify(redisTemplate, org.mockito.Mockito.atLeastOnce())
         .execute(scriptCaptor.capture(), any(List.class));
+  }
+
+  @Test
+  void lockContentionRecordsConflict() {
+    when(valueOps.setIfAbsent(any(), any(), any())).thenReturn(false);
+
+    service.processTick(1L, 2L);
+
+    verify(conflictTracker).recordConflict("script:1:2");
   }
 }

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/ConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/ConflictTracker.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.common.conflict;
+
+/** Simple interface for recording lock or tick conflicts. */
+public interface ConflictTracker {
+  /** Record a conflict for the given region or session key. */
+  void recordConflict(String key);
+}

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -1,0 +1,24 @@
+package net.firedevops.firemud.common.conflict;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/** Records conflict metadata in Redis for hotspot detection. */
+@Component
+@RequiredArgsConstructor
+public class RedisConflictTracker implements ConflictTracker {
+  private final StringRedisTemplate redisTemplate;
+
+  @Value("${firemud.conflict.ttlSeconds:300}")
+  private long ttlSeconds;
+
+  @Override
+  public void recordConflict(String key) {
+    String redisKey = "conflict:" + key;
+    redisTemplate.opsForValue().increment(redisKey);
+    redisTemplate.expire(redisKey, Duration.ofSeconds(ttlSeconds));
+  }
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.conflict.ConflictTracker;
 import net.firedevops.firemud.service.TickLockService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class TickLockServiceImpl implements TickLockService {
   private final StringRedisTemplate redisTemplate;
   private final MeterRegistry meterRegistry;
+  private final ConflictTracker conflictTracker;
 
   private Counter lockContentionCounter;
 
@@ -37,6 +39,7 @@ public class TickLockServiceImpl implements TickLockService {
     boolean acquired = Boolean.TRUE.equals(result);
     if (!acquired) {
       lockContentionCounter.increment();
+      conflictTracker.recordConflict("entity:" + tenantId + ":" + entityId);
     }
     return acquired;
   }

--- a/services/entity-management-service/src/main/resources/application-prod.yml
+++ b/services/entity-management-service/src/main/resources/application-prod.yml
@@ -42,6 +42,8 @@ firemud:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
+  conflict:
+    ttlSeconds: ${FIREMUD_CONFLICT_TTL_SECONDS:300}
 entity:
   cache:
     character-graph-ttl-seconds: ${FIREMUD_CHARACTER_CACHE_TTL_SECONDS:60}

--- a/services/entity-management-service/src/main/resources/application.yml
+++ b/services/entity-management-service/src/main/resources/application.yml
@@ -43,6 +43,8 @@ firemud:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}
     ca-cert: ${FIREMUD_GRPC_CA_CERT_PATH:certs/ca.crt}
+  conflict:
+    ttlSeconds: 300
 entity:
   cache:
     character-graph-ttl-seconds: 60

--- a/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickLockServiceImplTest.java
+++ b/services/entity-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickLockServiceImplTest.java
@@ -19,6 +19,7 @@ class TickLockServiceImplTest {
   private StringRedisTemplate redisTemplate;
   private ValueOperations<String, String> valueOps;
   private SimpleMeterRegistry meterRegistry;
+  private net.firedevops.firemud.common.conflict.ConflictTracker conflictTracker;
   private TickLockServiceImpl service;
 
   @BeforeEach
@@ -27,7 +28,8 @@ class TickLockServiceImplTest {
     valueOps = mock(ValueOperations.class);
     when(redisTemplate.opsForValue()).thenReturn(valueOps);
     meterRegistry = new SimpleMeterRegistry();
-    service = new TickLockServiceImpl(redisTemplate, meterRegistry);
+    conflictTracker = mock(net.firedevops.firemud.common.conflict.ConflictTracker.class);
+    service = new TickLockServiceImpl(redisTemplate, meterRegistry, conflictTracker);
     service.initMetrics();
     ReflectionTestUtils.setField(service, "tickDurationMs", 1000L);
   }
@@ -50,5 +52,6 @@ class TickLockServiceImplTest {
 
     org.junit.jupiter.api.Assertions.assertEquals(
         1.0, meterRegistry.get("tick_lock_contention_total").counter().count(), 0.001);
+    verify(conflictTracker).recordConflict("entity:1:2");
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.common.conflict.ConflictTracker;
 import net.firedevops.firemud.service.TickService;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,7 @@ public class TickServiceImpl implements TickService {
 
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;
+  private final ConflictTracker conflictTracker;
 
   @Value("${game.tick-duration-ms:1000}")
   private long tickDurationMs;
@@ -129,6 +131,7 @@ public class TickServiceImpl implements TickService {
         redisTemplate.opsForValue().setIfAbsent(lockKey, "1", Duration.ofMillis(tickDurationMs));
     if (Boolean.FALSE.equals(acquired)) {
       lockContentionCounter.increment();
+      conflictTracker.recordConflict("session:" + sessionId);
       logger.debug("Could not acquire tick lock {}", lockKey);
       return;
     }
@@ -158,6 +161,7 @@ public class TickServiceImpl implements TickService {
       awaitReplication();
     } catch (Exception ex) {
       logger.error("Tick processing failed, rolling back", ex);
+      conflictTracker.recordConflict("session:" + sessionId);
       luaTimer.record(
           () ->
               executeScriptWithRetry(

--- a/services/game-session-service/src/main/resources/application-prod.yml
+++ b/services/game-session-service/src/main/resources/application-prod.yml
@@ -23,6 +23,8 @@ game:
 firemud:
   services:
     game-logic-service: ${FIREMUD_SERVICES_GAME_LOGIC_SERVICE}
+  conflict:
+    ttlSeconds: ${FIREMUD_CONFLICT_TTL_SECONDS:300}
   grpc:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -22,6 +22,8 @@ game:
 firemud:
   services:
     game-logic-service: game-logic-service:6565
+  conflict:
+    ttlSeconds: 300
   grpc:
     cert-chain: ${FIREMUD_GRPC_CERT_CHAIN_PATH:certs/client.crt}
     private-key: ${FIREMUD_GRPC_PRIVATE_KEY_PATH:certs/client.key}

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -19,6 +19,7 @@ class TickServiceImplTest {
   private org.springframework.data.redis.core.ListOperations<String, Object> listOps;
   private org.springframework.data.redis.core.ValueOperations<String, Object> valueOps;
   private SimpleMeterRegistry meterRegistry;
+  private net.firedevops.firemud.common.conflict.ConflictTracker conflictTracker;
   private TickService service;
 
   @BeforeEach
@@ -29,7 +30,8 @@ class TickServiceImplTest {
     when(redisTemplate.opsForList()).thenReturn(listOps);
     when(redisTemplate.opsForValue()).thenReturn(valueOps);
     meterRegistry = new SimpleMeterRegistry();
-    service = new TickServiceImpl(redisTemplate, meterRegistry);
+    conflictTracker = mock(net.firedevops.firemud.common.conflict.ConflictTracker.class);
+    service = new TickServiceImpl(redisTemplate, meterRegistry, conflictTracker);
     ((TickServiceImpl) service).init();
   }
 
@@ -56,6 +58,7 @@ class TickServiceImplTest {
 
     org.junit.jupiter.api.Assertions.assertEquals(
         1.0, meterRegistry.get("game_session_lock_contention_total").counter().count(), 0.001);
+    verify(conflictTracker).recordConflict("session:2");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add `ConflictTracker` with Redis implementation
- record lock contention in conflict metadata for sessions, scripts and entities
- expose conflict TTL config in service configs

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6874b5415ab083308078e740afd7c022