### PR TITLE
Fix reconnection note in TCP proxy docs

### DIFF
--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -41,7 +41,7 @@ An OpenAPI specification for these REST endpoints lives in `services/tcp-proxy-s
   using a lightweight frame protocol.
 - Incoming bytes are queued and forwarded to the gateway in order.
 - If the connection is lost, the queue is flushed and the session is marked for
-  possible reconnection.
+  possible reconnection. (TODO: Not yet implemented)
 
 ### Service Interactions
 


### PR DESCRIPTION
## Summary
- clarify that marking sessions for reconnection is not yet implemented

## Testing
- `./gradlew check` *(fails: lintMarkdown errors)*

------
https://chatgpt.com/codex/tasks/task_e_68775f5dfb2c8330a8cf7ff696daebe7