### PR TITLE
docs: clarify reconnection status

### DIFF
--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -8,15 +8,15 @@ FireMUD enables seamless gameplay recovery across network interruptions, client 
 
 | Layer              | Responsibility                                                               |
 |-------------------|-------------------------------------------------------------------------------|
-| **TCP Proxy Service**      | Parses Telnet input, clears buffer, gRPC hooks (TODO: Not yet implemented) |
+| **TCP Proxy Service**      | Parses Telnet input and clears buffered commands; exposes gRPC hooks for session recovery (TODO: Not yet implemented) |
 | **Spring Cloud Gateway** | Stateless WebSocket passthrough; reconnects backend automatically (TODO: Not yet implemented) |
 | **Game Session Service**   | Restores session from Redis; rebinds socket, region, and timers (TODO: Not yet implemented) |
 
 Each layer handles fault tolerance independently.
 **Only client connection loss requires reauthentication.** (TODO: Not yet implemented)
-Game Session Service restarts are **transparent** if the client remains connected. (TODO: Not yet implemented)
+Game Session Service restarts are **intended to be transparent** if the client remains connected. (TODO: Not yet implemented)
 The Gateway is intended to automatically re-establish WebSocket sessions after a restart while Telnet clients stay bridged through the proxy. See [Protocol Bridging](./system-architecture-protocol-bridging.md) for how TCP and WebSocket clients share the same backend. (TODO: Not yet implemented)
-TCP Proxy restarts drop Telnet clients.
+TCP Proxy restarts drop Telnet clients, who must reconnect manually. (TODO: Not yet implemented)
 
 ---
 


### PR DESCRIPTION
## Summary
- update reconnection design doc to explicitly mention gRPC hooks and manual reconnects
- note that game session restart transparency is planned

## Testing
- `pre-commit run markdownlint --files design/architecture/system-architecture-reconnection.md`
- `pre-commit run trailing-whitespace --files design/architecture/system-architecture-reconnection.md`
- `pre-commit run end-of-file-fixer --files design/architecture/system-architecture-reconnection.md`

------
https://chatgpt.com/codex/tasks/task_e_687a3b5fe6248330ae9c992a2ad5410e