### PR TITLE
docs: clarify script hot deploy status

### DIFF
--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -56,7 +56,7 @@ Refer to the Automation & Scripting Service README for implementation details.
 ## 🔄 Deployment & Versioning
 
 - Script definitions are stored in the **Game Design Service** and versioned alongside other game assets.
-- Designers can deploy updated scripts without redeploying code. The Automation & Scripting Service retrieves the current live versions as needed.
+- Designers can deploy updated scripts without redeploying code. The Automation & Scripting Service retrieves the current live versions as needed. (TODO: Not yet implemented)
 - Script-only patches create a `scriptPatchVersion` tied to a `baseVersionId` so new behaviors can be loaded on the fly. See [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md#script-only-patch-versions) for how these patch versions work.
 - The Game Session Service tracks the active script version for each running game and sends a `NotifyScriptVersionUpdate` event when a new version should be loaded. The Automation & Scripting Service uses `ScriptVersionService` to reload the updated definitions without downtime. (TODO: Not yet implemented)
 - Timer events and scheduled evaluations always reference the version pinned by the Game Session Service at the moment they run. (TODO: Not yet implemented)


### PR DESCRIPTION
## Summary
- mark automation script hot deploy as not yet implemented

## Testing
- `./gradlew check` *(fails: Process 'command 'npx'' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_68775bf063c083309e016cd80b65d5b1