### PR TITLE
docs: remove manual line wrapping guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@ Please read the following documents before using AI tooling or submitting code c
 - [Global AI Rules](design/project-management/ai-rules-global.md)
 - [Local AI Rules](design/project-management/ai-rules-local.md)
 
-Please wrap lines at roughly 100 characters, but avoid enforcing this with tools since rendered
-links would become too short.
+Do not manually wrap lines. Let lines flow naturally so content displays cleanly on GitHub and in
+editors.
 
 These files contain the full coding conventions and workflow requirements. The
 `.windsurfrules` file in this repository simply points to `ai-rules-local.md`

--- a/design/project-management/ai-rules-global.md
+++ b/design/project-management/ai-rules-global.md
@@ -17,8 +17,8 @@
 - Prefer explicit over implicit behavior
 - Include boilerplate unless minimal examples are requested
 - Keep code clean, modular, and well organized
-- Aim for ~100-character lines for readability. Avoid tool-enforced widths that make wrapped
-  links too short.
+- Avoid manual line wrapping; let lines flow naturally so content displays correctly in editors and
+  on GitHub.
 - Refactor files over 300 lines
 
 ## 3. Validation and Error Handling


### PR DESCRIPTION
## Summary
- drop 100-character line wrapping guidance in root AI contribution doc
- instruct in global AI rules to avoid manual line wrapping so content renders well on GitHub

## Testing
- `pre-commit run --files AGENTS.md design/project-management/ai-rules-global.md`


------
https://chatgpt.com/codex/tasks/task_e_6896c38f5ac48330b7eac0925bd21207