### PR TITLE
Improve asset-storage documentation

### DIFF
--- a/design/architecture/microservices/game-design-service/asset-storage.md
+++ b/design/architecture/microservices/game-design-service/asset-storage.md
@@ -15,6 +15,7 @@ The `game_assets` table stores the raw binary data. Columns include:
 - `created_at` – upload timestamp
 
 The `data` column uses PostgreSQL `BYTEA` type to store the file contents.
+When returned in JSON, this byte array is Base64 encoded by default.
 
 An index named `idx_game_assets_tenant` speeds up queries scoped to a tenant.
 
@@ -23,8 +24,9 @@ An index named `idx_game_assets_tenant` speeds up queries scoped to a tenant.
 Assets are uploaded via `POST /assets` and the saved record is returned as a `GameAssetDto`.
 See the [OpenAPI specification](../../../../services/game-design-service/src/main/resources/openapi.yaml) for request details.
 Endpoints for downloading or deleting assets are not provided yet. (TODO: Not yet implemented)
+There is also no gRPC endpoint for asset management at this time. (TODO: Not yet implemented)
 
-A basic repository and service persist uploads using Spring Data JPA.
+A basic repository (`GameAssetRepository`) and service implementation (`GameAssetServiceImpl`) persist uploads using Spring Data JPA.
 
 When a design version is published these asset records will be copied to runtime services along with other game data. (TODO: Not yet implemented)
 


### PR DESCRIPTION
## Summary
- clarify the Game Design Service asset-storage doc
- note missing gRPC APIs

## Testing
- `./gradlew check` *(fails: lintMarkdown)*

------
https://chatgpt.com/codex/tasks/task_e_68777ce5d7ac8330822f25145acee5cb