### PR TITLE
Implement generator registry and hooks

### DIFF
--- a/design/architecture/system-architecture-procedural-generation.md
+++ b/design/architecture/system-architecture-procedural-generation.md
@@ -95,7 +95,7 @@ The following rules align generators with the core runtime and tooling:
 4. **Post-generation Population** – After rooms are created, the Automation & Scripting Service triggers population scripts based on room tags, biome, and difficulty zone.
 5. **Validation and Errors** – Generators validate parameters (biome compatibility, room counts, connectivity). Failures return `GenerationErrorDetail` objects and are logged for observability.
 6. **Editor Overlays** – Generators emit coordinates and optional map layers so the Game Editor can display a preview or dry-run JSON output.
-7. **Pluggable Interface** – Generators implement the `Generator` interface and are registered via the Automation & Scripting Service for future scripted or DSL-based generators.
+7. **Pluggable Interface** – Generators implement the `Generator` interface and are discovered via the `GeneratorRegistry` in the Automation & Scripting Service for future scripted or DSL-based generators.
 
 ---
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationHook.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationHook.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.service.generator;
+
+/** Hook invoked after a generator successfully produces rooms. */
+public interface GenerationHook {
+  void afterGeneration(GenerationParams params, GenerationResult result);
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationService.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationService.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.service.generator;
+
+/** Service that executes registered procedural generators. */
+public interface GenerationService {
+  GenerationResult generate(String generatorName, GenerationParams params);
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationServiceImpl.java
@@ -1,0 +1,37 @@
+package net.firedevops.firemud.service.generator;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Default implementation invoking a generator then running hooks. */
+@Service
+@RequiredArgsConstructor
+public class GenerationServiceImpl implements GenerationService {
+  private static final Logger logger = LoggerFactory.getLogger(GenerationServiceImpl.class);
+
+  private final GeneratorRegistry registry;
+  private final List<GenerationHook> hooks;
+
+  @Override
+  public GenerationResult generate(String generatorName, GenerationParams params) {
+    Generator generator = registry.get(generatorName);
+    if (generator == null) {
+      return new GenerationResult(
+          List.of(), new GenerationErrorDetail("UNKNOWN_GENERATOR", generatorName));
+    }
+    GenerationResult result = generator.generate(params);
+    if (result.error() == null) {
+      for (GenerationHook hook : hooks) {
+        try {
+          hook.afterGeneration(params, result);
+        } catch (Exception ex) {
+          logger.debug("Generation hook failed", ex);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GeneratorRegistry.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GeneratorRegistry.java
@@ -1,0 +1,23 @@
+package net.firedevops.firemud.service.generator;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Collects and provides access to available procedural generators. */
+@Component
+public class GeneratorRegistry {
+  private final Map<String, Generator> generators = new HashMap<>();
+
+  public GeneratorRegistry(List<Generator> beans) {
+    for (Generator g : beans) {
+      generators.put(g.getName(), g);
+    }
+  }
+
+  /** Returns the generator by name or {@code null} if not found. */
+  public Generator get(String name) {
+    return generators.get(name);
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/LoggingPopulationHook.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/LoggingPopulationHook.java
@@ -1,0 +1,16 @@
+package net.firedevops.firemud.service.generator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** Simple generation hook that logs population events. */
+@Component
+public class LoggingPopulationHook implements GenerationHook {
+  private static final Logger logger = LoggerFactory.getLogger(LoggingPopulationHook.class);
+
+  @Override
+  public void afterGeneration(GenerationParams params, GenerationResult result) {
+    logger.debug("Populating {} rooms for seed {}", result.rooms().size(), params.seed());
+  }
+}

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/generator/GenerationServiceImplTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/generator/GenerationServiceImplTest.java
@@ -1,0 +1,23 @@
+package net.firedevops.firemud.service.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class GenerationServiceImplTest {
+  @Test
+  void generatorAndHookInvoked() {
+    Generator generator = new DungeonGenerator();
+    GenerationHook hook = mock(GenerationHook.class);
+    GeneratorRegistry registry = new GeneratorRegistry(List.of(generator));
+    GenerationService service = new GenerationServiceImpl(registry, List.of(hook));
+    GenerationParams params = new GenerationParams(1L, 2, Map.of());
+    GenerationResult result = service.generate(generator.getName(), params);
+    assertEquals(2, result.rooms().size());
+    verify(hook).afterGeneration(params, result);
+  }
+}


### PR DESCRIPTION
## Summary
- update procedural generation docs to reference GeneratorRegistry
- add pluggable GeneratorRegistry
- implement GenerationService with post-generation hooks
- log room population events with LoggingPopulationHook
- test GenerationServiceImpl

## Testing
- `pre-commit run spotbugs --all-files`
- `pre-commit run --all-files` *(fails: Buf Lint - RPC naming error)*

------
https://chatgpt.com/codex/tasks/task_e_6874c0541c048330b3407e01fa878819