### PR TITLE
Update tracing architecture doc

### DIFF
--- a/design/architecture/system-architecture-tracing.md
+++ b/design/architecture/system-architecture-tracing.md
@@ -10,7 +10,7 @@ All services emit spans using the [OpenTelemetry](https://opentelemetry.io/) SDK
 
 - Deploy using the official [`opentelemetry-collector`](https://github.com/open-telemetry/opentelemetry-helm-charts) Helm chart or apply the sample manifest for local demos.
 - The collector runs as the `otel-collector` service inside the cluster so other pods can reach it via `http://otel-collector:4317`.
-- The collector exposes a `4317` gRPC endpoint. Services export spans to `http://otel-collector:4317` by default. The endpoint can be overridden via the `OTEL_ENDPOINT` environment variable (`otel.endpoint` property). See `.env.sample` and [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#observability) for defaults.
+- The collector exposes a `4317` gRPC endpoint. Services export spans to `http://otel-collector:4317` by default (see `.env.sample`). Override the address with the `OTEL_ENDPOINT` environment variable (`otel.endpoint` property). See [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#observability) for details.
 
   ```bash
   OTEL_ENDPOINT=http://collector.internal:4317
@@ -28,8 +28,8 @@ configuration sets the `service.name` resource from `spring.application.name`,
 uses a `BatchSpanProcessor`, and sends spans to the collector. The
 `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` from the
 [Shared Libraries](./system-architecture-shared-libraries.md) are registered in
-each `GrpcServerConfig` so requests are instrumented with logs, metrics, and
-spans consistently. See
+each service's gRPC configuration (`GrpcConfig` or `GrpcServerConfig`) so
+requests are instrumented with logs, metrics, and spans consistently. See
 [Logging & Monitoring](./system-architecture-logging-monitoring.md) for
 additional observability details. `TracingInterceptor` opens a span for each
 gRPC method and marks it successful or cancelled when the call completes.


### PR DESCRIPTION
## Summary
- clarify default collector endpoint and override
- note interceptors are registered via service gRPC config

## Testing
- `./gradlew check` *(fails: world-management-service compile error)*

------
https://chatgpt.com/codex/tasks/task_e_687af1a5571c83309d9456ed1b8b2034