### PR TITLE
Update tick architecture docs

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -74,7 +74,7 @@ Redis keys follow strict naming conventions to ensure:
 | `room:{tenantId}:{roomId}:occupants`     | Room occupancy snapshot                  |
 | `retry:{tenantId}:{regionId}`            | Retry queue for failed actions           |
 | `timer:{tenantId}:{entityId}:{effectId}` | Cooldown/effect timer metadata (in ms)   |
-| `remote:{entityId}` | Queue for cross-region command follow-ups |
+| `remote:{tenantId}:{entityId}` | Queue for cross-region command follow-ups |
 
 > 📌 For session-related keys and structure, see [Session Keys and Gameplay Binding](#-session-keys-and-gameplay-binding)
 > ⚠️ Tick regions and player sessions are **always scoped to a single Redis shard** to preserve atomicity. Cross-shard operations are avoided.

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -74,6 +74,7 @@ Redis keys follow strict naming conventions to ensure:
 | `room:{tenantId}:{roomId}:occupants`     | Room occupancy snapshot                  |
 | `retry:{tenantId}:{regionId}`            | Retry queue for failed actions           |
 | `timer:{tenantId}:{entityId}:{effectId}` | Cooldown/effect timer metadata (in ms)   |
+| `remote:{entityId}` | Queue for cross-region command follow-ups |
 
 > 📌 For session-related keys and structure, see [Session Keys and Gameplay Binding](#-session-keys-and-gameplay-binding)
 > ⚠️ Tick regions and player sessions are **always scoped to a single Redis shard** to preserve atomicity. Cross-shard operations are avoided.

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -216,7 +216,7 @@ The process is **asynchronous and multi-phased**:
 
 1. A tick-local command executes in the **origin region**.
 2. A follow-up action — including the `sourceEntityId` — is enqueued in the
-   **target region's** command queue (often under a `remote:{entityId}` key; see
+   **target region's** command queue (often under a `remote:{tenantId}:{entityId}` key; see
    [Redis Key Naming](./system-architecture-redis.md#🗂️-key-naming-and-shard-discipline)).
 3. The target region processes the action during its next tick and determines
    the outcome locally.

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -216,7 +216,8 @@ The process is **asynchronous and multi-phased**:
 
 1. A tick-local command executes in the **origin region**.
 2. A follow-up action — including the `sourceEntityId` — is enqueued in the
-   **target region's** command queue (often under a `remote:{entityId}` key).
+   **target region's** command queue (often under a `remote:{entityId}` key; see
+   [Redis Key Naming](./system-architecture-redis.md#🗂️-key-naming-and-shard-discipline)).
 3. The target region processes the action during its next tick and determines
    the outcome locally.
 4. The Game Session Service routes the result back to the origin region or


### PR DESCRIPTION
## Summary
- add remote queue to Redis key reference
- cross-reference remote keys in tick docs

## Testing
- `pre-commit run --files design/architecture/system-architecture-redis.md design/architecture/system-architecture-ticks.md` *(fails: Gradle tasks missing or slow)*

------
https://chatgpt.com/codex/tasks/task_e_6875a3ff09dc8330b4374cfc28fcc36d