### PR TITLE
Organize service task lists

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -1,37 +1,39 @@
 # Account Service Task List
 
-- [x] **Develop Account Service**
-  - [x] Implement user registration and authentication (OAuth2, JWT)
-  - [x] Implement session management and persistent logins
-  - [x] Implement role-based access control (RBAC) for admins, moderators, and players
-  - [x] Enable external account linking (Google, Discord, Steam)
-  - [x] Implement profile system with achievements, game history, and social features
-  - [x] Implement player data export & deletion (GDPR compliance)
-  - [x] Expose JWKS endpoint for token verification
-  - [x] Use saga orchestrator for account creation workflow
-  - [x] Implement self-service account recovery
-  - [x] Add optional 2FA for admin and moderator roles
-  - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
-- [x] **Develop Email & Notification System**
-  - [x] Implement email verification & password resets
-  - [x] Implement in-game notification system for events & messages
-  - [x] Configure SMTP provider and test templates
-  - [x] Document email and notification design in `account-service/design/README.md`
-  - [x] Add asynchronous NotificationService components with gRPC endpoints
-- [x] **Develop Monetization & Payment Module**
-  - [x] Integrate Stripe or similar for in-game purchases
-  - [x] Support subscriptions, one-time purchases, and donations
-  - [x] Enforce platform fee on transactions
-  - [x] Implement refund & chargeback handling
-  - [x] Use saga orchestrator for cross-service purchase workflows
-  - [x] Create `payment_transaction` and `subscription` entities in the Account Service
-  - [x] Add gRPC methods in `AccountService` for payments
-  - [x] Define proto contracts for payment and subscription flows in the account proto namespace
-  - [x] Add Flyway migration scripts for payment tables
-  - [x] Document monetization design in `account-service/design/README.md`
-  - [x] Implement virtual currency system (game-specific currencies)
-  - [x] Implement premium hosting tiers & features for game creators
-  - [x] Implement revenue-sharing system for game creators
+## Account Management
+- [x] Implement user registration and authentication (OAuth2, JWT)
+- [x] Implement session management and persistent logins
+- [x] Implement role-based access control (RBAC) for admins, moderators, and players
+- [x] Enable external account linking (Google, Discord, Steam)
+- [x] Implement profile system with achievements, game history, and social features
+- [x] Implement player data export & deletion (GDPR compliance)
+- [x] Expose JWKS endpoint for token verification
+- [x] Use saga orchestrator for account creation workflow
+- [x] Implement self-service account recovery
+- [x] Add optional 2FA for admin and moderator roles
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+
+## Email & Notification System
+- [x] Implement email verification & password resets
+- [x] Implement in-game notification system for events & messages
+- [x] Configure SMTP provider and test templates
+- [x] Document email and notification design in `account-service/design/README.md`
+- [x] Add asynchronous NotificationService components with gRPC endpoints
+
+## Monetization & Payment Module
+- [x] Integrate Stripe or similar for in-game purchases
+- [x] Support subscriptions, one-time purchases, and donations
+- [x] Enforce platform fee on transactions
+- [x] Implement refund & chargeback handling
+- [x] Use saga orchestrator for cross-service purchase workflows
+- [x] Create `payment_transaction` and `subscription` entities in the Account Service
+- [x] Add gRPC methods in `AccountService` for payments
+- [x] Define proto contracts for payment and subscription flows in the account proto namespace
+- [x] Add Flyway migration scripts for payment tables
+- [x] Document monetization design in `account-service/design/README.md`
+- [x] Implement virtual currency system (game-specific currencies)
+- [x] Implement premium hosting tiers & features for game creators
+- [x] Implement revenue-sharing system for game creators
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-automation-scripting-service.md
+++ b/design/project-management/task-list-automation-scripting-service.md
@@ -1,25 +1,31 @@
 # Automation & Scripting Service Task List
 
