### PR TITLE
Improve tracing docs

### DIFF
--- a/design/architecture/system-architecture-tracing.md
+++ b/design/architecture/system-architecture-tracing.md
@@ -10,10 +10,18 @@ All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK
 
 - Deploy using the official [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) Helm chart or the sample manifest in `k8s/monitoring/otel-collector.yaml`.
 - The collector exposes a `4317` gRPC endpoint. Services export spans to `http://otel-collector:4317` by default. The endpoint can be overridden via the `OTEL_ENDPOINT` environment variable (`otel.endpoint` property). See `.env.sample` and [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md) for defaults.
+
+  ```bash
+  OTEL_ENDPOINT=http://collector.internal:4317
+  ```
+
 - The collector forwards spans to Jaeger over gRPC port `14250`.
-- Metrics about the collector itself are scraped by Prometheus at `/metrics`.
+- Metrics about the collector itself are scraped by Prometheus at `/metrics` on
+  port `8888`. Expose this port in the service definition if using the sample
+  manifest.
 
 Every service relies on a shared `TracingConfig` in the `common-library`. This configuration sets the `service.name` resource from `spring.application.name`, uses a `BatchSpanProcessor`, and sends spans to the collector. `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` are registered in each `GrpcServerConfig` so requests are instrumented with logs, metrics, and spans consistently.
+`TracingInterceptor` opens a span for each gRPC method and marks it successful or cancelled when the call completes.
 
 ## 🎛️ Jaeger UI
 
@@ -34,3 +42,4 @@ Traces are stored and visualized with **Jaeger**. A minimal Jaeger deployment is
 - [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md)
 - [Microservice Template](./microservices/service-template.md)
 - [Infrastructure Overview](./infrastructure/README.md)
+- [System Context Diagram](./system-context-diagram.md)


### PR DESCRIPTION
## Summary
- expand tracing docs to mention metrics port 8888
- show how to override `OTEL_ENDPOINT`
- describe gRPC span details
- link back to the system context diagram

## Testing
- `./gradlew check --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687630447b6c833095a7fffe27317d91