### PR TITLE
Improve item balancing doc clarity

### DIFF
--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -1,10 +1,10 @@
 # Item & Equipment Balancing Tools
 
-Game balance relies heavily on item statistics and equipment progression. This document describes the planned tools for tuning those values. Balancing data will eventually follow the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. Designers will store changes through the `SaveRevision` gRPC endpoint and publish them via `PublishVersion` as part of the cross‑service saga outlined in [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md). See [Version Control for Design Assets](version-control.md) for more detail. (TODO: Not yet implemented)
+Game balance relies heavily on item statistics and equipment progression. This document outlines the planned tools for tuning those values. Balancing data will eventually follow the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. Designers will store changes via the `SaveRevision` gRPC endpoint and publish them with `PublishVersion`. These operations will participate in the cross-service saga described in [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md). See [Version Control for Design Assets](version-control.md) for more detail. (TODO: Not yet implemented)
 
 Balancing records are scoped by `tenantId` so multiple games can maintain independent item definitions. (TODO: Not yet implemented)
 
-All capabilities described below are planned features and are not available in the current implementation. (TODO: Not yet implemented)
+All capabilities described below are planned features and are not yet available in the current implementation. (TODO: Not yet implemented)
 
 > **Status: In Progress** – These balancing tools are still under development. (TODO: Not yet implemented)
 
@@ -13,7 +13,7 @@ All capabilities described below are planned features and are not available in t
 - **Item Stat Editor** – adjust damage, defense, and stat bonuses with real‑time validation. (TODO: Not yet implemented)
 - **Equipment Curves** – visualize power growth across item tiers to spot outliers. (TODO: Not yet implemented)
 - **Economy Impact** – preview vendor prices and drop rates to maintain a healthy in-game economy. (TODO: Not yet implemented)
-- **Integration with [Ability & Action Design Tools](ability-action-tools.md)** – compare ability damage with item stats for holistic balance. (TODO: Not yet implemented)
+- **Integration with [Ability & Action Design Tools](ability-action-tools.md)** – compare ability damage values with item stats for holistic balance. (TODO: Not yet implemented)
 - **Web-Based Interface** – edit and visualize stats through the planned drag‑and‑drop UI described in [Web-Based Visual Design Interface](web-visual-interface.md). (TODO: Not yet implemented)
 
 ## Workflow


### PR DESCRIPTION
## Summary
- clarify design-status disclaimer for item & equipment balancing tools
- tweak ability balancing bullet wording

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_687af41a17b88330a091a4d87a482c33