-- [x] **Develop Automation & Scripting Service**
-  - [x] Implement state-driven & event-driven NPC behaviors *(see [System Architecture: Scripting](../architecture/system-architecture-scripting.md))*
-  - [x] Implement procedural world generation
-  - [x] Implement scripted events for game mechanics and NPC interactions *(see [Automation & Scripting Service Design](../architecture/microservices/automation-scripting-service/README.md))*
-  - [x] Implement AI memory & dynamic NPC behaviors (NPCs remember past player interactions) *(see [Automation & Scripting Service Design](../architecture/microservices/automation-scripting-service/README.md))*
-  - [x] Implement player vs. environment (PvE) mechanics (random encounters, environmental hazards)
-  - [x] Implement faction & reputation system (players gain faction reputation over time)
-  - [x] Implement NPC aggression states (hostile, neutral, passive)
-  - [x] Implement NPC fleeing/surrender logic
-  - [x] Implement NPC formations & squad AI
-  - [x] Create sandboxed script runtime *(see [Scripting & Automation Framework](../architecture/system-architecture-scripting.md))*
-  - [x] Support hot reloading of scripts published by the Game Design Service *(see [Automation & Scripting Service Design](../architecture/microservices/automation-scripting-service/README.md))*
-  - [x] Provide web UI for script creation and testing
-  - [x] Add advanced AI modules for complex behaviors
-  - [ ] Copy published version data into scripting schema via Saga
-  - [x] Enforce fairness quotas and per-script resource limits
-  - [ ] Implement OverworldMapGenerator for biome-based terrain
-  - [ ] Support runtime generation requests via isolated ticks
-  - [ ] Persist generation seed metadata and spacing rules
-  - [ ] Trigger script-driven population after generation
+## Scripting Framework
+- [x] Create sandboxed script runtime *(see [Scripting & Automation Framework](../architecture/system-architecture-scripting.md))*
+- [x] Support hot reloading of scripts published by the Game Design Service *(see [Automation & Scripting Service Design](../architecture/microservices/automation-scripting-service/README.md))*
+- [x] Provide web UI for script creation and testing
+- [x] Add advanced AI modules for complex behaviors
+- [ ] Copy published version data into scripting schema via Saga
+- [x] Enforce fairness quotas and per-script resource limits
+- [ ] Support runtime generation requests via isolated ticks
+- [ ] Persist generation seed metadata and spacing rules
+- [ ] Trigger script-driven population after generation
+
+## NPC & AI Behavior
+- [x] Implement state-driven & event-driven NPC behaviors *(see [System Architecture: Scripting](../architecture/system-architecture-scripting.md))*
+- [x] Implement AI memory & dynamic NPC behaviors (NPCs remember past player interactions) *(see [Automation & Scripting Service Design](../architecture/microservices/automation-scripting-service/README.md))*
+- [x] Implement player vs. environment (PvE) mechanics (random encounters, environmental hazards)
+- [x] Implement faction & reputation system (players gain faction reputation over time)
+- [x] Implement NPC aggression states (hostile, neutral, passive)
+- [x] Implement NPC fleeing/surrender logic
+- [x] Implement NPC formations & squad AI
+- [x] Implement scripted events for game mechanics and NPC interactions *(see [Automation & Scripting Service Design](../architecture/microservices/automation-scripting-service/README.md))*
+
+## World Generation
+- [x] Implement procedural world generation
+- [ ] Implement OverworldMapGenerator for biome-based terrain
+
+## Security & Operations
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist

--- a/design/project-management/task-list-entity-management-service.md
+++ b/design/project-management/task-list-entity-management-service.md
@@ -1,15 +1,21 @@
 # Entity Management Service Task List
 
-- [x] **Develop Entity Management Service**
-  - [x] Implement player character storage
-  - [x] Implement NPC storage and data structures
-  - [x] Implement item and inventory management
-  - [x] Implement entity stats and progression tracking
-  - [x] Implement NPC respawn rules and timing
-  - [x] Implement cross-game account linking (allow single account across multiple hosted games)
-  - [x] Implement entity graph caching for fast lookups
-  - [x] Support complex crafting recipes
-  - [ ] Copy published version data into entity schema via Saga
+## Entity Storage
+- [x] Implement player character storage
+- [x] Implement NPC storage and data structures
+- [x] Implement item and inventory management
+- [x] Implement entity stats and progression tracking
+- [x] Implement NPC respawn rules and timing
+
+## Shared Account & Crafting
+- [x] Implement cross-game account linking (allow single account across multiple hosted games)
+- [x] Support complex crafting recipes
+
+## Performance & Data Sync
+- [x] Implement entity graph caching for fast lookups
+- [ ] Copy published version data into entity schema via Saga
+
+## Security & Operations
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist

