### PR TITLE
docs: add line wrapping guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@ Please read the following documents before using AI tooling or submitting code c
 - [Global AI Rules](design/project-management/ai-rules-global.md)
 - [Local AI Rules](design/project-management/ai-rules-local.md)
 
+Please wrap lines at roughly 100 characters, but avoid enforcing this with tools since rendered
+links would become too short.
+
 These files contain the full coding conventions and workflow requirements. The
 `.windsurfrules` file in this repository simply points to `ai-rules-local.md`
 for compatibility with Windsurf.

--- a/design/project-management/ai-rules-global.md
+++ b/design/project-management/ai-rules-global.md
@@ -17,6 +17,8 @@
 - Prefer explicit over implicit behavior
 - Include boilerplate unless minimal examples are requested
 - Keep code clean, modular, and well organized
+- Aim for ~100-character lines for readability. Avoid tool-enforced widths that make wrapped
+  links too short.
 - Refactor files over 300 lines
 
 ## 3. Validation and Error Handling


### PR DESCRIPTION
## Summary
- document ~100-character line wrapping guidance for AI contributions
- retain guidance only in global rules and root instructions, removing redundant note from local Java rules

## Testing
- `pre-commit run --files AGENTS.md design/project-management/ai-rules-global.md design/project-management/ai-rules-local.md` *(fails: Buf Lint "STANDARD" is not a known id or category)*

------
https://chatgpt.com/codex/tasks/task_e_68958d156f4483308dea3ca86e418658