### PR TITLE
Configure markdown wrap at 100 chars

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,8 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+max_line_length = 100
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,7 +1,11 @@
 {
   "config": {
     "default": true,
-    "MD013": false,
+    "MD013": {
+      "line_length": 100,
+      "code_blocks": false,
+      "tables": false
+    },
     "MD026": false
   },
   "ignores": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ Once your environment is running you can create a feature branch and submit a PR
 - Backend code targets Java 21+ with Spring Boot 3.x; frontend code follows standard React/TypeScript conventions.
 - Document public methods and classes with brief Javadoc comments.
 - Install the git hook in `config/git-hooks/pre-commit` to automatically format and lint your commits.
+- Wrap all Markdown files at 100 characters. Use `./gradlew lintMarkdownFix` or your editor's rewrap command.
 
 ## Pre-commit Hooks
 


### PR DESCRIPTION
## Summary
- enforce MD013 line length rule at 100 chars
- add Markdown limits to `.editorconfig`
- note wrapping requirement in CONTRIBUTING docs

## Testing
- `npx markdownlint-cli2 "**/*.md" --fix` *(fails: many MD013 violations)*
- `./gradlew check` *(fails: lintMarkdown MD013 line length violations)*

------
https://chatgpt.com/codex/tasks/task_e_68763a325b8c833084e1fd029a300a40