--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -1,34 +1,38 @@
 # Game Design Service Task List
 
-- [x] **Expand Game Design Service**
-  - [x] Provide game templates and configuration tools
-  - [x] Enable publishing of game versions
-  - [x] Use saga orchestrator for game publishing workflow
-  - [x] Ensure domain services copy data by `version_id` and never query the design database at runtime
-  - [x] Create design-time database models
-- [x] **Develop Game Design Service**
-  - [x] Implement world editing & customization tools
-  - [x] Implement scripting & event design tools
-  - [x] Build a **visual scripting editor** using a **component-based DSL**
-  - [x] Sandbox script execution with quotas via the Automation & Scripting Service
-  - [x] Implement ability & action design tools
-  - [x] Implement item & equipment balancing tools
-  - [x] Track version history and patch notes for published games
-  - [x] Build a web-based visual design interface
-  - [x] Integrate version control for design assets
-  - [x] Configure database storage for game assets
-    - [x] Provide asset upload API in Game Design Service
-    - [x] Document asset storage setup and configuration
-    - [ ] Provide asset download and delete APIs
-    - [ ] Add gRPC endpoints for asset management
-    - [ ] Copy assets to runtime services when publishing versions
-- [x] **Expand Scripting & Modding**
-  - [x] Implement event-driven scripting API for game creators
-  - [x] Implement in-game modding/plugin framework
-  - [x] Implement scripted AI behaviors for NPCs
-  - [ ] Notify downstream services when new versions are published
-  - [ ] Add import/export of design assets for sharing between games
-  - [ ] Add `owner_id` association to games and API
+## Game Templates & Publishing
+- [x] Provide game templates and configuration tools
+- [x] Enable publishing of game versions
+- [x] Use saga orchestrator for game publishing workflow
+- [x] Ensure domain services copy data by `version_id` and never query the design database at runtime
+- [x] Create design-time database models
+
+## Design Tools
+- [x] Implement world editing & customization tools
+- [x] Implement scripting & event design tools
+- [x] Build a **visual scripting editor** using a **component-based DSL**
+- [x] Sandbox script execution with quotas via the Automation & Scripting Service
+- [x] Implement ability & action design tools
+- [x] Implement item & equipment balancing tools
+- [x] Track version history and patch notes for published games
+- [x] Build a web-based visual design interface
+- [x] Integrate version control for design assets
+- [x] Configure database storage for game assets
+  - [x] Provide asset upload API in Game Design Service
+  - [x] Document asset storage setup and configuration
+  - [ ] Provide asset download and delete APIs
+  - [ ] Add gRPC endpoints for asset management
+  - [ ] Copy assets to runtime services when publishing versions
+
+## Scripting & Modding
+- [x] Implement event-driven scripting API for game creators
+- [x] Implement in-game modding/plugin framework
+- [x] Implement scripted AI behaviors for NPCs
+- [ ] Notify downstream services when new versions are published
+- [ ] Add import/export of design assets for sharing between games
+- [ ] Add `owner_id` association to games and API
+
+## Admin & Security
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 - [ ] Add MCP commands for room and item editing
 

--- a/design/project-management/task-list-game-logic-service.md
+++ b/design/project-management/task-list-game-logic-service.md
@@ -1,14 +1,20 @@
 # Game Logic Service Task List
 
-- [x] **Develop Game Logic Service**
-  - [x] Implement command parsing & validation
-  - [x] Implement action processing (movement, interactions, combat)
-  - [x] Implement roleplay actions & emotes
-  - [x] Implement event-driven logic processing (triggers, world events)
-  - [x] Implement action aliases system (custom command mappings)
-  - [x] Add scripting hooks for custom actions
-  - [x] Optimize performance for large-scale battles
-  - [ ] Copy published version data into logic schema via Saga
+## Command & Action Processing
+- [x] Implement command parsing & validation
+- [x] Implement action processing (movement, interactions, combat)
+- [x] Implement action aliases system (custom command mappings)
+- [x] Add scripting hooks for custom actions
+
+## Roleplay & Events
+- [x] Implement roleplay actions & emotes
+- [x] Implement event-driven logic processing (triggers, world events)
+
+## Performance & Data
+- [x] Optimize performance for large-scale battles
+- [ ] Copy published version data into logic schema via Saga
+
+## Security & Operations
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist

