### PR TITLE
Add metrics for tick retry visibility

### DIFF
--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -40,6 +40,9 @@ These notes summarize typical optimizations applied across FireMUD services.
   visibility into heavy script load.
 - Redis exporters publish Lua latency, lock contention and retry queue depth
   metrics so operators can spot hotspots in Grafana dashboards.
+- The Game Session Service exposes `tick_retry_queue_depth`,
+  `tick_requeued_action_total`, and `tick_retry_backoff_count_total` metrics for
+  per-region visibility into retries and backoff behavior.
 - Graceful degradation logic in the Game Session Service retries failed
   Redis operations so stalled ticks do not block gameplay.
 - The Game Session Service records `game_session_commands_enqueued_total` and

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -142,6 +142,8 @@ Each tick enforces a **soft execution budget** (e.g., 100ms):
 - **Oldest actions win** in conflict scenarios
 - Newer submissions are backlogged until resolved
 - Conflict metadata enables **hotspot detection** and livelock prevention
+- Metrics `tick_conflict_hotspot_detected_total` and `tick_retry_queue_depth`
+  help operators monitor these hotspots across regions.
 - Lua staging scripts limit how many commands or events move from queue to
   pending lists per tick. The defaults (`game.tick-max-commands` and
   `automation.tick-max-events`) spread heavy workloads across ticks so one

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -5,12 +5,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+import io.micrometer.core.instrument.MeterRegistry;
 
 /** Records conflict metadata in Redis for hotspot detection. */
 @Component
 @RequiredArgsConstructor
 public class RedisConflictTracker implements ConflictTracker {
   private final StringRedisTemplate redisTemplate;
+  private final MeterRegistry meterRegistry;
 
   @Value("${firemud.conflict.ttlSeconds:300}")
   private long ttlSeconds;
@@ -20,5 +22,6 @@ public class RedisConflictTracker implements ConflictTracker {
     String redisKey = "conflict:" + key;
     redisTemplate.opsForValue().increment(redisKey);
     redisTemplate.expire(redisKey, Duration.ofSeconds(ttlSeconds));
+    meterRegistry.counter("tick_conflict_hotspot_detected_total").increment();
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -11,6 +11,7 @@ import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.conflict.ConflictTracker;
+import net.firedevops.firemud.repository.GameInstanceRepository;
 import net.firedevops.firemud.service.TickService;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +32,7 @@ public class TickServiceImpl implements TickService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;
   private final ConflictTracker conflictTracker;
+  private final GameInstanceRepository gameInstanceRepository;
 
   @Value("${game.tick-duration-ms:1000}")
   private long tickDurationMs;
@@ -48,10 +50,10 @@ public class TickServiceImpl implements TickService {
   private Counter redisErrorCounter;
   private Counter lockContentionCounter;
   private Counter budgetExceededCounter;
+  private Counter requeuedActionCounter;
+  private Counter retryBackoffCounter;
   private Timer tickTimer;
   private Timer luaTimer;
-  private java.util.concurrent.atomic.AtomicInteger retryQueueDepth =
-      new java.util.concurrent.atomic.AtomicInteger();
   private RedisScript<Long> stageScript;
   private RedisScript<Long> commitScript;
   private RedisScript<Long> rollbackScript;
@@ -64,6 +66,7 @@ public class TickServiceImpl implements TickService {
       } catch (Exception ex) {
         attempts++;
         redisErrorCounter.increment();
+        retryBackoffCounter.increment();
         if (attempts >= 3) {
           logger.error("Redis script execution failed after {} attempts", attempts, ex);
           throw ex;
@@ -87,11 +90,9 @@ public class TickServiceImpl implements TickService {
     this.budgetExceededCounter = meterRegistry.counter("game_session_tick_budget_exceeded_total");
     this.tickTimer = meterRegistry.timer("game_session_tick_duration_ms");
     this.luaTimer = meterRegistry.timer("game_session_lua_latency_ms");
-    Gauge.builder(
-            "game_session_retry_queue_depth",
-            retryQueueDepth,
-            java.util.concurrent.atomic.AtomicInteger::get)
-        .register(meterRegistry);
+    this.requeuedActionCounter =
+        meterRegistry.counter("tick_requeued_action_total", "source", "player");
+    this.retryBackoffCounter = meterRegistry.counter("tick_retry_backoff_count_total");
     ResourceScriptSource commitSrc =
         new ResourceScriptSource(new ClassPathResource("redis/tick_commit.lua"));
     ResourceScriptSource stageSrc =
@@ -143,7 +144,15 @@ public class TickServiceImpl implements TickService {
     boolean solo = false;
     try {
       Long pending = redisTemplate.opsForList().size(pendingKey(sessionId));
-      retryQueueDepth.set(pending != null ? pending.intValue() : 0);
+      Long tenantId =
+          gameInstanceRepository.findById(sessionId).map(i -> i.getTenantId()).orElse(0L);
+      double depth = pending != null ? pending.doubleValue() : 0.0;
+      meterRegistry
+          .gauge(
+              "tick_retry_queue_depth",
+              io.micrometer.core.instrument.Tags.of(
+                  "tenantId", tenantId.toString(), "regionId", sessionId.toString()),
+              depth);
       if (pending != null && pending > 0) {
         logger.info("Replaying {} pending commands for {}", pending, sessionId);
         tickTimer.record(
@@ -174,6 +183,7 @@ public class TickServiceImpl implements TickService {
           () ->
               executeScriptWithRetry(
                   rollbackScript, List.of(pendingKey(sessionId), queueKey(sessionId))));
+      requeuedActionCounter.increment();
       awaitReplication();
     } finally {
       long elapsed = (System.nanoTime() - start) / 1_000_000;

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import net.firedevops.firemud.service.TickService;
+import net.firedevops.firemud.repository.GameInstanceRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -20,6 +21,7 @@ class TickServiceImplTest {
   private org.springframework.data.redis.core.ValueOperations<String, Object> valueOps;
   private SimpleMeterRegistry meterRegistry;
   private net.firedevops.firemud.common.conflict.ConflictTracker conflictTracker;
+  private net.firedevops.firemud.repository.GameInstanceRepository repository;
   private TickService service;
 
   @BeforeEach
@@ -31,7 +33,8 @@ class TickServiceImplTest {
     when(redisTemplate.opsForValue()).thenReturn(valueOps);
     meterRegistry = new SimpleMeterRegistry();
     conflictTracker = mock(net.firedevops.firemud.common.conflict.ConflictTracker.class);
-    service = new TickServiceImpl(redisTemplate, meterRegistry, conflictTracker);
+    repository = mock(net.firedevops.firemud.repository.GameInstanceRepository.class);
+    service = new TickServiceImpl(redisTemplate, meterRegistry, conflictTracker, repository);
     ((TickServiceImpl) service).init();
   }
 
@@ -74,4 +77,24 @@ class TickServiceImplTest {
     org.junit.jupiter.api.Assertions.assertEquals(
         1.0, meterRegistry.get("game_session_tick_budget_exceeded_total").counter().count(), 0.001);
   }
+
+  @Test
+  void retryQueueGaugeRecorded() {
+    when(valueOps.setIfAbsent(any(), any(), any())).thenReturn(true);
+    when(listOps.size(any())).thenReturn(3L);
+    var instance = new net.firedevops.firemud.entity.GameInstance();
+    instance.setId(2L);
+    instance.setTenantId(10L);
+    when(repository.findById(2L)).thenReturn(java.util.Optional.of(instance));
+    service.processTick(2L);
+    org.junit.jupiter.api.Assertions.assertEquals(
+        3.0,
+        meterRegistry
+            .get("tick_retry_queue_depth")
+            .tags("tenantId", "10", "regionId", "2")
+            .gauge()
+            .value(),
+        0.001);
+  }
+
 }


### PR DESCRIPTION
## Summary
- track conflict hotspots in `RedisConflictTracker`
- expose retry queue depth, requeue and backoff counters in tick service
- document new metrics in performance and tick architecture docs
- update unit tests for tick metrics

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6875a8d990808330bf4dcb73ab136679