### PR TITLE
Update database migrations doc

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -18,11 +18,16 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 
 - Every microservice maintains its own migration folder and changelog.
 - Schemas are isolated: services never modify each other's tables.
+- Tables currently reside in the `public` schema but will move to dedicated
+  schemas for each service for better isolation. See
+  [Multi-Tenancy](./system-architecture-multi-tenancy.md). (TODO: Not yet implemented)
 - Common tables shared by multiple services reside in the `common-library` module with its own migrations.
 - It contains saga table migrations described in [System Architecture – Transactions](./system-architecture-transactions.md).
 - Services that need these shared tables include the module as a dependency during their build.
 - The library packages its migrations inside the JAR so Flyway automatically
   picks them up from the classpath when each service starts.
+  The `common-library` itself does not run Flyway; consuming services execute
+  these migrations on startup.
 - New migrations are committed alongside service code so history stays with the owning service.
 
 ## 🔄 CI/CD Execution


### PR DESCRIPTION
## Summary
- note plans for per-service schemas and link to multi-tenancy doc
- clarify that common-library migrations run in consuming services

## Testing
- `pre-commit run --files design/architecture/system-architecture-database-migrations.md` *(fails: `buf`/`shellcheck`/`frontend-lint` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a02d1e1f88330baa4efea4f9d6fba