### PR TITLE
Run lint and fix markdown issues

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -113,8 +113,8 @@ and Lua scripts are confined to **one shard**. When an action spans regions
 (for example a player moving between rooms on different shards) the Game Session
 Service decomposes the transition into **two sequential ticks**:
 
-1. **Tick&nbsp;A** on *Shard&nbsp;X* performs exit logic and clears local state.
-2. **Tick&nbsp;B** on *Shard&nbsp;Y* applies entry logic and rebinds the
+1. **Tick&nbsp;A** on _Shard&nbsp;X_ performs exit logic and clears local state.
+2. **Tick&nbsp;B** on _Shard&nbsp;Y_ applies entry logic and rebinds the
    session in the new region.
 
 No lock or Lua script ever spans shards. The Game Session Service coordinates

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -87,14 +87,12 @@ Ticks are **region-scoped**, not globally synchronized. Each **tick region** (ty
 > Service ensures these ticks execute safely without overlap. See
 > [Shard Locality and Cross-Region Behavior](./system-architecture-redis.md#🔀-shard-locality-and-cross-region-behavior)
 > for a full description of this pattern.
-
 > 🌀 **Global effects are dispatched by fan-out.** Tick regions remain idle
 > unless explicitly triggered, so the Game Session Service injects commands into
 > each affected shard and forces a tick there. This guarantees the event is
 > applied even if a region would not tick on its own. See
 > [Global Effects and Region-Wide Coordination](./system-architecture-redis.md#🌀-global-effects-and-region-wide-coordination)
 > for details on the underlying Redis pattern.
-
 > 🧠 Tick regions are mapped to Redis shards for atomicity and lock discipline.
 
 ---


### PR DESCRIPTION
## Summary
- run CI-equivalent checks locally
- fix Markdown lint warnings in Redis and tick architecture docs

## Testing
- `./gradlew lintMarkdown`
- `./gradlew checkstyleMain`
- `./gradlew spotbugsMain`
- `buf lint`
- `npm run openapi:lint`
- `npm ci`
- `npm run lint`
- `npm run format -- -c`
- `npm run accessibility`
- `hadolint -c .hadolint.yaml $(find services -name Dockerfile)`


------
https://chatgpt.com/codex/tasks/task_e_68758ff51e188330ab4f3d3c9e0b8671