### PR TITLE
Add pg-dump cron service

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -180,6 +180,14 @@ upload them to an object bucket when `PG_DUMP_BUCKET` is configured. Retrieve a
 dump with `kubectl cp` or `aws s3 cp` and restore it with `psql` as shown in the
 runbooks. Velero schedules back up only Kubernetes manifests.
 
+### Local Database Cron Backups
+
+The Docker Compose stack includes a `pg-dump-cron` service that runs
+`dev-tools/pg-dump-rotate.sh` every 15 minutes. Dumps are written to the
+`./backups` directory and follow the same daily/weekly/monthly rotation policy as
+production. Set `PG_DUMP_BUCKET` and `PG_DUMP_ENDPOINT` to automatically upload
+the files to your object store.
+
 ### Optional Redis Persistence
 
 Redis normally starts empty between service restarts. If you want to keep the

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -57,9 +57,11 @@ For local development, use `./gradlew devUp` to start Docker Compose.
      perform an optional restore test in a temporary namespace. Trigger it
      from the GitHub Actions UI when needed.
    - **Maintain dump volume**: the `firemud-pg-dump` CronJob rotates files automatically,
-     but long-lived persistent volumes can still fill up. Periodically check
-     the `firemud-pg-dumps` PVC and prune old `*.sql.gz` files or run
-     `dev-tools/pg-dump-rotate.sh` manually to enforce retention.
+    but long-lived persistent volumes can still fill up. The Docker Compose
+    stack includes a `pg-dump-cron` service that runs the same rotation script
+    every 15 minutes. Periodically check the `firemud-pg-dumps` PVC and prune
+    old `*.sql.gz` files or run `dev-tools/pg-dump-rotate.sh` manually if
+    additional cleanup is required.
 2. **Redis Failure**
    - Redis nodes automatically resync using AOF and replication. Services reconnect on restart.
 3. **Full Cluster Restore**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,6 +251,23 @@ services:
       timeout: 5s
       retries: 5
 
+  pg-dump-cron:
+    build:
+      context: .
+      dockerfile: docker/pg-dump-cron.Dockerfile
+    env_file:
+      - .env
+    environment:
+      <<: *service-env
+      PG_DUMP_BUCKET: ${PG_DUMP_BUCKET:-}
+      PG_DUMP_ENDPOINT: ${PG_DUMP_ENDPOINT:-}
+      BACKUP_DIR: /backups
+    volumes:
+      - ./backups:/backups
+    restart: unless-stopped
+    depends_on:
+      - postgres
+
 volumes:
   postgres-data:
   redis-data:

--- a/docker/pg-dump-cron.Dockerfile
+++ b/docker/pg-dump-cron.Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:16
+USER root
+RUN apt-get update -y && apt-get install -y cron
+COPY dev-tools/pg-dump-rotate.sh /usr/local/bin/pg-dump-rotate.sh
+RUN chmod +x /usr/local/bin/pg-dump-rotate.sh
+COPY docker/pg-dump-cron.crontab /etc/cron.d/pg-dump
+RUN chmod 0644 /etc/cron.d/pg-dump && crontab /etc/cron.d/pg-dump
+CMD ["cron", "-f"]

--- a/docker/pg-dump-cron.crontab
+++ b/docker/pg-dump-cron.crontab
@@ -1,0 +1,3 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+*/15 * * * * root /usr/local/bin/pg-dump-rotate.sh >/proc/1/fd/1 2>&1


### PR DESCRIPTION
## Summary
- add docker-based cron service for rotating pg dumps
- document the new service in developer setup
- mention cron job in runbooks

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6874d4f042c083308679b39d9efdaf06