### PR TITLE
Add Dockerfile linting with hadolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,12 @@ jobs:
     steps:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v3
-      - name: Install hadolint
-        run: |
-          wget -O hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
-          chmod +x hadolint
-          sudo mv hadolint /usr/local/bin/
-      - name: Lint Dockerfiles
-        run: hadolint -c .hadolint.yaml docker/base.Dockerfile services/*/Dockerfile
+
+      - name: 🐳 Run Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          recursive: true
 
   build-and-test:
     name: Build and Test (${{ matrix.service }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,24 @@ jobs:
       - name: ⚙️ Generate Protobufs
         run: buf generate
 
+  docker-lint:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    needs: buf-check
+    steps:
+      - name: ⬇️ Checkout Code
+        uses: actions/checkout@v3
+      - name: Install hadolint
+        run: |
+          wget -O hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
+          chmod +x hadolint
+          sudo mv hadolint /usr/local/bin/
+      - name: Lint Dockerfiles
+        run: hadolint -c .hadolint.yaml docker/base.Dockerfile services/*/Dockerfile
+
   build-and-test:
     name: Build and Test (${{ matrix.service }})
-    needs: buf-check
+    needs: [buf-check, docker-lint]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,2 +1,5 @@
+failure-threshold: error
+trustedRegistries:
+  - ghcr.io
 ignored:
   - DL3007 # using latest tag for base image intentionally

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3007 # using latest tag for base image intentionally

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
         entry: buf lint
         language: system
         pass_filenames: false
+      - id: hadolint
+        name: Dockerfile Lint
+        entry: hadolint -c .hadolint.yaml
+        language: system
+        files: (?i)^Dockerfile$|\.Dockerfile$
       - id: frontend-lint
         name: Frontend ESLint
         entry: bash -c 'cd web-client && npm run lint && npm run format:fix'

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Before contributing, we recommend reviewing the following key documents:
 ### Additional Guidelines
 
 See the [Contributing Guidelines](./CONTRIBUTING.md) for branching strategy, testing requirements, and coding standards. Our AI coding conventions are documented in [Local Rules](design/project-management/ai-rules-local.md) and [Global Rules](design/project-management/ai-rules-global.md).
-The CI pipeline runs `./gradlew check`, which compiles and tests all modules while also running Spotless, Checkstyle, SpotBugs, and coverage reporting.
+The CI pipeline runs `./gradlew check`, which compiles and tests all modules while also running Spotless, Checkstyle, SpotBugs, **Hadolint**, and coverage reporting.
 
 ## Running Locally
 


### PR DESCRIPTION
## Summary
- use hadolint in pre-commit and CI
- ignore rule DL3007 with `.hadolint.yaml`
- mention hadolint in docs

## Testing
- `pip install pre-commit`
- `pre-commit run --files README.md .pre-commit-config.yaml .github/workflows/ci.yml .hadolint.yaml` *(failed: heavy tasks)*
- `./gradlew check` *(failed: process killed due to time)*

------
https://chatgpt.com/codex/tasks/task_e_6874d8302b0883308eb6f34530a2860a