### PR TITLE
Update tracing doc

### DIFF
--- a/design/architecture/system-architecture-tracing.md
+++ b/design/architecture/system-architecture-tracing.md
@@ -21,6 +21,8 @@ All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK
   on port `8888`. The example manifest does not currently expose this port, so
   the collector metrics are unavailable. (TODO: Not yet implemented)
 
+- The local Docker Compose stack does not include the collector or Jaeger yet. (TODO: Not yet implemented)
+
 Every service relies on a shared `TracingConfig` in the `common-library`. This
 configuration sets the `service.name` resource from `spring.application.name`,
 uses a `BatchSpanProcessor`, and sends spans to the collector. The


### PR DESCRIPTION
## Summary
- clarify that the local Docker Compose stack does not run Jaeger or the collector

## Testing
- `./gradlew --quiet check` *(fails: incompatible types in GameDesignGrpcService)*

------
https://chatgpt.com/codex/tasks/task_e_687a1466c32c8330a5b22fc82de5c1a0