### PR TITLE
Clarify remote tick behavior

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -108,26 +108,27 @@ All Lua scripts are:
 
 ### 🔀 Shard Locality and Cross-Region Behavior
 
-Redis **does not support cross-shard transactions**. Tick operations are bound
-to the shard that hosts their region. When an action spans regions — for
-example a player moving between rooms — the Game Session Service decomposes the
-transition into **separate ticks**:
+Redis **does not support cross-shard transactions**. All tick-related commands
+and Lua scripts are confined to **one shard**. When an action spans regions
+(for example a player moving between rooms on different shards) the Game Session
+Service decomposes the transition into **two sequential ticks**:
 
-1. The first tick exits the source region, clearing locks and staged state on
-   *Shard&nbsp;A*.
-2. A follow-up tick enters the destination region on *Shard&nbsp;B* and applies
-   the new state.
+1. **Tick&nbsp;A** on *Shard&nbsp;X* performs exit logic and clears local state.
+2. **Tick&nbsp;B** on *Shard&nbsp;Y* applies entry logic and rebinds the
+   session in the new region.
 
-These ticks never overlap or hold locks across shards. Lua scripts execute on a
-single shard at a time, guaranteeing atomicity and replay safety without any
-distributed coordination.
+No lock or Lua script ever spans shards. The Game Session Service coordinates
+these ticks so they never overlap, ensuring atomicity and deterministic replay
+without distributed transactions. See
+[Cross-Region Command Execution and Result Relay](./system-architecture-ticks.md#📡-cross-region-command-execution-and-result-relay)
+for how commands targeting another region are routed and resolved.
 
 ### 🌀 Global Effects and Region-Wide Coordination
 
-Some gameplay events span **multiple tick regions** — for example, a server-wide
-freeze, global weather change, or round reset. FireMUD avoids relying on idle
-regions to poll for these changes. Instead, the **Game Session Service**
-identifies all affected regions and **fan-outs tick tasks**:
+Tick regions **do not execute unless explicitly triggered**. Idle regions will
+never see scheduled global events on their own. To apply a world-wide effect —
+for example, a server-wide freeze or weather change — the **Game Session
+Service** identifies every active region and **fan-outs tick tasks**:
 
 1. Commands are injected into each region’s shard-local keyspace.
 2. A tick is triggered in that region to apply the effect atomically.

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -80,15 +80,20 @@ Ticks are **region-scoped**, not globally synchronized. Each **tick region** (ty
 - **Configurable pacing** per region (tick rate or delay)
 - **Elastic execution** across worker instances
 
-> 🔄 **Cross-region actions are split into sequential ticks.** The first tick
-> exits the source region and clears state from its shard. A follow-up tick
-> enters the destination region and applies state on that shard. The Game
-> Session Service ensures these ticks do not overlap or hold locks across
-> shards.
+> 🔄 **Cross-region actions are split into sequential ticks.**
+> **Tick&nbsp;A** (on the source shard) performs exit logic and clears local
+> state. **Tick&nbsp;B** (on the destination shard) applies entry logic and
+> rebinds the session. No lock or Lua script spans shards, and the Game Session
+> Service ensures these ticks execute safely without overlap. See
+> [Shard Locality and Cross-Region Behavior](./system-architecture-redis.md#🔀-shard-locality-and-cross-region-behavior)
+> for a full description of this pattern.
 
-> 🌀 **Global effects are dispatched by fan-out.** The Game Session Service
-> injects commands into each affected region's shard and triggers a tick there,
-> ensuring the event is applied even if that region was idle.
+> 🌀 **Global effects are dispatched by fan-out.** Tick regions remain idle
+> unless explicitly triggered, so the Game Session Service injects commands into
+> each affected shard and forces a tick there. This guarantees the event is
+> applied even if a region would not tick on its own. See
+> [Global Effects and Region-Wide Coordination](./system-architecture-redis.md#🌀-global-effects-and-region-wide-coordination)
+> for details on the underlying Redis pattern.
 
 > 🧠 Tick regions are mapped to Redis shards for atomicity and lock discipline.
 
@@ -202,6 +207,26 @@ Recovery is coordinated by Game Session Service and backed by:
 - `WAIT 1 100` for durable replication
 
 This supports **idempotent, replayable** ticks — without risk of duplicate effects or inconsistent state.
+
+---
+
+## 📡 Cross-Region Command Execution and Result Relay
+
+Some commands originate in one region but affect targets in another — for
+example, remote attacks, cross-world spells, or administrative inventory moves.
+The process is **asynchronous and multi-phased**:
+
+1. The origin region validates the command and enqueues it in the target
+   region's shard.
+2. The target region executes the command during its next tick (applying damage
+   or item changes locally).
+3. A result message is routed back to the origin region or directly to the
+   player's session via Redis queue or in-band message.
+
+Players see immediate feedback such as "Casting Fireball..." and later receive
+"🔥 Hit for 12 damage!" once the remote tick completes. No region waits
+synchronously for another shard, preserving responsiveness and full replay
+safety.
 
 ---
 


### PR DESCRIPTION
## Summary
- detail shard locality and global tick coordination in Redis doc
- explain cross-region commands and result relay in ticks doc

## Testing
- `./gradlew check` *(fails: linkCheck network errors)*

------
https://chatgpt.com/codex/tasks/task_e_687589e0ee2083308842988fc3de8a4d