### PR TITLE
Add egress policy and startup health checks

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,4 +8,5 @@ services:
       - REDISINSIGHT_HOST=0.0.0.0
     restart: unless-stopped
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   gateway:
@@ -55,8 +57,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   automation-scripting-service:
@@ -71,8 +75,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   entity-management-service:
@@ -87,8 +93,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   game-design-service:
@@ -103,8 +111,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   game-logic-service:
@@ -119,8 +129,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   game-session-service:
@@ -135,8 +147,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   logging-admin-service:
@@ -151,8 +165,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   social-groups-service:
@@ -167,8 +183,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   tcp-proxy-service:
@@ -183,8 +201,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
   world-management-service:
@@ -199,8 +219,10 @@ services:
     volumes: *service-vols
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     healthcheck:
       <<: *service-health
 

--- a/k8s/network-policies/README.md
+++ b/k8s/network-policies/README.md
@@ -1,11 +1,12 @@
 # Kubernetes Network Policies
 
-This folder contains baseline `NetworkPolicy` manifests for the FireMUD cluster. These policies restrict **ingress** traffic so only other pods inside the namespace can connect to the internal microservices.
+This folder contains baseline `NetworkPolicy` manifests for the FireMUD cluster. These policies restrict **ingress** traffic so only other pods inside the namespace can connect to the internal microservices. An additional egress policy limits outbound traffic from those services to the database, Redis, and other internal pods.
 
 Apply the policies after the base service deployments:
 
 ```bash
 kubectl apply -f network-policies/internal-services.yaml
+kubectl apply -f network-policies/internal-services-egress.yaml
 ```
 
 The gateway and TCP proxy remain accessible to external clients, while all other services accept connections only from within the cluster.

--- a/k8s/network-policies/internal-services-egress.yaml
+++ b/k8s/network-policies/internal-services-egress.yaml
@@ -1,8 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: internal-services
-# Ensure Helm release names for PostgreSQL and Redis match the labels below.
+  name: internal-services-egress
 spec:
   podSelector:
     matchExpressions:
@@ -12,33 +11,22 @@ spec:
           - spring-cloud-gateway
           - tcp-proxy-service
   policyTypes:
-    - Ingress
     - Egress
-  ingress:
-    - from:
-        - podSelector: {}
-      ports:
-        - protocol: TCP
-          port: 8080
-        - protocol: TCP
-          port: 6565
-        - protocol: TCP
-          port: 4317
-    - from:
+  egress:
+    - to:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: firemud-postgresql
       ports:
         - protocol: TCP
           port: 5432
-    - from:
+    - to:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: firemud-redis
       ports:
         - protocol: TCP
           port: 6379
-  egress:
     - to:
         - podSelector:
             matchExpressions:
@@ -54,17 +42,3 @@ spec:
           port: 6565
         - protocol: TCP
           port: 4317
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/instance: firemud-postgresql
-      ports:
-        - protocol: TCP
-          port: 5432
-    - to:
-        - podSelector:
-            matchLabels:
-              app.kubernetes.io/instance: firemud-redis
-      ports:
-        - protocol: TCP
-          port: 6379


### PR DESCRIPTION
## Summary
- restrict egress traffic for internal services with a new policy
- update existing internal network policy
- document how to apply the new policy
- wait for healthy postgres and redis in docker-compose

## Testing
- `pre-commit run --all-files` *(fails: SpotBugs job interrupted)*
- `./gradlew check` *(failed to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6875ab6819408330aa292716c43cf8b5