### PR TITLE
Add ShellCheck linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,26 @@ jobs:
       - name: ⚙️ Generate Protobufs
         run: buf generate
 
+  shellcheck:
+    name: ShellCheck
+    needs: buf-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout Code
+        uses: actions/checkout@v3
+
+      - name: 📦 Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: 🐚 Run ShellCheck
+        run: |
+          echo "::group::ShellCheck"
+          find dev-tools -name '*.sh' -print0 | xargs -0 shellcheck
+          echo "::endgroup::"
+
   build-and-test:
     name: Build and Test (${{ matrix.service }})
-    needs: buf-check
+    needs: [buf-check, shellcheck]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
         entry: bash -c 'cd web-client && npm run lint && npm run format:fix'
         language: system
         pass_filenames: false
+      - id: shellcheck
+        name: ShellCheck
+        entry: bash -c 'find dev-tools -name "*.sh" -print0 | xargs -0 shellcheck'
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Once your environment is running you can create a feature branch and submit a PR
 ## Pre-commit Hooks
 
 The repository includes a `.pre-commit-config.yaml` that runs Spotless,
-markdownlint, Checkstyle, and SpotBugs. Install the pre-commit tool and set up the hooks
+markdownlint, Checkstyle, SpotBugs, and ShellCheck. Install the pre-commit tool and set up the hooks
 with:
 
 ```bash
@@ -42,7 +42,7 @@ pip install pre-commit
 pre-commit install
 ```
 
-Hooks automatically format code, lint Markdown, and run static analysis before each commit.
+Hooks automatically format code, lint Markdown, run ShellCheck on our `dev-tools` scripts, and perform other static analysis before each commit.
 
 ## Testing Requirements
 


### PR DESCRIPTION
## Summary
- add a ShellCheck hook to the pre-commit config
- run ShellCheck in CI
- document ShellCheck in contributing guide

## Testing
- `pre-commit run --all-files` *(fails: BUILD FAILED; SpotBugs ended with exit code 1)*
- `./gradlew check` *(interrupted due to length)*

------
https://chatgpt.com/codex/tasks/task_e_6874d83e892c833098dcd1a870d00df1