### PR TITLE
Improve backup restore and monitoring

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -89,6 +89,9 @@ Because Redis is not a source of truth, this strategy guarantees a clean, determ
 ## 🐳 Local Development
 
 - Backups are restored using `dev-tools/restore-db.sh` with a snapshot file.
+- `dev-tools/restore-latest-db.sh` can fetch the newest dump from the object
+  store and restore it automatically when `PG_DUMP_BUCKET` and
+  `PG_DUMP_ENDPOINT` are configured.
 - Create ad hoc snapshots with `dev-tools/backup-db.sh` before restoring.
 - Services are restarted with **Docker Compose**.
 - Redis starts empty and repopulates when services access the database.
@@ -99,8 +102,9 @@ Because Redis is not a source of truth, this strategy guarantees a clean, determ
 
 - The `k8s/velero/verify-backups-cronjob.yaml` CronJob runs
   `dev-tools/verify-backups.sh` daily to ensure recent snapshots are present in
-  the object store. This CronJob is installed automatically by the production
-  Terraform modules.
+  the object store. The script now also verifies that the latest PostgreSQL dump
+  exists in `PG_DUMP_BUCKET`, failing the job if no dumps are found. This
+  CronJob is installed automatically by the production Terraform modules.
 - Operators should periodically test recovery by restoring a snapshot into a
   throwaway namespace with `dev-tools/restore-cluster.sh <backup-name>
   <namespace>` (or by setting `FIREMUD_K8S_NAMESPACE`) and verifying

--- a/dev-tools/pg-dump-rotate.sh
+++ b/dev-tools/pg-dump-rotate.sh
@@ -52,11 +52,21 @@ if [ -n "$BUCKET" ]; then
   if [ -n "$ENDPOINT" ]; then
     AWS_ARGS="--endpoint-url $ENDPOINT"
   fi
-  aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS
+  echo "Uploading $DUMP to s3://$BUCKET"
+  if ! aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS; then
+    echo "Failed to upload daily dump" >&2
+    exit 1
+  fi
   if [ "$DOW" = "7" ]; then
-    aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS
+    if ! aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS; then
+      echo "Failed to upload weekly dump" >&2
+      exit 1
+    fi
   fi
   if [ "$DOM" = "01" ]; then
-    aws s3 cp "$DUMP" "s3://$BUCKET/monthly/" $AWS_ARGS
+    if ! aws s3 cp "$DUMP" "s3://$BUCKET/monthly/" $AWS_ARGS; then
+      echo "Failed to upload monthly dump" >&2
+      exit 1
+    fi
   fi
 fi

--- a/dev-tools/restore-latest-db.sh
+++ b/dev-tools/restore-latest-db.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Download the most recent pg_dump from object storage and restore the database.
+# Requires PG_DUMP_BUCKET and PG_DUMP_ENDPOINT environment variables.
+set -euo pipefail
+
+BUCKET=${PG_DUMP_BUCKET:?PG_DUMP_BUCKET must be set}
+ENDPOINT=${PG_DUMP_ENDPOINT:?PG_DUMP_ENDPOINT must be set}
+
+command -v aws >/dev/null 2>&1 || {
+  echo "aws CLI not found" >&2
+  exit 1
+}
+
+TMP_DIR=$(mktemp -d)
+FILE="$TMP_DIR/latest.sql.gz"
+
+KEY=$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "daily/" \
+      --endpoint-url "$ENDPOINT" \
+      --query 'sort_by(Contents,&LastModified)[-1].Key' --output text)
+
+if [ "$KEY" = "None" ]; then
+  echo "No dumps found in bucket $BUCKET" >&2
+  exit 1
+fi
+
+aws s3 cp "s3://$BUCKET/$KEY" "$FILE" --endpoint-url "$ENDPOINT"
+
+echo "Restoring $KEY"
+
+gunzip -c "$FILE" | psql -h "${FIREMUD_POSTGRES_HOST:-localhost}" \
+                    -U "${FIREMUD_POSTGRES_USER:-firemud}" \
+                    -d "${FIREMUD_POSTGRES_DB:-firemud}"
+
+echo "Database restored from $KEY"

