### PR TITLE
feat(gateway): proxy asset store through gateway

### DIFF
--- a/design/architecture/game-customization-options.md
+++ b/design/architecture/game-customization-options.md
@@ -6,7 +6,7 @@ This brief document summarizes optional ways a hosted game can change its look a
 
 - Designers upload logos, favicons, and theme JSON through the **Game Design Service** at design time. Assets are packaged when a version is published.
 - At publish time, assets are pushed to an object store (e.g., S3, MinIO, or a CDN) under a `tenantId`/`version` path. A `manifest.json` mapping asset keys to public URLs is stored alongside them.
-- Runtime clients fetch this manifest using the URL recorded in the published version metadata and load assets directly from the CDN. The Game Design Service is never queried during gameplay.
+- Runtime clients fetch this manifest using the URL recorded in the published version metadata and load assets directly from the CDN or through the gateway's `/assets/**` route when a local MinIO instance is used. The Game Design Service is never queried during gameplay.
 - A `manifest.json` is generated for every published version, even when no assets are supplied, so version metadata remains consistent.
 - If the manifest is empty or missing fields, the default platform branding is applied.
 - The manifest can be extended with optional assets such as tutorial images, UI overlays, or CSS snippets.
@@ -24,10 +24,11 @@ Example `manifest.json`:
 - **Self-hosted S3**: For local development or private deployments, run an
   S3-compatible service such as MinIO. Docker Compose provides a `minio` service
   preconfigured with the `firemud-assets` bucket. In Kubernetes, apply the
-  manifests under `k8s/minio/` and expose the service with an Ingress or
-  port-forward. Point `ASSET_STORE_ENDPOINT` to this instance and set the bucket
-  and credentials via `ASSET_STORE_BUCKET`, `ASSET_STORE_ACCESS_KEY`,
-  `ASSET_STORE_SECRET_KEY`, and `ASSET_STORE_REGION`.
+  manifests under `k8s/minio/` and proxy `/assets/**` through the gateway
+  instead of exposing MinIO directly. Set `ASSET_STORE_ENDPOINT` to
+  `https://<gateway-domain>/assets` and supply the bucket and credentials via
+  `ASSET_STORE_BUCKET`, `ASSET_STORE_ACCESS_KEY`, `ASSET_STORE_SECRET_KEY`, and
+  `ASSET_STORE_REGION`.
 
 - The React client loads theme and asset files per tenant at runtime; see [Frontend Architecture](./system-architecture-frontend.md) for details.
 

--- a/design/architecture/system-architecture-frontend.md
+++ b/design/architecture/system-architecture-frontend.md
@@ -82,8 +82,9 @@ FireMUD aims to let each hosted game supply its own UI styling and layout tweaks
 - Published version metadata stores the manifest URL. At runtime the React app
   fetches this manifest to load logos, favicons, theme JSON, and optional route
   definitions, then applies Material-UI overrides.
