### PR TITLE
Update moderation policy doc

### DIFF
--- a/design/architecture/microservices/logging-admin-service/moderation-policies.md
+++ b/design/architecture/microservices/logging-admin-service/moderation-policies.md
@@ -1,22 +1,22 @@
 # 🛡️ Moderation Policies
 
 This file outlines recommended moderation rules for hosted FireMUD games.
-Operators can adapt these policies based on community needs while maintaining a safe environment for players. Several automated enforcement features mentioned below are planned but not yet available in the implementation.
+Operators can adapt these policies based on community needs while maintaining a safe environment for players. Many of the automated enforcement capabilities described below are still in development and are not available in the current implementation. (TODO: Not yet implemented)
 
 For details on moderation tooling see the [Logging & Admin Service design](./README.md).
 
 ## Core Policies
 
-1. **Zero Tolerance for Hate Speech** – racial, sexual, or other discriminatory language results in immediate bans. (TODO: Not yet implemented)
-2. **Profanity Filtering** – common swear words are automatically masked by the Social & Groups Service. Chat profanity events are reported to the Logging & Admin Service for audit purposes. See the [Social & Groups Service design](../social-groups-service/README.md) for filter details.
-3. **Harassment and Threats** – direct or implied threats are intended to lead to temporary suspensions or account deletion (TODO: Not yet implemented; suspension durations not yet supported)
-4. **Spam Prevention** – repeated unsolicited messages should trigger rate limiting and potential chat mutes. (TODO: Not yet implemented)
-5. **Cheating and Exploits** – using automation or bugs for unfair advantage results in account sanctions. (TODO: Not yet implemented)
+1. **Zero Tolerance for Hate Speech** – racial, sexual, or other discriminatory language results in immediate bans. Automated detection is planned but not yet implemented. (TODO: Not yet implemented)
+2. **Profanity Filtering** – common swear words are automatically masked by the Social & Groups Service. Chat profanity events are reported to the Logging & Admin Service for audit purposes. Operators cannot yet customize word lists per tenant. See the [Social & Groups Service design](../social-groups-service/README.md) for filter details. (TODO: Not yet implemented)
+3. **Harassment and Threats** – direct or implied threats should lead to temporary suspensions or account deletion. Suspension durations and automated detection are not yet supported. (TODO: Not yet implemented)
+4. **Spam Prevention** – repeated unsolicited messages should trigger rate limiting and potential chat mutes. Automated detection and mute functionality are not yet available. (TODO: Not yet implemented)
+5. **Cheating and Exploits** – using automation or bugs for unfair advantage results in account sanctions. Detection tooling and enforcement are still under development. (TODO: Not yet implemented)
 
 ## Profanity Filters
 
 The Social & Groups Service integrates a configurable word list. When detected, profanity is replaced with `*` characters before being routed to other players or persisted in logs.
-Operators can customize the word list per tenant (TODO: Not yet implemented).
+Operators will be able to customize the word list per tenant, but this option is not yet available. (TODO: Not yet implemented)
 Bypassing the filter with misspellings or Unicode look-alikes is considered a violation.
 
 ## Enforcement Workflow
@@ -25,7 +25,7 @@ Bypassing the filter with misspellings or Unicode look-alikes is considered a vi
 2. Moderators review the context and determine the severity. (TODO: Not yet implemented)
 3. Actions are recorded via `ApplyModerationAction` gRPC calls (see `logging_admin_service.proto`). The service
    coordinates a saga to delete the account and terminate any active sessions.
-   Records are persisted to the `moderation_actions` table.
+   Temporary suspensions are planned but not yet supported. Records are persisted to the `moderation_actions` table. (TODO: Not yet implemented)
 4. Notifications are sent to affected players with reason and duration (TODO: Not yet implemented; planned via the Account Service `NotificationService`).
 
 ## Appeals


### PR DESCRIPTION
## Summary
- clarify unimplemented moderation features and automation
- detail that profanity word lists aren't yet tenant-configurable

## Testing
- `pre-commit run markdownlint --files design/architecture/microservices/logging-admin-service/moderation-policies.md` *(fails: Process 'npx' finished with non-zero exit value 1)*
- `./gradlew lintMarkdown` *(fails: Process 'npx' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_687a189317208330ba6920d40bdb070e