### PR TITLE
Update authentication doc

### DIFF
--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -3,7 +3,7 @@
 This document describes how FireMUD authenticates clients, issues internal JWTs, manages session state, and enforces role-based access across services.
 
 Authentication is performed via plaintext `LOGIN` commands. Clients are stateless; session
-state is managed server-side in Redis and restored via the Game Session Service. The service
+state is managed server-side in Redis and restored via the Game Session Service (TODO: Not yet implemented). The service
 delegates credential verification to the Account Service's `/auth/login` endpoint.
 Accounts may
 also authenticate using linked external providers such as Google, Discord, or Steam. (TODO: Not
@@ -152,7 +152,7 @@ will be implemented in a future iteration. (TODO: Not yet implemented)
 | Auth Command          | `LOGIN` (or `LOGON`) — supports prompt or argument input         |
 | JWT Usage             | Internal-only for backend gRPC auth                             |
 | Claims                | `accountId`, `globalRoles[]`, `scopedRoles{}`                   |
-| Session State         | Stored in Redis; bound to socket by Game Session Service        |
+| Session State         | Stored in Redis; bound to socket by Game Session Service (TODO: Not yet implemented) |
 | Session TTL           | Controlled by `FIREMUD_AUTH_SESSION_EXPIRATION_MS`             |
 | Reauthentication      | Required after disconnect; resumes via Redis if valid (TODO: Not yet implemented) |
 | Role Enforcement      | Meta/control services only; gameplay services trust Game Session Service |


### PR DESCRIPTION
## Summary
- clarify that Redis session restoration is not yet implemented
- mark socket binding in summary table as pending

## Testing
- `./gradlew check --no-daemon` *(fails: Task :lintMarkdown FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_6877670498948330b021ba9bde778461