### PR TITLE
Fix Redis doc TODO markers

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -106,9 +106,9 @@ Redis’s single-threaded model is extended using **Lua scripts** for atomic ope
 
 - Entity lock acquisition (`tick:lock:*`)
 - Tick staging, commit, and rollback (`tick:pending:*`)
-- Timer lifecycle management
-- Session rebinding and deduplication (`session:*` keys)
-- Retry queue updates
+- Timer lifecycle management (TODO: Not yet implemented)
+- Session rebinding and deduplication (`session:*` keys) (TODO: Not yet implemented)
+- Retry queue updates (TODO: Not yet implemented)
 
 All Lua scripts are:
 
@@ -238,10 +238,10 @@ configured in [Environment & Secrets](./infrastructure/environment-and-secrets.m
 
 This state is used by the **Game Session Service** to:
 
-- Resume gameplay after disconnects
-- Rebind gameplay context to a new socket
-- Deduplicate reconnect attempts
-- Handle character takeovers (one session per character)
+- Resume gameplay after disconnects (TODO: Not yet implemented)
+- Rebind gameplay context to a new socket (TODO: Not yet implemented)
+- Deduplicate reconnect attempts (TODO: Not yet implemented)
+- Handle character takeovers (one session per character) (TODO: Not yet implemented)
 
 > 🔐 Key formats are internal and subject to change. Services treat Redis as a coordination layer, not a persistent or public contract.
 


### PR DESCRIPTION
## Summary
- mark unimplemented Redis features as TODO

## Testing
- `./gradlew check` *(fails: lintMarkdown errors in unrelated docs)*

------
https://chatgpt.com/codex/tasks/task_e_68777af26348833099c71d44f49ee884