### PR TITLE
Add docs link checking

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2.4.1
+        with:
+          args: --no-progress --verbose './**/*.md' --exclude './**/node_modules/**' --exclude './**/build/**' --exclude './**/.gradle/**'
+          fail: true
+          jobSummary: true
       - uses: actions/configure-pages@v3
       - name: Build documentation
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
         entry: bash -c 'cd web-client && npm run lint && npm run format:fix'
         language: system
         pass_filenames: false
+      - id: link-check
+        name: Link Check
+        entry: ./dev-tools/link-check.sh
+        language: script
+        pass_filenames: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,12 +117,17 @@ tasks.register<NpxTask>("lintMarkdownFix") {
     ))
 }
 
+tasks.register<Exec>("linkCheck") {
+    commandLine("bash", "./dev-tools/link-check.sh")
+}
+
 tasks.named("check") {
     dependsOn(
         "lintMarkdown",
         "checkstyleMain",
         "spotbugsMain",
-        "jacocoTestReport"
+        "jacocoTestReport",
+        "linkCheck"
     )
 }
 

--- a/dev-tools/link-check.sh
+++ b/dev-tools/link-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LYCHEE_VERSION="lychee-v0.19.1"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/lychee"
+BIN="$CACHE_DIR/lychee"
+URL="https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz"
+
+if [ ! -x "$BIN" ]; then
+  mkdir -p "$CACHE_DIR"
+  curl -sSL "$URL" | tar -xz -C "$CACHE_DIR"
+  chmod +x "$BIN"
+fi
+
+# Run link check on documentation files only
+FILES=$(find design -name '*.md' -type f -print; find . -maxdepth 1 -name '*.md' -type f)
+FILES=$(echo "$FILES" | grep -v '/node_modules/' | grep -v '/build/' | grep -v '/\.gradle/')
+
+OPTIONS="--scheme https --scheme http"
+"$BIN" --no-progress --verbose $OPTIONS $FILES


### PR DESCRIPTION
## Summary
- run lychee link checker in docs workflow
- include link checker in `./gradlew check`
- add link checker to pre-commit hooks
- helper script downloads lychee and checks docs

## Testing
- `./dev-tools/link-check.sh` *(fails: broken links found)*
- `pre-commit run --all-files` *(failed: process interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6874d8778b448330885284fe58c6becb