### PR TITLE
Implement tick budget metrics for scripting service

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -35,12 +35,16 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   @Value("${automation.tick-duration-ms:1000}")
   private long tickDurationMs;
 
+  @Value("${automation.tick-budget-ms:100}")
+  private long tickBudgetMs;
+
   @Value("${automation.tick-max-events:50}")
   private int tickMaxEvents;
 
   private Counter enqueueCounter;
   private Counter redisErrorCounter;
   private Counter lockContentionCounter;
+  private Counter budgetExceededCounter;
   private Timer tickTimer;
   private Timer luaTimer;
   private java.util.concurrent.atomic.AtomicInteger retryQueueDepth =
@@ -77,6 +81,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
     enqueueCounter = meterRegistry.counter("automation_tick_events_enqueued_total");
     redisErrorCounter = meterRegistry.counter("automation_tick_redis_errors_total");
     lockContentionCounter = meterRegistry.counter("automation_tick_lock_contention_total");
+    budgetExceededCounter = meterRegistry.counter("automation_tick_budget_exceeded_total");
     tickTimer = meterRegistry.timer("automation_tick_duration_ms");
     luaTimer = meterRegistry.timer("automation_lua_latency_ms");
     Gauge.builder(
@@ -123,6 +128,7 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   @Override
   @Timed(value = "automation.tick.process")
   public void processTick(Long tenantId, Long scriptId) {
+    long start = System.nanoTime();
     String lockKey = lockKey(tenantId, scriptId);
     Boolean acquired =
         redisTemplate.opsForValue().setIfAbsent(lockKey, "1", Duration.ofMillis(tickDurationMs));
@@ -170,6 +176,11 @@ public class ScriptTickServiceImpl implements ScriptTickService {
                   List.of(pendingKey(tenantId, scriptId), queueKey(tenantId, scriptId))));
       awaitReplication();
     } finally {
+      long elapsed = (System.nanoTime() - start) / 1_000_000;
+      if (elapsed > tickBudgetMs) {
+        budgetExceededCounter.increment();
+        logger.debug("Tick budget exceeded: {} ms", elapsed);
+      }
       redisTemplate.delete(lockKey);
     }
   }

--- a/services/automation-scripting-service/src/main/resources/application-prod.yml
+++ b/services/automation-scripting-service/src/main/resources/application-prod.yml
@@ -22,6 +22,7 @@ script:
 automation:
   tick-duration-ms: ${AUTOMATION_TICK_DURATION_MS:1000}
   tick-max-events: ${AUTOMATION_TICK_MAX_EVENTS:50}
+  tick-budget-ms: ${AUTOMATION_TICK_BUDGET_MS:100}
 
 server:
   compression:

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -23,6 +23,7 @@ script:
 automation:
   tick-duration-ms: 1000
   tick-max-events: 50
+  tick-budget-ms: 100
 
 server:
   compression:

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptTickServiceImplTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/impl/ScriptTickServiceImplTest.java
@@ -71,4 +71,18 @@ class ScriptTickServiceImplTest {
 
     verify(conflictTracker).recordConflict("script:1:2");
   }
+
+  @Test
+  void slowTickIncrementsBudgetMetric() {
+    when(valueOps.setIfAbsent(any(), any(), any())).thenReturn(true);
+    when(redisTemplate.execute(any(RedisScript.class), any(List.class))).thenReturn(1L);
+    when(listOps.size(any())).thenReturn(0L);
+
+    org.springframework.test.util.ReflectionTestUtils.setField(service, "tickBudgetMs", 0L);
+
+    service.processTick(1L, 2L);
+
+    org.junit.jupiter.api.Assertions.assertEquals(
+        1.0, meterRegistry.get("automation_tick_budget_exceeded_total").counter().count(), 0.001);
+  }
 }


### PR DESCRIPTION
## Summary
- enforce tick budget in ScriptTickService
- expose automation.tick-budget-ms property
- add unit test

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6874d330b5d08330a9d8ca3b7622acab