### PR TITLE
docs: clarify logging monitoring

### DIFF
--- a/design/architecture/system-architecture-logging-monitoring.md
+++ b/design/architecture/system-architecture-logging-monitoring.md
@@ -21,7 +21,7 @@ This document consolidates the platform's observability architecture.
   `FLUENT_ELASTICSEARCH_PORT` environment variables
   ([Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#observability)).
 - Operators search logs primarily through Kibana, but the Logging & Admin Service
-  offers a focused UI for moderation and audit trails.
+  offers a focused UI for moderation and audit trails. (TODO: Not yet implemented)
 
 ## 📈 Metrics & Tracing
 
@@ -38,12 +38,13 @@ This document consolidates the platform's observability architecture.
 - Business methods in services are annotated with `@Timed` to publish custom Prometheus timers.
 - Most services expose a `/actuator/prometheus` endpoint for metrics. Scrape intervals
   are tuned per environment (typically 15s in development and 30s in production).
-- Metrics for Redis are collected via the [`redis-exporter`](../../k8s/monitoring/redis-exporter.yaml) deployment. A PostgreSQL exporter can also be added for database metrics.
+- Metrics for Redis are collected via the [`redis-exporter`](../../k8s/monitoring/redis-exporter.yaml) deployment. A PostgreSQL exporter can also be added for database metrics. (TODO: Not yet implemented)
 - Distributed traces are exported via OTLP and correlated with logs using the same
   `traceId` value.
-- Metrics use the same `traceId` label via the `MetricsInterceptor`, making it easy to correlate latency spikes with specific traces and log entries.
-- The OpenTelemetry collector endpoint is configurable via the `OTEL_ENDPOINT`
-  environment variable ([Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md)).
+- Metrics use the same `traceId` label via the `MetricsInterceptor`, making it easy
+  to correlate latency spikes with specific traces and log entries. (TODO: Not yet implemented)
+- The OpenTelemetry collector endpoint is configurable via the `OTEL_ENDPOINT` environment variable
+  ([Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md)).
 
 ## 🩺 Health Checks
 


### PR DESCRIPTION
## Summary
- document redis/OTEL env variable update
- mark TODOs for features not implemented

## Testing
- `./gradlew check --no-daemon` *(fails: lintMarkdown MD013 line length)*

------
https://chatgpt.com/codex/tasks/task_e_68774bb69d488330a35c47b54b24b986