### PR TITLE
Update velero docs and runbooks

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -25,6 +25,8 @@ This document defines the backup schedule and disaster recovery procedures for F
       backupStorageLocation:
         bucket: firemud-backups
       ```
+    Always leave `defaultVolumesToFsBackup` set to `false` so Velero backs up
+    only Kubernetes manifests and not persistent volume contents.
 
     For local clusters without cloud storage, deploy the `k8s/velero/minio.yaml`
     manifest and configure Velero with a local backup location:
@@ -47,7 +49,8 @@ This document defines the backup schedule and disaster recovery procedures for F
       ```
 
       Run `dev-tools/setup-local-backup.sh` to deploy MinIO, create the
-      `firemud-backups` bucket, and install Velero automatically.
+      `firemud-backups` bucket, and install Velero automatically. Keep
+      `defaultVolumesToFsBackup` disabled to avoid saving PVC data.
 
   - If the database service fails completely:
   1. Restore the most recent `pg_dump` file from the `firemud-pg-dumps` volume or object store.

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -56,6 +56,10 @@ For local development, use `./gradlew devUp` to start Docker Compose.
    - A manual workflow `manual-backup-restore.yml` can verify backups and
      perform an optional restore test in a temporary namespace. Trigger it
      from the GitHub Actions UI when needed.
+   - **Maintain dump volume**: the `firemud-pg-dump` CronJob rotates files automatically,
+     but long-lived persistent volumes can still fill up. Periodically check
+     the `firemud-pg-dumps` PVC and prune old `*.sql.gz` files or run
+     `dev-tools/pg-dump-rotate.sh` manually to enforce retention.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/k8s/terraform-production/README.md
+++ b/k8s/terraform-production/README.md
@@ -22,6 +22,10 @@ The module exposes variables to configure Velero:
 - `velero_bucket_prefix` – Prefix inside the bucket for backups.
 - `velero_credentials_secret` – Name of the Kubernetes secret containing credentials.
 
+The module sets `configuration.defaultVolumesToFsBackup` to `false` to ensure Velero
+backs up only Kubernetes manifests. Do not change this unless you intend to back up
+PVC contents via filesystem snapshots.
+
 Create a `terraform.tfvars` file (or pass variables via the CLI) with values for
 these settings. An example `terraform.tfvars.example` is provided:
 

--- a/k8s/terraform-production/main.tf
+++ b/k8s/terraform-production/main.tf
@@ -58,6 +58,10 @@ resource "helm_release" "velero" {
     name  = "credentials.existingSecret"
     value = var.velero_credentials_secret
   }
+  set {
+    name  = "configuration.defaultVolumesToFsBackup"
+    value = "false"
+  }
 }
 
 locals {

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -10,13 +10,14 @@ Apply the manifests with:
 kubectl apply -f schedule.yaml -n velero
 ```
 
-Ensure Velero is installed and configured with access to your object storage bucket prior to applying the schedule. A starter [values.example.yaml](./values.example.yaml) file is included. Copy it to `values.yaml` and edit the provider and bucket for your environment.
+Ensure Velero is installed and configured with access to your object storage bucket prior to applying the schedule. A starter [values.example.yaml](./values.example.yaml) file is included. Copy it to `values.yaml` and edit the provider and bucket for your environment. Keep `defaultVolumesToFsBackup: false` so PVCs are not backed up.
 
 Example `values.yaml` snippet when using AWS S3:
 
 ```yaml
 configuration:
   provider: aws
+  defaultVolumesToFsBackup: false
   backupStorageLocation:
     bucket: firemud-backups
     prefix: postgres

--- a/k8s/velero/values.example.yaml
+++ b/k8s/velero/values.example.yaml
@@ -2,6 +2,7 @@
 # Customize the provider and bucket name for your environment.
 configuration:
   provider: aws
+  defaultVolumesToFsBackup: false
   backupStorageLocation:
     bucket: firemud-backups
     prefix: postgres


### PR DESCRIPTION
## Summary
- document `defaultVolumesToFsBackup: false` in sample values file
- advise using `defaultVolumesToFsBackup` in Velero README
- add velero option to production Terraform module and README
- note pg dump volume maintenance in runbooks
- clarify backup doc about keeping volume snapshots disabled

## Testing
- `pre-commit run --all-files` *(fails: buf lint issues)*
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6874b22d02ac833096538677f4908ea6