### PR TITLE
Fix lint issues from CI scripts

### DIFF
--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -222,7 +222,7 @@ The process is **asynchronous and multi-phased**:
 
 Players experience a smooth flow:
 
-```
+```text
 🕒 You cast Fireball...
 🔥 Your Fireball hits Player B for 12 damage!
 ```

--- a/dev-tools/generate-erd.sh
+++ b/dev-tools/generate-erd.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Generate ERD diagrams and verify Flyway migrations for all services.
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- address markdown lint by specifying code block language
- add bash shebang to generate-erd.sh

## Testing
- `find dev-tools -name '*.sh' -print0 | xargs -0 shellcheck`
- `./gradlew lintMarkdown`
- `trivy fs --scanners vuln --skip-dirs node_modules .`
- `buf lint`


------
https://chatgpt.com/codex/tasks/task_e_6875a43b0b2c83308f968f7e6534e380