### PR TITLE
Fix deployment docs

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -100,9 +100,9 @@ Docker Compose and Kubernetes rely on the following monitoring tools:
 
 - Prometheus scrapes metrics from all services. (TODO: Not yet implemented)
 - Grafana dashboards visualize performance metrics. (TODO: Not yet implemented)
-- Alertmanager notifies on failures or latency spikes.
+- Alertmanager notifies on failures or latency spikes. (TODO: Not yet implemented)
 - OpenTelemetry spans are emitted by services for distributed tracing.
-- Jaeger stores these traces for debugging and analysis.
+- Jaeger stores these traces for debugging and analysis. (TODO: Not yet implemented)
 
 ### 📜 Log Aggregation
 


### PR DESCRIPTION
## Summary
- note Alertmanager and Jaeger are not yet implemented

## Testing
- `pre-commit run --files design/architecture/infrastructure/deployment-environments.md` *(fails: shellcheck, markdownlint, spotbugs, buf not installed)*
- `./gradlew check` *(fails: markdown lints and Java compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a33a6def48330a4efe03cd0a172e0