### PR TITLE
Improve social groups doc

### DIFF
--- a/design/architecture/microservices/logging-admin-service/admin-ui.md
+++ b/design/architecture/microservices/logging-admin-service/admin-ui.md
@@ -22,7 +22,7 @@ and permissions are enforced using the `globalRoles` and `scopedRoles` claims.
 These capabilities map to existing REST endpoints exposed by the service.
 Planned routes include:
 
-```
+```text
 GET  /logs
 POST /reports
 POST /moderation/actions

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -174,20 +174,20 @@ files change.
 curl http://localhost:8080/ping
 ```
 
+Example chat request:
+
+```bash
+curl -X POST http://localhost:8080/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantId":1,"senderAccountId":100,"content":"hello"}'
+```
+
 #### gRPC
 
 - `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`social_groups_service.proto`](../../../protos/social-groups/v1/social_groups_service.proto).
 
 ```bash
 grpcurl -plaintext localhost:6565 social_groups.v1.SocialGroupsService/Ping
-```
-
-- `POST /chat` – send a chat message filtered for profanity.
-
-```bash
-curl -X POST http://localhost:8080/chat \
-  -H 'Content-Type: application/json' \
-  -d '{"tenantId":1,"senderAccountId":100,"content":"hello"}'
 ```
 
 ### Metrics & Tracing
@@ -228,3 +228,4 @@ guidance.
 - Optional voice chat integration via a WebRTC gateway. (TODO: Not yet implemented)
 - Presence indicators and notifications when friends come online. (TODO: Not yet implemented)
 - Broadcast and out-of-game email capabilities for game creators. (TODO: Not yet implemented)
+- Retrieval endpoints for chat and mail history. (TODO: Not yet implemented)


### PR DESCRIPTION
## Summary
- fix Markdown lint issue in Logging Admin doc
- improve Social Groups service doc
  - move chat example and ensure fenced code formatting
  - add note on planned chat and mail retrieval endpoints

## Testing
- `./gradlew check` *(fails: world-management-service compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_687af48255d88330988fddea3bcf03c4