### PR TITLE
Refine playtesting feedback plan

### DIFF
--- a/design/project-management/playtesting-feedback.md
+++ b/design/project-management/playtesting-feedback.md
@@ -1,14 +1,16 @@
 # 🔄 Playtesting & Feedback Plan
 
-Early adopters can try new features in a short-lived staging environment
-created by the [`preview.yml`](../../.github/workflows/preview.yml) workflow.
-This environment is intended to mirror production but with smaller node sizes.
+Early adopters can try new features in short-lived environments created by the
+[`preview.yml`](../../.github/workflows/preview.yml) workflow. Pull requests
+spin up a Docker Compose stack that mirrors production services on a smaller
+scale. A dedicated staging cluster for broader playtests is planned; see
+[Deployment Environments](../architecture/infrastructure/deployment-environments.md#🎮-staging-environment-for-playtesting).
 (TODO: Not yet implemented)
 
 1. **Invite testers** from the community via Discord and email. (TODO: Not yet implemented)
 2. **Collect feedback** using a shared form linked in the web client. (TODO: Not yet implemented)
 3. **Review logs and metrics** in Grafana and Kibana to detect crashes or errors. See [Logging & Monitoring](../architecture/system-architecture-logging-monitoring.md) and [Analytics Dashboards](../architecture/microservices/logging-admin-service/analytics-dashboards.md). (TODO: Not yet implemented)
 4. **Iterate on the UI** based on usability issues reported by testers. (TODO: Not yet implemented)
+5. **Nightly resets** will clear test data from the staging cluster to keep environments clean. (TODO: Not yet implemented)
 
-The staging cluster resets nightly so broken worlds or accounts do not persist. (TODO: Not yet implemented)
 Feedback informs our UI/UX roadmap and upcoming releases.


### PR DESCRIPTION
## Summary
- refine intro paragraph for preview environment
- add nightly reset note
- link to deployment environment docs

## Testing
- `./gradlew check` *(fails: lintMarkdown via npx)*

------
https://chatgpt.com/codex/tasks/task_e_6877611c5f7c833083dc675bdc95d491