### PR TITLE
Implement spacing multiplier and generation metadata

### DIFF
--- a/design/architecture/system-architecture-procedural-generation.md
+++ b/design/architecture/system-architecture-procedural-generation.md
@@ -79,6 +79,7 @@ All generators emit a normalized structure:
 | `biome`       | Biome or terrain type (if applicable)              |
 | `elevation`   | Numeric terrain height (used for visuals or logic) |
 | `regionId`    | Optional grouping for partitioned maps             |
+| `spacingMultiplier` | Adjusts travel cost when rooms are sparsely placed |
 
 In **full-grid mode**, every terrain tile becomes a room.
 In **sparse mode**, only selected POIs and waypoints are emitted.

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
@@ -25,10 +25,30 @@ public class DungeonGenerator implements Generator {
       return new GenerationResult(result, null);
     }
     // first room has no connection
-    result.add(new GeneratedRoom(1, 0));
+    result.add(
+        new GeneratedRoom(
+            1,
+            0,
+            0,
+            0,
+            java.util.Map.of(),
+            java.util.List.of("start"),
+            "cave",
+            0,
+            null));
     for (int i = 2; i <= rooms; i++) {
-      long connectTo = result.get(rnd.nextInt(result.size())).id();
-      result.add(new GeneratedRoom(i, connectTo));
+      long connectTo = result.get(rnd.nextInt(result.size())).roomId();
+      result.add(
+          new GeneratedRoom(
+              i,
+              connectTo,
+              i - 1,
+              0,
+              java.util.Map.of(),
+              java.util.List.of(),
+              "cave",
+              0,
+              null));
     }
     return new GenerationResult(result, null);
   }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GeneratedRoom.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GeneratedRoom.java
@@ -1,4 +1,13 @@
 package net.firedevops.firemud.service.generator;
 
-/** Simple DTO representing a procedurally generated room. */
-public record GeneratedRoom(long id, long connectedTo) {}
+/** DTO representing a procedurally generated room with metadata for editor overlays. */
+public record GeneratedRoom(
+    long roomId,
+    long connectedTo,
+    int x,
+    int y,
+    java.util.Map<String, Long> exitMap,
+    java.util.List<String> tags,
+    String biome,
+    int elevation,
+    Long regionId) {}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/SpawnPopulationHook.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/SpawnPopulationHook.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.service.generator;
+
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.service.PveEncounterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/** Simple population hook that spawns NPC encounters based on biome. */
+@Component
+@RequiredArgsConstructor
+public class SpawnPopulationHook implements GenerationHook {
+  private static final Logger logger = LoggerFactory.getLogger(SpawnPopulationHook.class);
+
+  private final PveEncounterService encounterService;
+
+  @Override
+  public void afterGeneration(GenerationParams params, GenerationResult result) {
+    for (GeneratedRoom room : result.rooms()) {
+      String biome = room.biome() != null ? room.biome() : "default";
+      try {
+        encounterService.generateEvent(biome, params.seed() + room.roomId());
+      } catch (Exception ex) {
+        logger.debug("Failed to populate room {}", room.roomId(), ex);
+      }
+    }
+  }
+}

--- a/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/generator/DungeonGeneratorTest.java
+++ b/services/automation-scripting-service/src/test/java/unit/net/firedevops/firemud/service/generator/DungeonGeneratorTest.java
@@ -16,6 +16,7 @@ class DungeonGeneratorTest {
     List<GeneratedRoom> rooms = result.rooms();
     assertEquals(5, rooms.size());
     assertFalse(rooms.stream().skip(1).anyMatch(r -> r.connectedTo() == 0));
+    assertEquals(0, rooms.get(0).x());
   }
 
   @Test

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/dto/RegionDto.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/dto/RegionDto.java
@@ -11,4 +11,5 @@ public record RegionDto(
     Integer shardId,
     Long generationSeed,
     String generatorType,
-    String generatorParams) {}
+    String generatorParams,
+    Double spacingMultiplier) {}

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Region.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Region.java
@@ -39,5 +39,9 @@ public class Region {
   @Column(name = "generator_params")
   private String generatorParams;
 
+  /** Multiplier applied to travel cost in sparse areas. */
+  @Column(name = "spacing_multiplier", nullable = false)
+  private Double spacingMultiplier = 1.0;
+
   @Version private int version;
 }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/TravelServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/TravelServiceImpl.java
@@ -20,24 +20,26 @@ public class TravelServiceImpl implements TravelService {
       return List.of(startRoomId);
     }
     List<RoomExit> exits = exitRepository.findByTenantId(tenantId);
-    Map<Long, List<Long>> graph = buildGraph(exits);
+    Map<Long, List<RoomExit>> graph = buildGraph(exits);
     return dijkstra(graph, startRoomId, targetRoomId);
   }
 
