### PR TITLE
Update modding framework doc

### DIFF
--- a/design/architecture/microservices/game-design-service/modding-framework.md
+++ b/design/architecture/microservices/game-design-service/modding-framework.md
@@ -1,7 +1,7 @@
 # In-Game Modding and Plugin Framework
 
 This document sketches the planned modding system that allows administrators to extend a published game without republishing a full version. (TODO: Not yet implemented)
-> **Status: In Progress** – The modding framework is still under active development and not yet available in production.
+> **Status: In Progress** – The modding framework is still under active development and not yet available in production. (TODO: Not yet implemented)
 Plugins will share the same component-based DSL and sandbox used by the Automation & Scripting Service so custom logic can be hot reloaded safely. Management APIs for enabling or disabling plugins will live in the Logging & Admin Service. (TODO: Not yet implemented)
 
 ## 🎯 Goals


### PR DESCRIPTION
## Summary
- clarify status of in-game modding framework

## Testing
- `pre-commit run --files design/architecture/microservices/game-design-service/modding-framework.md` *(fails: lintMarkdown could not run)*
- `./gradlew check` *(fails: compilation warnings and errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a17cb5b088330b6ba657d226de0db