### PR TITLE
Fix docs: versioning runtime clarifications

### DIFF
--- a/design/architecture/system-architecture-versioning-runtime.md
+++ b/design/architecture/system-architecture-versioning-runtime.md
@@ -12,8 +12,8 @@ The **Game Design Service** stores the authoritative game configuration (world l
 
 1. When a version is ready, creators trigger a **Publish** action in the Game Design Service.
 2. The service writes a new `version_id` and associated records to its database.
-3. Domain services (World Management, Entity Management, etc.) copy the relevant data into their own schemas using this `version_id`. Once copied, that data becomes read-only for the release so runtime services never pull directly from the design database. (TODO: Not yet implemented)
-4. A notification or message informs the Game Session Service that a new version exists. (TODO: Not yet implemented)
+3. Domain services (World Management, Entity Management, etc.) copy the relevant data into their own schemas using this `version_id`. Once copied, that data becomes read-only for the release so runtime services never pull directly from the design database. The copy workflow will use sagas to coordinate cross‑service updates. (TODO: Not yet implemented)
+4. A notification or message informs the Game Session Service that a new version exists so game instances can be restarted or patched. (TODO: Not yet implemented)
 
 Published versions are immutable; further changes require publishing a new `version_id`.
 
@@ -33,7 +33,8 @@ and a `scriptPatchVersion` value such as `v42-script.3`:
 ```
 
 Script-only versions appear in version history and audit logs but do not trigger
-a data copy or world restart. Runtime services reload the affected scripts in
+a data copy or world restart. (TODO: Not yet implemented)
+Runtime services reload the affected scripts in
 memory and continue using the underlying `baseVersionId` for all other assets.
 When a patch is published the Game Design Service calls the
 [`NotifyScriptVersionUpdate`](./microservices/automation-scripting-service/README.md#notifyscriptversionupdate)
@@ -75,7 +76,7 @@ They are **defined in the Game Design Service** and copied into the **Game Sessi
   (TODO: Not yet implemented)
 - The Game Session Service persists active flag values in its `feature_flag` table.
   Sessions use consistent configuration even after reconnects.
-  The Logging & Admin Service may store audit entries.
+  The Logging & Admin Service may store audit entries. (TODO: Not yet implemented)
   It is not the source of truth for runtime behavior.
 - During each tick cycle the active flags are applied before executing game logic.
   See [Tick System](./system-architecture-ticks.md) for details. (TODO: Not yet implemented)


### PR DESCRIPTION
## Summary
- clarify that version data copy uses sagas and still TODO
- mark audit logs and feature flag flows as not implemented

## Testing
- `./gradlew check` *(failed: Gradle check interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68775ce79c6c8330ae3c1b86f856cbe7