-  private Map<Long, List<Long>> buildGraph(List<RoomExit> exits) {
-    Map<Long, List<Long>> graph = new HashMap<>();
+  private Map<Long, List<RoomExit>> buildGraph(List<RoomExit> exits) {
+    Map<Long, List<RoomExit>> graph = new HashMap<>();
     for (RoomExit exit : exits) {
-      graph
-          .computeIfAbsent(exit.getFromRoom().getId(), k -> new ArrayList<>())
-          .add(exit.getToRoom().getId());
-      graph
-          .computeIfAbsent(exit.getToRoom().getId(), k -> new ArrayList<>())
-          .add(exit.getFromRoom().getId());
+      graph.computeIfAbsent(exit.getFromRoom().getId(), k -> new ArrayList<>()).add(exit);
+      // add reverse edge
+      RoomExit reverse = new RoomExit();
+      reverse.setFromRoom(exit.getToRoom());
+      reverse.setToRoom(exit.getFromRoom());
+      reverse.setCost(exit.getCost());
+      reverse.setTenantId(exit.getTenantId());
+      graph.computeIfAbsent(exit.getToRoom().getId(), k -> new ArrayList<>()).add(reverse);
     }
     return graph;
   }
 
-  private List<Long> dijkstra(Map<Long, List<Long>> graph, Long start, Long end) {
+  private List<Long> dijkstra(Map<Long, List<RoomExit>> graph, Long start, Long end) {
     Map<Long, Integer> dist = new HashMap<>();
     Map<Long, Long> prev = new HashMap<>();
     PriorityQueue<Long> queue = new PriorityQueue<>(Comparator.comparingInt(dist::get));
@@ -53,8 +55,11 @@ public class TravelServiceImpl implements TravelService {
       if (current.equals(end)) {
         break;
       }
-      for (Long neighbor : graph.getOrDefault(current, Collections.emptyList())) {
-        int alt = dist.get(current) + 1;
+      for (RoomExit exit : graph.getOrDefault(current, Collections.emptyList())) {
+        Long neighbor = exit.getToRoom().getId();
+        double multiplier = exit.getFromRoom().getRegion().getSpacingMultiplier();
+        int cost = (int) Math.round(exit.getCost() * multiplier);
+        int alt = dist.get(current) + cost;
         if (alt < dist.getOrDefault(neighbor, Integer.MAX_VALUE)) {
           dist.put(neighbor, alt);
           prev.put(neighbor, current);

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
@@ -82,6 +82,10 @@ public class WorldCreationServiceImpl implements WorldCreationService {
     // Newly created worlds start on the local shard. Admin tooling can
     // redistribute regions later for scaling.
     region.setShardId(worldProperties.getLocalShardId());
+    region.setGenerationSeed(System.currentTimeMillis());
+    region.setGeneratorType("SimpleDungeonGenerator");
+    region.setGeneratorParams("{}");
+    region.setSpacingMultiplier(1.0);
     region.setName("Starter Region");
     regionRepository.save(region);
   }

--- a/services/world-management-service/src/main/resources/db/migration/V9__region_spacing_multiplier.sql
+++ b/services/world-management-service/src/main/resources/db/migration/V9__region_spacing_multiplier.sql
@@ -1,0 +1,2 @@
+ALTER TABLE region \
+    ADD COLUMN spacing_multiplier DOUBLE PRECISION NOT NULL DEFAULT 1.0;

--- a/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TravelServiceImplTest.java
+++ b/services/world-management-service/src/test/java/unit/net/firedevops/firemud/service/impl/TravelServiceImplTest.java
@@ -24,10 +24,15 @@ class TravelServiceImplTest {
   void findsSimplePath() {
     Room r1 = new Room();
     r1.setId(1L);
+    net.firedevops.firemud.entity.Region region = new net.firedevops.firemud.entity.Region();
+    region.setSpacingMultiplier(1.0);
+    r1.setRegion(region);
     Room r2 = new Room();
     r2.setId(2L);
+    r2.setRegion(r1.getRegion());
     Room r3 = new Room();
     r3.setId(3L);
+    r3.setRegion(r1.getRegion());
     RoomExit e1 = new RoomExit();
     e1.setFromRoom(r1);
     e1.setToRoom(r2);


### PR DESCRIPTION
## Summary
- capture spacingMultiplier in design docs for traversing sparse maps
- expose more metadata in GeneratedRoom
- log spawn events with new SpawnPopulationHook
- add spacingMultiplier to Region and use during pathfinding
- seed region metadata in WorldCreationService
- database migration for spacingMultiplier

## Testing
- `./gradlew test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6874d57d6e34833085f565bce6078625