### PR TITLE
Fix docs around Redis session keys

### DIFF
--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -211,7 +211,7 @@ FireMUD actively monitors Redis performance and tick health:
   - Basic connection health via the `redis.up` gauge exposed in
     `DatabaseAutoConfiguration`
 - Metrics are scraped via a [`redis-exporter`](../../k8s/monitoring/redis-exporter.yaml) deployment
-  (applyable via [`k8s/README.md`](../../k8s/README.md))
+  (deployable via the instructions in [`k8s/README.md`](../../k8s/README.md))
 - **Grafana dashboards** visualize tick throughput and hotspots
 - **Prometheus Alertmanager** sends alerts if metrics exceed thresholds
 - **Graceful degradation** logic reduces gameplay interruption if Redis temporarily stalls (TODO: Not yet implemented)
@@ -232,6 +232,9 @@ Redis stores transient gameplay session state for each connected player, includi
 - Tick region participation and queued commands
 - Timer and cooldown data (TODO: Not yet implemented)
 - Conflict and retry metadata
+
+Session keys use the prefix `session:{tenantId}:{sessionId}` as described in the
+[Game Session Service README](./microservices/game-session-service/README.md#redis-keys).
 
 Session entries expire after `FIREMUD_AUTH_SESSION_EXPIRATION_MS` milliseconds as
 configured in [Environment & Secrets](./infrastructure/environment-and-secrets.md#authentication).

--- a/design/project-management/task-list-spring-cloud-gateway.md
+++ b/design/project-management/task-list-spring-cloud-gateway.md
@@ -12,6 +12,7 @@
   - [x] Add gRPC `GatewayManagementService` for remote route configuration
 
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+
 ## Reusable Microservice Checklist
 
 These tasks apply to every FireMUD service unless noted otherwise. Gateway and


### PR DESCRIPTION
## Summary
- minor formatting fix for gateway task list
- document `session:{tenantId}:{sessionId}` key prefix in Redis architecture
- note redis-exporter deployment instructions

## Testing
- `./gradlew check` *(fails: Process finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_687a15d80c4c8330baa564f9540d5bbf