### PR TITLE
Update ability design tools doc

### DIFF
--- a/design/architecture/microservices/game-design-service/ability-action-tools.md
+++ b/design/architecture/microservices/game-design-service/ability-action-tools.md
@@ -1,10 +1,10 @@
 # Ability & Action Design Tools
 
-This document outlines the planned editors for defining abilities, actions and combat mechanics. The tooling is part of the Game Design Service and will push finalized data to the Game Logic Service during version publishing.
+This document outlines the planned editors for defining abilities, actions and combat mechanics. The tooling is part of the Game Design Service and will push finalized data to the Game Logic Service during version publishing. (TODO: Not yet implemented)
 
 > **Status: In Progress** – These tooling features are not yet implemented.
 
-Game creators will be able to build complex combat systems without modifying the core engine. All definitions are design-time data stored with a tenant so multiple games remain isolated.
+Game creators will be able to build complex combat systems without modifying the core engine. (TODO: Not yet implemented) All definitions are design-time data stored with a tenant so multiple games remain isolated.
 
 ## Capabilities
 


### PR DESCRIPTION
## Summary
- clarify that exporting ability data to the Game Logic Service is not yet implemented
- mark combat system editor as not yet implemented

## Testing
- `./gradlew lintMarkdown` *(fails: 22 markdownlint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68775e68d05483308bf76109d8dca171