### PR TITLE
Fix Game Design Service docs and gRPC errors

### DIFF
--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -149,6 +149,8 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 
 ### REST & gRPC Endpoints
 
+Default ports: REST on `8080`, gRPC on `6565`.
+
 #### REST
 
 - `GET /ping` – basic health check returning `"pong"`.
@@ -178,7 +180,7 @@ Publishing a game version is coordinated using the Saga utilities from `firemud-
 
 ## Local Development Notes
 
-`TestDataSeeder` populates a demo game, template, revision and version when the `dev` Spring profile is active. A simple smoke-test script verifies both REST and gRPC endpoints. Cross-service integration tests live under `src/test/java/crossservice` and can be executed once dependent services are available.
+`TestDataSeeder` populates a demo game, template, revision and version when the `dev` Spring profile is active. Run `services/game-design-service/smoke-test.sh` to verify both REST and gRPC endpoints. Cross-service integration tests live under `src/test/java/crossservice` and can be executed once dependent services are available.
 
 ## Future Enhancements
 

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Game.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Game.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @Entity
-@Table(name = "games")
+@Table(name = "game")
 public class Game {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 @Entity
-@Table(name = "revisions")
+@Table(name = "revision")
 public class Revision {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 @Entity
-@Table(name = "versions")
+@Table(name = "version")
 public class Version {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.service.impl;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.dto.RevisionDto;
 import net.firedevops.firemud.dto.VersionDto;
@@ -20,6 +21,7 @@ import net.firedevops.firemud.gamedesign.v1.SaveRevisionResponse;
 import net.firedevops.firemud.service.PingService;
 import net.firedevops.firemud.service.RevisionService;
 import net.firedevops.firemud.service.VersionService;
+import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
 
 @GRpcService
@@ -28,6 +30,12 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   private final PingService pingService;
   private final RevisionService revisionService;
   private final VersionService versionService;
+  private final MeterRegistry meterRegistry;
+
+  private ErrorDetail error(String code, String message) {
+    meterRegistry.counter("grpc.app_error", "code", code).increment();
+    return ErrorDetail.newBuilder().setCode(code).setMessage(message).build();
+  }
 
   @Override
   @Timed(value = "gamedesignGrpc.ping")
@@ -41,38 +49,41 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   @Timed(value = "gamedesignGrpc.saveRevision")
   public void saveRevision(
       SaveRevisionRequest request, StreamObserver<SaveRevisionResponse> responseObserver) {
+    SaveRevisionResponse.Builder builder = SaveRevisionResponse.newBuilder();
     try {
       RevisionDto dto =
           new RevisionDto(
               null, request.getTenantId(), request.getAuthorAccountId(), request.getData(), null);
       RevisionDto saved = revisionService.saveRevision(dto);
-      responseObserver.onNext(SaveRevisionResponse.newBuilder().setRevisionId(saved.id()).build());
-      responseObserver.onCompleted();
+      builder.setRevisionId(saved.id());
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+      builder.setError(error("INVALID_ARGUMENT", ex.getMessage()));
     } catch (Exception ex) {
       responseObserver.onError(
           Status.INTERNAL.withDescription("failed").withCause(ex).asRuntimeException());
+      return;
     }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
   }
 
   @Override
   @Timed(value = "gamedesignGrpc.publishVersion")
   public void publishVersion(
       PublishVersionRequest request, StreamObserver<PublishVersionResponse> responseObserver) {
+    PublishVersionResponse.Builder builder = PublishVersionResponse.newBuilder();
     try {
       VersionDto version = versionService.publishVersion(request.getTenantId(), request.getNotes());
-      responseObserver.onNext(
-          PublishVersionResponse.newBuilder().setVersionId(version.id()).build());
-      responseObserver.onCompleted();
+      builder.setVersionId(version.id());
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+      builder.setError(error("INVALID_ARGUMENT", ex.getMessage()));
     } catch (Exception ex) {
       responseObserver.onError(
           Status.INTERNAL.withDescription("failed").withCause(ex).asRuntimeException());
+      return;
     }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
   }
 
   @Override
@@ -80,6 +91,8 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   public void publishScriptPatchVersion(
       PublishScriptPatchVersionRequest request,
       StreamObserver<PublishScriptPatchVersionResponse> responseObserver) {
+    PublishScriptPatchVersionResponse.Builder builder =
+        PublishScriptPatchVersionResponse.newBuilder();
     try {
       VersionDto version =
           versionService.publishScriptPatchVersion(
@@ -87,16 +100,16 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
               request.getBaseVersionId(),
               request.getScriptPatchVersion(),
               request.getNotes());
-      responseObserver.onNext(
-          PublishScriptPatchVersionResponse.newBuilder().setVersionId(version.id()).build());
-      responseObserver.onCompleted();
+      builder.setVersionId(version.id());
     } catch (IllegalArgumentException ex) {
-      responseObserver.onError(
-          Status.INVALID_ARGUMENT.withDescription(ex.getMessage()).asRuntimeException());
+      builder.setError(error("INVALID_ARGUMENT", ex.getMessage()));
     } catch (Exception ex) {
       responseObserver.onError(
           Status.INTERNAL.withDescription("failed").withCause(ex).asRuntimeException());
+      return;
     }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
   }
 
   @Override

--- a/services/game-design-service/src/main/resources/db/migration/V5__update_version_table.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V5__update_version_table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE version
+    ADD COLUMN version_number INT NOT NULL DEFAULT 1,
+    ADD COLUMN base_version_id BIGINT REFERENCES version(id),
+    ADD COLUMN script_patch_version VARCHAR(100),
+    ADD COLUMN is_script_only BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN notes VARCHAR(255),
+    DROP COLUMN IF EXISTS revision_ids;


### PR DESCRIPTION
## Summary
- update data model docs with port info and local tooling references
- update game design gRPC service to return ErrorDetail objects
- use singular table names for JPA entities
- add migration to extend version table schema

## Testing
- `./gradlew check --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6875d1c0d0f48330a53316ffb5b39bf5