--- a/design/project-management/task-list-game-session-service.md
+++ b/design/project-management/task-list-game-session-service.md
@@ -1,23 +1,29 @@
 # Game Session Service Task List
 
-- [x] **Expand Game Session Service**
-  - [x] Implement game instance lifecycle (start, stop, restart)
-  - [x] Support multi-tenancy for hosted games
-  - [x] Implement tick orchestration using Redis for command queues
-  - [x] Implement Lua-based staging, commit, and rollback scripts for tick transactions
-  - [x] Implement distributed lock acquisition in Redis for tick updates
-  - [x] Implement tick replay and crash recovery logic
-  - [x] Persist session state in Redis for reconnect recovery
-  - [x] Enforce single-session control per character (session takeover on new login)
-  - [x] Manage runtime feature flags and expose toggle API via Logging & Admin Service ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
-  - [x] Plan for cross-region sharding and session handoff
-  - [x] Implement `game_manifest` table for version coordination
-  - [x] Emit gameplay analytics for operators
-  - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
-  - [ ] Track login attempts per IP and temporarily blacklist repeated failures
-  - [ ] Send notification emails for suspicious login activity
-  - [ ] Detect command spam or abnormal tick patterns using abuse heuristics
-  - [ ] Implement graceful degradation when Redis operations stall to avoid gameplay interruption
+## Session Lifecycle
+- [x] Implement game instance lifecycle (start, stop, restart)
+- [x] Support multi-tenancy for hosted games
+- [x] Persist session state in Redis for reconnect recovery
+- [x] Enforce single-session control per character (session takeover on new login)
+- [x] Plan for cross-region sharding and session handoff
+
+## Tick Management
+- [x] Implement tick orchestration using Redis for command queues
+- [x] Implement Lua-based staging, commit, and rollback scripts for tick transactions
+- [x] Implement distributed lock acquisition in Redis for tick updates
+- [x] Implement tick replay and crash recovery logic
+- [ ] Implement graceful degradation when Redis operations stall to avoid gameplay interruption
+
+## Analytics & Coordination
+- [x] Manage runtime feature flags and expose toggle API via Logging & Admin Service ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
+- [x] Implement `game_manifest` table for version coordination
+- [x] Emit gameplay analytics for operators
+
+## Security
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+- [ ] Track login attempts per IP and temporarily blacklist repeated failures
+- [ ] Send notification emails for suspicious login activity
+- [ ] Detect command spam or abnormal tick patterns using abuse heuristics
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -1,24 +1,32 @@
 # Logging & Admin Service Task List
 
-- [x] **Develop Logging & Admin Service**
+## Logging & Monitoring
 - [x] Collect logs from all services and provide search dashboards
+- [x] Deploy Fluent Bit sidecars to forward logs to Elasticsearch
+- [x] Integrate Alertmanager for automated alerts
+- [x] Provide analytics dashboards for operators
+- [x] Evaluate adopting a zero-trust network model for internal traffic
+
+## Moderation Tools
 - [x] Allow players to report others for abuse/violations
 - [x] Store logs for admin moderation and auditing
-- [x] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
-  - [x] Provide analytics dashboards for operators
-  - [x] Define moderation policies including profanity filters
-- [x] Integrate Alertmanager for automated alerts
-- [x] Deploy Fluent Bit sidecars to forward logs to Elasticsearch
-- [x] Evaluate adopting a zero-trust network model for internal traffic
-- [x] Create **Saga Dashboard** to inspect workflow states and failures
-- [x] Integrate saga metrics and timeout recovery
-- [x] Use saga orchestrator for multi-service admin operations (bans, content revocation)
+- [x] Define moderation policies including profanity filters
+- [ ] Provide web interface to review flagged logs
 - [x] Build role-based admin UI
+- [ ] Implement playtesting feedback form and store results for analytics
+
+## Feature Flags & Configuration
+- [x] Expose runtime feature flag toggles ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
 - [ ] Add UI for managing runtime feature flags
 - [ ] Record audit trails for feature flag changes and account events
 - [ ] Persist transaction logs for purchases and subscription events
-- [ ] Provide web interface to review flagged logs
-- [ ] Implement playtesting feedback form and store results for analytics
+
+## Saga Operations
+- [x] Create **Saga Dashboard** to inspect workflow states and failures
+- [x] Integrate saga metrics and timeout recovery
+- [x] Use saga orchestrator for multi-service admin operations (bans, content revocation)
+
+## Security
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -1,16 +1,20 @@
 # Social & Groups Service Task List
 