-- Assets are loaded directly from the CDN; the Game Design Service is never
-  queried during gameplay.
+- Assets are loaded directly from the CDN or via the gateway's `/assets/**`
+  route when a self-hosted MinIO instance is used; the Game Design Service is
+  never queried during gameplay.
 - If the manifest omits an asset, the default platform styling is used.
 - Core components remain shared so feature updates reach all games without
   forks. (TODO: Not yet implemented)

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -103,8 +103,20 @@ See [Backup & Disaster Recovery](./system-architecture-backup-recovery.md) for b
      sh -c "mc alias set local http://minio:9000 $ACCESS $SECRET && mc mb local/firemud-assets"
    ```
 
-3. Services access the bucket using the `ASSET_STORE_*` environment variables.
-4. To remove a published tenant version, delete the corresponding prefix:
+3. Allow public reads and CORS from the gateway domain:
+
+   ```bash
+   kubectl run mc --rm -it --image=minio/mc --command -- \
+     sh -c "mc alias set local http://minio:9000 $ACCESS $SECRET && \
+            mc anonymous set download local/firemud-assets && \
+            printf '[{\"AllowedMethods\":[\"GET\"],\"AllowedOrigins\":[\"https://your-gateway-domain\"],\"AllowedHeaders\":[\"*\"]}]' > /tmp/cors.json && \
+            mc cors set local/firemud-assets /tmp/cors.json"
+   ```
+
+4. Services access the bucket using the `ASSET_STORE_*` environment variables. When the
+   gateway proxies `/assets/**` to MinIO, set `ASSET_STORE_ENDPOINT` to
+   `https://<gateway-domain>/assets` so published manifests generate public URLs.
+5. To remove a published tenant version, delete the corresponding prefix:
 
    ```bash
    kubectl run mc --rm -it --image=minio/mc --command -- \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -278,11 +278,20 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    entrypoint: ["sh", "-c", "mc alias set local http://minio:9000 $ASSET_STORE_ACCESS_KEY $ASSET_STORE_SECRET_KEY && mc mb --ignore-existing local/$ASSET_STORE_BUCKET"]
+    entrypoint:
+      - sh
+      - -c
+      - |
+        mc alias set local http://minio:9000 $ASSET_STORE_ACCESS_KEY $ASSET_STORE_SECRET_KEY &&
+        mc mb --ignore-existing local/$ASSET_STORE_BUCKET &&
+        mc anonymous set download local/$ASSET_STORE_BUCKET &&
+        printf '[{"AllowedMethods":["GET"],"AllowedOrigins":["%s"],"AllowedHeaders":["*"]}]' "$ASSET_STORE_CORS_ORIGIN" > /tmp/cors.json &&
+        mc cors set local/$ASSET_STORE_BUCKET /tmp/cors.json
     environment:
       ASSET_STORE_ACCESS_KEY: ${ASSET_STORE_ACCESS_KEY:-minio}
       ASSET_STORE_SECRET_KEY: ${ASSET_STORE_SECRET_KEY:-minio123}
       ASSET_STORE_BUCKET: ${ASSET_STORE_BUCKET:-firemud-assets}
+      ASSET_STORE_CORS_ORIGIN: ${ASSET_STORE_CORS_ORIGIN:-http://localhost:8080}
 
   pg-dump-cron:
     build:

--- a/k8s/minio/README.md
+++ b/k8s/minio/README.md
@@ -25,10 +25,20 @@ published game assets.
 4. Create the bucket used by FireMUD:
 
    ```bash
-   kubectl run mc --rm -it --image=minio/mc --command -- \
-     sh -c "mc alias set local http://minio:9000 MINIOADMIN MINIOADMIN && mc mb local/firemud-assets"
-   ```
+    kubectl run mc --rm -it --image=minio/mc --command -- \
+      sh -c "mc alias set local http://minio:9000 MINIOADMIN MINIOADMIN && mc mb local/firemud-assets"
+    ```
 
-Expose the service with an Ingress or Port-forward as needed. Configure
-application services using the `ASSET_STORE_*` environment variables to point to
-this endpoint.
+5. Allow public reads and CORS from the gateway domain:
+
+    ```bash
+    kubectl run mc --rm -it --image=minio/mc --command -- \
+      sh -c "mc alias set local http://minio:9000 MINIOADMIN MINIOADMIN && \
+             mc anonymous set download local/firemud-assets && \
+             printf '[{\"AllowedMethods\":[\"GET\"],\"AllowedOrigins\":[\"https://your-gateway-domain\"],\"AllowedHeaders\":[\"*\"]}]' > /tmp/cors.json && \
+             mc cors set local/firemud-assets /tmp/cors.json"
+    ```
+
+ Expose the service with an Ingress or Port-forward as needed. Configure
+ application services using the `ASSET_STORE_*` environment variables to point to
+ this endpoint.

--- a/services/spring-cloud-gateway/src/main/resources/routes-dev.yml
+++ b/services/spring-cloud-gateway/src/main/resources/routes-dev.yml
@@ -38,3 +38,9 @@ spring:
           uri: http://world-management-service:8080
           predicates:
             - Path=/api/world/**
+        - id: asset-store
+          uri: http://minio:9000
+          predicates:
+            - Path=/assets/**
+          filters:
+            - StripPrefix=1 # remove /assets before forwarding

--- a/services/spring-cloud-gateway/src/main/resources/routes-prod.yml
+++ b/services/spring-cloud-gateway/src/main/resources/routes-prod.yml
@@ -38,3 +38,9 @@ spring:
           uri: http://world-management-service.default.svc.cluster.local:8080
           predicates:
             - Path=/api/world/**
+        - id: asset-store
+          uri: http://minio.default.svc.cluster.local:9000
+          predicates:
+            - Path=/assets/**
+          filters:
+            - StripPrefix=1 # remove /assets before forwarding


### PR DESCRIPTION
## Summary
- expose MinIO asset bucket through the gateway for dev and prod
- configure MinIO setup to allow public reads and CORS for gateway access
- document asset-store runbooks for enabling public bucket and gateway endpoint
- clarify design docs so manifests can reference the gateway's `/assets/**` route when using self-hosted S3

## Testing
- `pre-commit run --files design/architecture/game-customization-options.md design/architecture/system-architecture-frontend.md`

------
https://chatgpt.com/codex/tasks/task_e_689856693a508330baf0448a3b0d51a5