### PR TITLE
Fix asset storage docs

### DIFF
--- a/design/architecture/microservices/game-design-service/asset-storage.md
+++ b/design/architecture/microservices/game-design-service/asset-storage.md
@@ -20,7 +20,7 @@ An index named `idx_game_assets_tenant` speeds up queries scoped to a tenant.
 
 ## API
 
-Assets are uploaded via `POST /assets` and the saved record is returned as a `GameAssetDto`.
+Assets are uploaded via `POST /assets` and the saved record, including the binary `data` field, is returned as a `GameAssetDto`.
 See the [OpenAPI specification](../../../../services/game-design-service/src/main/resources/openapi.yaml) for request details.
 Endpoints for downloading or deleting assets are not provided yet. (TODO: Not yet implemented)
 
@@ -28,4 +28,4 @@ A basic repository and service persist uploads using Spring Data JPA.
 
 When a design version is published these asset records will be copied to runtime services along with other game data. (TODO: Not yet implemented)
 
-See [Game Design Service Architecture](../../../design/architecture/microservices/game-design-service/README.md) for how these assets fit into published versions.
+See [Game Design Service Architecture](README.md) for how these assets fit into published versions.

--- a/services/game-design-service/src/main/resources/openapi.yaml
+++ b/services/game-design-service/src/main/resources/openapi.yaml
@@ -44,6 +44,9 @@ components:
           type: string
         contentType:
           type: string
+        data:
+          type: string
+          format: byte
         createdAt:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- clarify asset upload response includes data field
- fix relative path to GDS README
- include data field in GameAssetDto schema

## Testing
- `pre-commit run --files services/game-design-service/src/main/resources/openapi.yaml design/architecture/microservices/game-design-service/asset-storage.md` *(fails: lintMarkdown)*
- `./gradlew check` *(fails: lintMarkdown)*

------
https://chatgpt.com/codex/tasks/task_e_68777ce5d7ac8330822f25145acee5cb