-- [x] __Develop Social & Groups Service__
-  - [x] Enable cross-game friend lists and social graph
-  - [x] Support private messages, global chat, and guild channels
-  - [x] Implement player-to-player mail system (asynchronous in-game messaging)
-  - [x] Allow players to form and manage guilds
-  - [x] Implement guild ranking & permissions system
-  - [x] Implement shared guild storage and alliance system
-  - [x] Provide rich moderation tools for chat
-  - [x] Add optional voice chat integration
+## Social Features
+- [x] Enable cross-game friend lists and social graph
+- [x] Support private messages, global chat, and guild channels
+- [x] Implement player-to-player mail system (asynchronous in-game messaging)
+
+## Guild Management
+- [x] Allow players to form and manage guilds
+- [x] Implement guild ranking & permissions system
+- [x] Implement shared guild storage and alliance system
+- [x] Use saga orchestrator for guild creation workflow
+
+## Moderation & Extras
+- [x] Provide rich moderation tools for chat
+- [x] Add optional voice chat integration
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
-  - [x] Use saga orchestrator for guild creation workflow
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-spring-cloud-gateway.md
+++ b/design/project-management/task-list-spring-cloud-gateway.md
@@ -1,21 +1,24 @@
 # Spring Cloud Gateway Task List
 
-- [x] **Finalize Spring Cloud Gateway design**
-- [x] **Develop Spring Cloud Gateway**
-  - [x] Handle API routing and request validation
-  - [x] Terminate TLS and forward traffic to internal services using mTLS
-  - [x] Collect connection metrics and throttle abusive clients
-  - [x] Create gateway route configuration files for all services
-  - [x] Add baseline route configuration for Spring Cloud Gateway
-  - [x] Create `GatewayController` endpoints for dynamic route management
-  - [x] Allow creation of custom gateway routes via API
-  - [x] Add gRPC `GatewayManagementService` for remote route configuration
+## Design
+- [x] Finalize Spring Cloud Gateway design
 
-  - [ ] Automatically re-establish WebSocket tunnels on restart
-  - [ ] Allow route target overrides via FIREMUD_SERVICES_* env vars
-  - [ ] Persist dynamic routes in the route_config table
-  - [ ] Trace WebSocket requests and responses for observability
+## Core Gateway
+- [x] Handle API routing and request validation
+- [x] Terminate TLS and forward traffic to internal services using mTLS
+- [x] Collect connection metrics and throttle abusive clients
+- [x] Add baseline route configuration for Spring Cloud Gateway
+- [ ] Automatically re-establish WebSocket tunnels on restart
+- [ ] Trace WebSocket requests and responses for observability
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+
+## Dynamic Route Management
+- [x] Create gateway route configuration files for all services
+- [x] Create `GatewayController` endpoints for dynamic route management
+- [x] Allow creation of custom gateway routes via API
+- [x] Add gRPC `GatewayManagementService` for remote route configuration
+- [ ] Allow route target overrides via FIREMUD_SERVICES_* env vars
+- [ ] Persist dynamic routes in the route_config table
 ## Reusable Microservice Checklist
 
 These tasks apply to every FireMUD service unless noted otherwise. Gateway and

--- a/design/project-management/task-list-tcp-proxy-service.md
+++ b/design/project-management/task-list-tcp-proxy-service.md
@@ -1,20 +1,24 @@
 # TCP Proxy Service Task List
 
