### PR TITLE
Fix ERD diagram path in migration docs

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -37,7 +37,7 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 - During deployment GitHub Actions builds the Docker image, pushes it, and Kubernetes restarts the service. Full automation of this step is still being developed (TODO: Not yet implemented).
 - On startup the container executes Flyway against its database schema before the Spring application fully starts.
 - The `dev-tools/generate-erd.sh` script uses Flyway to clean and migrate temporary databases when generating ERD diagrams.
-- Diagrams are written to `design/erd/` and uploaded as artifacts in CI.
+- Diagrams are written to `design/erd-diagrams/` and uploaded as artifacts in CI.
 
 Migrations are therefore applied consistently in every environment without manual steps.
 


### PR DESCRIPTION
## Summary
- clarify output directory for ERD diagrams

## Testing
- `pre-commit run --files design/architecture/system-architecture-database-migrations.md` *(fails: markdownlint task via gradle)*
- `./gradlew check` *(fails: lintMarkdown via npx)*

------
https://chatgpt.com/codex/tasks/task_e_687756267a588330b246b9bb651c4642