### PR TITLE
Clarify scripting execution model

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -21,7 +21,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 - Scripts run inside a sandboxed engine to prevent malicious behavior.
 - Scripts are authored in a **component-based DSL** using a visual editor so
   designers can build behaviors without coding.
-- AI computations are optimized for large worlds using tick-based batching.
+- AI computations are optimized for large worlds by evaluating scripts on a separate schedule and batching the resulting commands before handing them to the tick system.
 - Script definitions are versioned and can be hot reloaded without downtime as
   described in [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
 - The service listens for a `NotifyScriptVersionUpdate` event and reloads the
@@ -42,7 +42,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 - Scriptable quests and event triggers
 - Persistent NPC memory and dynamic reactions
 - Timers and delayed actions for asynchronous events
-- Tick-based AI execution for efficient CPU usage and fair scheduling — AI logic runs during tick cycles only when triggered by events, avoiding constant background processing
+- Script evaluation occurs outside the tick system. Results are queued as commands that run during tick cycles, ensuring fair scheduling without blocking gameplay.
 - Faction reputation influences NPC aggression states. NPCs may become **FLEEING** or **SURRENDERED** when low on health or morale, allowing players to resolve encounters non-lethally.
 
 ### PvE Mechanics
@@ -72,9 +72,9 @@ random when the Game Session Service requests a PvE interaction.
 - Events from the Game Session Service trigger script execution via gRPC.
 - The sandboxed engine limits CPU time and memory for each script to prevent
   runaway behavior.
-- Tick execution uses `ScriptTickService` to stage, commit, and roll back events
-  in Redis. Locks `tick:lock:{tenantId}:{scriptId}` ensure only one tick runs at
-  a time. See [Tick System and Runtime Design](../system-architecture-ticks.md).
+- The service uses `ScriptTickService` to stage, commit, and roll back events in Redis.
+  This runs independently of the main game tick loop. Locks `tick:lock:{tenantId}:{scriptId}`
+  ensure only one script tick operates at a time. See [Tick System and Runtime Design](../system-architecture-ticks.md) for how queued commands are processed.
 
 ### gRPC APIs
 

--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -32,8 +32,9 @@ These notes summarize typical optimizations applied across FireMUD services.
   actions are rolled back and retried automatically.
 - Tick regions execute independently so work can be parallelized across
   threads and servers for better scalability and fault isolation.
-- The Automation & Scripting Service batches NPC logic in tick cycles and
-  enforces per-script quotas via Redis to avoid runaway automation.
+- The Automation & Scripting Service evaluates scripts on its own schedule and
+  injects resulting commands into tick queues. Per-script quotas are enforced
+  via Redis before queuing to avoid runaway automation.
   Quota enforcement metrics (`script_quota_allowed_total`,
   `script_quota_denied_total`) and automation queue metrics
   (`automation_queue_enqueued_total`, `automation_queue_drained_total`) provide

--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -25,9 +25,9 @@ This document outlines how FireMUD executes custom in-game behavior through a sa
 
 ## ⚙️ Integration with Game Logic & Tick System
 
-- During each tick, the Automation & Scripting Service evaluates scheduled scripts and queues resulting commands.
-- Commands are processed by the **Game Logic Service** in deterministic order, ensuring consistent outcomes.
-- Scripts can react to world events, NPC states, or timers provided by the tick system.
+- **Scripts do not execute inside the tick system.** The Automation & Scripting Service evaluates scripts independently—on a schedule, via timers, or in response to events—and injects the resulting commands into command queues.
+- These commands are processed during the **next tick cycle** by the Game Logic Service, preserving fairness, determinism, and replay safety.
+- Script evaluation never blocks or interferes with tick execution. Scripts can still react to world events, NPC states, or timers provided by the tick system.
 
 ## 🔄 Deployment & Versioning
 
@@ -42,8 +42,10 @@ The Automation & Scripting Service now enforces several safeguards to prevent ru
 scripts and ensure fair resource usage:
 
 - `ScriptQuotaService` limits how often a script may execute within a configurable
-  window. When the quota is exceeded the event is ignored and metrics are emitted
+  window. **Quota checks happen before commands are enqueued**, so abusive scripts never reach
+  the tick queues. When the quota is exceeded the event is ignored and metrics are emitted
   for monitoring.
+- The tick system only processes these queued commands—it never runs script logic itself.
 - Metrics track script execution and help detect logic that attempts to monopolize
   CPU time or grief other players.
 - Administrators may disable or throttle problematic scripts via the Game Design


### PR DESCRIPTION
## Summary
- clarify that scripts execute outside the tick system
- note quota enforcement happens before commands enter tick queues
- update automation service docs to describe independent scheduling
- update performance optimization docs to reflect new model

## Testing
- `pre-commit run --files design/architecture/system-architecture-scripting.md design/architecture/microservices/automation-scripting-service/README.md design/architecture/performance-optimization.md` *(fails: markdownlint task)*

------
https://chatgpt.com/codex/tasks/task_e_6875ac1223788330b3d2536c5605d952