### PR TITLE
Update reconnection strategy doc

### DIFF
--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -42,7 +42,7 @@ TCP Proxy restarts drop Telnet clients.
 
 ### Game Session Service
 
-- Uses Redis to store and recover session state, including command queues, tick participation, cooldowns, and retry info (TODO: Not yet implemented)
+- Uses Redis to store session state such as command queues, tick participation, cooldowns, and retry info. Reconnect logic will restore these details. (TODO: Not yet implemented)
 - On reconnect, rebinds:
   - Socket connection (TODO: Not yet implemented)
   - Tick region context (TODO: Not yet implemented)


### PR DESCRIPTION
## Summary
- clarify that Game Session Service stores session state now but reconnection restore logic is pending

## Testing
- `pre-commit run --all-files` *(fails: buf lint missing STANDARD category)*

------
https://chatgpt.com/codex/tasks/task_e_687a1118aef483309b948f1013f9752c