### PR TITLE
Update environment docs

### DIFF
--- a/design/architecture/infrastructure/environment-and-secrets.md
+++ b/design/architecture/infrastructure/environment-and-secrets.md
@@ -17,7 +17,7 @@ This document explains how configuration values and sensitive secrets are suppli
 - Sensitive values (database passwords, JWT keys, TLS certificates) are stored in Kubernetes `Secret` objects. JWT keys and TLS certificates are issued by **cert-manager**.
 - The manifests in `k8s/base/` demonstrate loading these via `envFrom` so that services receive the same variables as in development.
 - TLS certificates are provisioned by **cert-manager** and rotated automatically. Other secrets, such as database passwords, are stored in standard Kubernetes `Secret` objects and must be rotated manually. Automated database password rotation is planned. (TODO: Not yet implemented)
-- Services reload TLS certificates and JWT secrets at runtime when these Secrets update. gRPC server certificate hot reload will be added in a future release. (TODO: Not yet implemented)
+- Services reload TLS certificates for gRPC client channels and JWT secrets when these Secrets update. gRPC server certificate hot reload will be added in a future release. (TODO: Not yet implemented)
 - This live reload behavior relies on the `TlsCertificateWatcher` and `JwtSecretWatcher` utilities from the shared library. A `GrpcServerTlsReloader` exists for server certificates but is not currently wired into the services. (TODO: Not yet implemented)
 - **Kubernetes Secrets** is the chosen mechanism for storing all sensitive
   credentials. External secret stores like Vault are not planned at this
@@ -90,7 +90,7 @@ In Kubernetes deployments the certificates are mounted at `/tls`, and the
 environment variables point to that directory (for example,
 `FIREMUD_GRPC_CERT_CHAIN_PATH=/tls/client.crt`). Services watch these files for
 changes so new certificates are loaded without restarts via `TlsCertificateWatcher`. Certificate reload for
-gRPC servers will use `GrpcServerTlsReloader` but is not yet wired into the services. (TODO: Not yet implemented)
+gRPC servers will use `GrpcServerTlsReloader` but this integration is still pending. (TODO: Not yet implemented)
 See [System Architecture: Security](../system-architecture-security.md#key-and-certificate-rotation)
 for details on the hot reload mechanism.
 

--- a/design/architecture/system-architecture-grpc.md
+++ b/design/architecture/system-architecture-grpc.md
@@ -127,7 +127,7 @@ All internal gRPC calls use **mutual TLS**. Each service sets the following envi
 | `FIREMUD_GRPC_PRIVATE_KEY_PATH` | Path to the private key |
 | `FIREMUD_GRPC_CA_CERT_PATH` | CA bundle used to verify peers |
 
-The [Environment & Secrets](./infrastructure/environment-and-secrets.md#grpc-tls-certificates) guide describes how these values are provided. The shared library includes a [`GrpcServerTlsReloader`](./system-architecture-shared-libraries.md) component that hot reloads certificates when they change.
+The [Environment & Secrets](./infrastructure/environment-and-secrets.md#grpc-tls-certificates) guide describes how these values are provided. The shared library includes a `GrpcServerTlsReloader` component to hot reload server certificates, but services do not yet use it. (TODO: Not yet implemented)
 
 Adopting these conventions helps keep FireMUD services consistent and makes it easier for new contributors to work with the APIs. See [Security Architecture](./system-architecture-security.md#🤝-cross-service-trust) for mTLS design.
 


### PR DESCRIPTION
## Summary
- clarify which secrets reload at runtime
- mention that gRPC server certificate reload isn't used yet
- note same in gRPC design doc

## Testing
- `pre-commit run --files design/architecture/infrastructure/environment-and-secrets.md design/architecture/system-architecture-grpc.md` *(fails: markdownlint, buf lint, frontend-lint, shellcheck)*

------
https://chatgpt.com/codex/tasks/task_e_687a095e4d38833080d872ab26a4c3ed