### PR TITLE
Run partial CI checks locally

### DIFF
--- a/protos/buf.yaml
+++ b/protos/buf.yaml
@@ -1,7 +1,7 @@
 version: v1
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_DIRECTORY_MATCH
 breaking:


### PR DESCRIPTION
## Summary
- run local CI tasks (buf lint, hadolint, shellcheck, npm lint/format/accessibility, openapi lint, Gradle check for account service)
- update buf lint config to use `STANDARD` category

## Testing
- `buf lint`
- `find services -name Dockerfile -print -exec hadolint -c .hadolint.yaml {} +`
- `find dev-tools -name "*.sh" -print0 | xargs -0 shellcheck`
- `npm run lint`
- `npm run format:fix`
- `npm run accessibility`
- `npm run openapi:lint`
- `./gradlew :account-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68762d62fcd08330b6ebf07d6b970a28