### PR TITLE
Update gateway JWT handling

### DIFF
--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -46,7 +46,7 @@ environments work out of the box.
 ### Filter Chain
 
 - Authentication, rate limiting, and logging filters run before routing.
-- `JwtAuthFilter` passes any provided JWT to backend admin services; validation occurs in those services.
+- `JwtAuthFilter` requires an `Authorization` header on admin routes and forwards the JWT unmodified. Validation occurs in the consuming service.
 - WebSocket upgrades are handled with heartbeat and idle timeout logic.
 
 ### Key Routes

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/JwtAuthFilter.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/JwtAuthFilter.java
@@ -1,10 +1,5 @@
 package net.firedevops.firemud.filter;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtException;
-import java.util.List;
-import net.firedevops.firemud.common.security.JwtUtil;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -14,14 +9,14 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
-/** Global filter validating JWTs on admin routes. */
+/**
+ * Global filter ensuring admin routes include an Authorization header.
+ *
+ * <p>The gateway does not validate or inspect JWTs. Services that require role-based access parse
+ * tokens themselves.
+ */
 @Component
 public class JwtAuthFilter implements WebFilter, Ordered {
-  private final JwtUtil jwtUtil;
-
-  public JwtAuthFilter(JwtUtil jwtUtil) {
-    this.jwtUtil = jwtUtil;
-  }
 
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
@@ -36,19 +31,7 @@ public class JwtAuthFilter implements WebFilter, Ordered {
       return exchange.getResponse().setComplete();
     }
 
-    String token = authHeader.substring(7);
-    try {
-      Jws<Claims> claims = jwtUtil.parseToken(token);
-      List<String> roles = claims.getBody().get("globalRoles", List.class);
-      if (roles == null || (!roles.contains("platformAdmin") && !roles.contains("moderator"))) {
-        exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
-        return exchange.getResponse().setComplete();
-      }
-      return chain.filter(exchange);
-    } catch (JwtException ex) {
-      exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-      return exchange.getResponse().setComplete();
-    }
+    return chain.filter(exchange);
   }
 
   @Override

--- a/services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/JwtAuthFilterTest.java
+++ b/services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/JwtAuthFilterTest.java
@@ -2,9 +2,6 @@ package net.firedevops.firemud.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Map;
-import net.firedevops.firemud.common.security.JwtUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -13,8 +10,7 @@ import org.springframework.mock.web.server.MockServerWebExchange;
 import reactor.core.publisher.Mono;
 
 class JwtAuthFilterTest {
-  private final JwtUtil jwtUtil = new JwtUtil("testsecretkeytestsecretkeytest1234", 3600000);
-  private final JwtAuthFilter filter = new JwtAuthFilter(jwtUtil);
+  private final JwtAuthFilter filter = new JwtAuthFilter();
 
   @Test
   void rejectsRequestWithoutToken() {
@@ -25,11 +21,10 @@ class JwtAuthFilterTest {
   }
 
   @Test
-  void allowsRequestWithValidRole() {
-    String token = jwtUtil.generateToken("user", Map.of("globalRoles", List.of("platformAdmin")));
+  void allowsRequestWithToken() {
     MockServerHttpRequest.BaseBuilder<?> builder =
         MockServerHttpRequest.get("/api/admin/test")
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+            .header(HttpHeaders.AUTHORIZATION, "Bearer sometoken");
     MockServerWebExchange exchange = MockServerWebExchange.from(builder);
     filter.filter(exchange, e -> Mono.empty()).block();
     // no status set implies success (200)


### PR DESCRIPTION
## Summary
- clarify token handling in Spring Cloud Gateway docs
- simplify `JwtAuthFilter` so the gateway only checks for Authorization header
- update unit tests to reflect the new behavior

## Testing
- `./gradlew :spring-cloud-gateway:check`
- `SKIP=buf,frontend-lint,shellcheck pre-commit run --files design/architecture/microservices/spring-cloud-gateway/README.md services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/JwtAuthFilter.java services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/JwtAuthFilterTest.java`

------
https://chatgpt.com/codex/tasks/task_e_6875c035a9348330ace873228ed51ff5