### PR TITLE
docs: fix chat history persistence formatting

### DIFF
--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -97,6 +97,7 @@ These notes summarize typical optimizations applied across FireMUD services.
   - **Tells:** 48 hours or 50 messages per player
   - **Guild/City:** 48 hours or 50 messages per guild or city
   - **Account messages:** 48 hours or 50 messages
+  
   Older messages are persisted in PostgreSQL for long-term retrieval.
 - High concurrency load tests with Gatling, located under `dev-tools/load-testing`, help determine scaling limits and guide database indexing improvements.
 


### PR DESCRIPTION
## Summary
- ensure chat history persistence note renders as separate paragraph

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `./gradlew check` *(fails: Task ':account-service:spotlessJava' uses outputs of ':account-service:generateProto' without dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689856dc821083309a2db5b21c55e52e