### PR TITLE
Add tasks for TODO items

### DIFF
--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -12,6 +12,7 @@
 - [x] Use saga orchestrator for account creation workflow
 - [x] Implement self-service account recovery
 - [x] Add optional 2FA for admin and moderator roles
+- [ ] Implement account ban and suspension workflows with audit logging
 - [ ] Wire TLS and JWT secret watchers to reload credentials without downtime
 - [ ] Automate JWKS key rotation using cert-manager and update services to poll for changes
 

--- a/design/project-management/task-list-game-session-service.md
+++ b/design/project-management/task-list-game-session-service.md
@@ -9,6 +9,7 @@
 - [x] Plan for cross-region sharding and session handoff
 - [ ] Forward TOTP codes to the Account Service during login
 - [ ] Refresh roles in-session when `scopedRoles` are updated
+- [ ] Implement `LOGIN`/`LOGON` command handling for interactive and parameterized logins
 
 ## Tick Management
 
@@ -18,11 +19,13 @@
 - [x] Implement tick replay and crash recovery logic
 - [ ] Implement graceful degradation when Redis operations stall to avoid gameplay interruption
 - [ ] Record conflict metadata during retries to highlight hotspots and enable adaptive throttling
+- [ ] Support per-tenant tick intervals to customize pacing across games
 
 ## Analytics & Coordination
 
 - [x] Manage runtime feature flags and expose toggle API via Logging & Admin Service ([Versioning & Runtime Configuration](../architecture/system-architecture-versioning-runtime.md))
 - [x] Implement `game_manifest` table for version coordination
+- [ ] Restart active sessions when a new game version is published
 - [x] Emit gameplay analytics for operators
 - [ ] Apply runtime feature flags during tick processing
 


### PR DESCRIPTION
## Summary
- document pending account ban and suspension workflows
- add session service tasks for LOGIN command handling
- include per-tenant tick intervals in task list
- restart sessions when new versions are published

## Testing
- `./gradlew check` *(fails: incompatible types in GameDesignClient)*

------
https://chatgpt.com/codex/tasks/task_e_687a395f893c8330bc5363183b1e760c