### PR TITLE
Doc fix for backup recovery

### DIFF
--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -49,7 +49,7 @@ credentials:
 
 Run `dev-tools/setup-local-backup.sh` to deploy MinIO, create the `firemud-backups` bucket, and install Velero automatically. Keep `defaultVolumesToFsBackup` disabled to avoid saving PVC data.
 
-  - If the database service fails completely:
+- If the database service fails completely:
   1. Restore the most recent `pg_dump` file from the `firemud-pg-dumps` volume or object store.
   2. Restart services to resume operation.
   3. Redis repopulates transient state from PostgreSQL on access.


### PR DESCRIPTION
## Summary
- fix bullet list formatting in the backup and recovery doc

## Testing
- `./gradlew checkstyleMain`
- `pre-commit run --files design/architecture/system-architecture-backup-recovery.md` *(fails: Execution failed for task ':lintMarkdown')*

------
https://chatgpt.com/codex/tasks/task_e_6877559e80dc8330a69b79b2346c5f37