### PR TITLE
Implement tick pause API for backups

### DIFF
--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -79,6 +79,9 @@ Orchestrates live game sessions, including tick execution, player input validati
 - `EnqueueCommand` – adds a player action to the next tick's queue.
 - `QueryState` – retrieves condensed session or player state for monitoring.
 - `ToggleFeatureFlag` – updates runtime flags for a tenant.
+- `PauseTicks` – temporarily halt tick execution before a backup.
+- `ResumeTicks` – resume tick processing after the backup begins.
+- `GetTickStatus` – returns `RUNNING` or `PAUSED` for backup orchestration.
 
 ## Dependencies
 

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -30,6 +30,17 @@ configuration:
 
 Always leave `defaultVolumesToFsBackup` set to `false` so Velero backs up only Kubernetes manifests and not persistent volume contents.
 
+### Coordinated Tick Pausing
+
+PostgreSQL dumps must capture a consistent view of gameplay state. Before a `pg_dump` begins, the Game Session Service exposes `PauseTicks` and `ResumeTicks` gRPC commands. The backup workflow:
+
+1. Calls `PauseTicks` with a reason string.
+2. Polls `GetTickStatus` until the service reports `PAUSED`, which indicates all in‑flight ticks have completed.
+3. Starts `pg_dump` immediately. Ticks may resume as soon as the dump command starts because PostgreSQL snapshots the data at launch time.
+4. Invokes `ResumeTicks` so queued commands continue processing.
+
+Velero continues backing up Kubernetes manifests only and does **not** pause any services. Tick pausing is required only at the start of `pg_dump`, not for its entire runtime.
+
 For local clusters without cloud storage, deploy the `k8s/velero/minio.yaml` manifest and configure Velero with a local backup location:
 
 ```yaml

--- a/dev-tools/firemud-backup.sh
+++ b/dev-tools/firemud-backup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Pause ticks, wait until paused, run pg_dump, then resume ticks.
+set -euo pipefail
+
+ADDR=${FIREMUD_GAME_SESSION_GRPC_ADDR:-localhost:9090}
+REASON=${1:-"backup"}
+
+grpcurl -plaintext -d '{"reason":"'"$REASON"'"}' "$ADDR" game_session.v1.GameSessionService/PauseTicks
+
+until grpcurl -plaintext -d '{}' "$ADDR" game_session.v1.GameSessionService/GetTickStatus | grep -q 'PAUSED'; do
+  sleep 1
+done
+
+pg_dump -h "${FIREMUD_POSTGRES_HOST}" -U "${FIREMUD_POSTGRES_USER}" -d "${FIREMUD_POSTGRES_DB}" | gzip > "firemud_$(date +%Y%m%d%H%M%S).sql.gz"
+
+grpcurl -plaintext -d '{"reason":"'"$REASON"'"}' "$ADDR" game_session.v1.GameSessionService/ResumeTicks
+

--- a/protos/game-session/v1/game_session_service.proto
+++ b/protos/game-session/v1/game_session_service.proto
@@ -15,6 +15,12 @@ service GameSessionService {
   rpc EnqueueCommand(EnqueueCommandRequest) returns (EnqueueCommandResponse);
   rpc QueryState(QueryStateRequest) returns (QueryStateResponse);
   rpc ToggleFeatureFlag(ToggleFeatureFlagRequest) returns (ToggleFeatureFlagResponse);
+  // Pause tick execution so a consistent pg_dump can be taken.
+  rpc PauseTicks(PauseTicksRequest) returns (PauseTicksResponse);
+  // Resume tick execution after a backup.
+  rpc ResumeTicks(ResumeTicksRequest) returns (ResumeTicksResponse);
+  // Report whether ticks are currently paused.
+  rpc GetTickStatus(GetTickStatusRequest) returns (GetTickStatusResponse);
 }
 
 message StartSessionRequest {
@@ -81,5 +87,37 @@ message ToggleFeatureFlagRequest {
 
 message ToggleFeatureFlagResponse {
   bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+// Administrative request to pause tick execution.
+message PauseTicksRequest {
+  string reason = 1;
+}
+
+message PauseTicksResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+// Resume ticks after a backup has started.
+message ResumeTicksRequest {
+  string reason = 1;
+}
+
+message ResumeTicksResponse {
+  bool success = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message GetTickStatusRequest {}
+
+enum TickStatus {
+  RUNNING = 0;
+  PAUSED = 1;
+}
+
+message GetTickStatusResponse {
+  TickStatus status = 1;
   shared.v1.ErrorDetail error = 2;
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/TickService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/TickService.java
@@ -10,4 +10,13 @@ public interface TickService {
 
   /** Retrieve the latest persisted state for monitoring. */
   String queryState(Long sessionId);
+
+  /** Request that new ticks stop starting. */
+  void pauseTicks(String reason);
+
+  /** Allow ticks to resume normally. */
+  void resumeTicks(String reason);
+
+  /** Whether ticks are currently paused. */
+  net.firedevops.firemud.gamesession.v1.TickStatus getTickStatus();
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -8,15 +8,22 @@ import net.firedevops.firemud.dto.StartSessionRequest;
 import net.firedevops.firemud.gamesession.v1.EnqueueCommandRequest;
 import net.firedevops.firemud.gamesession.v1.EnqueueCommandResponse;
 import net.firedevops.firemud.gamesession.v1.GameSessionServiceGrpc;
+import net.firedevops.firemud.gamesession.v1.GetTickStatusRequest;
+import net.firedevops.firemud.gamesession.v1.GetTickStatusResponse;
+import net.firedevops.firemud.gamesession.v1.PauseTicksRequest;
+import net.firedevops.firemud.gamesession.v1.PauseTicksResponse;
 import net.firedevops.firemud.gamesession.v1.PingRequest;
 import net.firedevops.firemud.gamesession.v1.PingResponse;
 import net.firedevops.firemud.gamesession.v1.QueryStateRequest;
 import net.firedevops.firemud.gamesession.v1.QueryStateResponse;
 import net.firedevops.firemud.gamesession.v1.RestartSessionRequest;
 import net.firedevops.firemud.gamesession.v1.RestartSessionResponse;
+import net.firedevops.firemud.gamesession.v1.ResumeTicksRequest;
+import net.firedevops.firemud.gamesession.v1.ResumeTicksResponse;
 import net.firedevops.firemud.gamesession.v1.StartSessionResponse;
 import net.firedevops.firemud.gamesession.v1.StopSessionRequest;
 import net.firedevops.firemud.gamesession.v1.StopSessionResponse;
+import net.firedevops.firemud.gamesession.v1.TickStatus;
 import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagRequest;
 import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagResponse;
 import net.firedevops.firemud.service.FeatureFlagService;
@@ -193,5 +200,35 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     }
+  }
+
+  @Override
+  @Timed(value = "gamesessionGrpc.pauseTicks")
+  public void pauseTicks(
+      PauseTicksRequest request, StreamObserver<PauseTicksResponse> responseObserver) {
+    tickService.pauseTicks(request.getReason());
+    PauseTicksResponse response = PauseTicksResponse.newBuilder().setSuccess(true).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  @Timed(value = "gamesessionGrpc.resumeTicks")
+  public void resumeTicks(
+      ResumeTicksRequest request, StreamObserver<ResumeTicksResponse> responseObserver) {
+    tickService.resumeTicks(request.getReason());
+    ResumeTicksResponse response = ResumeTicksResponse.newBuilder().setSuccess(true).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  @Timed(value = "gamesessionGrpc.getTickStatus")
+  public void getTickStatus(
+      GetTickStatusRequest request, StreamObserver<GetTickStatusResponse> responseObserver) {
+    TickStatus status = tickService.getTickStatus();
+    GetTickStatusResponse response = GetTickStatusResponse.newBuilder().setStatus(status).build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
@@ -19,6 +19,9 @@ public class TickScheduler {
   @Scheduled(fixedDelayString = "${game.tick-duration-ms:1000}")
   @Timed(value = "game_session.tick_scheduler")
   public void runTicks() {
+    if (tickService.getTickStatus() == net.firedevops.firemud.gamesession.v1.TickStatus.PAUSED) {
+      return;
+    }
     List<GameInstance> running = repository.findByStatus("RUNNING");
     for (GameInstance instance : running) {
       tickService.processTick(instance.getId());

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -6,6 +6,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
@@ -56,6 +58,8 @@ public class TickServiceImpl implements TickService {
   private RedisScript<Long> stageScript;
   private RedisScript<Long> commitScript;
   private RedisScript<Long> rollbackScript;
+  private final AtomicBoolean pauseRequested = new AtomicBoolean(false);
+  private final AtomicInteger activeTicks = new AtomicInteger();
 
   private Long executeScriptWithRetry(RedisScript<Long> script, List<String> keys, Object... args) {
     int attempts = 0;
@@ -130,6 +134,10 @@ public class TickServiceImpl implements TickService {
   @Timed(value = "gamesession.tick.process")
   @Async("tickExecutor")
   public void processTick(Long sessionId) {
+    if (pauseRequested.get()) {
+      logger.debug("Tick processing skipped while paused");
+      return;
+    }
     long start = System.nanoTime();
     Long tenantId = findTenantId(sessionId);
     String lockKey = lockKey(tenantId, sessionId);
@@ -141,6 +149,7 @@ public class TickServiceImpl implements TickService {
       logger.debug("Could not acquire tick lock {}", lockKey);
       return;
     }
+    activeTicks.incrementAndGet();
     String head = null;
     boolean solo = false;
     try {
@@ -198,6 +207,7 @@ public class TickServiceImpl implements TickService {
         logger.debug("Tick budget exceeded: {} ms", elapsed);
       }
       redisTemplate.delete(lockKey);
+      activeTicks.decrementAndGet();
     }
   }
 
@@ -207,6 +217,25 @@ public class TickServiceImpl implements TickService {
     Long tenantId = findTenantId(sessionId);
     Object state = redisTemplate.opsForValue().get(stateKey(tenantId, sessionId));
     return state != null ? state.toString() : "{}";
+  }
+
+  @Override
+  public void pauseTicks(String reason) {
+    pauseRequested.set(true);
+    logger.info("Tick pause requested: {}", reason);
+  }
+
+  @Override
+  public void resumeTicks(String reason) {
+    pauseRequested.set(false);
+    logger.info("Tick resume requested: {}", reason);
+  }
+
+  @Override
+  public net.firedevops.firemud.gamesession.v1.TickStatus getTickStatus() {
+    return pauseRequested.get() && activeTicks.get() == 0
+        ? net.firedevops.firemud.gamesession.v1.TickStatus.PAUSED
+        : net.firedevops.firemud.gamesession.v1.TickStatus.RUNNING;
   }
 
   private Long findTenantId(Long sessionId) {

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
@@ -7,10 +7,17 @@ import io.grpc.stub.StreamObserver;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.dto.GameInstanceDto;
+import net.firedevops.firemud.gamesession.v1.GetTickStatusRequest;
+import net.firedevops.firemud.gamesession.v1.GetTickStatusResponse;
+import net.firedevops.firemud.gamesession.v1.PauseTicksRequest;
+import net.firedevops.firemud.gamesession.v1.PauseTicksResponse;
 import net.firedevops.firemud.gamesession.v1.PingRequest;
 import net.firedevops.firemud.gamesession.v1.PingResponse;
+import net.firedevops.firemud.gamesession.v1.ResumeTicksRequest;
+import net.firedevops.firemud.gamesession.v1.ResumeTicksResponse;
 import net.firedevops.firemud.gamesession.v1.StartSessionRequest;
 import net.firedevops.firemud.gamesession.v1.StartSessionResponse;
+import net.firedevops.firemud.gamesession.v1.TickStatus;
 import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.PingService;
@@ -90,5 +97,73 @@ class GameSessionGrpcServiceTest {
         });
 
     assertEquals("1", ref.get().getSessionId());
+  }
+
+  @Test
+  void pauseAndResumeTicksDelegateToService() {
+    PingService pingService = Mockito.mock(PingService.class);
+    GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
+    FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    TickService tickService = Mockito.mock(TickService.class);
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    GameSessionGrpcService service =
+        new GameSessionGrpcService(
+            pingService, gameInstanceService, featureFlagService, tickService, meterRegistry);
+
+    service.pauseTicks(
+        PauseTicksRequest.newBuilder().setReason("backup").build(),
+        new StreamObserver<PauseTicksResponse>() {
+          @Override
+          public void onNext(PauseTicksResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {
+            fail(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    Mockito.verify(tickService).pauseTicks("backup");
+
+    Mockito.when(tickService.getTickStatus()).thenReturn(TickStatus.PAUSED);
+
+    AtomicReference<GetTickStatusResponse> statusRef = new AtomicReference<>();
+    service.getTickStatus(
+        GetTickStatusRequest.getDefaultInstance(),
+        new StreamObserver<GetTickStatusResponse>() {
+          @Override
+          public void onNext(GetTickStatusResponse value) {
+            statusRef.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {
+            fail(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertEquals(TickStatus.PAUSED, statusRef.get().getStatus());
+
+    service.resumeTicks(
+        ResumeTicksRequest.newBuilder().setReason("done").build(),
+        new StreamObserver<ResumeTicksResponse>() {
+          @Override
+          public void onNext(ResumeTicksResponse value) {}
+
+          @Override
+          public void onError(Throwable t) {
+            fail(t);
+          }
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    Mockito.verify(tickService).resumeTicks("done");
   }
 }


### PR DESCRIPTION
## Summary
- add PauseTicks, ResumeTicks, and GetTickStatus RPCs
- block TickScheduler when ticks are paused
- track tick pause state in TickService
- expose pause controls via GameSession gRPC API and tests
- document coordinated tick pausing for backups
- update Game Session Service docs and add helper script

## Testing
- `./gradlew :game-session-service:spotlessApply`
- `./gradlew :game-session-service:check`

------
https://chatgpt.com/codex/tasks/task_e_687b055e9c4083309d1cf1e82db6df90