### PR TITLE
Update social groups friend tables

### DIFF
--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -11,7 +11,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 - Deliver real-time chat notifications
 - Manage guild creation, membership, and roles
 - Maintain friend lists and cross-game social graphs
-- Feed chat logs to the Logging & Admin Service for moderation
+- Store chat logs locally; profanity events generate moderation reports via the Logging & Admin Service
 
 ## Architecture / Design Notes
 
@@ -35,7 +35,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 - Guild creation and membership changes participate in Saga workflows so other
   services remain consistent. See [Transaction Strategies](../system-architecture-transactions.md).
 - Chat history and guild data are stored with a `tenantId` so conversations are
-  isolated per game. Redis stream keys also include this prefix. See
+  isolated per game. Redis list keys also include this prefix. See
   [Multi-Tenancy](../system-architecture-multi-tenancy.md).
 - Cross-service calls always forward the `tenantId` so features remain isolated;
   see [Multi-Tenancy](../system-architecture-multi-tenancy.md) for details.
@@ -57,10 +57,9 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 
 - `chat_message` table persists guild and private messages.
 - `guild` and `guild_member` tables store group ownership and membership roles.
-- `friend_link` table tracks both account-to-account and per-game friendships.
-  All friendship data lives in this service. Per-game friend records include the
-  `tenantId` and player IDs, while account-level friends reference global account
-  IDs only. Games can mirror these links in their UI when the feature is enabled.
+- `friend_links` table stores per-game friendships scoped by `tenantId`.
+- `account_friend_links` table stores account-to-account friendships shared across games.
+- Games can mirror these links in their UI when the feature is enabled.
 - `mail_message` table stores asynchronous player mail.
 - `faction` and `faction_standing` tables maintain player reputation. The
   [Automation & Scripting Service](../automation-scripting-service/README.md)
@@ -68,7 +67,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
 
 ### Chat Pipeline
 
-- Messages are published to Redis streams and fanned out to WebSocket channels
+- Messages are cached in Redis lists and delivered to WebSocket channels
   through the Spring Cloud Gateway.
 - Guild and direct messages share a common persistence model for history.
 

