### PR TITLE
Update customization docs

### DIFF
--- a/design/architecture/game-customization-options.md
+++ b/design/architecture/game-customization-options.md
@@ -6,22 +6,40 @@ This brief document summarizes the ways a hosted game can change its look and fe
 
 - Each tenant provides a Material‑UI theme file that overrides default colors and fonts.
 - Logos and favicon assets are loaded at runtime based on the `tenantId`.
-- Optional layout tweaks can be enabled via feature flags in the Game Design Service.
+- The React client loads theme and asset files per tenant at runtime; see
+  [Frontend Architecture](./system-architecture-frontend.md).
+- Optional layout tweaks can be enabled via **runtime feature flags** defined in
+  the Game Design Service and toggled through the
+  [Logging & Admin Service](./microservices/logging-admin-service/README.md).
+- Locale files are loaded at runtime using `react-i18next` so games can provide
+  their own translations.
 
 ## World Configuration
 
-- Game worlds are defined entirely through the Game Design Service. Creators can add rooms, items and NPCs using the web editor or by importing JSON files.
+- Game worlds are defined entirely through the Game Design Service. Creators can
+  add rooms, items and NPCs using the [world editing tools](./microservices/game-design-service/world-editing-tools.md) or by importing JSON files.
+- Additional design-time utilities like the [ability & action tools](./microservices/game-design-service/ability-action-tools.md) and [item & equipment balancing](./microservices/game-design-service/item-equipment-balancing.md) help tune gameplay without code changes.
 - Published versions are stored per tenant so multiple games can coexist on the same infrastructure. Minor fixes can be rolled out as **script-only patch versions** linked to a `baseVersionId` so worlds do not need to restart.
 
 ## Scripting Hooks
 
 - Custom scripts drive dynamic events and NPC behaviour.
+- The planned [modding framework](./microservices/game-design-service/modding-framework.md) will allow runtime plugins for additional behavior.
 - Scripts are versioned alongside other game data and can be hot reloaded by the Automation & Scripting Service. Designers may publish a `scriptPatchVersion` like `v42-script.3` to update automation without republishing all assets.
+
+## Runtime Settings
+
+- Feature flags and pacing options such as tick intervals are stored per tenant.
+- Flags are defined in the Game Design Service but toggled through the [Logging & Admin Service](./microservices/logging-admin-service/README.md).
+- The Game Session Service loads these settings at runtime so changes can take effect without republishing.
 
 These options allow extensive personalization while keeping the underlying platform maintainable.
 
 ## 📚 Related Documentation
 
+- [Frontend Architecture](./system-architecture-frontend.md)
+- [Logging & Admin Service](./microservices/logging-admin-service/README.md)
 - [System Architecture Overview](./system-architecture-overview.md)
 - [Automation & Scripting Service](./microservices/automation-scripting-service/README.md)
 - [Game Design Service](./microservices/game-design-service/README.md)
+- [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md)


### PR DESCRIPTION
## Summary
- document runtime feature flag workflow
- link to frontend customization and i18n details
- mention design time tools for world editing
- call out planned modding framework
- add runtime settings section with tick interval note

## Testing
- `./gradlew check` *(fails: Process finished due to manual interruption after long build)*

------
https://chatgpt.com/codex/tasks/task_e_6875b786636c833094368eb2b741b339