### PR TITLE
Update procedural generation design doc

### DIFF
--- a/design/architecture/system-architecture-procedural-generation.md
+++ b/design/architecture/system-architecture-procedural-generation.md
@@ -84,7 +84,7 @@ All generators emit a normalized structure:
 | `elevation`   | Numeric terrain height (used for visuals or logic) |
 | `regionId`    | Optional grouping for partitioned maps             |
 
-`spacingMultiplier` is stored on the containing region to adjust travel cost when rooms are sparse. (TODO: Not yet implemented)
+`spacingMultiplier` is stored on the containing region to adjust travel cost when rooms are sparse. The `TravelService` multiplies exit costs by this value when pathfinding so long treks across empty terrain feel slower.
 
 In **full-grid mode**, every terrain tile becomes a room.
 In **sparse mode**, only selected POIs and waypoints are emitted.
@@ -96,12 +96,12 @@ In **sparse mode**, only selected POIs and waypoints are emitted.
 The following rules align generators with the core runtime and tooling:
 
 1. **Solo Tick Scheduling** – Runtime generation is queued like any other command but includes `requiresSoloTick: true`. The Game Session Service executes it in an isolated tick with an extended 500&nbsp;ms budget.
-2. **Seed Metadata** – All requests specify a seed and the Automation & Scripting Service stores `seed`, `generatorType`, and raw params in the region metadata table for later inspection. (TODO: Not yet implemented)
+2. **Seed Metadata** – All requests specify a seed. During world creation these values are persisted by the World Management Service, while storing them for runtime generation is still pending. (TODO: Not yet implemented)
 3. **Sparse Traversal Rules** – Sparse rooms exist on the map. A `spacingMultiplier` value on each region influences movement cost and travel time between them. (TODO: Not yet implemented)
 4. **Post-generation Population** – After rooms are created, the Automation & Scripting Service triggers population scripts based on room tags, biome, and difficulty zone. Basic hooks exist but full script-driven population is pending. (TODO: Not yet implemented)
 5. **Validation and Errors** – Generators validate parameters. Room count checks are implemented, while biome compatibility and connectivity validation are pending (TODO: Not yet implemented). Failures return `GenerationErrorDetail` objects and are logged for observability.
 6. **Editor Overlays** – Generators emit coordinates and optional map layers so the Game Editor can display a preview or dry-run JSON output. (TODO: Not yet implemented)
-7. **Pluggable Interface** – Generators implement the `Generator` interface and are discovered via the `GeneratorRegistry` in the Automation & Scripting Service. Discovery currently relies on Spring bean scanning and may be extended for scripted or DSL-based generators. (TODO: Not yet implemented)
+7. **Pluggable Interface** – Generators implement the `Generator` interface and are discovered via the `GeneratorRegistry` in the Automation & Scripting Service. Discovery currently relies on Spring bean scanning. Support for scripted or DSL-based generators is planned. (TODO: Not yet implemented)
 
 Generation parameters can be tuned at runtime through the [Procedural Generation Rules API](./microservices/world-management-service/README.md#procedural-generation-rules-api). Administrators may adjust room density or terrain variation without redeploying the service. (TODO: Not yet implemented)
 


### PR DESCRIPTION
## Summary
- document TravelService usage of `spacingMultiplier`
- clarify seed metadata persistence
- tweak pluggable generator interface notes

## Testing
- `pre-commit run --files design/architecture/system-architecture-procedural-generation.md` *(failed: markdown lint task)*
- `./gradlew check -x test` *(failed: lintMarkdown task)*

------
https://chatgpt.com/codex/tasks/task_e_687a05aabf108330ba7bba9c758810ab