### PR TITLE
Update scripting integration docs

### DIFF
--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -42,7 +42,7 @@ Scripts may register handlers for a set of standard lifecycle events. The Automa
 - **Scripts do not execute inside the tick system.** The Automation & Scripting Service evaluates scripts independently—on a schedule, via timers, or in response to events—and enqueues the resulting commands into each entity's command queue.
 - These queued commands run during the **next tick cycle** via the normal Game Session and Game Logic flow, ensuring deterministic, replayable behavior that follows the tick system's fairness and retry rules.
 - Script evaluation never blocks or interferes with tick execution. Scripts can still react to world events, NPC states, or timers provided by the tick system.
-- Script-generated commands may fail due to lock contention or because the target resides in another region. These cases are retried or routed across regions by the Game Session Service just like player actions.
+- Script-generated commands—like any gameplay command—may fail due to lock contention or target remote regions. These cases are automatically handled by the Game Session Service via standard tick rescheduling and cross-region routing logic.
 - The Automation & Scripting Service only determines which commands to inject. It may query world state via gRPC but never mutates entity or world data directly—every action passes through the Game Session Service so tick regions remain consistent.
 
 ## 🔄 Deployment & Versioning


### PR DESCRIPTION
## Summary
- clarify failure handling for script-generated commands

## Testing
- `./gradlew check` *(fails: environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5efb1c483308f674a7445fd10c1