### PR TITLE
Fix TcpProxyCrossService test configuration

### DIFF
--- a/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -29,6 +32,8 @@ import org.testcontainers.utility.DockerImageName;
     webEnvironment = WebEnvironment.RANDOM_PORT,
     classes = TcpProxyServiceApplication.class,
     properties = {"TCP_PROXY_PORT=2323"})
+@EnableAutoConfiguration(
+    exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TcpProxyCrossServiceIntegrationTest {
   static GenericContainer<?> gateway =


### PR DESCRIPTION
## Summary
- disable DB/Redis auto-config for TcpProxyCrossServiceIntegrationTest

## Testing
- `./gradlew :tcp-proxy-service:check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6874d5f595548330b68d0ddc35fc0212