### PR TITLE
docs: clarify script patch handling

### DIFF
--- a/design/architecture/system-architecture-versioning-runtime.md
+++ b/design/architecture/system-architecture-versioning-runtime.md
@@ -33,7 +33,7 @@ and a `scriptPatchVersion` value such as `v42-script.3`:
 ```
 
 Script-only versions appear in version history and audit logs but do not trigger
-a data copy or world restart. (TODO: Not yet implemented)
+a data copy or world restart.
 Runtime services reload the affected scripts in
 memory and continue using the underlying `baseVersionId` for all other assets.
 When a patch is published the Game Design Service calls the


### PR DESCRIPTION
## Summary
- clarify that script-only versions already reload scripts and don't trigger a restart

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a07fb1030833087659d24f132de80