### PR TITLE
Improve tracing documentation

### DIFF
--- a/design/architecture/system-architecture-tracing.md
+++ b/design/architecture/system-architecture-tracing.md
@@ -6,9 +6,9 @@ This document explains how distributed traces are collected and visualized acros
 
 ## 📡 OpenTelemetry Collector
 
-All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK. A dedicated **OpenTelemetry Collector** runs inside the Kubernetes cluster to receive OTLP traffic and forward it to storage backends.
+All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK. A dedicated **OpenTelemetry Collector** runs inside the Kubernetes cluster to receive OTLP traffic and forward it to storage backends. A sample manifest is provided at `k8s/monitoring/otel-collector.yaml`.
 
-- Deploy using the official [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) Helm chart or apply the sample manifest in `k8s/monitoring/otel-collector.yaml` for local demos.
+- Deploy using the official [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) Helm chart or apply the sample manifest for local demos.
 - The collector runs as the `otel-collector` service inside the cluster so other pods can reach it via `http://otel-collector:4317`.
 - The collector exposes a `4317` gRPC endpoint. Services export spans to `http://otel-collector:4317` by default. The endpoint can be overridden via the `OTEL_ENDPOINT` environment variable (`otel.endpoint` property). See `.env.sample` and [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#observability) for defaults.
 
@@ -23,7 +23,7 @@ All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK
 
 - The local Docker Compose stack does not include the collector or Jaeger yet. (TODO: Not yet implemented)
 
-Every service relies on a shared `TracingConfig` in the `common-library`. This
+Every service relies on a shared `TracingConfig` in the `common-library` (`services/common-library/src/main/java/net/firedevops/firemud/common/config/TracingConfig.java`). This
 configuration sets the `service.name` resource from `spring.application.name`,
 uses a `BatchSpanProcessor`, and sends spans to the collector. The
 `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from the


### PR DESCRIPTION
## Summary
- clarify location of sample OTel collector manifest
- mention exact TracingConfig path
- retain TODO markers for unimplemented items

## Testing
- `./gradlew check` *(fails: lintMarkdown)*

------
https://chatgpt.com/codex/tasks/task_e_687a20e636908330a2a803251d8639d7