### PR TITLE
Fix CI Chrome install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 
       - name: Install Chrome
-        run: sudo apt install -y ./google-chrome-stable_current_amd64.deb
+        run: sudo apt install -y --allow-downgrades ./google-chrome-stable_current_amd64.deb
 
       - name: ♿ Run Accessibility Audit
         run: |

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -91,7 +91,7 @@ to be installed. On Debian-based systems you can install it with:
 ```bash
 sudo apt install -y wget
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo apt install -y ./google-chrome-stable_current_amd64.deb
+sudo apt install -y --allow-downgrades ./google-chrome-stable_current_amd64.deb
 ```
 
 Then execute:


### PR DESCRIPTION
## Summary
- allow downgrades when installing cached Chrome in CI
- document the flag in developer setup

## Testing
- `./gradlew spotlessApply lintMarkdownFix`
- `./gradlew check` *(fails: compile errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_6889c71f336c8330a68a7786967e4b3e