### PR TITLE
Update world creation workflow doc

### DIFF
--- a/design/architecture/microservices/world-management-service/world-creation-workflow.md
+++ b/design/architecture/microservices/world-management-service/world-creation-workflow.md
@@ -3,26 +3,28 @@
 World creation is a long running process that will eventually copy design data
 and prepare the initial world state for a new game instance. The workflow uses
 the shared **Saga** utilities from `firemud-common` so each step can be rolled
-back if another step fails. The process is triggered by `WorldCreationService`
-when a tenant launches a new game world.
+back if another step fails. `WorldCreationService` is invoked when a tenant
+launches a new game world, typically from the Game Session Service.
 
 Currently the implementation only inserts a starter region. The method that
 would schedule placeholder events is a stub and does not yet create records.
-Copying the full design from the Game Design Service has not been implemented.
-(TODO: Not yet implemented)
+Copying the full design from the Game Design Service has not been implemented
+(TODO: Not yet implemented). Additional steps, such as bulk terrain generation
+or NPC population, remain planned.
 
 ## Steps
 
 1. **Copy Design Data & Create Starter Region** – fetches the published version
    from the Game Design Service and inserts an initial region using the local
    shard configuration (`WORLD_LOCAL_SHARD_ID`). The current code merely verifies
-   connectivity with the Game Design Service and inserts a single starter
-   region. Additional regions and full data copy will follow once more design
-   data is available. (TODO: Not yet implemented)
+   connectivity with the Game Design Service and inserts a single "Starter
+   Region" record populated with default `SimpleDungeonGenerator` parameters.
+   Additional regions and a true data copy will follow once more design data is
+   available. (TODO: Not yet implemented)
 2. **Schedule Initial Events** – intended to insert world events such as an
    initial weather state so `WorldEventService` can apply them after the world
-   starts. This step is currently a stub and does not persist any events. (TODO:
-   Not yet implemented)
+   starts. This step is currently a stub and does not persist any events
+   (TODO: Not yet implemented).
 
 Additional steps may be added for large games
 such as generating terrain chunks or spawning default NPCs. (TODO: Not yet implemented)


### PR DESCRIPTION
## Summary
- clarify how world creation is triggered
- note starter region defaults
- clean up TODO markers for unimplemented behavior

## Testing
- `./gradlew check` *(fails: lintMarkdown errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a19d29bfc8330a98447a83fa50e77