### PR TITLE
Add optimisic locking & indexes to automation service

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/Faction.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/Faction.java
@@ -18,4 +18,8 @@ public class Faction {
   private String name;
 
   private String description;
+
+  @Version
+  @Column(name = "row_version")
+  private int version;
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/FactionStanding.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/FactionStanding.java
@@ -23,4 +23,8 @@ public class FactionStanding {
 
   @Column(nullable = false)
   private int reputation = 0;
+
+  @Version
+  @Column(name = "row_version")
+  private int version;
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormation.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormation.java
@@ -24,4 +24,8 @@ public class NpcFormation {
   @Enumerated(EnumType.STRING)
   @Column(name = "formation_type", nullable = false)
   private FormationType formationType;
+
+  @Version
+  @Column(name = "row_version")
+  private int version;
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormationMember.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcFormationMember.java
@@ -17,4 +17,8 @@ public class NpcFormationMember {
 
   @Column(name = "npc_id", nullable = false)
   private Long npcId;
+
+  @Version
+  @Column(name = "row_version")
+  private int version;
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcMemory.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/NpcMemory.java
@@ -22,4 +22,8 @@ public class NpcMemory {
 
   @Column(name = "tenant_id", nullable = false)
   private Long tenantId;
+
+  @Version
+  @Column(name = "row_version")
+  private int version;
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/ScriptDefinition.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/entity/ScriptDefinition.java
@@ -17,9 +17,13 @@ public class ScriptDefinition {
   @Column(nullable = false, length = 100)
   private String name;
 
-  @Column(nullable = false, length = 20)
-  private String version;
+  @Column(name = "version", nullable = false, length = 20)
+  private String scriptVersion;
 
   @Column(nullable = false, columnDefinition = "TEXT")
   private String definition;
+
+  @Version
+  @Column(name = "row_version")
+  private int rowVersion;
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/mapper/ScriptDefinitionMapper.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/mapper/ScriptDefinitionMapper.java
@@ -3,10 +3,13 @@ package net.firedevops.firemud.mapper;
 import net.firedevops.firemud.dto.ScriptDefinitionDto;
 import net.firedevops.firemud.entity.ScriptDefinition;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ScriptDefinitionMapper {
+  @Mapping(source = "scriptVersion", target = "version")
   ScriptDefinitionDto toDto(ScriptDefinition entity);
 
+  @Mapping(source = "version", target = "scriptVersion")
   ScriptDefinition toEntity(ScriptDefinitionDto dto);
 }

--- a/services/automation-scripting-service/src/main/resources/db/migration/V3__optimistic_locking_and_indexes.sql
+++ b/services/automation-scripting-service/src/main/resources/db/migration/V3__optimistic_locking_and_indexes.sql
@@ -1,0 +1,17 @@
+ALTER TABLE scripts ADD COLUMN row_version INT NOT NULL DEFAULT 0;
+ALTER TABLE npc_memory ADD COLUMN row_version INT NOT NULL DEFAULT 0;
+ALTER TABLE factions ADD COLUMN row_version INT NOT NULL DEFAULT 0;
+ALTER TABLE faction_standing ADD COLUMN row_version INT NOT NULL DEFAULT 0;
+ALTER TABLE npc_formations ADD COLUMN row_version INT NOT NULL DEFAULT 0;
+ALTER TABLE npc_formation_member ADD COLUMN row_version INT NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_scripts_tenant_id ON scripts(tenant_id);
+CREATE INDEX idx_npc_memory_tenant_id ON npc_memory(tenant_id);
+CREATE INDEX idx_npc_memory_npc_id ON npc_memory(npc_id);
+CREATE INDEX idx_factions_tenant_id ON factions(tenant_id);
+CREATE INDEX idx_faction_standing_tenant_id ON faction_standing(tenant_id);
+CREATE INDEX idx_faction_standing_faction_id ON faction_standing(faction_id);
+CREATE INDEX idx_npc_formations_tenant_id ON npc_formations(tenant_id);
+CREATE INDEX idx_npc_formations_leader_npc_id ON npc_formations(leader_npc_id);
+CREATE INDEX idx_npc_formation_member_formation_id ON npc_formation_member(formation_id);
+CREATE INDEX idx_npc_formation_member_npc_id ON npc_formation_member(npc_id);


### PR DESCRIPTION
## Summary
- implement guidelines from performance-optimization.md
- add row_version columns and indexes to automation-scripting tables
- add @Version fields to entities
- map DTO version property with MapStruct

## Testing
- `./gradlew check --no-daemon` *(fails: Process 'command 'bash'' finished with non-zero exit value 2)*

------
https://chatgpt.com/codex/tasks/task_e_6874dd89759883308db8986a00acdd8c