### PR TITLE
Fix CI workflow YAML syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
         run: |
           git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
 
-  - name: ⚠️ Buf Breaking
-    if: github.event_name == 'pull_request'
-    run: |
-      buf breaking --against ".git#ref=${{ github.event.pull_request.base.sha }}"
+      - name: ⚠️ Buf Breaking
+        if: github.event_name == 'pull_request'
+        run: |
+          buf breaking --against ".git#ref=${{ github.event.pull_request.base.sha }}"
 
-  - name: ⚙️ Generate Protobufs
-    run: buf generate
+      - name: ⚙️ Generate Protobufs
+        run: buf generate
 
   docker-lint:
     name: Dockerfile Lint


### PR DESCRIPTION
## Summary
- fix indentation in the Buf check steps of the CI workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: Execution failed for task ':lintMarkdown')*
- `./gradlew check` *(fails: Task :lintMarkdown FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6875a4b06f0c8330a4752ab7f305d5b4