### PR TITLE
Update protocol bridging doc

### DIFF
--- a/design/architecture/system-architecture-protocol-bridging.md
+++ b/design/architecture/system-architecture-protocol-bridging.md
@@ -10,7 +10,7 @@ FireMUD enables real-time interaction through two types of client connections:
 
 | Client Type             | Protocol       | Entry Point                     |
 |-------------------------|----------------|----------------------------------|
-| Web-based clients       | WebSocket      | Spring Cloud Gateway (`/ws/game/**`) |
+| Web-based clients       | WebSocket      | Spring Cloud Gateway (`/ws`) |
 | Traditional MUD clients | TCP (Telnet)   | TCP Proxy Service (custom)      |
 
 Despite their differences, both protocols are normalized into the same internal architecture using a **WebSocket-based session layer**.
@@ -44,16 +44,19 @@ Despite their differences, both protocols are normalized into the same internal 
   - Accepts and parses Telnet line-based input.
   - Sanitizes incoming data and allows only a safe subset of
     **Telnet protocol commands** as outlined in
-    [Security Architecture](../system-architecture-security.md#telnet-command-handling-and-future-controls).
+    [Security Architecture](./system-architecture-security.md#telnet-command-handling-and-future-controls).
   - Runs alongside Spring Cloud Gateway in the network **DMZ**, so no client ever reaches internal services directly.
   - Normalizes the connection.
+  - Supports Telnet-over-TLS when `TCP_PROXY_TLS_ENABLED` is set.
+  - Applies per-IP connection and message rate limits using
+    `TCP_PROXY_MAX_CONNECTIONS_PER_IP` and `TCP_PROXY_MAX_MSGS_PER_SEC`.
   - Creates a WebSocket connection to Spring Cloud Gateway on behalf of the TCP client.
   - Proxies I/O between the TCP client and Spring Cloud Gateway.
   - Buffers active input while the client remains connected and discards it if
     the TCP connection drops.
   - Telnet clients keep a sticky connection to the TCP Proxy Service; reconnection and
     session recovery are handled as described in
-    [Reconnection Strategy](../system-architecture-reconnection.md).
+    [Reconnection Strategy](./system-architecture-reconnection.md).
   - Disconnect handling is **layered**: the proxy cleans up Telnet sessions,
     the gateway automatically recreates WebSocket backends, and the Game Session
     Service reloads state from Redis.
@@ -84,5 +87,5 @@ The `game-session-service` is the central component responsible for:
 - [Infrastructure Overview](./infrastructure/README.md)
 - [Gateway Architecture](./system-architecture-gateway.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)
-- [Reconnection Strategy](../system-architecture-reconnection.md)
-- [MCP Support](../system-architecture-mcp-support.md)
+- [Reconnection Strategy](./system-architecture-reconnection.md)
+- [MCP Support](./system-architecture-mcp-support.md)


### PR DESCRIPTION
## Summary
- align WebSocket path in bridging overview
- fix relative links to other architecture docs
- mention TCP proxy TLS and rate limit settings

## Testing
- `pre-commit run --files design/architecture/system-architecture-protocol-bridging.md` *(failed: Spotless interrupted)*
- `./gradlew spotlessCheck` *(failed: format violations)*

------
https://chatgpt.com/codex/tasks/task_e_6875cfe1c2888330b70506198f6d4e0f