### PR TITLE
Update multi-tenancy doc

### DIFF
--- a/design/architecture/system-architecture-multi-tenancy.md
+++ b/design/architecture/system-architecture-multi-tenancy.md
@@ -8,8 +8,7 @@ This document explains how FireMUD hosts many independent games on shared infras
 
 - Players have a **single platform account** managed by the **Account Service**.
 - The same account can join multiple games. Each game is identified by a `tenantId`.
-- `tenantId` values are string GUIDs and appear in every API. Standardizing on
-  strings avoids type mismatches across gRPC, REST, and database models.
+- `tenantId` values are string GUIDs and appear in every API. Standardizing on strings avoids type mismatches across gRPC, REST, and database models. Database tables store this column as `VARCHAR(36)`.
 - Character data and progress are scoped per `tenantId`; a player may have different characters in different games.
 - Authentication is global, but services always check the requested `tenantId` when retrieving or updating game data.
 - Friend lists and guilds are maintained by the Social & Groups Service. Per-game
@@ -18,10 +17,10 @@ This document explains how FireMUD hosts many independent games on shared infras
 
 ## 🗂️ Data Separation per Service
 
-- Every microservice stores data in its own PostgreSQL database schema.
+- All microservices connect to a single PostgreSQL instance and store data in service-specific schemas. Current migrations place tables in the `public` schema but will move to dedicated schemas.
 - Databases are **shared across tenants**, with a `tenantId` column on each table to isolate data.
 - Services enforce the `tenantId` filter on all queries to prevent cross-game access.
-- Redis keys also include the `tenantId` so cached session state and runtime data remain isolated.
+- Redis keys prefix the `tenantId` as described in the [Redis Architecture](./system-architecture-redis.md#key-format-examples) so cached session state and runtime data remain isolated.
 - The React frontend loads per-tenant themes and branding files. See
   [Game Customization Options](./game-customization-options.md) and the
   [Frontend Architecture](./system-architecture-frontend.md) for details.
@@ -33,8 +32,8 @@ This document explains how FireMUD hosts many independent games on shared infras
 - Creating a new game world triggers a Saga across services. The steps are
   outlined in [World Creation Workflow](./microservices/world-management-service/world-creation-workflow.md).
 - All microservices run as shared deployments; there is **no tenant-specific infrastructure** or dedicated clusters.
-- Game Session Service instances scale horizontally based on overall load. Per-game resource quotas may be enforced so one tenant cannot exhaust cluster capacity. See [Game Session Service design notes](./microservices/game-session-service/README.md#architecture--design-notes) for details.
-  Quota thresholds are configured per tenant and metrics expose current usage so
+- Game Session Service instances scale horizontally based on overall load. Per-game resource quotas are planned so one tenant cannot exhaust cluster capacity. This feature is not yet implemented. See [Game Session Service design notes](./microservices/game-session-service/README.md#architecture--design-notes) for details.
+  Quota thresholds will be configured per tenant and metrics will expose current usage so
   operators can track `active_sessions` and quota denials.
 
 ---


### PR DESCRIPTION
## Summary
- clarify tenant ID GUID usage in docs
- note per-service schema strategy and link redis key formats
- mention planned game session quotas

## Testing
- `pre-commit run --files design/architecture/system-architecture-multi-tenancy.md` *(fails: Checkstyle interrupted)*
- `./gradlew check` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6876302607808330a5f72faf87c4dd5f