-- [x] **Implement dedicated TCP Proxy Service bridging Telnet clients to the Gateway**
-- [x] **Define Telnet bridge gRPC APIs for TCP Proxy Service**
-- [x] **Develop TCP Proxy Service**
-  - [x] Implement Telnet networking and WebSocket bridging
-  - [x] Buffer Telnet input and discard on disconnect to support reconnection
-  - [x] Initialize `TcpProxyServiceApplication` with Netty server (implement connection pipeline)
-  - [x] Enforce Telnet protocol command whitelist and input sanitization
-  - [x] Implement connection throttling and rate limits
-  - [x] Support TLS termination for secure Telnet clients
-  - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
-  - [ ] Handle Telnet option negotiation and character encoding quirks
-  - [ ] Negotiate the Mud Client Protocol (MCP) when supported
-  - [ ] Invoke `NotifyDisconnect` and `PushBufferedInput` gRPC events for session recovery
-  - [ ] Integrate with the Reconnection Strategy to resume sessions transparently
-  - [ ] Support mutual TLS when forwarding WebSocket traffic to the gateway
+## Telnet Bridge
+- [x] Implement dedicated TCP Proxy Service bridging Telnet clients to the Gateway
+- [x] Define Telnet bridge gRPC APIs for TCP Proxy Service
+- [x] Implement Telnet networking and WebSocket bridging
+- [x] Support TLS termination for secure Telnet clients
+- [ ] Support mutual TLS when forwarding WebSocket traffic to the gateway
+- [ ] Handle Telnet option negotiation and character encoding quirks
+- [ ] Negotiate the Mud Client Protocol (MCP) when supported
+
+## Connection Management
+- [x] Buffer Telnet input and discard on disconnect to support reconnection
+- [x] Initialize `TcpProxyServiceApplication` with Netty server (implement connection pipeline)
+- [x] Enforce Telnet protocol command whitelist and input sanitization
+- [x] Implement connection throttling and rate limits
+- [ ] Invoke `NotifyDisconnect` and `PushBufferedInput` gRPC events for session recovery
+- [ ] Integrate with the Reconnection Strategy to resume sessions transparently
+
+## Security
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 

--- a/design/project-management/task-list-world-management-service.md
+++ b/design/project-management/task-list-world-management-service.md
@@ -1,21 +1,29 @@
 # World Management Service Task List
 
-- [x] **Develop World Management Service**
-  - [x] Implement world map storage (rooms, regions)
-  - [x] Implement instance-based game spaces (e.g., dungeons, player housing)
-  - [x] Define instance rules, expiration, and persistence
-  - [x] Implement world event scheduling system (seasonal events, resets)
-  - [x] Implement environmental effects & persistent world state (weather, dynamic NPC behaviors)
-  - [x] Implement travel & navigation system (movement, teleportation, pathfinding)
-  - [x] Implement A* or Dijkstra-based pathfinding for NPCs & movement validation
-  - [x] Use saga orchestrator for world creation workflow
-  - [x] Provide tools to fine-tune procedural generation rules
-  - [x] Support multi-server world shards
-  - [ ] Copy published version data into world schema via Saga
-  - [ ] Publish gRPC notifications when world state changes
-  - [ ] Track character locations and instance occupancy
-  - [ ] Implement world snapshot API for backup and recovery
-  - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+## Map & Instances
+- [x] Implement world map storage (rooms, regions)
+- [x] Implement instance-based game spaces (e.g., dungeons, player housing)
+- [x] Define instance rules, expiration, and persistence
+- [x] Implement A* or Dijkstra-based pathfinding for NPCs & movement validation
+
+## World Events & Effects
+- [x] Implement world event scheduling system (seasonal events, resets)
+- [x] Implement environmental effects & persistent world state (weather, dynamic NPC behaviors)
+- [x] Implement travel & navigation system (movement, teleportation, pathfinding)
+
+## Scalability & Generation
+- [x] Use saga orchestrator for world creation workflow
+- [x] Provide tools to fine-tune procedural generation rules
+- [x] Support multi-server world shards
+
+## Data Sync & Notifications
+- [ ] Copy published version data into world schema via Saga
+- [ ] Publish gRPC notifications when world state changes
+- [ ] Track character locations and instance occupancy
+
+## Administration & Backup
+- [ ] Implement world snapshot API for backup and recovery
+- [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist
 


### PR DESCRIPTION
## Summary
- group individual service task lists by category for clarity

## Testing
- `pre-commit run --files design/project-management/task-list-account-service.md design/project-management/task-list-automation-scripting-service.md design/project-management/task-list-entity-management-service.md design/project-management/task-list-game-design-service.md design/project-management/task-list-game-logic-service.md design/project-management/task-list-game-session-service.md design/project-management/task-list-logging-admin-service.md design/project-management/task-list-social-groups-service.md design/project-management/task-list-spring-cloud-gateway.md design/project-management/task-list-tcp-proxy-service.md design/project-management/task-list-world-management-service.md`

------
https://chatgpt.com/codex/tasks/task_e_687a1a85f5e48330bef03569b492a511