### PR TITLE
Enable sidecar logging and enrich log context

### DIFF
--- a/design/architecture/system-architecture-logging-monitoring.md
+++ b/design/architecture/system-architecture-logging-monitoring.md
@@ -6,7 +6,7 @@ This document consolidates the platform's observability architecture.
 
 ## 🔍 Logging Pipeline
 
-- **Fluent Bit** sidecars collect service logs.
+- **Fluent Bit** sidecars collect service logs from every microservice.
 - Logs are stored in **Elasticsearch** and explored through **Kibana** dashboards.
 - The **Logging & Admin Service** exposes moderation tools and log queries.
 - Logs are emitted in JSON with request tracing fields (e.g., `traceId`, `playerId`)

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -61,10 +61,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -44,6 +44,40 @@ spec:
               port: 2323
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -65,10 +65,43 @@ spec:
               port: 8080
             initialDelaySeconds: 15
             periodSeconds: 20
+        - name: fluent-bit
+          image: fluent/fluent-bit:2.2.2
+          imagePullPolicy: Always
+          args: ["-c", "/fluent-bit/etc/fluent-bit.conf"]
+          env:
+            - name: FLUENT_ELASTICSEARCH_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_HOST
+            - name: FLUENT_ELASTICSEARCH_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: firemud-config
+                  key: FLUENT_ELASTICSEARCH_PORT
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: grpc-tls
           secret:
             secretName: firemud-grpc-tls
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: containers
+          hostPath:
+            path: /var/lib/docker/containers
 ---
 apiVersion: v1
 kind: Service

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/DungeonGenerator.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.service.generator;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/LoggingInterceptor.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/grpc/LoggingInterceptor.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.common.grpc;
 
 import io.grpc.*;
+import io.opentelemetry.api.trace.Span;
+import java.util.UUID;
 import net.firedevops.firemud.common.LoggingUtil;
 import org.slf4j.Logger;
+import org.slf4j.MDC;
 
 /** Logs gRPC method calls and duration. */
 public class LoggingInterceptor implements ServerInterceptor {
@@ -13,20 +16,54 @@ public class LoggingInterceptor implements ServerInterceptor {
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
     String method = call.getMethodDescriptor().getFullMethodName();
     long start = System.currentTimeMillis();
-    logger.info("gRPC call: {}", method);
-    return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(
-        next.startCall(call, headers)) {
+
+    String correlationId = MDC.get("correlationId");
+    boolean addedCorrelationId = false;
+    if (correlationId == null) {
+      correlationId = UUID.randomUUID().toString();
+      MDC.put("correlationId", correlationId);
+      addedCorrelationId = true;
+    }
+    String traceId = Span.current().getSpanContext().getTraceId();
+    MDC.put("traceId", traceId);
+
+    final String cid = correlationId;
+    final String tid = traceId;
+    final boolean removeCorrelation = addedCorrelationId;
+
+    logger.info("gRPC call: {} correlationId={} traceId={}", method, cid, tid);
+
+    ServerCall.Listener<ReqT> listener = next.startCall(call, headers);
+    return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(listener) {
       @Override
       public void onComplete() {
         long duration = System.currentTimeMillis() - start;
-        logger.info("gRPC call completed: {} ({} ms)", method, duration);
+        logger.info(
+            "gRPC call completed: {} ({} ms) correlationId={} traceId={}",
+            method,
+            duration,
+            cid,
+            tid);
+        MDC.remove("traceId");
+        if (removeCorrelation) {
+          MDC.remove("correlationId");
+        }
         super.onComplete();
       }
 
       @Override
       public void onCancel() {
         long duration = System.currentTimeMillis() - start;
-        logger.warn("gRPC call cancelled: {} ({} ms)", method, duration);
+        logger.warn(
+            "gRPC call cancelled: {} ({} ms) correlationId={} traceId={}",
+            method,
+            duration,
+            cid,
+            tid);
+        MDC.remove("traceId");
+        if (removeCorrelation) {
+          MDC.remove("correlationId");
+        }
         super.onCancel();
       }
     };


### PR DESCRIPTION
## Summary
- deploy Fluent Bit sidecars with every service manifest
- include trace and correlation IDs in LoggingInterceptor
- clarify Fluent Bit usage in monitoring docs
- fix lint on DungeonGenerator

## Testing
- `./gradlew lintMarkdown`
- `./gradlew check` *(failed: Build timed out or produced no result)*

------
https://chatgpt.com/codex/tasks/task_e_6875c3bf5bf8833091898d1d9ae2febb