### PR TITLE
Update migration doc

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -7,7 +7,9 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 ## 🚀 Migration Tool
 
 - **Flyway** is used for all schema migrations.
-- Each service's `build.gradle.kts` applies the `org.flywaydb.flyway` plugin and pulls in `flyway-core`.
+- Each service's `build.gradle.kts` applies the `org.flywaydb.flyway` plugin.
+  Most services explicitly depend on `flyway-core`, while others rely on the
+  plugin's default dependency.
 - Versioned SQL files live under each service in `src/main/resources/db/migration/`.
 - Migrations follow the `V<version>__<description>.sql` naming convention.
 - Every module begins with a `V1__init.sql` baseline and numbers sequentially from there.


### PR DESCRIPTION
## Summary
- clarify that some services rely on Flyway plugin's default dependency
- keep notes about upcoming CI validation and deployment automation

## Testing
- `./gradlew check` *(fails: lintMarkdown task with 90 markdown errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a2068ddd08330829fd50d17fde121