### PR TITLE
Update automation tick docs

### DIFF
--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -135,6 +135,7 @@ Additional variables tune the scripting engine:
 | `SCRIPT_QUOTA_WINDOWSECONDS` | Length of the quota window in seconds | `60` |
 | `AUTOMATION_TICK_DURATION_MS` | Duration of a processing tick in milliseconds | `1000` |
 | `AUTOMATION_TICK_MAX_EVENTS` | Max events staged from the automation queue each tick | `50` |
+| `AUTOMATION_TICK_BUDGET_MS` | Soft execution budget for a script tick in milliseconds | `100` |
 
 ## Proto Files
 

--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -82,6 +82,7 @@ The scripting engine exposes several environment variables so operators can tune
 | `SCRIPT_QUOTA_WINDOWSECONDS` | Length of the quota window in seconds |
 | `AUTOMATION_TICK_DURATION_MS` | Duration of a script processing tick in milliseconds |
 | `AUTOMATION_TICK_MAX_EVENTS` | Max events staged from the automation queue each tick |
+| `AUTOMATION_TICK_BUDGET_MS` | Soft execution budget for a script tick in milliseconds |
 
 See the [Automation & Scripting Service README](./microservices/automation-scripting-service/README.md#environment-variables) for default values and additional details.
 


### PR DESCRIPTION
## Summary
- document `AUTOMATION_TICK_BUDGET_MS` in the scripting architecture overview
- add the same env var to the Automation & Scripting Service README

## Testing
- `./gradlew check` *(failed: OpenJDK warnings, build output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6875d07bbbe08330bed36dbcb7da9d73