### PR TITLE
Add tasks for design TODOs

### DIFF
--- a/design/project-management/task-list-game-design-service.md
+++ b/design/project-management/task-list-game-design-service.md
@@ -17,6 +17,7 @@
 - [x] Track version history and patch notes for published games
 - [x] Build a web-based visual design interface
 - [x] Integrate version control for design assets
+- [ ] Implement data-driven rule configuration so games can adjust mechanics without redeploying
 - [x] Configure database storage for game assets
   - [x] Provide asset upload API in Game Design Service
   - [x] Document asset storage setup and configuration

--- a/design/project-management/task-list-game-session-service.md
+++ b/design/project-management/task-list-game-session-service.md
@@ -6,6 +6,8 @@
 - [x] Persist session state in Redis for reconnect recovery
 - [x] Enforce single-session control per character (session takeover on new login)
 - [x] Plan for cross-region sharding and session handoff
+- [ ] Forward TOTP codes to the Account Service during login
+- [ ] Refresh roles in-session when `scopedRoles` are updated
 
 ## Tick Management
 - [x] Implement tick orchestration using Redis for command queues
@@ -18,6 +20,7 @@
 - [x] Manage runtime feature flags and expose toggle API via Logging & Admin Service ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
 - [x] Implement `game_manifest` table for version coordination
 - [x] Emit gameplay analytics for operators
+- [ ] Apply runtime feature flags during tick processing
 
 ## Security
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime

--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -5,6 +5,7 @@
 - [x] Deploy Fluent Bit sidecars to forward logs to Elasticsearch
 - [x] Integrate Alertmanager for automated alerts
 - [x] Provide analytics dashboards for operators
+- [ ] Implement real-time analytics on game performance
 - [x] Evaluate adopting a zero-trust network model for internal traffic
 
 ## Moderation Tools

--- a/design/project-management/task-list-social-groups-service.md
+++ b/design/project-management/task-list-social-groups-service.md
@@ -4,6 +4,10 @@
 - [x] Enable cross-game friend lists and social graph
 - [x] Support private messages, global chat, and guild channels
 - [x] Implement player-to-player mail system (asynchronous in-game messaging)
+- [ ] Deliver real-time chat notifications via WebSocket channels
+- [ ] Integrate faction reputation data from the Automation & Scripting Service
+- [ ] Show presence indicators when friends come online
+- [ ] Provide broadcast and out-of-game email capabilities for game creators
 
 ## Guild Management
 - [x] Allow players to form and manage guilds
@@ -14,6 +18,7 @@
 ## Moderation & Extras
 - [x] Provide rich moderation tools for chat
 - [x] Add optional voice chat integration
+- [ ] Integrate WebRTC voice gateway and record connection events
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 
 ## Reusable Microservice Checklist


### PR DESCRIPTION
## Summary
- track data-driven rules in game design service task list
- add OTP forwarding, runtime flags, and role refresh to session service tasks
- include real-time analytics bullet in logging-admin tasks
- expand social groups service tasks with chat notifications, presence, and voice gateway

## Testing
- `pre-commit run --all-files` *(fails: BUILD FAILED in 7s)*

------
https://chatgpt.com/codex/tasks/task_e_687a341f10e0833092cf4ffaa1896a8c