### PR TITLE
Improve k8s security settings and docs

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -70,7 +70,8 @@ these variables.
 ### gRPC TLS Certificates
 
 Mutual TLS protects all gRPC calls between services. Certificates are normally
-provisioned by **cert-manager** and mounted from Kubernetes Secrets.
+provisioned by **cert-manager** and mounted from Kubernetes Secrets. A sample
+`Certificate` manifest is provided at `k8s/base/firemud-grpc-certificate.yaml`.
 
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -50,8 +49,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -67,8 +65,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -84,8 +81,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -101,8 +97,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -118,8 +113,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -135,8 +129,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -152,8 +145,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -169,8 +161,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -186,8 +177,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres
@@ -203,8 +193,7 @@ services:
       <<: *service-env
     env_file:
       - .env
-    volumes:
-      - ./dev-tools/certs:/app/certs:ro
+    volumes: *service-vols
     restart: unless-stopped
     depends_on:
       - postgres

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,6 +1,7 @@
 # Shared base image for FireMUD services
 FROM eclipse-temurin:21-jre
 LABEL org.opencontainers.image.source="https://github.com/firedevops/FireMUD"
-RUN addgroup --system firemud && adduser --system --ingroup firemud firemud
+RUN addgroup --system --gid 1000 firemud \
+    && adduser --system --uid 1000 --ingroup firemud firemud
 WORKDIR /app
 USER firemud

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -26,7 +26,10 @@ After the services are running, apply the default network policies found in
 
 ```bash
 kubectl apply -f network-policies/internal-services.yaml
+kubectl apply -f base/firemud-grpc-certificate.yaml
 ```
+The policy allows gRPC (8080, 6565) and OpenTelemetry traffic on port `4317` in
+addition to database access.
 
 ## Monitoring Components
 

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: account-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: account-service
           image: ghcr.io/firemud/account-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: automation-scripting-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: automation-scripting-service
           image: ghcr.io/firemud/automation-scripting-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: entity-management-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: entity-management-service
           image: ghcr.io/firemud/entity-management-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/firemud-grpc-certificate.yaml
+++ b/k8s/base/firemud-grpc-certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: firemud-grpc-tls
+spec:
+  secretName: firemud-grpc-tls
+  dnsNames:
+    - "firemud.example.com"
+  issuerRef:
+    name: firemud-ca-issuer
+    kind: ClusterIssuer

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: game-design-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: game-design-service
           image: ghcr.io/firemud/game-design-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: game-logic-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: game-logic-service
           image: ghcr.io/firemud/game-logic-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: game-session-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: game-session-service
           image: ghcr.io/firemud/game-session-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: logging-admin-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: logging-admin-service
           image: ghcr.io/firemud/logging-admin-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:
@@ -76,6 +79,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: social-groups-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: social-groups-service
           image: ghcr.io/firemud/social-groups-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -14,6 +14,8 @@ spec:
       labels:
         app: spring-cloud-gateway
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: spring-cloud-gateway
           image: ghcr.io/firemud/spring-cloud-gateway:latest
@@ -35,6 +37,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: tcp-proxy-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: tcp-proxy-service
           image: ghcr.io/firemud/tcp-proxy-service:latest
@@ -21,6 +23,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -13,6 +13,8 @@ spec:
       labels:
         app: world-management-service
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: world-management-service
           image: ghcr.io/firemud/world-management-service:latest
@@ -39,6 +41,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             runAsGroup: 1000
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
             requests:

--- a/k8s/helm/_helpers.tpl
+++ b/k8s/helm/_helpers.tpl
@@ -11,3 +11,15 @@ limits:
   cpu: "400m"
   memory: "512Mi"
 {{- end -}}
