### PR TITLE
Align k8s manifests with design notes

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -223,6 +223,11 @@ require it. Open Kreya, choose **Open Project** and select the project file to
 invoke gRPC methods. When proto definitions change, update the project by
 pointing Kreya to the modified `.proto` files.
 
+Smoke test scripts also target `localhost:6565`. Docker Compose does not
+publish this port to the host, so run them inside the Compose network with
+`docker compose exec <service> ./smoke-test.sh` or set `GRPC_ADDR` to the
+service hostname (e.g., `account-service:6565`).
+
 ### Redis Debugging
 
 Use the Redis CLI (`redis-cli -h localhost -p 6379`) to inspect transient game state. Useful commands include:

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: account-service
           image: ghcr.io/firemud/account-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -40,6 +40,16 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "400m"
+              memory: "512Mi"
+          ports:
+            - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -67,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: automation-scripting-service
           image: ghcr.io/firemud/automation-scripting-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: entity-management-service
           image: ghcr.io/firemud/entity-management-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/firemud-db-env.yaml
+++ b/k8s/base/firemud-db-env.yaml
@@ -15,8 +15,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: firemud-secret
-stringData:
-  FIREMUD_POSTGRES_USER: firemud
-  FIREMUD_POSTGRES_PASSWORD: firemud
-  FIREMUD_AUTH_JWT_SECRET: changeit-changeit-changeit-changeit
+data:
+  FIREMUD_POSTGRES_USER: ZmlyZW11ZA==
+  FIREMUD_POSTGRES_PASSWORD: ZmlyZW11ZA==
+  FIREMUD_AUTH_JWT_SECRET: Y2hhbmdlaXQtY2hhbmdlaXQtY2hhbmdlaXQtY2hhbmdlaXQ=
 

--- a/k8s/base/firemud-grpc-tls.yaml
+++ b/k8s/base/firemud-grpc-tls.yaml
@@ -2,16 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: firemud-grpc-tls
-stringData:
-  client.crt: |
-    -----BEGIN CERTIFICATE-----
-    example
-    -----END CERTIFICATE-----
-  client.key: |
-    -----BEGIN PRIVATE KEY-----
-    example
-    -----END PRIVATE KEY-----
-  ca.crt: |
-    -----BEGIN CERTIFICATE-----
-    example
-    -----END CERTIFICATE-----
+data:
+  client.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCmV4YW1wbGUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+  client.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCmV4YW1wbGUKLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQ==
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCmV4YW1wbGUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: game-design-service
           image: ghcr.io/firemud/game-design-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: game-logic-service
           image: ghcr.io/firemud/game-logic-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: game-session-service
           image: ghcr.io/firemud/game-session-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: logging-admin-service
           image: ghcr.io/firemud/logging-admin-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -63,7 +64,7 @@ spec:
             periodSeconds: 20
         - name: fluent-bit
           image: fluent/fluent-bit:2.2.2
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
           volumeMounts:
             - name: varlog
@@ -97,5 +98,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: social-groups-service
           image: ghcr.io/firemud/social-groups-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: spring-cloud-gateway
           image: ghcr.io/firemud/spring-cloud-gateway:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -45,6 +45,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -72,5 +73,8 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: LoadBalancer

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: tcp-proxy-service
           image: ghcr.io/firemud/tcp-proxy-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: world-management-service
           image: ghcr.io/firemud/world-management-service:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
@@ -49,6 +49,7 @@ spec:
               memory: "512Mi"
           ports:
             - containerPort: 8080
+            - containerPort: 6565
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -76,5 +77,8 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      protocol: TCP
+    - port: 6565
+      targetPort: 6565
       protocol: TCP
   type: ClusterIP

--- a/k8s/network-policies/internal-services.yaml
+++ b/k8s/network-policies/internal-services.yaml
@@ -19,9 +19,13 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 6565
   egress:
     - to:
         - podSelector: {}
       ports:
         - protocol: TCP
           port: 8080
+        - protocol: TCP
+          port: 6565


### PR DESCRIPTION
## Summary
- expose gRPC port 6565 across microservice Services and NetworkPolicy
- add resource limits to Account Service
- switch all base manifests to `imagePullPolicy: Always`
- encode example Secrets with base64
- document running smoke tests within Docker Compose network

## Testing
- `./gradlew check --no-daemon` *(fails: JVM garbage collector thrashing)*

------
https://chatgpt.com/codex/tasks/task_e_6874b49df01c83309de5787d410033a7