### PR TITLE
Improve item balance docs

### DIFF
--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -1,6 +1,6 @@
 # Item & Equipment Balancing Tools
 
-Game balance relies heavily on item statistics and equipment progression. This document describes helper tools for tuning those values. Balancing data follows the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. (TODO: Not yet implemented)
+Game balance relies heavily on item statistics and equipment progression. This document describes the planned tools for tuning those values. Balancing data will follow the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. See [Version Control for Design Assets](version-control.md) for more detail. (TODO: Not yet implemented)
 
 > **Status: In Progress** – These balancing tools are still under development. (TODO: Not yet implemented)
 
@@ -12,7 +12,7 @@ Game balance relies heavily on item statistics and equipment progression. This d
 
 ## Workflow
 
-1. Items and equipment are defined through the Entity Designer (see [World Editing & Customization Tools](world-editing-tools.md)).
+1. Items and equipment are defined through the Entity Designer (see [World Editing & Customization Tools](world-editing-tools.md)). (TODO: Not yet implemented)
 2. Balancing views aggregate stats and show graphs for cost vs. power. (TODO: Not yet implemented)
 3. Finalized changes are published as part of a game version and copied to the Entity Management Service. (TODO: Not yet implemented)
 
@@ -20,3 +20,4 @@ Game balance relies heavily on item statistics and equipment progression. This d
 
 - [Game Design Service Architecture](README.md)
 - [World Editing & Customization Tools](world-editing-tools.md)
+- [Version Control for Design Assets](version-control.md)


### PR DESCRIPTION
## Summary
- clarify item balancing doc and reference version control
- mark entity designer step as not yet implemented

## Testing
- `pre-commit run --all-files` *(fails: Cannot find package '@eslint/js')*
- `./gradlew check` *(fails: lintMarkdown failures)*

------
https://chatgpt.com/codex/tasks/task_e_68777dd66f4483309279ca7ee79c663a