+
+{{- define "firemud.fullname" -}}
+{{ printf "%s-%s" .Release.Name .Chart.Name }}
+{{- end -}}
+
+{{- define "firemud.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{ .Values.serviceAccount.name | default (include "firemud.fullname" .) }}
+{{- else }}
+{{ .Values.serviceAccount.name | default "default" }}
+{{- end }}
+{{- end -}}

--- a/k8s/helm/account-service/templates/deployment.yaml
+++ b/k8s/helm/account-service/templates/deployment.yaml
@@ -11,6 +11,11 @@ spec:
       labels:
 {{ include "firemud.labels" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "firemud.serviceAccountName" . }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: account-service
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -21,5 +26,17 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           resources:
 {{ include "firemud.resources" . | indent 12 }}

--- a/k8s/helm/account-service/templates/serviceaccount.yaml
+++ b/k8s/helm/account-service/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "firemud.serviceAccountName" . }}
+{{- end }}

--- a/k8s/helm/account-service/values.yaml
+++ b/k8s/helm/account-service/values.yaml
@@ -5,3 +5,15 @@ service:
   type: ClusterIP
   port: 8080
 extraEnv: {}
+serviceAccount:
+  create: true
+  name: ""
+readinessProbe:
+  path: /actuator/health
+  initialDelaySeconds: 5
+  periodSeconds: 10
+livenessProbe:
+  path: /actuator/health
+  initialDelaySeconds: 15
+  periodSeconds: 20
+affinity: {}

--- a/k8s/helm/game-session-service/templates/deployment.yaml
+++ b/k8s/helm/game-session-service/templates/deployment.yaml
@@ -11,6 +11,11 @@ spec:
       labels:
 {{ include "firemud.labels" . | indent 8 }}
     spec:
+      serviceAccountName: {{ include "firemud.serviceAccountName" . }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: game-session-service
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -21,5 +26,17 @@ spec:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: 8080
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           resources:
 {{ include "firemud.resources" . | indent 12 }}

--- a/k8s/helm/game-session-service/templates/serviceaccount.yaml
+++ b/k8s/helm/game-session-service/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "firemud.serviceAccountName" . }}
+{{- end }}

--- a/k8s/helm/game-session-service/values.yaml
+++ b/k8s/helm/game-session-service/values.yaml
@@ -5,3 +5,15 @@ service:
   type: ClusterIP
   port: 8080
 extraEnv: {}
+serviceAccount:
+  create: true
+  name: ""
+readinessProbe:
+  path: /actuator/health
+  initialDelaySeconds: 5
+  periodSeconds: 10
+livenessProbe:
+  path: /actuator/health
+  initialDelaySeconds: 15
+  periodSeconds: 20
+affinity: {}

--- a/k8s/network-policies/internal-services.yaml
+++ b/k8s/network-policies/internal-services.yaml
@@ -21,6 +21,8 @@ spec:
           port: 8080
         - protocol: TCP
           port: 6565
+        - protocol: TCP
+          port: 4317
     - from:
         - podSelector:
             matchLabels:
@@ -43,6 +45,8 @@ spec:
           port: 8080
         - protocol: TCP
           port: 6565
+        - protocol: TCP
+          port: 4317
     - to:
         - podSelector:
             matchLabels:

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
@@ -27,28 +27,12 @@ public class DungeonGenerator implements Generator {
     // first room has no connection
     result.add(
         new GeneratedRoom(
-            1,
-            0,
-            0,
-            0,
-            java.util.Map.of(),
-            java.util.List.of("start"),
-            "cave",
-            0,
-            null));
+            1, 0, 0, 0, java.util.Map.of(), java.util.List.of("start"), "cave", 0, null));
     for (int i = 2; i <= rooms; i++) {
       long connectTo = result.get(rnd.nextInt(result.size())).roomId();
       result.add(
           new GeneratedRoom(
-              i,
-              connectTo,
-              i - 1,
-              0,
-              java.util.Map.of(),
-              java.util.List.of(),
-              "cave",
-              0,
-              null));
+              i, connectTo, i - 1, 0, java.util.Map.of(), java.util.List.of(), "cave", 0, null));
     }
     return new GenerationResult(result, null);
   }


### PR DESCRIPTION
## Summary
- match Docker UID with Kubernetes securityContext
- reuse docker-compose volume anchor
- harden securityContext settings across deployments
- document cert-manager Certificate example
- allow OpenTelemetry port in network policy
- add service account templates and probes to Helm charts

## Testing
- `./gradlew :automation-scripting-service:spotlessApply`
- `./gradlew check` *(fails: Process 'command 'bash'' finished with non-zero exit value 2)*

------
https://chatgpt.com/codex/tasks/task_e_68759103a8248330828f48b92b4b9830