--- a/dev-tools/verify-backups.sh
+++ b/dev-tools/verify-backups.sh
@@ -19,3 +19,19 @@ if [ "$BACKUP_COUNT" -eq 0 ]; then
 fi
 
 echo "Found $BACKUP_COUNT Velero backups in $NAMESPACE"
+
+if [ -n "${PG_DUMP_BUCKET:-}" ]; then
+  command -v aws >/dev/null 2>&1 || {
+    echo "aws CLI not found" >&2
+    exit 1
+  }
+  KEY=$(aws s3api list-objects-v2 --bucket "$PG_DUMP_BUCKET" \
+        --prefix "daily/" \
+        --endpoint-url "${PG_DUMP_ENDPOINT:-}" \
+        --query 'sort_by(Contents,&LastModified)[-1].Key' --output text 2>/dev/null || echo None)
+  if [ "$KEY" = "None" ]; then
+    echo "No pg_dump files found in bucket $PG_DUMP_BUCKET" >&2
+    exit 1
+  fi
+  echo "Latest pg_dump: $KEY"
+fi

--- a/k8s/postgres/pg-dump-cronjob.yaml
+++ b/k8s/postgres/pg-dump-cronjob.yaml
@@ -105,11 +105,21 @@ data:
       if [ -n "$ENDPOINT" ]; then
         AWS_ARGS="--endpoint-url $ENDPOINT"
       fi
-      aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS
+      echo "Uploading $DUMP to s3://$BUCKET"
+      if ! aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS; then
+        echo "Failed to upload daily dump" >&2
+        exit 1
+      fi
       if [ "$DOW" = "7" ]; then
-        aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS
+        if ! aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS; then
+          echo "Failed to upload weekly dump" >&2
+          exit 1
+        fi
       fi
       if [ "$DOM" = "01" ]; then
-        aws s3 cp "$DUMP" "s3://$BUCKET/monthly/" $AWS_ARGS
+        if ! aws s3 cp "$DUMP" "s3://$BUCKET/monthly/" $AWS_ARGS; then
+          echo "Failed to upload monthly dump" >&2
+          exit 1
+        fi
       fi
     fi

--- a/k8s/velero/verify-backups-cronjob.yaml
+++ b/k8s/velero/verify-backups-cronjob.yaml
@@ -51,3 +51,19 @@ data:
     
     echo "Found $BACKUP_COUNT Velero backups in $NAMESPACE"
 
+    if [ -n "${PG_DUMP_BUCKET:-}" ]; then
+      command -v aws >/dev/null 2>&1 || {
+        echo "aws CLI not found" >&2
+        exit 1
+      }
+      KEY=$(aws s3api list-objects-v2 --bucket "$PG_DUMP_BUCKET" \
+            --prefix "daily/" \
+            --endpoint-url "${PG_DUMP_ENDPOINT:-}" \
+            --query 'sort_by(Contents,&LastModified)[-1].Key' --output text 2>/dev/null || echo None)
+      if [ "$KEY" = "None" ]; then
+        echo "No pg_dump files found in bucket $PG_DUMP_BUCKET" >&2
+        exit 1
+      fi
+      echo "Latest pg_dump: $KEY"
+    fi
+


### PR DESCRIPTION
## Summary
- add a script to restore the latest PostgreSQL dump from object storage
- log and fail CronJob if pg_dump uploads fail
- check pg_dump bucket in verify-backups script and CronJob
- document new restore helper and monitoring

## Testing
- `./gradlew --no-daemon --max-workers=1 check` *(fails: Gradle build daemon stopped due to memory)*

------
https://chatgpt.com/codex/tasks/task_e_6874d58efd008330b104840bf942bcb3