### PR TITLE
Update CI/CD docs

### DIFF
--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -18,7 +18,7 @@ This document describes the basic continuous integration and deployment strategy
 - **Create release PRs automatically** using the `release-please` workflow.
 - **Generate database ERD diagrams** as build artifacts after each run. The diagrams are stored in `design/erd-diagrams/` and uploaded as workflow artifacts.
 
-The CI job first performs a **Buf breaking change check** to ensure protobuf APIs remain compatible. It then runs formatting and lint steps followed by a matrix of Gradle `check` tasks—one per microservice—which compile and test each module while running Spotless, Checkstyle, and SpotBugs. **Hadolint** checks Dockerfiles and **ShellCheck** validates shell scripts. Coverage reports are generated with JaCoCo and a Trivy security scan runs on the workspace. Node 20 is also configured so the pipeline can lint OpenAPI definitions, run the React client’s linters, and execute an accessibility audit using headless Chrome. After the scan, the job executes `dev-tools/generate-erd.sh` to build ERD diagrams from the service migrations and uploads them as artifacts. A link check verifies all documentation links. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
+The CI job first performs a **Buf breaking change check** to ensure protobuf APIs remain compatible. It then runs formatting and lint steps followed by a matrix of Gradle `check` tasks—one per microservice—which compile and test each module while running Spotless, Checkstyle, and SpotBugs. **Hadolint** checks Dockerfiles and **ShellCheck** validates shell scripts. Coverage reports are generated with JaCoCo and a Trivy security scan runs on the workspace. Node 20 is also configured so the pipeline can lint OpenAPI definitions, run the React client’s linters, and execute an accessibility audit using headless Chrome. After the scan, the job executes `dev-tools/generate-erd.sh` to build ERD diagrams from the service migrations and uploads them as artifacts. Documentation links are verified in the `docs.yml` workflow before publishing to GitHub Pages. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
 
 ---
 
@@ -138,7 +138,8 @@ deploy:
 
 New service versions are deployed alongside existing ones. If issues appear after
 a rollout, prior releases can be reinstated and the newer copies scaled down or
-removed.
+removed. Automated rollback or canary deployments are planned but not yet
+implemented. (TODO: Not yet implemented)
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that link checks run via docs.yml
- note rollback automation is planned

## Testing
- `pre-commit run --files design/architecture/system-architecture-cicd.md` *(fails: lintMarkdown task)*

------
https://chatgpt.com/codex/tasks/task_e_68776728e13c833098b9a59a5c4eeb47