### PR TITLE
docs: clarify tracing architecture

### DIFF
--- a/design/architecture/system-architecture-tracing.md
+++ b/design/architecture/system-architecture-tracing.md
@@ -21,8 +21,16 @@ All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK
   on port `8888`. The example manifest does not currently expose this port, so
   the collector metrics are unavailable. (TODO: Not yet implemented)
 
-Every service relies on a shared `TracingConfig` in the `common-library`. This configuration sets the `service.name` resource from `spring.application.name`, uses a `BatchSpanProcessor`, and sends spans to the collector. `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` are registered in each `GrpcServerConfig` so requests are instrumented with logs, metrics, and spans consistently. See [Logging & Monitoring](./system-architecture-logging-monitoring.md) for additional observability details.
-`TracingInterceptor` opens a span for each gRPC method and marks it successful or cancelled when the call completes.
+Every service relies on a shared `TracingConfig` in the `common-library`. This
+configuration sets the `service.name` resource from `spring.application.name`,
+uses a `BatchSpanProcessor`, and sends spans to the collector. The
+`LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from the
+[Shared Libraries](./system-architecture-shared-libraries.md) are registered in
+each `GrpcServerConfig` so requests are instrumented with logs, metrics, and
+spans consistently. See
+[Logging & Monitoring](./system-architecture-logging-monitoring.md) for
+additional observability details. `TracingInterceptor` opens a span for each
+gRPC method and marks it successful or cancelled when the call completes.
 
 ## 🎛️ Jaeger UI
 


### PR DESCRIPTION
## Summary
- clarify docs about shared tracing interceptors
- link to shared libraries doc for context

## Testing
- `pre-commit run --files design/architecture/system-architecture-tracing.md` *(fails: lintMarkdown missing npx)*

------
https://chatgpt.com/codex/tasks/task_e_687a07410c0483308a4c11c30565aced