### PR TITLE
Add missing TODO action items

### DIFF
--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -316,3 +316,8 @@ The standard microservice checklist is now copied into each service task list.
 - [x] Plan for **end-to-end UI testing** using Cypress or Playwright once the
   web UI is stable
 - [x] Evaluate localization and internationalization support for the React client
+- [ ] Configure **IPVS** or similar load balancing mode in Kubernetes clusters
+- [ ] Add **PostgreSQL exporter** for Prometheus metrics
+- [ ] Automate **database password rotation** using cert-manager or Secret syncing
+- [ ] Support **multi-region deployments** for lower latency
+- [ ] Schedule **nightly resets** of the staging playtest environment


### PR DESCRIPTION
## Summary
- add tasks for multi-region, IPVS, exporter, password rotation, and resets

## Testing
- `./gradlew check` *(fails: incompatible types; see log)*

------
https://chatgpt.com/codex/tasks/task_e_687af22355ec83308ca8804a5f0db60e