### PR TITLE
docs: clarify saga participants

### DIFF
--- a/design/architecture/system-architecture-transactions.md
+++ b/design/architecture/system-architecture-transactions.md
@@ -63,10 +63,10 @@ FireMUD uses a **shared saga orchestration library**, not a separate microservic
 
 - **Orchestration**:
   - Centralized in the **firemud-common** library (saga package)
-  - The engine and its Flyway migrations live in `services/common-library`
+  - The engine and its Flyway migrations live in `services/common-library/src/main/resources/db/migration`
   - Hosts define saga flows declaratively using a fluent API
   - Saga execution is initiated by services like Account or Game Design, but **coordination logic lives in the library**
-  - Participating services include **Account**, **Game Session**, **World Management**, **Social Groups**, and **Logging & Admin**
+  - Participating services include **Account**, **Game Design**, **Game Session**, **World Management**, **Automation Scripting**, **Social Groups**, and **Logging & Admin**
   
 - **State Management**:
   - All saga state is persisted in the `saga_instance` and `saga_step` tables provided by the common library
@@ -74,7 +74,7 @@ FireMUD uses a **shared saga orchestration library**, not a separate microservic
   - Supports compensation
   - Automatic retries and alerting (TODO: Not yet implemented)
   - `SagaRunner` emits a `sagas.active` metric and attaches a `correlationId` to logs for each workflow
-  - Operators monitor progress in the Saga Dashboard provided by the [Logging & Admin Service](./microservices/logging-admin-service/README.md)
+  - Operators monitor progress via the Saga Dashboard (`/sagas` and `/sagas/{id}/steps` endpoints) provided by the [Logging & Admin Service](./microservices/logging-admin-service/README.md)
   
 - **Execution Model**:
   - Steps are gRPC calls to owning services
@@ -98,8 +98,9 @@ sagaBuilder("accountCreation")
 
 This design centralizes logic, improves visibility, and avoids coupling orchestration directly into gameplay services.
 The `firemud-common` library provides a `SagaBuilder` class implementing this pattern.
-Services include the library and the accompanying Flyway migrations to persist
-saga state in the `saga_instance` and `saga_step` tables.
+Services include the library and the accompanying Flyway migrations located in
+`services/common-library/src/main/resources/db/migration` to persist saga state
+in the `saga_instance` and `saga_step` tables.
 Example saga flows are documented in [World Creation Workflow](./microservices/world-management-service/world-creation-workflow.md)
 and in the Logging & Admin Service README.
 


### PR DESCRIPTION
## Summary
- expand saga participant list with game design and automation scripting services
- specify migration path for saga tables
- document Logging & Admin Service endpoints for saga dashboard

## Testing
- `pre-commit run markdownlint --files design/architecture/system-architecture-transactions.md`

------
https://chatgpt.com/codex/tasks/task_e_687a14c39f2083308e4c906388e05f4d