### PR TITLE
Update Redis doc for missing TODO

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -134,7 +134,7 @@ Redis **does not support cross-shard operations**. All tick locks, Lua scripts,
 and queued commands execute on a **single shard** aligned to the tick region.
 When an action crosses regional boundaries (for example a player moving between
 rooms on different shards) the Game Session Service decomposes the transition
-into **two sequential ticks**:
+into **two sequential ticks** (TODO: Not yet implemented):
 
 1. **Tick&nbsp;A** on _Shard&nbsp;X_ performs exit logic and clears local state.
 2. **Tick&nbsp;B** on _Shard&nbsp;Y_ applies entry logic and rebinds the


### PR DESCRIPTION
## Summary
- mark cross-region tick handoff as not yet implemented in Redis architecture doc

## Testing
- `pre-commit run --files design/architecture/system-architecture-redis.md` *(fails: Process 'npx' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687777f6c0488330923971775322b993