### PR TITLE
Clarify grpc docs around interceptors and metrics

### DIFF
--- a/design/architecture/system-architecture-grpc.md
+++ b/design/architecture/system-architecture-grpc.md
@@ -59,9 +59,13 @@ All proto files use `syntax = "proto3"` and set `java_package` and `java_multipl
 
 ## 🛠️ Tooling
 
-- **Buf** (`buf.yaml`) — Lints proto files, detects breaking changes, and drives code generation. The repository stores this configuration under `protos/`.
+- **Buf** ([buf.yaml](../../protos/buf.yaml)) — Lints proto files, detects breaking changes, and drives code generation. The repository stores this configuration under `protos/`.
 - **`protoc-gen-grpc-java`** — Generates Java service stubs for gRPC communication. The generated code is included in service builds via Gradle.
 - **`protoc-gen-doc`** — Produces HTML or Markdown API documentation to encourage inline comments.
+
+## 🚦 Shared Interceptors
+
+Every gRPC service registers the `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from the [Shared Libraries](./system-architecture-shared-libraries.md). These interceptors add trace identifiers to logs, record request metrics, and create OpenTelemetry spans so observability is consistent across services.
 
 ## 🔄 Schema Evolution Rules
 

--- a/design/architecture/system-architecture-logging-monitoring.md
+++ b/design/architecture/system-architecture-logging-monitoring.md
@@ -30,9 +30,10 @@ This document consolidates the platform's observability architecture.
 - **OpenTelemetry** spans provide distributed tracing across ticks and requests.
   Traces are collected by an OpenTelemetry Collector and visualized with Jaeger.
   See [Tracing](./system-architecture-tracing.md) for deployment details.
-- Metrics are recorded with Micrometer and emitted through a shared
-  `MetricsInterceptor` so all gRPC endpoints expose consistent counters like
-  `grpc.server.requests` and `grpc.app_error`.
+  - Metrics are recorded with Micrometer. The shared `MetricsInterceptor`
+    tracks `grpc.server.requests` for each call. Services increment the
+    `grpc.app_error` counter in their `error()` helpers as described in the
+    [gRPC API Style guidelines](./system-architecture-grpc.md).
 - Most services expose a `/actuator/prometheus` endpoint for metrics. Scrape intervals
   are tuned per environment (typically 15s in development and 30s in production).
 - Distributed traces are exported via OTLP and correlated with logs using the same


### PR DESCRIPTION
## Summary
- mention shared interceptors explicitly in the gRPC style guide
- link directly to buf.yaml configuration
- clarify how grpc.app_error metric is recorded in logging/monitoring docs

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_687624c74ac88330a71ec319f8ae5d5a