### PR TITLE
Fix MCP doc todo

### DIFF
--- a/design/architecture/system-architecture-mcp-support.md
+++ b/design/architecture/system-architecture-mcp-support.md
@@ -6,7 +6,7 @@ This document outlines how FireMUD will incorporate the Mud Client Protocol (MCP
 
 - Allow editors and automated tools to communicate with the server using structured MCP messages. (TODO: Not yet implemented)
 - Enable scripted workflows where the AI can create rooms, items, and NPCs via standardized commands. (TODO: Not yet implemented)
-- Maintain backward compatibility with traditional telnet clients that do not understand MCP.
+- Maintain backward compatibility with traditional Telnet clients that do not understand MCP. (TODO: Not yet implemented)
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- mark compatibility with Telnet clients as not yet implemented in the MCP support doc

## Testing
- `pre-commit run --files design/architecture/system-architecture-mcp-support.md` *(fails: Spotless requires formatting)*
- `./gradlew check` *(fails: spotlessJavaCheck failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a1d8a06748330835dbd7108df40ff