### PR TITLE
Align image paths and clarify docs

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -52,6 +52,10 @@ Use the aggregated task to build container images for all services:
 ```
 
 Each invocation runs Spring Boot's `bootBuildImage` for every module and tags the images with `latest`.
+The microservice Dockerfiles extend the shared base image
+`ghcr.io/firedevops/firemud-base:latest`. If the base image is missing or out of
+date, build it locally with `./gradlew buildBaseImage` or pull the published
+version from GitHub Container Registry.
 
 ## ✅ Markdown Linting via Gradle
 

--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -26,6 +26,8 @@ FireMUD uses Docker Compose for local development and testing:
 - Docker Compose can monitor health using `healthcheck` blocks in `docker-compose.yml`.
 - Health status is visible via `docker ps` (e.g., `healthy`, `unhealthy`), but:
   - Docker does **not** automatically restart unhealthy containers by default.
+    Even with `restart: unless-stopped` configured, containers remain
+    running in an `unhealthy` state until manually restarted.
   - Docker’s `depends_on` only controls startup order, not service readiness.
   - See [Reconnection Strategy](../system-architecture-reconnection.md) for how sessions survive service restarts in Docker Compose.
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -67,7 +67,7 @@ The production Terraform modules provision persistent volumes for PostgreSQL and
 
 ## Helm Charts
 
-The [`helm/`](./helm) folder contains example charts. Use `values-local.yaml` or `values-dev.yaml` to override connection details and feature flags when deploying locally:
+The [`helm/`](./helm) folder contains example charts. Use `values-local.yaml` or `values-dev.yaml` to override connection details and feature flags when deploying locally. `values-local.yaml` also reduces replica counts to 1 so a Kind or minikube cluster doesn't run out of resources:
 
 ```bash
 helm install game-session ./helm/game-session-service -f helm/values-local.yaml

--- a/k8s/helm/values-local.yaml
+++ b/k8s/helm/values-local.yaml
@@ -1,6 +1,10 @@
 redis:
   host: redis
   port: 6379
+account-service:
+  replicaCount: 1
+game-session-service:
+  replicaCount: 1
 tickInterval: 100
 features:
   enableFoo: true

