### PR TITLE
Update database migration doc

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -12,6 +12,8 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 - Migrations follow the `V<version>__<description>.sql` naming convention.
 - Every module begins with a `V1__init.sql` baseline and numbers sequentially from there.
 - `spring.flyway.enabled=true` in `application.yml` triggers migration execution on startup.
+- Flyway reads connection settings from the `FIREMUD_POSTGRES_*` environment variables described in
+  [Environment & Secrets](./infrastructure/environment-and-secrets.md).
 - Java-based callbacks are avoided; migrations remain SQL-only for portability.
 
 ## 📂 Per-Service Organization
@@ -19,7 +21,8 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 - Every microservice maintains its own migration folder and changelog.
 - Schemas are isolated: services never modify each other's tables.
 - Tables currently reside in the `public` schema but will move to dedicated
-  schemas for each service for better isolation. See
+  schemas for each service for better isolation. Dedicated schema names will
+  match the owning service (for example `account_service`). See
   [Multi-Tenancy](./system-architecture-multi-tenancy.md). (TODO: Not yet implemented)
 - Common tables shared by multiple services reside in the `common-library` module with its own migrations.
 - It contains saga table migrations described in [System Architecture – Transactions](./system-architecture-transactions.md).


### PR DESCRIPTION
## Summary
- clarify connection variables for Flyway migrations
- note planned per-service schema names for migrations

## Testing
- `pre-commit run markdownlint --files design/architecture/system-architecture-database-migrations.md` *(fails: lint errors in unrelated docs)*

------
https://chatgpt.com/codex/tasks/task_e_687a2068ddd08330829fd50d17fde121