### PR TITLE
Add TODO tracking tasks for assets and world service

### DIFF
--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -19,6 +19,9 @@
   - [x] Configure database storage for game assets
     - [x] Provide asset upload API in Game Design Service
     - [x] Document asset storage setup and configuration
+    - [ ] Provide asset download and delete APIs
+    - [ ] Add gRPC endpoints for asset management
+    - [ ] Copy assets to runtime services when publishing versions
 - [x] **Expand Scripting & Modding**
   - [x] Implement event-driven scripting API for game creators
   - [x] Implement in-game modding/plugin framework

--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -11,6 +11,10 @@
   - [x] Use saga orchestrator for world creation workflow
   - [x] Provide tools to fine-tune procedural generation rules
   - [x] Support multi-server world shards
+  - [ ] Publish world change events to Game Session and Automation services
+  - [ ] Expose gRPC API for pathfinding queries
+  - [ ] Track character locations in a `character_location` table
+  - [ ] Implement chunk-based world snapshots for backups and recovery
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist


### PR DESCRIPTION
## Summary
- add missing tasks for download/delete asset APIs, gRPC endpoints, and asset publishing
- add missing tasks for world change events, pathfinding API, character locations, and snapshots

## Testing
- `./gradlew check` *(fails: ScriptVersionServiceImpl formatting, markdown lint)*

------
https://chatgpt.com/codex/tasks/task_e_687a159b56b883309aa28644a3a08298