### PR TITLE
Fix admin UI doc

### DIFF
--- a/design/architecture/microservices/logging-admin-service/admin-ui.md
+++ b/design/architecture/microservices/logging-admin-service/admin-ui.md
@@ -1,9 +1,11 @@
 # 🖥️ Role-Based Admin UI
 
 This document outlines the **planned** administration interface. There is
-currently no dedicated React application in the repository. Moderators and
-administrators will eventually interact with the service through a lightweight
-React interface. Credentials are exchanged with the Account Service, which issues
+currently no dedicated **admin** React application in the repository. The
+`web-client` module provides the main player-facing UI but does not expose the
+tools described here. Moderators and administrators will eventually interact
+with the service through a lightweight React interface. Credentials are
+exchanged with the Account Service, which issues
 JWTs for backend calls. These tokens remain server-side as described in
 [Authentication & Authorization](../../system-architecture-authentication.md),
 and permissions are enforced using the `globalRoles` and `scopedRoles` claims.
@@ -19,8 +21,7 @@ and permissions are enforced using the `globalRoles` and `scopedRoles` claims.
 
 These capabilities map to existing REST endpoints such as `/logs`, `/reports`,
 `/moderation/actions`, `/feature-flags/toggle`, and `/sagas`. The backend
-implementations are present, but no user interface consumes them yet. (TODO: Not
-yet implemented)
+implementations are present, but no admin user interface consumes them yet. (TODO: Not yet implemented)
 
 The UI will be packaged as a separate web module served by the Logging & Admin Service. Styling relies on Material‑UI components, and all API calls will be protected by the existing security interceptors described in the [Logging & Admin Service design](./README.md). (TODO: Not yet implemented)
 


### PR DESCRIPTION
## Summary
- clarify that only a player-facing React module exists
- note no admin UI consumes the available REST APIs yet

## Testing
- `./gradlew check` *(fails: lintMarkdown)*

------
https://chatgpt.com/codex/tasks/task_e_687a0b1a13a883309e40851d3d1ccf17