### PR TITLE
Add web client task list

### DIFF
--- a/design/project-management/task-list-web-client.md
+++ b/design/project-management/task-list-web-client.md
@@ -1,0 +1,26 @@
+# Web Client Task List
+
+## Core Features
+
+- [ ] Build admin and Game Design interface modules alongside the player-facing client
+- [ ] Transition to a feature-first folder structure under `src/features`
+- [ ] Create `pages/` and shared `components/` directories
+- [ ] Add RTK Query endpoints for login and character retrieval
+- [ ] Integrate WebSocket events with RTK Query caches
+- [ ] Implement `npm run test` with Jest and React Testing Library
+- [ ] Extend API mocking using **msw**
+
+## Customization & Internationalization
+
+- [ ] Load theme files per `tenantId` to support game-specific branding
+- [ ] Allow Material-UI theme overrides and optional extra routes
+- [ ] Keep core components shared so updates reach all games
+- [ ] Add i18n support with `react-i18next`
+
+## End-to-End Testing
+
+- [ ] Add Playwright tests running against the Docker Compose stack
+
+---
+
+*Frontend tasks follow the same CI and linting conventions as backend services.*

--- a/design/project-management/task-list.md
+++ b/design/project-management/task-list.md
@@ -11,6 +11,7 @@ Service-specific tasks are tracked in separate files within this folder. Quick l
 - [Game Session Service](task-list-game-session-service.md)
 - [Logging & Admin Service](task-list-logging-admin-service.md)
 - [Social & Groups Service](task-list-social-groups-service.md)
+- [Web Client](task-list-web-client.md)
 - [Spring Cloud Gateway](task-list-spring-cloud-gateway.md)
 - [TCP Proxy Service](task-list-tcp-proxy-service.md)
 - [World Management Service](task-list-world-management-service.md)


### PR DESCRIPTION
## Summary
- add missing `task-list-web-client.md`
- link web client tasks from the main checklist

## Testing
- `./gradlew spotlessApply`
- `./gradlew check` *(fails: cannot find symbol Size in VersionDto)*

------
https://chatgpt.com/codex/tasks/task_e_687afce370e8833081fb741249ee8cd5