### PR TITLE
Improve reconnection strategy docs

### DIFF
--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -14,7 +14,7 @@ FireMUD enables seamless gameplay recovery across network interruptions, client 
 
 Each layer handles fault tolerance independently.
 **Only client connection loss requires reauthentication.**
-Game Session Service restarts are **transparent** if the client remains connected. TCP Proxy restarts drop Telnet clients. Spring Cloud Gateway restarts disconnect Web clients, but Telnet clients proxied through the Gateway remain connected.
+Game Session Service restarts are **transparent** if the client remains connected. The Gateway automatically re-establishes WebSocket sessions after a restart while Telnet clients stay bridged through the proxy. TCP Proxy restarts drop Telnet clients.
 
 ---
 
@@ -25,6 +25,7 @@ Game Session Service restarts are **transparent** if the client remains connecte
 - Accepts raw TCP input and assembles it into commands
 - Buffers input **during connection**, but **clears on disconnect**
 - No gameplay state is preserved across reconnects — Game Session Service handles recovery
+- Runtime options such as the listening port and gateway WebSocket URL are configured via `TCP_PROXY_PORT` and `GATEWAY_WS_URL` (see the [TCP Proxy Service README](./microservices/tcp-proxy-service/README.md#environment-variables)).
 
 ### Spring Cloud Gateway (Web Clients)
 
@@ -32,7 +33,7 @@ Game Session Service restarts are **transparent** if the client remains connecte
 - Automatically re-establishes backend connections if restarted
 - Holds no gameplay, auth, or session state
 
-> TCP Proxy restarts drop Telnet connections. Spring Cloud Gateway restarts disconnect Web clients only; Telnet clients proxied through the Gateway remain connected.
+> TCP Proxy restarts drop Telnet connections. Spring Cloud Gateway restarts temporarily disconnect Web clients, but the WebSocket connection is reestablished automatically. Telnet clients proxied through the Gateway remain connected.
 
 ### Game Session Service
 
@@ -42,7 +43,8 @@ Game Session Service restarts are **transparent** if the client remains connecte
   - Tick region context
   - Timers and in-flight actions
 
-> 🔗 Full structure of Redis session keys is documented in [Session Keys and Gameplay Binding](./system-architecture-redis.md#🧠-session-keys-and-gameplay-binding)
+> 🔗 Full structure of Redis session keys is documented in [Session Keys and Gameplay Binding](./system-architecture-redis.md#🧠-session-keys-and-gameplay-binding).
+> See also the [Game Session Service README](./microservices/game-session-service/README.md#redis-keys) for how session state is stored for reconnect recovery.
 
 ---
 
@@ -55,7 +57,7 @@ Clients must send a `LOGIN` command **after any disconnect**, such as:
 - If two-factor authentication is enabled, include the one-time `otp` value with the `LOGIN` command. See [Account Service – Two-Factor Authentication](./microservices/account-service/README.md#two-factor-authentication).
 
 Redis-backed session state enables seamless resumption if valid, or fresh login if expired.
-Session entries in Redis expire after `FIREMUD_AUTH_SESSION_EXPIRATION_MS` milliseconds as documented in [Environment and Secrets](./infrastructure/environment-and-secrets.md#authentication).
+Session entries in Redis expire after `FIREMUD_AUTH_SESSION_EXPIRATION_MS` milliseconds (defaults to `3600000`, or **1 hour**) as documented in [Environment and Secrets](./infrastructure/environment-and-secrets.md#authentication).
 
 > 🧭 For full details on `LOGIN` behavior, argument formats, and session flow, see [Authentication & Authorization](./system-architecture-authentication.md#🔁-login-and-session-flow)
 
@@ -102,3 +104,4 @@ Gameplay resumes cleanly when a session is resumed — whether due to reconnect 
 - [Tick System and Runtime Design](./system-architecture-ticks.md)
 - [Redis Architecture](./system-architecture-redis.md)
 - [Authentication & Authorization](./system-architecture-authentication.md)
+- [Game Session Service README](./microservices/game-session-service/README.md)


### PR DESCRIPTION
## Summary
- expand reconnection docs with session TTL default
- reference Game Session Service README
- mention TCP proxy env vars
- clarify how gateway restarts behave

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6876263a4d248330b5029a1ff37c73fd