--- a/services/account-service/src/test/java/crossservice/net/firedevops/firemud/AccountCrossServiceIntegrationTest.java
+++ b/services/account-service/src/test/java/crossservice/net/firedevops/firemud/AccountCrossServiceIntegrationTest.java
@@ -41,8 +41,7 @@ class AccountCrossServiceIntegrationTest {
 
   @Container
   static GenericContainer<?> loggingAdminService =
-      new GenericContainer<>(
-              DockerImageName.parse("ghcr.io/firedevops/logging-admin-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/logging-admin-service:latest"))
           .withExposedPorts(8080);
 
   @DynamicPropertySource

--- a/services/automation-scripting-service/src/test/java/crossservice/net/firedevops/firemud/AutomationScriptingCrossServiceIntegrationTest.java
+++ b/services/automation-scripting-service/src/test/java/crossservice/net/firedevops/firemud/AutomationScriptingCrossServiceIntegrationTest.java
@@ -33,8 +33,7 @@ class AutomationScriptingCrossServiceIntegrationTest {
 
   @Container
   static GenericContainer<?> gameSessionService =
-      new GenericContainer<>(
-              DockerImageName.parse("ghcr.io/firedevops/game-session-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/game-session-service:latest"))
           .withExposedPorts(8080);
 
   @LocalServerPort private int port;

--- a/services/entity-management-service/src/test/java/crossservice/net/firedevops/firemud/EntityManagementCrossServiceIntegrationTest.java
+++ b/services/entity-management-service/src/test/java/crossservice/net/firedevops/firemud/EntityManagementCrossServiceIntegrationTest.java
@@ -36,8 +36,7 @@ class EntityManagementCrossServiceIntegrationTest {
 
   @Container
   static GenericContainer<?> gameSessionService =
-      new GenericContainer<>(
-              DockerImageName.parse("ghcr.io/firedevops/game-session-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/game-session-service:latest"))
           .withExposedPorts(8080);
 
   @LocalServerPort private int port;

--- a/services/game-design-service/src/test/java/crossservice/net/firedevops/firemud/GameDesignCrossServiceIntegrationTest.java
+++ b/services/game-design-service/src/test/java/crossservice/net/firedevops/firemud/GameDesignCrossServiceIntegrationTest.java
@@ -33,7 +33,7 @@ class GameDesignCrossServiceIntegrationTest {
   @Container
   static GenericContainer<?> worldManagementService =
       new GenericContainer<>(
-              DockerImageName.parse("ghcr.io/firedevops/world-management-service:latest"))
+              DockerImageName.parse("ghcr.io/firemud/world-management-service:latest"))
           .withExposedPorts(8080);
 
   @LocalServerPort private int port;

--- a/services/game-session-service/src/test/java/crossservice/net/firedevops/firemud/GameSessionCrossServiceIntegrationTest.java
+++ b/services/game-session-service/src/test/java/crossservice/net/firedevops/firemud/GameSessionCrossServiceIntegrationTest.java
@@ -30,7 +30,7 @@ import org.testcontainers.utility.DockerImageName;
 class GameSessionCrossServiceIntegrationTest {
 
   private static GenericContainer<?> gameLogicService =
-      new GenericContainer<>(DockerImageName.parse("ghcr.io/firedevops/game-logic-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/game-logic-service:latest"))
           .withExposedPorts(8080);
 
   private static boolean containerStarted;

--- a/services/logging-admin-service/src/test/java/crossservice/net/firedevops/firemud/LoggingAdminCrossServiceIntegrationTest.java
+++ b/services/logging-admin-service/src/test/java/crossservice/net/firedevops/firemud/LoggingAdminCrossServiceIntegrationTest.java
@@ -34,7 +34,7 @@ class LoggingAdminCrossServiceIntegrationTest {
 
   @Container
   static GenericContainer<?> accountService =
-      new GenericContainer<>(DockerImageName.parse("ghcr.io/firedevops/account-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/account-service:latest"))
           .withExposedPorts(8080);
 
   @LocalServerPort private int port;

--- a/services/social-groups-service/src/test/java/crossservice/net/firedevops/firemud/SocialGroupsCrossServiceIntegrationTest.java
+++ b/services/social-groups-service/src/test/java/crossservice/net/firedevops/firemud/SocialGroupsCrossServiceIntegrationTest.java
@@ -34,8 +34,7 @@ import org.testcontainers.utility.DockerImageName;
 class SocialGroupsCrossServiceIntegrationTest {
 
   static GenericContainer<?> loggingAdminService =
-      new GenericContainer<>(
-              DockerImageName.parse("ghcr.io/firedevops/logging-admin-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/logging-admin-service:latest"))
           .withExposedPorts(8080);
 
   @BeforeAll

--- a/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
@@ -37,8 +37,7 @@ import org.testcontainers.utility.DockerImageName;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TcpProxyCrossServiceIntegrationTest {
   static GenericContainer<?> gateway =
-      new GenericContainer<>(
-              DockerImageName.parse("ghcr.io/firedevops/spring-cloud-gateway:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/spring-cloud-gateway:latest"))
           .withExposedPorts(8080);
 
   private static boolean gatewayStarted = false;

--- a/services/world-management-service/src/test/java/crossservice/net/firedevops/firemud/WorldManagementCrossServiceIntegrationTest.java
+++ b/services/world-management-service/src/test/java/crossservice/net/firedevops/firemud/WorldManagementCrossServiceIntegrationTest.java
@@ -32,7 +32,7 @@ class WorldManagementCrossServiceIntegrationTest {
 
   @Container
   static GenericContainer<?> gameDesignService =
-      new GenericContainer<>(DockerImageName.parse("ghcr.io/firedevops/game-design-service:latest"))
+      new GenericContainer<>(DockerImageName.parse("ghcr.io/firemud/game-design-service:latest"))
           .withExposedPorts(8080);
 
   @LocalServerPort private int port;


### PR DESCRIPTION
## Summary
- fix healthcheck docs about restart behavior
- mention shared base Docker image
- mention replica overrides in Helm docs
- set replicaCount=1 in local values
- use ghcr.io/firemud registry in cross-service tests

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6875b9a34ad48330b76d769f923b8e11