### PR TITLE
Improve gateway architecture doc

### DIFF
--- a/design/architecture/system-architecture-gateway.md
+++ b/design/architecture/system-architecture-gateway.md
@@ -31,7 +31,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 - Kubernetes DNS-based service names configured in the `prod` profile of
   `application.yml` (used in production)
 - Initial routes are loaded on startup from `routes-dev.yml` or `routes-prod.yml` via `spring.config.import`.
-- Initial route targets are fixed. Future versions will allow overrides using environment variables prefixed `FIREMUD_SERVICES_`, consistent with `ServiceEndpointsProperties`. See [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#service-discovery). (TODO: Not yet implemented)
+- Initial route targets are fixed. Future versions will allow per-service overrides using environment variables prefixed `FIREMUD_SERVICES_`, matching the `ServiceEndpointsProperties` approach used by other microservices. See [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#service-discovery). (TODO: Not yet implemented)
 
 ---
 
@@ -77,6 +77,7 @@ Spring Cloud Gateway provides centralized management of client traffic, offering
 - JWTs presented on admin or REST endpoints are validated by the consuming service. Gameplay clients do not provide tokens.
 - Cross-cutting filters (e.g., rate limiting, logging, CORS)
 - `application.yml` defines `RequestRateLimiter` and `Retry` filters that apply to every route by default.
+  - The rate limiter stores tokens in Redis; the gateway reads `FIREMUD_REDIS_HOST` and `FIREMUD_REDIS_PORT` for this connection.
 - Service isolation through route-based access control
 - Easy expansion of routes for new microservices
 - TLS termination and mTLS between services are described in [Security Architecture](../system-architecture-security.md).
@@ -89,7 +90,7 @@ add, update, or remove routes using either the REST API (`/routes`) or the
 restarting the service. See the
 [Spring Cloud Gateway microservice documentation](./microservices/spring-cloud-gateway/README.md#rest--grpc-endpoints)
 for example requests and supported fields. The gRPC interface is defined in [`gateway_management_service.proto`](../../protos/spring-cloud-gateway/v1/gateway_management_service.proto) and the REST schema in [`openapi.yaml`](../../services/spring-cloud-gateway/src/main/resources/openapi.yaml).
-Dynamic routes are stored only in memory; persistent storage is planned. (TODO: Not yet implemented)
+Dynamic routes are stored only in memory and are lost on service restart. A PostgreSQL `route_config` table exists for future persistence. (TODO: Not yet implemented)
 
 ## 📈 Observability
 


### PR DESCRIPTION
## Summary
- clarify role of Redis in rate limiting
- note dynamic route persistence via `route_config` table not yet implemented
- expand guidance on env var overrides for routes

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_687a03ae39a08330a81315a1ed6bb7ae