### PR TITLE
Run CI checks and fix markdown

### DIFF
--- a/dev-tools/generate-erd.sh
+++ b/dev-tools/generate-erd.sh
@@ -49,7 +49,7 @@ for service in "${SERVICES[@]}"; do
       --command=schema \
       --info-level=standard \
       --output-format=png \
-      --output-file=/output/${service}.png
+      --output-file="/output/${service}.png"
   fi
 
 done

--- a/dev-tools/link-check.sh
+++ b/dev-tools/link-check.sh
@@ -16,5 +16,5 @@ fi
 FILES=$(find design -name '*.md' -type f -print; find . -maxdepth 1 -name '*.md' -type f)
 FILES=$(echo "$FILES" | grep -v '/node_modules/' | grep -v '/build/' | grep -v '/\.gradle/')
 
-OPTIONS="--scheme https --scheme http"
-"$BIN" --no-progress --verbose $OPTIONS $FILES
+OPTIONS=(--scheme https --scheme http)
+"$BIN" --no-progress --verbose "${OPTIONS[@]}" "$FILES"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,6 @@ org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m
 
 version=0.1.0

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -28,6 +28,7 @@ After the services are running, apply the default network policies found in
 kubectl apply -f network-policies/internal-services.yaml
 kubectl apply -f base/firemud-grpc-certificate.yaml
 ```
+
 The policy allows gRPC (8080, 6565) and OpenTelemetry traffic on port `4317` in
 addition to database access.
 


### PR DESCRIPTION
## Summary
- fix markdown lint warning in `k8s/README.md`
- set Gradle memory limits so `gradlew check` passes locally
- quote ERD generation path
- quote link-check options and files

## Testing
- `npm run openapi:lint`
- `./gradlew check`
- `find dev-tools -name '*.sh' -print0 | xargs -0 shellcheck`
- `hadolint services/tcp-proxy-service/Dockerfile`


------
https://chatgpt.com/codex/tasks/task_e_6875a948d64c8330af0f6ce7bf8739b5