### PR TITLE
Update tracing architecture doc

### DIFF
--- a/design/architecture/system-architecture-tracing.md
+++ b/design/architecture/system-architecture-tracing.md
@@ -8,7 +8,8 @@ This document explains how distributed traces are collected and visualized acros
 
 All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK. A dedicated **OpenTelemetry Collector** runs inside the Kubernetes cluster to receive OTLP traffic and forward it to storage backends.
 
-- Deploy using the official [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) Helm chart or the sample manifest in `k8s/monitoring/otel-collector.yaml`.
+- Deploy using the official [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) Helm chart or apply the sample manifest in `k8s/monitoring/otel-collector.yaml` for local demos.
+- The collector runs as the `otel-collector` service inside the cluster so other pods can reach it via `http://otel-collector:4317`.
 - The collector exposes a `4317` gRPC endpoint. Services export spans to `http://otel-collector:4317` by default. The endpoint can be overridden via the `OTEL_ENDPOINT` environment variable (`otel.endpoint` property). See `.env.sample` and [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md) for defaults.
 
   ```bash


### PR DESCRIPTION
## Summary
- clarify default OTEL collector service and usage
- mark collector metrics and Jaeger retention as not yet implemented

## Testing
- `npx markdownlint-cli2 design/architecture/system-architecture-tracing.md`

------
https://chatgpt.com/codex/tasks/task_e_68775c80e064833085fd2bac0acbd0f6