### PR TITLE
docs: clarify secrets reload

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -18,6 +18,7 @@ This document explains how configuration values and sensitive secrets are suppli
 - The manifests in `k8s/base/` demonstrate loading these via `envFrom` so that services receive the same variables as in development.
 - Secrets are provisioned by **cert-manager** and rotated automatically. The
   sample `firemud-secret` Secret is defined in `k8s/base/firemud-db-env.yaml` and contains placeholder values only for local demos; production deployments must supply real credentials.
+- Services reload TLS certificates and JWT secrets at runtime when these Secrets update.
 - **Kubernetes Secrets** is the chosen mechanism for storing all sensitive
   credentials. External secret stores like Vault are not planned at this
   stage.


### PR DESCRIPTION
## Summary
- clarify that TLS certificates and JWT secrets reload automatically

## Testing
- `pre-commit run --files design/architecture/infrastructure/environment-and-secrets.md` *(failed: lintMarkdown)*
- `./gradlew lintMarkdown` *(failed: line length issues)*

------
https://chatgpt.com/codex/tasks/task_e_68774f7b97a4833096647b609f44ece0