### PR TITLE
docs: clarify shared library autoconfig

### DIFF
--- a/design/architecture/system-architecture-shared-libraries.md
+++ b/design/architecture/system-architecture-shared-libraries.md
@@ -23,13 +23,18 @@ DTO records for common tasks (paging, IDs, basic metadata) live here so services
   attach a `correlationId` via `SagaRunner` for cross-service tracing.
 - **Security Utilities** – `JwtUtil` for verifying tokens (and building them
   within the Account Service only) plus `AuthTokenInterceptor`,
-  `SessionContext`, and `RequireAdminRole` helpers for centrally enforcing
-  JWT-based roles. See the [Authentication Design](./system-architecture-authentication.md).
+  `SessionContext`, `ReloadableJwtUtil`, and `RequireAdminRole` helpers for
+  centrally enforcing JWT-based roles and supporting secret rotation. See the
+  [Authentication Design](./system-architecture-authentication.md).
 - **Database Connectors** – `DatabaseAutoConfiguration` with `PostgresProperties` and `RedisProperties` reduces boilerplate setup. Defaults suit Docker Compose but any field can be overridden with `FIREMUD_POSTGRES_*` or `FIREMUD_REDIS_*` environment variables.
 - **gRPC Interceptors** – `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` provide consistent instrumentation and OpenTelemetry spans for every service.
 - **Service Discovery & Config** – Central location for discovering other services and handling environment properties.
 - `ServiceEndpointsProperties` loads the base URLs for each microservice and is enabled by `CommonAutoConfiguration`.
-- **Spring Boot Starter** – Lightweight autoconfiguration for logging, JWT, Redis and PostgreSQL so services can opt in.
+- **Spring Boot Starter** – Provides `DatabaseAutoConfiguration` for
+  PostgreSQL/Redis and `CommonAutoConfiguration` for shared service properties.
+  Logging and JWT helpers are available but are configured manually.
+- **Conflict Tracking** – `ConflictTracker` and `RedisConflictTracker` record
+  tick conflicts in Redis for hotspot detection.
 - **TLS & Secret Watchers** – `GrpcServerTlsReloader`, `TlsCertificateWatcher`, and `JwtSecretWatcher` reload certificates and JWT secrets without restarting the service.
 - **gRPC Types** – Shared definitions (e.g., `ErrorDetail`, `PagingRequest`) in `protos/shared/`; each service generates its own stubs.
 

--- a/protos/shared/v1/README.md
+++ b/protos/shared/v1/README.md
@@ -3,5 +3,6 @@
 This folder contains protobuf messages that are reused across multiple FireMUD services.
 
 - `errors.proto` defines the `ErrorDetail` message returned on failures.
+- `paging.proto` defines the `PagingRequest` message for consistent list pagination.
 
 Import these definitions from service-specific proto files using `import "shared/v1/errors.proto"`.

--- a/protos/shared/v1/paging.proto
+++ b/protos/shared/v1/paging.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package shared.v1;
+
+option java_package = "net.firedevops.firemud.shared.v1";
+option java_multiple_files = true;
+
+/** Standard paging request for list RPCs. */
+message PagingRequest {
+  // 1-based page index.
+  int32 page = 1;
+
+  // Maximum number of items per page.
+  int32 page_size = 2;
+}


### PR DESCRIPTION
## Summary
- describe additional Spring Boot autoconfiguration modules
- mention ReloadableJwtUtil and ConflictTracker
- add missing `paging.proto` definition
- document PagingRequest in shared proto README

## Testing
- `./gradlew check` *(fails: :automation-scripting-service:spotlessJavaCheck)*

------
https://chatgpt.com/codex/tasks/task_e_6875c5502a1c833097147c4184eb8fab