### PR TITLE
Conditionally load Postgres datasource and fix SpotBugs deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,9 @@ subprojects {
     tasks.named("spotbugsMain") {
         dependsOn("compileJava")
     }
+    tasks.named("spotbugsTest") {
+        dependsOn("compileTestJava")
+    }
 
     tasks.test {
         useJUnitPlatform()

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/config/DatabaseAutoConfiguration.java
@@ -10,6 +10,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Objects;
 import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -34,6 +35,7 @@ public class DatabaseAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnClass(name = "org.postgresql.Driver")
   public DataSource dataSource() {
     String url =
         String.format(


### PR DESCRIPTION
## Summary
- avoid creating a DataSource when the Postgres driver is absent
- wire SpotBugs test task to compileTestJava to satisfy Gradle dependency validation

## Testing
- `./gradlew :tcp-proxy-service:check`
- `./gradlew :common-library:check`


------
https://chatgpt.com/codex/tasks/task_e_6895a45cca308330b91784e7ba3860c1