### PR TITLE
Expand scripting docs

### DIFF
--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -17,6 +17,20 @@ This document outlines how FireMUD executes custom in-game behavior through a sa
 - The editor exports structured data—**not raw Lua or general-purpose code**—which the service compiles into execution units.
 - This approach prevents arbitrary behavior and limits scripts to the capabilities exposed by the platform.
 
+## Supported Script Events
+
+Scripts may register handlers for a set of standard lifecycle events. The Automation & Scripting Service emits these events and queues them as commands so they run during the normal tick flow.
+
+- `onLoad` – when the script is first loaded or hot reloaded
+- `onSpawn` – when the associated entity enters the world
+- `onDeath` – when the entity dies
+- `onDestroy` – when the entity is permanently removed
+- `onEnterRegion` – when the entity moves into a new region
+- `onLeaveRegion` – when the entity leaves a region
+- `onTimerExpire` – when a scheduled timer finishes
+- `onCommand` – when a player targets the entity with a command
+- `onInterval` – periodic execution at a configured rate
+
 ## 🔒 Sandboxing & Security
 
 - Script execution occurs in a **sandbox** with restricted APIs and resource limits.
@@ -25,16 +39,20 @@ This document outlines how FireMUD executes custom in-game behavior through a sa
 
 ## ⚙️ Integration with Game Logic & Tick System
 
-- **Scripts do not execute inside the tick system.** The Automation & Scripting Service evaluates scripts independently—on a schedule, via timers, or in response to events—and injects the resulting commands into command queues.
-- These commands are processed during the **next tick cycle** by the Game Logic Service, preserving fairness, determinism, and replay safety.
+- **Scripts do not execute inside the tick system.** The Automation & Scripting Service evaluates scripts independently—on a schedule, via timers, or in response to events—and enqueues the resulting commands into each entity's command queue.
+- These queued commands run during the **next tick cycle** via the normal Game Session and Game Logic flow, ensuring deterministic, replayable behavior that follows the tick system's fairness and retry rules.
 - Script evaluation never blocks or interferes with tick execution. Scripts can still react to world events, NPC states, or timers provided by the tick system.
+- Script-generated commands may fail due to lock contention or because the target resides in another region. These cases are retried or routed across regions by the Game Session Service just like player actions.
+- The Automation & Scripting Service only determines which commands to inject. It may query world state via gRPC but never mutates entity or world data directly—every action passes through the Game Session Service so tick regions remain consistent.
 
 ## 🔄 Deployment & Versioning
 
 - Script definitions are stored in the **Game Design Service** and versioned alongside other game assets.
 - Designers can deploy updated scripts without redeploying code. The Automation & Scripting Service retrieves the current live versions as needed.
 - Script-only patches create a `scriptPatchVersion` tied to a `baseVersionId` so new behaviors can be loaded on the fly.
-- Previous versions remain available for rollback or auditing.
+- The Game Session Service tracks the active script version for each running game and notifies the Automation & Scripting Service when a new version should be loaded.
+- Timer events and scheduled evaluations always reference the version pinned by the Game Session Service at the moment they run.
+- Older versions remain in the database for auditing or rollback, but only the pinned version is executed.
 
 ## 🛡️ Fairness & Abuse Prevention
 

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -1,11 +1,11 @@
 package net.firedevops.firemud.common.conflict;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
-import io.micrometer.core.instrument.MeterRegistry;
 
 /** Records conflict metadata in Redis for hotspot detection. */
 @Component

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -2,7 +2,6 @@ package net.firedevops.firemud.service.impl;
 
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
@@ -147,12 +146,11 @@ public class TickServiceImpl implements TickService {
       Long tenantId =
           gameInstanceRepository.findById(sessionId).map(i -> i.getTenantId()).orElse(0L);
       double depth = pending != null ? pending.doubleValue() : 0.0;
-      meterRegistry
-          .gauge(
-              "tick_retry_queue_depth",
-              io.micrometer.core.instrument.Tags.of(
-                  "tenantId", tenantId.toString(), "regionId", sessionId.toString()),
-              depth);
+      meterRegistry.gauge(
+          "tick_retry_queue_depth",
+          io.micrometer.core.instrument.Tags.of(
+              "tenantId", tenantId.toString(), "regionId", sessionId.toString()),
+          depth);
       if (pending != null && pending > 0) {
         logger.info("Replaying {} pending commands for {}", pending, sessionId);
         tickTimer.record(

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import net.firedevops.firemud.service.TickService;
-import net.firedevops.firemud.repository.GameInstanceRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -96,5 +95,4 @@ class TickServiceImplTest {
             .value(),
         0.001);
   }
-
 }


### PR DESCRIPTION
## Summary
- add explicit script lifecycle event docs
- clarify automation service command handling and version tracking
- reformat Java files via `spotless`

## Testing
- `./gradlew :common-library:spotlessApply`
- `./gradlew :game-session-service:spotlessApply`
- `./gradlew check` *(fails: build was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6875afdc534c8330aa89821559fbeb61