### PR TITLE
Fix protobuf generated source path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,12 @@ subprojects {
         sourceDirs.setFrom(sourceDirs.files.filterNot { it.path.contains(generatedDir) })
     }
 
+    // SpotBugs analyzes the compiled classes, so ensure it runs after Java
+    // compilation to avoid implicit dependency issues reported by Gradle.
+    tasks.named("spotbugsMain") {
+        dependsOn("compileJava")
+    }
+
     tasks.test {
         useJUnitPlatform()
         finalizedBy("jacocoTestReport")

--- a/gradle/proto-convention.gradle
+++ b/gradle/proto-convention.gradle
@@ -2,6 +2,23 @@ apply plugin: 'com.google.protobuf'
 
 def libs = project.extensions.getByName('libs')
 
+// Define proto source directory before configuring the protobuf plugin so that
+// the plugin wires the generate tasks and compile dependencies correctly.
+sourceSets {
+    main {
+        proto.srcDir rootProject.file('protos')
+    }
+}
+
+// Include the generated Protobuf sources in the main Java source set. The
+// protobuf Gradle plugin outputs files under `generated/sources`, not
+// `generated/source`, so point to the correct directories so that the
+// compiler can locate both message classes and gRPC stubs.
+sourceSets.main.java.srcDirs += [
+    'build/generated/sources/proto/main/java',
+    'build/generated/sources/proto/main/grpc'
+]
+
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
@@ -20,13 +37,7 @@ protobuf {
     }
 }
 
-sourceSets.main.java.srcDirs += [
-    'build/generated/source/proto/main/java',
-    'build/generated/source/proto/main/grpc'
-]
-
-sourceSets {
-    main {
-        proto.srcDir rootProject.file('protos')
-    }
+// Ensure that the Java compilation runs after Protobuf code generation.
+tasks.named('compileJava') {
+    dependsOn('generateProto')
 }


### PR DESCRIPTION
## Summary
- ensure protobuf-generated Java sources are included and compiled
- run SpotBugs after Java compilation to avoid implicit dependency warnings

## Testing
- `./gradlew :account-service:check`
- `SKIP=spotbugs pre-commit run --all-files` *(fails: Executable `buf` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68919fee328c833083ebac89722a82a6