### PR TITLE
Fix SpotBugs EI_EXPOSE_REP2 warnings

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.common.config;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lettuce.core.metrics.MicrometerCommandLatencyRecorder;
 import io.lettuce.core.metrics.MicrometerOptions;
 import io.lettuce.core.resource.ClientResources;
@@ -20,6 +21,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
 @EnableConfigurationProperties({PostgresProperties.class, RedisProperties.class})
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Properties are injected and not modified")
 public class DatabaseAutoConfiguration {
   private final PostgresProperties postgres;
   private final RedisProperties redis;

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.common.conflict;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,9 @@ import org.springframework.stereotype.Component;
 /** Records conflict metadata in Redis for hotspot detection. */
 @Component
 @RequiredArgsConstructor
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected dependencies are safe to store without defensive copies")
 public class RedisConflictTracker implements ConflictTracker {
   private final StringRedisTemplate redisTemplate;
   private final MeterRegistry meterRegistry;

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/MetricsInterceptor.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/MetricsInterceptor.java
@@ -1,11 +1,15 @@
 package net.firedevops.firemud.common.grpc;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.*;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.Objects;
 
 /** Records gRPC call metrics using Micrometer. */
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "MeterRegistry is injected and safe to store")
 public class MetricsInterceptor implements ServerInterceptor {
   private final MeterRegistry registry;
 

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/saga/SagaRunner.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/saga/SagaRunner.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.common.saga;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,6 +15,9 @@ import org.springframework.stereotype.Component;
 
 /** Executes sagas with correlation ID handling and metrics. */
 @Component
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Repositories and metrics are injected and immutable")
 public class SagaRunner {
   private final SagaMetrics metrics;
   private final SagaInstanceRepository instanceRepository;


### PR DESCRIPTION
## Summary
- suppress SpotBugs EI_EXPOSE_REP2 warnings on injected fields

## Testing
- `./gradlew check`
- `pre-commit run --all-files` *(fails: `buf` and `hadolint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5afd5f88330ae8c85bddd78b55e