### PR TITLE
Add namespace and service account to k8s manifests

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -3,19 +3,20 @@
 This directory contains Kubernetes manifests and Helm chart placeholders for deploying the FireMUD services.
 
 The `base/` folder provides minimal deployment files that can be applied to a development cluster:
+These manifests assume a `firemud` namespace; include `-n firemud` when applying them.
 
 ```bash
-kubectl apply -f base/account-service.yaml
-kubectl apply -f base/automation-scripting-service.yaml
-kubectl apply -f base/entity-management-service.yaml
-kubectl apply -f base/game-design-service.yaml
-kubectl apply -f base/game-logic-service.yaml
-kubectl apply -f base/game-session-service.yaml
-kubectl apply -f base/logging-admin-service.yaml
-kubectl apply -f base/social-groups-service.yaml
-kubectl apply -f base/tcp-proxy-service.yaml
-kubectl apply -f base/world-management-service.yaml
-kubectl apply -f base/spring-cloud-gateway.yaml
+kubectl apply -n firemud -f base/account-service.yaml
+kubectl apply -n firemud -f base/automation-scripting-service.yaml
+kubectl apply -n firemud -f base/entity-management-service.yaml
+kubectl apply -n firemud -f base/game-design-service.yaml
+kubectl apply -n firemud -f base/game-logic-service.yaml
+kubectl apply -n firemud -f base/game-session-service.yaml
+kubectl apply -n firemud -f base/logging-admin-service.yaml
+kubectl apply -n firemud -f base/social-groups-service.yaml
+kubectl apply -n firemud -f base/tcp-proxy-service.yaml
+kubectl apply -n firemud -f base/world-management-service.yaml
+kubectl apply -n firemud -f base/spring-cloud-gateway.yaml
 ```
 
 The file `base/firemud-db-env.yaml` defines the shared `firemud-config`
@@ -25,8 +26,8 @@ After the services are running, apply the default network policies found in
 `network-policies/` to restrict traffic to internal pods only:
 
 ```bash
-kubectl apply -f network-policies/internal-services.yaml
-kubectl apply -f base/firemud-grpc-certificate.yaml
+kubectl apply -n firemud -f network-policies/internal-services.yaml
+kubectl apply -n firemud -f base/firemud-grpc-certificate.yaml
 ```
 
 The policy allows gRPC (8080, 6565) and OpenTelemetry traffic on port `4317` in
@@ -44,10 +45,10 @@ The `monitoring/` folder provides example manifests for observability tools:
 Apply them with:
 
 ```bash
-kubectl apply -f monitoring/redis-exporter.yaml
-kubectl apply -f monitoring/otel-collector.yaml
-kubectl apply -f monitoring/jaeger.yaml
-kubectl apply -f monitoring/alertmanager.yaml
+kubectl apply -n firemud -f monitoring/redis-exporter.yaml
+kubectl apply -n firemud -f monitoring/otel-collector.yaml
+kubectl apply -n firemud -f monitoring/jaeger.yaml
+kubectl apply -n firemud -f monitoring/alertmanager.yaml
 ```
 
 Customize these manifests with proper image repositories and resource limits before running in production.
@@ -71,4 +72,10 @@ The [`helm/`](./helm) folder contains example charts. Use `values-local.yaml` or
 
 ```bash
 helm install game-session ./helm/game-session-service -f helm/values-local.yaml
+```
+
+For production deployments, use the umbrella chart:
+
+```bash
+helm upgrade --install firemud ./charts/firemud -n firemud --create-namespace
 ```

--- a/k8s/base/README.md
+++ b/k8s/base/README.md
@@ -5,18 +5,20 @@ This directory contains minimal deployment files for running the core FireMUD se
 Apply all manifests with:
 
 ```bash
-kubectl apply -f account-service.yaml
-kubectl apply -f automation-scripting-service.yaml
-kubectl apply -f entity-management-service.yaml
-kubectl apply -f game-design-service.yaml
-kubectl apply -f game-logic-service.yaml
-kubectl apply -f game-session-service.yaml
-kubectl apply -f logging-admin-service.yaml
-kubectl apply -f social-groups-service.yaml
-kubectl apply -f tcp-proxy-service.yaml
-kubectl apply -f world-management-service.yaml
-kubectl apply -f spring-cloud-gateway.yaml
+kubectl apply -n firemud -f account-service.yaml
+kubectl apply -n firemud -f automation-scripting-service.yaml
+kubectl apply -n firemud -f entity-management-service.yaml
+kubectl apply -n firemud -f game-design-service.yaml
+kubectl apply -n firemud -f game-logic-service.yaml
+kubectl apply -n firemud -f game-session-service.yaml
+kubectl apply -n firemud -f logging-admin-service.yaml
+kubectl apply -n firemud -f social-groups-service.yaml
+kubectl apply -n firemud -f tcp-proxy-service.yaml
+kubectl apply -n firemud -f world-management-service.yaml
+kubectl apply -n firemud -f spring-cloud-gateway.yaml
 ```
