### PR TITLE
Update tick docs with background tick note

### DIFF
--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -92,6 +92,9 @@ Ticks are **region-scoped**, not globally synchronized. Each **tick region** (ty
 > applied even if a region would not tick on its own. See
 > [Global Effects and Region-Wide Coordination](./system-architecture-redis.md#🌀-global-effects-and-region-wide-coordination)
 > for details on the underlying Redis pattern.
+> 🔄 **Regions still execute a lightweight background tick** (for example every
+> second) so queued timers, cooldowns, and delayed events progress even when no
+> players are present.
 > 🧠 Tick regions are mapped to Redis shards for atomicity and lock discipline.
 ---
 


### PR DESCRIPTION
## Summary
- note lightweight background tick cadence in tick regions

## Testing
- `pre-commit run --all-files` *(fails: lintMarkdown: non-zero exit value 1)*
- `./gradlew check` *(fails: task lintMarkdown not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875aa106b5883309b304b31b295f5ed