### PR TITLE
Clarify item equipment balancing docs

### DIFF
--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -1,6 +1,6 @@
 # Item & Equipment Balancing Tools
 
-Game balance relies heavily on item statistics and equipment progression. This document describes helper tools for tuning those values.
+Game balance relies heavily on item statistics and equipment progression. This document describes helper tools for tuning those values. Balancing data follows the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. (TODO: Not yet implemented)
 
 > **Status: In Progress** – These balancing tools are still under development. (TODO: Not yet implemented)
 
@@ -12,9 +12,9 @@ Game balance relies heavily on item statistics and equipment progression. This d
 
 ## Workflow
 
-1. Items and equipment are defined through the Entity Designer.
-2. Balancing views aggregate stats and show graphs for cost vs. power.
-3. Finalized changes are published as part of a game version and copied to the Entity Management Service.
+1. Items and equipment are defined through the Entity Designer (see [World Editing & Customization Tools](world-editing-tools.md)).
+2. Balancing views aggregate stats and show graphs for cost vs. power. (TODO: Not yet implemented)
+3. Finalized changes are published as part of a game version and copied to the Entity Management Service. (TODO: Not yet implemented)
 
 ## 📚 Related Documentation
 


### PR DESCRIPTION
## Summary
- clarify revision workflow in the item & equipment balancing doc
- cross-link the Entity Designer doc
- mark workflow steps as not yet implemented

## Testing
- `./gradlew check` *(fails: lintMarkdown task)*

------
https://chatgpt.com/codex/tasks/task_e_68775e8aa7148330b62f23b9ed56a700