### PR TITLE
Clarify TCP proxy buffering

### DIFF
--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -15,7 +15,7 @@ The OpenAPI specification for the `/ping` health endpoint lives in `services/tcp
 
 - Spring Boot service hosting a lightweight Netty-based Telnet server.
 - Buffers incoming input while the client remains connected and discards it if the TCP
-  session drops. (TODO: Not yet implemented)
+  session drops.
 - Handles Telnet negotiation and character encoding quirks (TODO: Not yet implemented).
 - Negotiates the Mud Client Protocol (MCP) when supported. See [MCP Support](../system-architecture-mcp-support.md). (TODO: Not yet implemented)
 - Works with the Reconnection Strategy to resume sessions transparently. (TODO: Not yet implemented)
@@ -193,5 +193,5 @@ information.
 
 ## Future Enhancements
 
-- Additional abuse heuristics and advanced command filtering.
-- Auto-scaling policies for heavy traffic bursts.
+- Additional abuse heuristics and advanced command filtering. (TODO: Not yet implemented)
+- Auto-scaling policies for heavy traffic bursts. (TODO: Not yet implemented)


### PR DESCRIPTION
## Summary
- clarify that connection buffering is implemented in the TCP proxy service
- mark future enhancements as TODOs

## Testing
- `./gradlew check` *(fails: lintMarkdown)*

------
https://chatgpt.com/codex/tasks/task_e_687a3634ff108330bd7c15bd739bdc31