### PR TITLE
Update multi-tenancy and social docs

### DIFF
--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -46,7 +46,6 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Supports instance-based spaces in conjunction with the World Management Service
   so characters can enter private dungeons or personalized housing without affecting
   the shared world state.
-- Stores per-game friendship links on characters for local social features.
 
 ### Data Model
 
@@ -56,8 +55,6 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - Character location and instance membership are stored by the World Management
   Service rather than this service.
 - Entity graphs cache inventory relationships for fast lookups.
-- `character_friend` table stores per-game friend links used by the Game Logic
-  Service.
 
 ### gRPC APIs
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -61,10 +61,10 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 
 - `chat_message` table persists guild and private messages.
 - `guild` and `guild_member` tables store group ownership and membership roles.
-- `friend_link` table tracks account or character friendships and blocks.
-- Per-game friendships are stored on character records in the Entity Management
-  Service. When a game opts in, account-level friends from this service are
-  mirrored as in-game friends automatically.
+- `friend_link` table tracks both account-to-account and per-game friendships.
+  All friendship data lives in this service. Per-game friend records include the
+  `tenantId` and player IDs, while account-level friends reference global account
+  IDs only. Games can mirror these links in their UI when the feature is enabled.
 - `mail_message` table stores asynchronous player mail.
 - `faction` and `faction_standing` tables maintain player reputation. The
   [Automation & Scripting Service](../automation-scripting-service/README.md)

--- a/design/architecture/system-architecture-multi-tenancy.md
+++ b/design/architecture/system-architecture-multi-tenancy.md
@@ -8,8 +8,13 @@ This document explains how FireMUD hosts many independent games on shared infras
 
 - Players have a **single platform account** managed by the **Account Service**.
 - The same account can join multiple games. Each game is identified by a `tenantId`.
+- `tenantId` values are string GUIDs and appear in every API. Standardizing on
+  strings avoids type mismatches across gRPC, REST, and database models.
 - Character data and progress are scoped per `tenantId`; a player may have different characters in different games.
 - Authentication is global, but services always check the requested `tenantId` when retrieving or updating game data.
+- Friend lists and guilds are maintained by the Social & Groups Service. Per-game
+  friendships store `tenantId` and player IDs, while account-to-account
+  friendships reference global account IDs.
 
 ## 🗂️ Data Separation per Service
 
@@ -17,13 +22,20 @@ This document explains how FireMUD hosts many independent games on shared infras
 - Databases are **shared across tenants**, with a `tenantId` column on each table to isolate data.
 - Services enforce the `tenantId` filter on all queries to prevent cross-game access.
 - Redis keys also include the `tenantId` so cached session state and runtime data remain isolated.
+- The React frontend loads per-tenant themes and branding files. See
+  [Game Customization Options](./game-customization-options.md) and the
+  [Frontend Architecture](./system-architecture-frontend.md) for details.
 
 ## ⚙️ Tenant Configuration & Scaling
 
 - Game-specific settings—such as world size, tick intervals, and feature flags—are stored in configuration tables keyed by `tenantId`.
   Runtime flag behavior is described in [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md).
+- Creating a new game world triggers a Saga across services. The steps are
+  outlined in [World Creation Workflow](./microservices/world-management-service/world-creation-workflow.md).
 - All microservices run as shared deployments; there is **no tenant-specific infrastructure** or dedicated clusters.
 - Game Session Service instances scale horizontally based on overall load. Per-game resource quotas may be enforced so one tenant cannot exhaust cluster capacity. See [Game Session Service design notes](./microservices/game-session-service/README.md#architecture--design-notes) for details.
+  Quota thresholds are configured per tenant and metrics expose current usage so
+  operators can track `active_sessions` and quota denials.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify `tenantId` data type
- link tenant creation workflow
- mention theming
- describe friendship storage in Social & Groups service
- note quota metrics and remove outdated Entity Management references

## Testing
- `./gradlew check` *(fails: exit code 1 due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6875b6a2e4588330879927adb716fb5f