### PR TITLE
Improve gateway doc

### DIFF
--- a/design/architecture/system-architecture-gateway.md
+++ b/design/architecture/system-architecture-gateway.md
@@ -14,9 +14,10 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
+- Auto‑scaling policies for high concurrency are planned. (TODO: Not yet implemented)
 - Telnet clients keep a **persistent TCP connection** to the TCP Proxy Service; the Gateway
   itself does not hold session state between reconnects
-- Gateway restarts are expected to automatically re-establish WebSocket connections to backend services. (TODO: Not yet implemented)
+- Gateway restarts are expected to automatically re-establish WebSocket connections to backend services. See [Reconnection Strategy](../system-architecture-reconnection.md). (TODO: Not yet implemented)
 - The Gateway and TCP Proxy Service run in the **network DMZ** and are the only ingress points for clients. NetworkPolicies restrict direct access to internal services. See [Security Architecture](../system-architecture-security.md#🌐-network-security--boundary-design) for details.
 
 > **Important:**
@@ -90,7 +91,7 @@ add, update, or remove routes using either the REST API (`/routes`) or the
 restarting the service. See the
 [Spring Cloud Gateway microservice documentation](./microservices/spring-cloud-gateway/README.md#rest--grpc-endpoints)
 for example requests and supported fields. The gRPC interface is defined in [`gateway_management_service.proto`](../../protos/spring-cloud-gateway/v1/gateway_management_service.proto) and the REST schema in [`openapi.yaml`](../../services/spring-cloud-gateway/src/main/resources/openapi.yaml).
-Dynamic routes are stored only in memory and are lost on service restart. A PostgreSQL `route_config` table exists for future persistence. (TODO: Not yet implemented)
+Dynamic routes are stored only in memory and are lost on service restart. A PostgreSQL `route_config` table exists but is not yet used for persistence. (TODO: Not yet implemented)
 
 ## 📈 Observability
 


### PR DESCRIPTION
## Summary
- add reconnection doc link and auto-scaling note
- clarify future route persistence

## Testing
- `./gradlew check` *(fails: spotless violation in ScriptVersionServiceImpl.java)*

------
https://chatgpt.com/codex/tasks/task_e_687a102ee2a883308ec85b7098cf7972