### PR TITLE
docs: clarify game design service features

### DIFF
--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Offers tools for building worlds, items, actions, and events that make up each game. Used by creators to design content without touching the underlying code. It also maintains versioned game configurations and templates so new game instances can be created with predefined rules and administrators.
+Offers tools for building worlds, items, actions, and events that make up each game. Used by creators to design content without touching the underlying code. It also maintains versioned game configurations and templates so new game instances can be created with predefined rules. Default administrator setup is planned. (TODO: Not yet implemented)
 
 ### Responsibilities
 
@@ -39,8 +39,8 @@ Offers tools for building worlds, items, actions, and events that make up each g
 - Scripting and event workflow creation. (TODO: Not yet implemented)
 - Visual editor for building scripts in the same component-based DSL used by the
   Automation & Scripting Service. (TODO: Not yet implemented)
-- [Game templates](game-templates.md) with predefined rulesets and administrators. (TODO: Not yet implemented)
-- Version and patch note management for published games. (TODO: Not yet implemented)
+- [Game templates](game-templates.md) with predefined rulesets. Admin account configuration is planned. (TODO: Not yet implemented)
+- Patch note management for published games. (TODO: Not yet implemented)
 - Supports script-only patch versions that reference a `baseVersionId` and
   generate a new `scriptPatchVersion` without requiring a full publish.
 - Does not track individual script definitions at runtime; only the patch
@@ -71,7 +71,7 @@ Offers tools for building worlds, items, actions, and events that make up each g
 ### gRPC APIs
 
 - `SaveRevision` – persists a new or updated design asset.
-- `PublishVersion` – freezes a set of revisions and notifies downstream services. (TODO: Not yet implemented)
+- `PublishVersion` – freezes a set of revisions. Notifications to downstream services are not yet implemented. (TODO: Not yet implemented)
 - `PublishScriptPatchVersion` – creates a script-only patch version referencing a base version.
 - `ListVersions` – enumerates published versions for selection when creating a
   game instance.


### PR DESCRIPTION
## Summary
- update game design service overview to note admin template setup is planned
- clarify TODO status for game templates and patch notes
- refine description of PublishVersion gRPC API

## Testing
- `./gradlew spotlessCheck`
- `./gradlew lintMarkdown` *(fails: Process 'npx' finished with non-zero exit value 1)*
- `./gradlew checkstyleMain` *(fails: incompatible types in world-management-service)*

------
https://chatgpt.com/codex/tasks/task_e_687a33d7b01c8330af716299364cf7ab