### PR TITLE
docs: clarify item balancing design

### DIFF
--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -1,6 +1,8 @@
 # Item & Equipment Balancing Tools
 
-Game balance relies heavily on item statistics and equipment progression. This document describes the planned tools for tuning those values. Balancing data will eventually follow the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. See [Version Control for Design Assets](version-control.md) for more detail. (TODO: Not yet implemented)
+Game balance relies heavily on item statistics and equipment progression. This document describes the planned tools for tuning those values. Balancing data will eventually follow the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. Designers will store changes through the `SaveRevision` gRPC endpoint and publish them via `PublishVersion` as part of the cross‑service saga outlined in [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md). See [Version Control for Design Assets](version-control.md) for more detail. (TODO: Not yet implemented)
+
+Balancing records are scoped by `tenantId` so multiple games can maintain independent item definitions. (TODO: Not yet implemented)
 
 All capabilities described below are planned features and are not available in the current implementation. (TODO: Not yet implemented)
 


### PR DESCRIPTION
## Summary
- expand item & equipment balancing design for cross-service saga
- mention tenant scoping of item balancing records

## Testing
- `./gradlew check` *(fails: lintMarkdown task)*

------
https://chatgpt.com/codex/tasks/task_e_687a3474a3e883308d0f50738f15619d