--- a/protos/social-groups/v1/social_groups_service.proto
+++ b/protos/social-groups/v1/social_groups_service.proto
@@ -52,6 +52,7 @@ message AddFriendRequest {
   string tenant_id = 1;
   string account_id = 2;
   string friend_account_id = 3;
+  bool account_level = 4;
 }
 
 message AddFriendResponse {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AccountFriendLinkDto.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AccountFriendLinkDto.java
@@ -1,0 +1,12 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+/** DTO for account-level friend links. */
+public record AccountFriendLinkDto(
+    Long id,
+    @NotNull Long accountId,
+    @NotNull Long friendAccountId,
+    String status,
+    Instant createdAt) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddFriendRequest.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/dto/AddFriendRequest.java
@@ -3,4 +3,7 @@ package net.firedevops.firemud.dto;
 import jakarta.validation.constraints.NotNull;
 
 public record AddFriendRequest(
-    @NotNull Long tenantId, @NotNull Long accountId, @NotNull Long friendAccountId) {}
+    @NotNull Long tenantId,
+    @NotNull Long accountId,
+    @NotNull Long friendAccountId,
+    boolean accountLevel) {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/AccountFriendLink.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/entity/AccountFriendLink.java
@@ -1,0 +1,27 @@
+package net.firedevops.firemud.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import lombok.Data;
+
+/** Entity representing an account-level friendship. */
+@Data
+@Entity
+@Table(name = "account_friend_links")
+public class AccountFriendLink {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long accountId;
+
+  @Column(nullable = false)
+  private Long friendAccountId;
+
+  @Column(nullable = false, length = 20)
+  private String status;
+
+  @Column(nullable = false)
+  private Instant createdAt;
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/AccountFriendLinkMapper.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/mapper/AccountFriendLinkMapper.java
@@ -1,0 +1,14 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.AccountFriendLinkDto;
+import net.firedevops.firemud.entity.AccountFriendLink;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+/** MapStruct mapper for account-level friend links. */
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface AccountFriendLinkMapper {
+  AccountFriendLinkDto toDto(AccountFriendLink entity);
+
+  AccountFriendLink toEntity(AccountFriendLinkDto dto);
+}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/AccountFriendLinkRepository.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/repository/AccountFriendLinkRepository.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.repository;
+
+import net.firedevops.firemud.entity.AccountFriendLink;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/** Repository for account-level friend links. */
+@Repository
+public interface AccountFriendLinkRepository extends JpaRepository<AccountFriendLink, Long> {}

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/FriendServiceImpl.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.dto.AddFriendRequest;
 import net.firedevops.firemud.dto.FriendLinkDto;
+import net.firedevops.firemud.entity.AccountFriendLink;
 import net.firedevops.firemud.entity.FriendLink;
 import net.firedevops.firemud.mapper.FriendLinkMapper;
+import net.firedevops.firemud.repository.AccountFriendLinkRepository;
 import net.firedevops.firemud.repository.FriendLinkRepository;
 import net.firedevops.firemud.service.FriendService;
 import org.slf4j.Logger;
@@ -20,19 +22,42 @@ public class FriendServiceImpl implements FriendService {
   private static final Logger logger = LoggingUtil.getLogger(FriendServiceImpl.class);
 
   private final FriendLinkRepository friendLinkRepository;
+  private final AccountFriendLinkRepository accountFriendLinkRepository;
   private final FriendLinkMapper friendLinkMapper;
 
   @Override
   @Transactional
   @Timed(value = "friend.add")
   public FriendLinkDto addFriend(AddFriendRequest request) {
-    logger.info("Adding friend {} -> {}", request.accountId(), request.friendAccountId());
-    FriendLink link = new FriendLink();
-    link.setTenantId(request.tenantId());
-    link.setAccountId(request.accountId());
-    link.setFriendAccountId(request.friendAccountId());
-    link.setStatus("active");
-    link.setCreatedAt(Instant.now());
-    return friendLinkMapper.toDto(friendLinkRepository.save(link));
+    logger.info(
+        "Adding friend {} -> {} (accountLevel={})",
+        request.accountId(),
+        request.friendAccountId(),
+        request.accountLevel());
+    if (request.accountLevel()) {
+      AccountFriendLink afl = new AccountFriendLink();
+      afl.setAccountId(request.accountId());
+      afl.setFriendAccountId(request.friendAccountId());
+      afl.setStatus("active");
+      afl.setCreatedAt(Instant.now());
+      accountFriendLinkRepository.save(afl);
+      // Map to existing DTO for simplicity
+      FriendLink dto = new FriendLink();
+      dto.setId(afl.getId());
+      dto.setTenantId(request.tenantId());
+      dto.setAccountId(afl.getAccountId());
+      dto.setFriendAccountId(afl.getFriendAccountId());
+      dto.setStatus(afl.getStatus());
+      dto.setCreatedAt(afl.getCreatedAt());
+      return friendLinkMapper.toDto(dto);
+    } else {
+      FriendLink link = new FriendLink();
+      link.setTenantId(request.tenantId());
+      link.setAccountId(request.accountId());
+      link.setFriendAccountId(request.friendAccountId());
+      link.setStatus("active");
+      link.setCreatedAt(Instant.now());
+      return friendLinkMapper.toDto(friendLinkRepository.save(link));
+    }
   }
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/SocialGroupsGrpcService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/SocialGroupsGrpcService.java
@@ -116,7 +116,8 @@ public class SocialGroupsGrpcService extends SocialGroupsServiceGrpc.SocialGroup
           new AddFriendRequest(
               Long.valueOf(request.getTenantId()),
               Long.valueOf(request.getAccountId()),
-              Long.valueOf(request.getFriendAccountId()));
+              Long.valueOf(request.getFriendAccountId()),
+              request.getAccountLevel());
       friendService.addFriend(dto);
       AddFriendResponse response = AddFriendResponse.newBuilder().setSuccess(true).build();
       responseObserver.onNext(response);

--- a/services/social-groups-service/src/main/resources/db/migration/V7__account_friend_links.sql
+++ b/services/social-groups-service/src/main/resources/db/migration/V7__account_friend_links.sql
@@ -1,0 +1,10 @@
+CREATE TABLE account_friend_links (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL,
+    friend_account_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_account_friend_links_account_id ON account_friend_links(account_id);
+CREATE INDEX idx_account_friend_links_friend_id ON account_friend_links(friend_account_id);

--- a/services/social-groups-service/src/main/resources/openapi.yaml
+++ b/services/social-groups-service/src/main/resources/openapi.yaml
@@ -25,6 +25,8 @@ components:
           type: integer
         friendAccountId:
           type: integer
+        accountLevel:
+          type: boolean
       required:
         - tenantId
         - accountId

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/FriendControllerTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/controller/FriendControllerTest.java
@@ -42,7 +42,7 @@ class FriendControllerTest {
 
   @Test
   void addFriendReturnsDto() throws Exception {
-    AddFriendRequest request = new AddFriendRequest(1L, 2L, 3L);
+    AddFriendRequest request = new AddFriendRequest(1L, 2L, 3L, false);
     FriendLinkDto response = new FriendLinkDto(1L, 1L, 2L, 3L, "active", null);
     when(friendService.addFriend(request)).thenReturn(response);
 

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/FriendServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/FriendServiceImplTest.java
@@ -9,6 +9,7 @@ import net.firedevops.firemud.dto.AddFriendRequest;
 import net.firedevops.firemud.dto.FriendLinkDto;
 import net.firedevops.firemud.entity.FriendLink;
 import net.firedevops.firemud.mapper.FriendLinkMapper;
+import net.firedevops.firemud.repository.AccountFriendLinkRepository;
 import net.firedevops.firemud.repository.FriendLinkRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,13 +23,14 @@ class FriendServiceImplTest {
   @BeforeEach
   void setUp() {
     repository = Mockito.mock(FriendLinkRepository.class);
+    AccountFriendLinkRepository accountRepo = Mockito.mock(AccountFriendLinkRepository.class);
     FriendLinkMapper mapper = Mappers.getMapper(FriendLinkMapper.class);
-    service = new FriendServiceImpl(repository, mapper);
+    service = new FriendServiceImpl(repository, accountRepo, mapper);
   }
 
   @Test
   void addFriendReturnsDto() {
-    AddFriendRequest request = new AddFriendRequest(1L, 2L, 3L);
+    AddFriendRequest request = new AddFriendRequest(1L, 2L, 3L, false);
     FriendLink saved = new FriendLink();
     saved.setId(1L);
     saved.setTenantId(1L);


### PR DESCRIPTION
## Summary
- split account and in-game friendships into separate tables
- add AccountFriendLink JPA entity, repository, mapper and DTO
- include `accountLevel` flag in friend request proto and API
- update service logic and tests for new field
- document Redis list usage and new tables

## Testing
- `./gradlew generateProto`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6875d654ee608330adfbf0d4369a4317