### PR TITLE
Fix Velero backup instructions

### DIFF
--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -29,7 +29,7 @@ The repository includes a `verify-backups-cronjob.yaml` manifest that runs
 CronJob automatically, but you can apply it manually in other environments:
 
 ```bash
-kubectl apply -f verify-backups-cronjob.yaml -n velero
+kubectl apply -f verify-backups-cronjob.yaml -n firemud
 ```
 
 ## Local Backup with MinIO


### PR DESCRIPTION
## Summary
- align README with CronJob namespace

## Testing
- `./gradlew check` *(fails: JVM garbage collector thrashing)*

------
https://chatgpt.com/codex/tasks/task_e_6874b76c0f98833089c225d037ec9b9e