### PR TITLE
Fix customization docs

### DIFF
--- a/design/architecture/game-customization-options.md
+++ b/design/architecture/game-customization-options.md
@@ -19,7 +19,7 @@ This brief document summarizes the ways a hosted game can change its look and fe
 ## World Configuration
 
 - Game worlds are defined entirely through the Game Design Service. Creators can
-  add rooms, items and NPCs using the [world editing tools](./microservices/game-design-service/world-editing-tools.md) or by importing JSON files.
+  add rooms, items and NPCs using the [world editing tools](./microservices/game-design-service/world-editing-tools.md) or by importing JSON files. (TODO: Not yet implemented)
 - Additional design-time utilities like the [ability & action tools](./microservices/game-design-service/ability-action-tools.md) and [item & equipment balancing](./microservices/game-design-service/item-equipment-balancing.md) help tune gameplay without code changes. (TODO: Not yet implemented)
 - Published versions are stored per tenant so multiple games can coexist on the same infrastructure. Minor fixes can be rolled out as **script-only patch versions** linked to a `baseVersionId` so worlds do not need to restart. See [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md) for details.
 


### PR DESCRIPTION
## Summary
- mark world editing tools doc link as not yet implemented

## Testing
- `pre-commit run markdownlint --files design/architecture/game-customization-options.md` *(fails: markdownlint on unrelated docs)*

------
https://chatgpt.com/codex/tasks/task_e_687766cddef883308a94764a66623a25