### PR TITLE
Improve deployment configuration

### DIFF
--- a/design/architecture/system-architecture-testing.md
+++ b/design/architecture/system-architecture-testing.md
@@ -45,7 +45,7 @@ For workflows that span multiple services, such as account creation and world pr
 
 ```kotlin
 val network = Network.newNetwork()
-val postgres = PostgreSQLContainer<Nothing>("postgres:15").withNetwork(network)
+val postgres = PostgreSQLContainer<Nothing>("postgres:16").withNetwork(network)
 val accountService = GenericContainer("account-service:latest").withNetwork(network)
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,8 @@ x-service-volumes: &service-vols
   - ./dev-tools/certs:/app/certs:ro
 
 x-service-resources: &service-resources
-  deploy:
-    resources:
-      limits:
-        cpus: "0.5"
-        memory: 512M
+  cpus: "0.5"
+  mem_limit: 512m
 
 services:
   account-service:
@@ -255,6 +252,8 @@ services:
     build:
       context: .
       dockerfile: docker/pg-dump-cron.Dockerfile
+    cpus: "0.5"
+    mem_limit: 256m
     env_file:
       - .env
     environment:

--- a/k8s/helm/_helpers.tpl
+++ b/k8s/helm/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* Common helper templates for FireMUD Helm charts */}}
+{{- define "firemud.labels" -}}
+app: {{ .Chart.Name }}
+{{- end -}}
+
+{{- define "firemud.resources" -}}
+requests:
+  cpu: "200m"
+  memory: "256Mi"
+limits:
+  cpu: "400m"
+  memory: "512Mi"
+{{- end -}}

--- a/k8s/helm/account-service/templates/_helpers.tpl
+++ b/k8s/helm/account-service/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* Common helper templates for FireMUD Helm charts */}}
+{{- define "firemud.labels" -}}
+app: {{ .Chart.Name }}
+{{- end -}}
+
+{{- define "firemud.resources" -}}
+requests:
+  cpu: "200m"
+  memory: "256Mi"
+limits:
+  cpu: "400m"
+  memory: "512Mi"
+{{- end -}}

--- a/k8s/helm/account-service/templates/deployment.yaml
+++ b/k8s/helm/account-service/templates/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: account-service
+{{ include "firemud.labels" . | indent 6 }}
   template:
     metadata:
       labels:
-        app: account-service
+{{ include "firemud.labels" . | indent 8 }}
     spec:
       containers:
         - name: account-service
@@ -21,3 +21,5 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          resources:
+{{ include "firemud.resources" . | indent 12 }}

--- a/k8s/helm/game-session-service/templates/_helpers.tpl
+++ b/k8s/helm/game-session-service/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* Common helper templates for FireMUD Helm charts */}}
+{{- define "firemud.labels" -}}
+app: {{ .Chart.Name }}
+{{- end -}}
+
+{{- define "firemud.resources" -}}
+requests:
+  cpu: "200m"
+  memory: "256Mi"
+limits:
+  cpu: "400m"
+  memory: "512Mi"
+{{- end -}}

--- a/k8s/helm/game-session-service/templates/deployment.yaml
+++ b/k8s/helm/game-session-service/templates/deployment.yaml
@@ -5,11 +5,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: game-session-service
+{{ include "firemud.labels" . | indent 6 }}
   template:
     metadata:
       labels:
-        app: game-session-service
+{{ include "firemud.labels" . | indent 8 }}
     spec:
       containers:
         - name: game-session-service
@@ -21,3 +21,5 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          resources:
+{{ include "firemud.resources" . | indent 12 }}

--- a/k8s/network-policies/account-service.yaml
+++ b/k8s/network-policies/account-service.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: account-service-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: account-service
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: firemud-postgresql
+      ports:
+        - protocol: TCP
+          port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: firemud-redis
+      ports:
+        - protocol: TCP
+          port: 6379
+    - to:
+        - podSelector:
+            matchExpressions:
+              - key: app
+                operator: NotIn
+                values:
+                  - spring-cloud-gateway
+                  - tcp-proxy-service
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 6565

--- a/k8s/network-policies/internal-services.yaml
+++ b/k8s/network-policies/internal-services.yaml
@@ -21,8 +21,18 @@ spec:
           port: 8080
         - protocol: TCP
           port: 6565
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: firemud-postgresql
+      ports:
         - protocol: TCP
           port: 5432
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: firemud-redis
+      ports:
         - protocol: TCP
           port: 6379
   egress:
@@ -33,7 +43,17 @@ spec:
           port: 8080
         - protocol: TCP
           port: 6565
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: firemud-postgresql
+      ports:
         - protocol: TCP
           port: 5432
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: firemud-redis
+      ports:
         - protocol: TCP
           port: 6379

--- a/k8s/postgres/pg-dump-cronjob.yaml
+++ b/k8s/postgres/pg-dump-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: pg-dump
-              image: postgres:15
+              image: postgres:16
               envFrom:
                 - configMapRef:
                     name: firemud-config


### PR DESCRIPTION
## Summary
- configure memory and CPU limits in docker-compose
- align PostgreSQL versions to 16
- add reusable Helm helper templates and apply to service charts
- tighten internal NetworkPolicy and add example per‑service policy

## Testing
- `pre-commit` *(fails: Gradle build daemon stopped)*
- `./gradlew check` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6874e24b4170833090ecdcf9f58fd49e