+
+These manifests assume a `firemud` namespace.
 
 These files expose the services internally using `ClusterIP` (except the gateway and TCP proxy which are `LoadBalancer`). See the [Deployment Environments](../../design/architecture/infrastructure/deployment-environments.md) document for production considerations.
 
@@ -28,20 +30,14 @@ Ports align with the design documents:
 
 All deployments include basic readiness and liveness probes that hit the `/actuator/health` endpoint (or open a TCP socket for the proxy service) as described in the design docs.
 
-Spring Boot services run with the `prod` Spring profile by default. This is set via the `SPRING_PROFILES_ACTIVE` environment variable in each deployment manifest.
-
 ## Database Settings
 
-All Spring Boot services expect PostgreSQL and Redis connection details via
-environment variables. A `firemud-config` `ConfigMap` and `firemud-secret`
-`Secret` are provided to supply these values:
+All Spring Boot services expect PostgreSQL and Redis connection details via environment variables. A `firemud-config` `ConfigMap` and `firemud-secret` `Secret` are provided to supply these values:
 
 ```bash
 FIREMUD_POSTGRES_HOST=postgres
 FIREMUD_POSTGRES_PORT=5432
 FIREMUD_POSTGRES_DB=firemud
-FIREMUD_POSTGRES_USER=firemud
-FIREMUD_POSTGRES_PASSWORD=firemud
 FIREMUD_REDIS_HOST=redis
 FIREMUD_REDIS_PORT=6379
 OTEL_ENDPOINT=http://otel-collector:4317
@@ -49,9 +45,6 @@ FLUENT_ELASTICSEARCH_HOST=elasticsearch
 FLUENT_ELASTICSEARCH_PORT=9200
 ```
 
-Each deployment loads these variables using `envFrom`. Replace the sample
-credentials or mount your own Secrets for production environments.
+Each deployment loads these variables using `envFrom`. Replace the sample credentials or mount your own Secrets for production environments.
 
-An example `HorizontalPodAutoscaler` manifest is provided in `hpa-example.yaml`.
-It is commented out by default and can be customized with CPU or other metrics
-when deploying to production clusters.
+An example `HorizontalPodAutoscaler` manifest is provided in `hpa-example.yaml`. It is commented out by default and can be customized with CPU or other metrics when deploying to production clusters.

--- a/k8s/base/account-service.yaml
+++ b/k8s/base/account-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: account-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: account-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: account-service
 spec:
   selector:

--- a/k8s/base/automation-scripting-service.yaml
+++ b/k8s/base/automation-scripting-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: automation-scripting-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: automation-scripting-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: automation-scripting-service
 spec:
   selector:

--- a/k8s/base/entity-management-service.yaml
+++ b/k8s/base/entity-management-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: entity-management-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: entity-management-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: entity-management-service
 spec:
   selector:

--- a/k8s/base/firemud-db-env.yaml
+++ b/k8s/base/firemud-db-env.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: firemud
   name: firemud-config
 data:
   FIREMUD_POSTGRES_HOST: postgres
@@ -16,6 +17,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: firemud
   name: firemud-secret
 data:
   FIREMUD_POSTGRES_USER: ZmlyZW11ZA==

--- a/k8s/base/firemud-grpc-certificate.yaml
+++ b/k8s/base/firemud-grpc-certificate.yaml
@@ -1,6 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  namespace: firemud
   name: firemud-grpc-tls
 spec:
   secretName: firemud-grpc-tls

--- a/k8s/base/firemud-grpc-tls.yaml
+++ b/k8s/base/firemud-grpc-tls.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  namespace: firemud
   name: firemud-grpc-tls
 data:
   client.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCmV4YW1wbGUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==

--- a/k8s/base/game-design-service.yaml
+++ b/k8s/base/game-design-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: game-design-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: game-design-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: game-design-service
 spec:
   selector:

