### PR TITLE
Fix modding framework doc and lint

### DIFF
--- a/design/architecture/microservices/game-design-service/modding-framework.md
+++ b/design/architecture/microservices/game-design-service/modding-framework.md
@@ -2,7 +2,7 @@
 
 This document sketches the planned modding system that allows administrators to extend a published game without republishing a full version. (TODO: Not yet implemented)
 > **Status: In Progress** – The modding framework is still under active development and not yet available in production.
-Plugins will share the same component-based DSL and sandbox used by the Automation & Scripting Service so custom logic can be hot reloaded safely. Management APIs for enabling or disabling plugins will live in the Logging & Admin Service. (TODO: Not yet implemented)
+Plugins will share the same component-based DSL and sandbox used by the Automation & Scripting Service so custom logic can be hot reloaded safely. (TODO: Not yet implemented) Management APIs for enabling or disabling plugins will live in the Logging & Admin Service. (TODO: Not yet implemented)
 
 ## 🎯 Goals
 

--- a/design/project-management/task-list-spring-cloud-gateway.md
+++ b/design/project-management/task-list-spring-cloud-gateway.md
@@ -12,6 +12,7 @@
   - [x] Add gRPC `GatewayManagementService` for remote route configuration
 
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
+
 ## Reusable Microservice Checklist
 
 These tasks apply to every FireMUD service unless noted otherwise. Gateway and


### PR DESCRIPTION
## Summary
- clarify plugin framework is not implemented
- fix markdown lint in gateway task list

## Testing
- `./gradlew lintMarkdown`
- `./gradlew spotlessCheck` *(fails: :automation-scripting-service:spotlessJavaCheck)*

------
https://chatgpt.com/codex/tasks/task_e_687a17cb5b088330b6ba657d226de0db