### PR TITLE
fix: disable unused data sources in tcp proxy

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
@@ -5,11 +5,13 @@ import net.firedevops.firemud.common.config.CommonAutoConfiguration;
 import net.firedevops.firemud.telnet.TelnetServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.event.EventListener;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
 @Import(CommonAutoConfiguration.class)
 public class TcpProxyServiceApplication {
   private final TelnetServer telnetServer;


### PR DESCRIPTION
## Summary
- disable auto configuration for JDBC and Redis in TcpProxyServiceApplication to avoid unintended Hikari initialization

## Testing
- `./gradlew :tcp-proxy-service:test --rerun-tasks --info`
- `./gradlew :tcp-proxy-service:check --rerun-tasks` *(fails: Task :tcp-proxy-service:spotbugsTest FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68958bbe881c8330a7d6e1237e8aa33d