### PR TITLE
docs: update customization guide

### DIFF
--- a/design/architecture/game-customization-options.md
+++ b/design/architecture/game-customization-options.md
@@ -27,7 +27,7 @@ This brief document summarizes the ways a hosted game can change its look and fe
 
 - Custom scripts drive dynamic events and NPC behaviour. (TODO: Not yet implemented)
 - The planned [modding framework](./microservices/game-design-service/modding-framework.md) will allow runtime plugins for additional behavior. (TODO: Not yet implemented)
-- Scripts are versioned alongside other game data and can be hot reloaded by the Automation & Scripting Service. Designers may publish a `scriptPatchVersion` like `v42-script.3` to update automation without republishing all assets. (TODO: Not yet implemented)
+- Scripts are versioned alongside other game data and can be hot reloaded by the [Automation & Scripting Service](./microservices/automation-scripting-service/README.md). Designers may publish a `scriptPatchVersion` like `v42-script.3` to update automation without republishing all assets. (TODO: Not yet implemented)
 
 ## Runtime Settings
 
@@ -36,7 +36,7 @@ This brief document summarizes the ways a hosted game can change its look and fe
   [Multi-Tenancy](./system-architecture-multi-tenancy.md)).
   Per-tenant tick intervals are planned. (TODO: Not yet implemented)
 - Flags are defined in the Game Design Service but toggled through the [Logging & Admin Service](./microservices/logging-admin-service/README.md). (TODO: Not yet implemented)
-- The Game Session Service loads these settings at runtime so changes can take effect without republishing. (TODO: Not yet implemented)
+- The [Game Session Service](./microservices/game-session-service/README.md) loads these settings at runtime so changes can take effect without republishing. (TODO: Not yet implemented)
 
 These options allow extensive personalization while keeping the underlying platform maintainable.
 


### PR DESCRIPTION
## Summary
- clarify how scripts are reloaded by linking to the Automation & Scripting Service
- link to the Game Session Service for runtime settings info

## Testing
- `pre-commit run --files design/architecture/game-customization-options.md` *(fails: Spotless task fails during Gradle build)*
- `./gradlew check` *(fails: SpotBugs violation)*

------
https://chatgpt.com/codex/tasks/task_e_687a0e0082048330811d68f9a1e9a2e4