### PR TITLE
docs: clarify database migrations

### DIFF
--- a/design/architecture/system-architecture-database-migrations.md
+++ b/design/architecture/system-architecture-database-migrations.md
@@ -26,6 +26,7 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
   schemas for each service for better isolation. Dedicated schema names will
   match the owning service (for example `account_service`). See
   [Multi-Tenancy](./system-architecture-multi-tenancy.md). (TODO: Not yet implemented)
+  This transition is planned for a future release.
 - Common tables shared by multiple services reside in the `common-library` module with its own migrations.
 - It contains saga table migrations described in [System Architecture – Transactions](./system-architecture-transactions.md).
 - Services that need these shared tables include the module as a dependency during their build.
@@ -38,17 +39,17 @@ This document explains how FireMUD manages PostgreSQL schema changes across its 
 ## 🔄 CI/CD Execution
 
 - Flyway runs automatically when a service container starts.
+  If any migration fails, the application startup aborts so issues are caught early.
 - In development you can run `./gradlew flywayMigrate` for a single service.
 - Execute this task from the service directory or prefix the project name (e.g.,
   `./gradlew :account-service:flywayMigrate`).
 - You can also run `./gradlew :service:flywayInfo`, `flywayClean`, or `flywayRepair` to troubleshoot local databases. **Use `flywayClean` with caution** because it drops tables.
 - Run `./gradlew :service:flywayValidate` to verify migrations before committing.
-- The CI pipeline will eventually run `flywayValidate` for all services to catch
-  migration issues early. (TODO: Not yet implemented)
+- The CI pipeline will eventually run `flywayValidate` for all services to catch migration issues early. (TODO: Not yet implemented)
 - See [DEVELOPER_SETUP.md](../../DEVELOPER_SETUP.md) for the environment variables needed to connect to your local PostgreSQL instance. Copy the `FIREMUD_POSTGRES_*` values from `.env.sample` into `.env` so Flyway can connect locally.
 - During deployment GitHub Actions builds the Docker image, pushes it, and Kubernetes restarts the service. Full automation of this step is still being developed (TODO: Not yet implemented).
 - On startup the container executes Flyway against its database schema before the Spring application fully starts.
-- The `dev-tools/generate-erd.sh` script uses Flyway to clean and migrate temporary databases when generating ERD diagrams.
+- The [`dev-tools/generate-erd.sh`](../../dev-tools/generate-erd.sh) script uses Flyway to clean and migrate temporary databases when generating ERD diagrams.
 - Diagrams are written to `design/erd/` and the CI workflow collects this
    directory as an artifact.
 


### PR DESCRIPTION
## Summary
- expand database migrations guide
- note that migrations abort startup on failure
- link ERD generator script

## Testing
- `pre-commit run --files design/architecture/system-architecture-database-migrations.md` *(fails: SpotBugs compile error)*

------
https://chatgpt.com/codex/tasks/task_e_687ae5ad88348330a3f18d352264b36a