--- a/k8s/base/game-logic-service.yaml
+++ b/k8s/base/game-logic-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: game-logic-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: game-logic-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: game-logic-service
 spec:
   selector:

--- a/k8s/base/game-session-service.yaml
+++ b/k8s/base/game-session-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: game-session-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: game-session-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: game-session-service
 spec:
   selector:

--- a/k8s/base/logging-admin-service.yaml
+++ b/k8s/base/logging-admin-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: logging-admin-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: logging-admin-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: logging-admin-service
 spec:
   selector:

--- a/k8s/base/service-account.yaml
+++ b/k8s/base/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: firemud-app
+  namespace: firemud

--- a/k8s/base/social-groups-service.yaml
+++ b/k8s/base/social-groups-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: social-groups-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: social-groups-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: social-groups-service
 spec:
   selector:

--- a/k8s/base/spring-cloud-gateway.yaml
+++ b/k8s/base/spring-cloud-gateway.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: spring-cloud-gateway
 spec:
   replicas: 2
@@ -14,6 +15,7 @@ spec:
       labels:
         app: spring-cloud-gateway
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -102,6 +104,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: spring-cloud-gateway
 spec:
   selector:

--- a/k8s/base/tcp-proxy-service.yaml
+++ b/k8s/base/tcp-proxy-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: tcp-proxy-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: tcp-proxy-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -82,6 +84,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: tcp-proxy-service
 spec:
   selector:

--- a/k8s/base/world-management-service.yaml
+++ b/k8s/base/world-management-service.yaml
@@ -2,6 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: world-management-service
 spec:
   replicas: 2
@@ -13,6 +14,7 @@ spec:
       labels:
         app: world-management-service
     spec:
+      serviceAccountName: firemud-app
       securityContext:
         fsGroup: 1000
       containers:
@@ -106,6 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: world-management-service
 spec:
   selector:

--- a/k8s/monitoring/alertmanager.yaml
+++ b/k8s/monitoring/alertmanager.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: alertmanager
 spec:
   replicas: 1
@@ -29,6 +30,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: alertmanager
 spec:
   selector:
@@ -42,6 +44,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: firemud
   name: alertmanager-config
 data:
   alertmanager.yml: |

--- a/k8s/monitoring/jaeger.yaml
+++ b/k8s/monitoring/jaeger.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: jaeger
 spec:
   replicas: 1
@@ -27,6 +28,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: jaeger
 spec:
   selector:

--- a/k8s/monitoring/otel-collector.yaml
+++ b/k8s/monitoring/otel-collector.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: otel-collector
 spec:
   replicas: 1
@@ -30,6 +31,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: otel-collector
 spec:
   selector:
@@ -44,6 +46,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: firemud
   name: otel-collector-config
 data:
   config.yaml: |

--- a/k8s/monitoring/redis-exporter.yaml
+++ b/k8s/monitoring/redis-exporter.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: firemud
   name: redis-exporter
 spec:
   replicas: 1
@@ -23,6 +24,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: firemud
   name: redis-exporter
 spec:
   selector:

--- a/k8s/network-policies/account-service.yaml
+++ b/k8s/network-policies/account-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  namespace: firemud
   name: account-service-egress
 # Release names "firemud-postgresql" and "firemud-redis" must match the
 # corresponding Helm deployments.

--- a/k8s/network-policies/internal-services-egress.yaml
+++ b/k8s/network-policies/internal-services-egress.yaml
@@ -1,6 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  namespace: firemud
   name: internal-services-egress
 spec:
   podSelector:

--- a/k8s/network-policies/internal-services.yaml
+++ b/k8s/network-policies/internal-services.yaml
@@ -1,6 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  namespace: firemud
   name: internal-services
 # Ensure Helm release names for PostgreSQL and Redis match the labels below.
 spec:

--- a/k8s/velero/verify-backups-cronjob.yaml
+++ b/k8s/velero/verify-backups-cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: check
-            image: velero/velero:latest
+            image: velero/velero:v1.12.3
             command: ["/bin/sh", "-c", "/scripts/verify-backups.sh"]
             volumeMounts:
             - name: script


### PR DESCRIPTION
## Summary
- ensure all Kubernetes manifests specify `namespace: firemud`
- create a shared ServiceAccount and use it in deployments
- pin Velero verify CronJob image to v1.12.3
- update docs with namespace instructions and helm example

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6875dbf838708330bd62a3b7cdd4b769