### PR TITLE
docs: clarify world creation workflow

### DIFF
--- a/design/architecture/microservices/world-management-service/world-creation-workflow.md
+++ b/design/architecture/microservices/world-management-service/world-creation-workflow.md
@@ -1,20 +1,23 @@
 # World Creation Workflow
 
-World creation is a long running process that copies design data and prepares the
-initial world state for a new game instance. The workflow uses the shared
-**Saga** utilities from `firemud-common` so each step can be rolled back if
-another step fails. The process is triggered by `WorldCreationService` when a
-tenant launches a new game world. At the time of writing the service only
-inserts a starter region and schedules placeholder events; full data copy from
-the Game Design Service is still planned. (TODO: Not yet implemented)
+World creation is a long running process that will eventually copy design data
+and prepare the initial world state for a new game instance. The workflow uses
+the shared **Saga** utilities from `firemud-common` so each step can be rolled
+back if another step fails. The process is triggered by `WorldCreationService`
+when a tenant launches a new game world.
+
+Currently the implementation only inserts a starter region and schedules
+placeholder events; copying the full design from the Game Design Service has not
+been implemented. (TODO: Not yet implemented)
 
 ## Steps
 
 1. **Copy Design Data & Create Starter Region** – fetches the published version
    from the Game Design Service and inserts an initial region using the local
-   shard configuration (`WORLD_LOCAL_SHARD_ID`).
-   Additional regions will be added once more design data is available.
-   (TODO: Not yet implemented)
+   shard configuration (`WORLD_LOCAL_SHARD_ID`). The current code merely verifies
+   connectivity with the Game Design Service and inserts a single starter
+   region. Additional regions and full data copy will follow once more design
+   data is available. (TODO: Not yet implemented)
 2. **Schedule Initial Events** – inserts world events such as an initial
    weather state so `WorldEventService` can apply them after the world
    starts. (TODO: Not yet implemented)
@@ -34,7 +37,7 @@ new SagaBuilder()
 
 The saga state is stored in the `saga_instance` and `saga_step` tables defined
 in the common library. Operators can inspect progress through the Logging &
-Admin Service's saga dashboard.
+Admin Service's saga dashboard. (TODO: Not yet implemented)
 
 See [World Management Service](README.md) for additional service context.
 


### PR DESCRIPTION
## Summary
- refine world creation workflow doc
- note that design data and event scheduling are unimplemented
- mark saga dashboard as TODO

## Testing
- `./gradlew check` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687780b1ba8483309ae0fee838db74dc