### PR TITLE
Clarify protocol bridging TODO markers

### DIFF
--- a/design/architecture/system-architecture-protocol-bridging.md
+++ b/design/architecture/system-architecture-protocol-bridging.md
@@ -64,10 +64,10 @@ Despite their differences, both protocols are normalized into the same internal 
     the TCP connection drops.
   - Telnet clients keep a sticky connection to the TCP Proxy Service; reconnection and
     session recovery are handled as described in
-    [Reconnection Strategy](./system-architecture-reconnection.md) _(TODO: Not yet implemented)_.
+    [Reconnection Strategy](./system-architecture-reconnection.md) (TODO: Not yet implemented).
   - Disconnect handling is **layered**: the proxy cleans up Telnet sessions,
-    the gateway automatically recreates WebSocket backends _(TODO: Not yet implemented)_, and the Game Session
-    Service reloads state from Redis _(TODO: Not yet implemented)_.
+    the gateway automatically recreates WebSocket backends (TODO: Not yet implemented), and the Game Session
+    Service reloads state from Redis (TODO: Not yet implemented).
   - The proxy defines gRPC events `NotifyDisconnect` and `PushBufferedInput` so
     the Game Session Service can recover Telnet sessions. These stubs currently
     only log when called. (TODO: Not yet implemented)
@@ -89,7 +89,7 @@ The `game-session-service` is the central component responsible for:
 - Maintaining game session state per client connection.
 - Handling command parsing and game world interaction.
 - Sending and receiving text streams in a line-based protocol format.
-- Managing disconnects, reconnections, and session cleanup _(TODO: Not yet implemented)_.
+- Managing disconnects, reconnections, and session cleanup (TODO: Not yet implemented).
 
 > Whether a client is connected via WebSocket directly or tunneled through the TCP Proxy Service, the backend **treats all sessions the same**.
 


### PR DESCRIPTION
## Summary
- document bridging of telnet and websocket clients
- mark reconnect and cleanup features as not yet implemented

## Testing
- `pre-commit run --files design/architecture/system-architecture-protocol-bridging.md` *(fails: Spotless, compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a110296e083308f8fcd2ae618cc57