### PR TITLE
Update TCP proxy docs

### DIFF
--- a/design/architecture/microservices/logging-admin-service/admin-ui.md
+++ b/design/architecture/microservices/logging-admin-service/admin-ui.md
@@ -22,7 +22,7 @@ and permissions are enforced using the `globalRoles` and `scopedRoles` claims.
 These capabilities map to existing REST endpoints exposed by the service.
 Planned routes include:
 
-```
+```text
 GET  /logs
 POST /reports
 POST /moderation/actions

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -9,13 +9,13 @@ The OpenAPI specification for the `/ping` health endpoint lives in `services/tcp
 
 - Accept Telnet connections and perform protocol negotiation (TODO: Not yet implemented)
 - Proxy buffered input to Spring Cloud Gateway as WebSocket frames
+  (queue is cleared on disconnect; resend on reconnect is planned) (TODO: Not yet implemented)
 - Provide graceful disconnect and reconnection handling (TODO: Not yet implemented)
 
 ## Architecture / Design Notes
 
 - Spring Boot service hosting a lightweight Netty-based Telnet server.
-- Buffers incoming input while the client remains connected and discards it if the TCP
-  session drops.
+- Buffers incoming input while the client remains connected and discards it if the TCP session drops. Resending buffered commands after reconnect is not yet supported (TODO: Not yet implemented).
 - Handles Telnet negotiation and character encoding quirks (TODO: Not yet implemented).
 - Negotiates the Mud Client Protocol (MCP) when supported. See [MCP Support](../system-architecture-mcp-support.md). (TODO: Not yet implemented)
 - Works with the Reconnection Strategy to resume sessions transparently. (TODO: Not yet implemented)
@@ -54,8 +54,7 @@ events used internally when communicating with other microservices:
     drops so the session may be suspended. (TODO: Not yet implemented)
 - **PushBufferedInput** – forwards any queued commands after a reconnect
     event. (TODO: Not yet implemented)
-These gRPC events are defined but the current implementation does not yet invoke them. (TODO: Not yet implemented)
-At present the service only logs when these methods are called; no other microservices are contacted. (TODO: Not yet implemented)
+These gRPC events are defined but currently only logged; no other microservices are contacted (TODO: Not yet implemented)
 These messages live in [`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
 
 ### Telnet Command Handling


### PR DESCRIPTION
## Summary
- clarify TCP proxy reconnection notes
- fix Markdown linting in logging-admin-service docs

## Testing
- `./gradlew check` *(fails: compilation error in world-management-service)*

------
https://chatgpt.com/codex/tasks/task_e_687af4a2df6c83308840bfcd09be907c