### PR TITLE
Add TODO follow-up tasks

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -11,6 +11,7 @@
   - [x] Use saga orchestrator for account creation workflow
   - [x] Implement self-service account recovery
   - [x] Add optional 2FA for admin and moderator roles
+  - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 - [x] **Develop Email & Notification System**
   - [x] Implement email verification & password resets
   - [x] Implement in-game notification system for events & messages

--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -15,6 +15,7 @@
   - [x] Provide web UI for script creation and testing
   - [x] Add advanced AI modules for complex behaviors
   - [x] Enforce fairness quotas and per-script resource limits
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-entity-management-service.md
+++ b/design/project-management/task-list-entity-management-service.md
@@ -9,6 +9,7 @@
   - [x] Implement cross-game account linking (allow single account across multiple hosted games)
   - [x] Implement entity graph caching for fast lookups
   - [x] Support complex crafting recipes
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -23,6 +23,8 @@
   - [x] Implement event-driven scripting API for game creators
   - [x] Implement in-game modding/plugin framework
   - [x] Implement scripted AI behaviors for NPCs
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+- [ ] Add MCP commands for room and item editing
 
 ## Versioning & Runtime Configuration
 

--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -8,6 +8,7 @@
   - [x] Implement action aliases system (custom command mappings)
   - [x] Add scripting hooks for custom actions
   - [x] Optimize performance for large-scale battles
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-game-session-service.md
+++ b/design/project-management/task-list-game-session-service.md
@@ -13,6 +13,7 @@
   - [x] Plan for cross-region sharding and session handoff
   - [x] Implement `game_manifest` table for version coordination
   - [x] Emit gameplay analytics for operators
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -14,6 +14,8 @@
 - [x] Integrate saga metrics and timeout recovery
 - [x] Use saga orchestrator for multi-service admin operations (bans, content revocation)
 - [x] Build role-based admin UI
+- [ ] Implement playtesting feedback form and store results for analytics
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -9,6 +9,7 @@
   - [x] Implement shared guild storage and alliance system
   - [x] Provide rich moderation tools for chat
   - [x] Add optional voice chat integration
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
   - [x] Use saga orchestrator for guild creation workflow
 
 ## Reusable Microservice Checklist

--- a/design/project-management/task-list-spring-cloud-gateway.md
+++ b/design/project-management/task-list-spring-cloud-gateway.md
@@ -11,6 +11,7 @@
   - [x] Allow creation of custom gateway routes via API
   - [x] Add gRPC `GatewayManagementService` for remote route configuration
 
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 ## Reusable Microservice Checklist
 
 These tasks apply to every FireMUD service unless noted otherwise. Gateway and

--- a/design/project-management/task-list-tcp-proxy-service.md
+++ b/design/project-management/task-list-tcp-proxy-service.md
@@ -9,6 +9,8 @@
   - [x] Enforce Telnet protocol command whitelist and input sanitization
   - [x] Implement connection throttling and rate limits
   - [x] Support TLS termination for secure Telnet clients
+- [ ] Support Mud Client Protocol (MCP) negotiation with clients
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -11,6 +11,7 @@
   - [x] Use saga orchestrator for world creation workflow
   - [x] Provide tools to fine-tune procedural generation rules
   - [x] Support multi-server world shards
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 


### PR DESCRIPTION
## Summary
- add TODO follow-ups in service task lists

## Testing
- `pre-commit run markdownlint --files design/project-management/task-list-account-service.md design/project-management/task-list-automation-scripting-service.md design/project-management/task-list-entity-management-service.md design/project-management/task-list-game-design-service.md design/project-management/task-list-game-logic-service.md design/project-management/task-list-game-session-service.md design/project-management/task-list-logging-admin-service.md design/project-management/task-list-social-groups-service.md design/project-management/task-list-spring-cloud-gateway.md design/project-management/task-list-tcp-proxy-service.md design/project-management/task-list-world-management-service.md`

------
https://chatgpt.com/codex/tasks/task_e_687a0ebfb7208330b0ecaff459eaad77