### PR TITLE
Update scripting architecture doc

### DIFF
--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -12,24 +12,24 @@ This document outlines how FireMUD executes custom in-game behavior through a sa
 
 ## 🧩 Component‑Based Scripting DSL
 
-- Scripts are authored in a **visual editor** where designers assemble **predefined components** (conditions, actions, timers, etc.).
+- Scripts are authored in a **visual editor** where designers assemble **predefined components** (conditions, actions, timers, etc.). (TODO: Not yet implemented)
 - Each component maps to a safe, well-defined operation in the Automation & Scripting Service.
-- The editor exports structured data—**not raw Lua or general-purpose code**—which the service compiles into execution units.
+- The editor exports structured data—**not raw Lua or general-purpose code**—which the service compiles into execution units. (TODO: Not yet implemented)
 - This approach prevents arbitrary behavior and limits scripts to the capabilities exposed by the platform.
 
 ## Supported Script Events
 
 Scripts may register handlers for a set of standard lifecycle events. The Automation & Scripting Service emits these events and queues them as commands so they run during the normal tick flow.
 
-- `onLoad` – when the script is first loaded or hot reloaded
-- `onSpawn` – when the associated entity enters the world
-- `onDeath` – when the entity dies
-- `onDestroy` – when the entity is permanently removed
-- `onEnterRegion` – when the entity moves into a new region
-- `onLeaveRegion` – when the entity leaves a region
-- `onTimerExpire` – when a scheduled timer finishes
-- `onCommand` – when a player targets the entity with a command
-- `onInterval` – periodic execution at a configured rate
+- `onLoad` – when the script is first loaded or hot reloaded (TODO: Not yet implemented)
+- `onSpawn` – when the associated entity enters the world (TODO: Not yet implemented)
+- `onDeath` – when the entity dies (TODO: Not yet implemented)
+- `onDestroy` – when the entity is permanently removed (TODO: Not yet implemented)
+- `onEnterRegion` – when the entity moves into a new region (TODO: Not yet implemented)
+- `onLeaveRegion` – when the entity leaves a region (TODO: Not yet implemented)
+- `onTimerExpire` – when a scheduled timer finishes (TODO: Not yet implemented)
+- `onCommand` – when a player targets the entity with a command (TODO: Not yet implemented)
+- `onInterval` – periodic execution at a configured rate (TODO: Not yet implemented)
 
 ## Advanced NPC Behavior Modules
 
@@ -40,9 +40,9 @@ Refer to the Automation & Scripting Service README for implementation details.
 
 ## 🔒 Sandboxing & Security
 
-- Script execution occurs in a **sandbox** with restricted APIs and resource limits.
+- Script execution occurs in a **sandbox** with restricted APIs and resource limits. (TODO: Not yet implemented)
 - Components interact with the **Game Logic Service** through validated gRPC calls.
-- The service enforces **per-script quotas** that limit how many events a script may enqueue and the duration of each tick. CPU and memory limits are planned for a future release.
+- The service enforces **per-script quotas** that limit how many events a script may enqueue and the duration of each tick. CPU and memory limits are planned for a future release. (TODO: Not yet implemented)
 
 ## ⚙️ Integration with Game Logic & Tick System
 
@@ -58,8 +58,8 @@ Refer to the Automation & Scripting Service README for implementation details.
 - Script definitions are stored in the **Game Design Service** and versioned alongside other game assets.
 - Designers can deploy updated scripts without redeploying code. The Automation & Scripting Service retrieves the current live versions as needed.
 - Script-only patches create a `scriptPatchVersion` tied to a `baseVersionId` so new behaviors can be loaded on the fly. See [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md#script-only-patch-versions) for how these patch versions work.
-- The Game Session Service tracks the active script version for each running game and sends a `NotifyScriptVersionUpdate` event when a new version should be loaded. The Automation & Scripting Service uses `ScriptVersionService` to reload the updated definitions without downtime.
-- Timer events and scheduled evaluations always reference the version pinned by the Game Session Service at the moment they run.
+- The Game Session Service tracks the active script version for each running game and sends a `NotifyScriptVersionUpdate` event when a new version should be loaded. The Automation & Scripting Service uses `ScriptVersionService` to reload the updated definitions without downtime. (TODO: Not yet implemented)
+- Timer events and scheduled evaluations always reference the version pinned by the Game Session Service at the moment they run. (TODO: Not yet implemented)
 - Older versions remain in the database for auditing or rollback, but only the pinned version is executed.
 
 ## 🛡️ Fairness & Abuse Prevention


### PR DESCRIPTION
## Summary
- clarify scripting architecture and identify features not yet implemented

## Testing
- `pre-commit run --files design/architecture/system-architecture-scripting.md` *(fails: lintMarkdown exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68774ee10e588330bf21ab76ba251461