### PR TITLE
Fix database migration doc

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -21,8 +21,8 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 - Common tables shared by multiple services reside in the `common-library` module with its own migrations.
 - It contains saga table migrations described in [System Architecture – Transactions](./system-architecture-transactions.md).
 - Services that need these shared tables include the module as a dependency during their build.
-- The library packages its migrations inside the JAR, so Flyway automatically
-  picks them up from the classpath when the service starts.
+- The library packages its migrations inside the JAR so Flyway automatically
+  picks them up from the classpath when each service starts.
 - New migrations are committed alongside service code so history stays with the owning service.
 
 ## 🔄 CI/CD Execution
@@ -33,11 +33,14 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
   `./gradlew :account-service:flywayMigrate`).
 - You can also run `./gradlew :service:flywayInfo`, `flywayClean`, or `flywayRepair` to troubleshoot local databases. **Use `flywayClean` with caution** because it drops tables.
 - Run `./gradlew :service:flywayValidate` to verify migrations before committing.
+- The CI pipeline will eventually run `flywayValidate` for all services to catch
+  migration issues early. (TODO: Not yet implemented)
 - See [DEVELOPER_SETUP.md](../../DEVELOPER_SETUP.md) for the environment variables needed to connect to your local PostgreSQL instance. Copy the `FIREMUD_POSTGRES_*` values from `.env.sample` into `.env` so Flyway can connect locally.
 - During deployment GitHub Actions builds the Docker image, pushes it, and Kubernetes restarts the service. Full automation of this step is still being developed (TODO: Not yet implemented).
 - On startup the container executes Flyway against its database schema before the Spring application fully starts.
 - The `dev-tools/generate-erd.sh` script uses Flyway to clean and migrate temporary databases when generating ERD diagrams.
-- Diagrams are written to `design/erd-diagrams/` and uploaded as artifacts in CI.
+- Diagrams are written to `design/erd-diagrams/` and the CI job collects this
+  directory as an artifact.
 
 Migrations are therefore applied consistently in every environment without manual steps.
 


### PR DESCRIPTION
## Summary
- clarify how Flyway migrations from common-library are loaded
- note upcoming flywayValidate step in CI
- mention CI artifact path for ERD diagrams

## Testing
- `pre-commit run --files design/architecture/system-architecture-database-migrations.md` *(failed: lintMarkdown)*
- `./gradlew check` *(failed: lintMarkdown)*

------
https://chatgpt.com/codex/tasks/task_e_687767369030833092c080c8fc331fd6