### PR TITLE
Update tick documentation

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -77,7 +77,7 @@ Redis keys follow strict naming conventions to ensure:
 | `remote:{tenantId}:{entityId}` | Queue for cross-region command follow-ups |
 
 > 🔗 `remote:{tenantId}:{entityId}` keys route cross-region commands. See [Cross-Region Command Execution and Result Relay](./system-architecture-ticks.md#📡-cross-region-command-execution-and-result-relay)
->    for details.
+> for details.
 > 📌 For session-related keys and structure, see [Session Keys and Gameplay Binding](#-session-keys-and-gameplay-binding)
 > ⚠️ Tick regions and player sessions are **always scoped to a single Redis shard** to preserve atomicity. Cross-shard operations are avoided.
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -218,8 +218,8 @@ The process is **asynchronous and multi-phased**:
    [Redis Key Naming](./system-architecture-redis.md#🗂️-key-naming-and-shard-discipline)).
 3. The target region processes the action during its next tick and determines
    the outcome locally.
-4. The Game Session Service routes the result back to the origin region or
-   directly to the player's active session.
+4. The Game Session Service uses the `sourceEntityId` to route the result back
+   to the origin region or directly to the player's active session.
 
 Players experience a smooth flow:
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -28,6 +28,7 @@ After the services are running, apply the default network policies found in
 kubectl apply -f network-policies/internal-services.yaml
 kubectl apply -f base/firemud-grpc-certificate.yaml
 ```
+
 The policy allows gRPC (8080, 6565) and OpenTelemetry traffic on port `4317` in
 addition to database access.
 


### PR DESCRIPTION
## Summary
- tweak cross-region command handling docs
- fix blockquote spacing in Redis architecture docs
- add blank line in network policy docs

## Testing
- `pre-commit run --files design/architecture/system-architecture-ticks.md design/architecture/system-architecture-redis.md k8s/README.md` *(fails: `buf` and frontend lint missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875aa106b5883309b304b31b295f5ed