### PR TITLE
Run CI/CD tests locally

### DIFF
--- a/dev-tools/generate-erd.sh
+++ b/dev-tools/generate-erd.sh
@@ -2,6 +2,12 @@
 # Generate ERD diagrams and verify Flyway migrations for all services.
 set -euo pipefail
 
+# Check for Docker since ERD generation requires it
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: Docker is not installed or not in PATH" >&2
+  exit 1
+fi
+
 SERVICES=(
   account-service
   automation-scripting-service


### PR DESCRIPTION
## Summary
- run various tests from `.github/workflows`
- add docker check before running ERD generation script

## Testing
- `./gradlew :account-service:check`
- `buf lint`
- `find services -name Dockerfile -print0 | xargs -0 hadolint`
- `find dev-tools -name '*.sh' -print0 | xargs -0 shellcheck`
- `npm ci && npm run lint && npm run format -- -c`
- `trivy fs --config .trivy.yaml .`
- `./dev-tools/generate-erd.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6875c22235c083309b27a820ae6368ea