### PR TITLE
Update game templates docs

### DIFF
--- a/design/architecture/microservices/game-design-service/game-templates.md
+++ b/design/architecture/microservices/game-design-service/game-templates.md
@@ -13,8 +13,9 @@ creators can quickly spin up new projects without starting from scratch.
   template. (TODO: Not yet implemented)
 - **Admin Accounts** – initial administrators configured at template creation. (TODO: Not yet implemented)
 
-`GameTemplateDto` contains `tenantId`, `name`, an optional `description`, the raw
-`config` JSON and a `createdAt` timestamp. The `config` field is currently
+`GameTemplateDto` includes `id`, `tenantId`, `name`, an optional `description`,
+the raw `config` JSON and a `createdAt` timestamp. The `id` is assigned by the
+database when the template is saved. The `config` field is currently
 free-form JSON. A structured schema describing world layout, starter items,
 default rulesets and admin accounts will be introduced in a future revision.
 (TODO: Not yet implemented)
@@ -36,6 +37,15 @@ curl -X POST http://localhost:8080/templates \
 The service validates the payload and stores it in the `game_templates` table.
 Templates can then be listed per `tenantId` to help bootstrap new games.
 Template names must be unique for each tenant to avoid collisions.
+
+To list templates:
+
+```bash
+curl "http://localhost:8080/templates?tenantId=1"
+```
+
+See [openapi.yaml](../../../../services/game-design-service/src/main/resources/openapi.yaml)
+for request and response schemas.
 
 Management currently exists only via REST. Use `POST /templates` to create templates and
 `GET /templates?tenantId=<id>` to list them. gRPC endpoints for creating,


### PR DESCRIPTION
## Summary
- clarify GameTemplateDto fields, note ID assignment
- add example template listing curl command
- link to OpenAPI schema for requests/responses

## Testing
- `./gradlew check` *(fails: lintMarkdown error)*

------
https://chatgpt.com/codex/tasks/task_e_687a0a5a6a508330b44349d8276a4ec7