### PR TITLE
Improve CI caching for Node and Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,16 +129,6 @@ jobs:
       - name: 📑 Lint OpenAPI Specs
         run: npm --prefix config/openapi run openapi:lint
 
-      - name: 💾 Cache Node Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.npm
-            node_modules
-            config/openapi/node_modules
-          key: node-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: node-${{ runner.os }}-
-
       - name: 📦 Install Frontend Dependencies
         run: npm ci
         working-directory: web-client

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -41,5 +41,7 @@ jobs:
             ghcr.io/benhook1013/${{ matrix.service }}:${{ github.sha }}
             ghcr.io/benhook1013/${{ matrix.service }}:latest
             ghcr.io/benhook1013/${{ matrix.service }}:${{ github.ref_name }}
-          cache-from: type=gha
+          cache-from: |
+            type=registry,ref=ghcr.io/benhook1013/${{ matrix.service }}:latest
+            type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           services="account-service automation-scripting-service entity-management-service game-design-service game-logic-service game-session-service logging-admin-service social-groups-service spring-cloud-gateway tcp-proxy-service world-management-service"
           for service in $services; do
+            docker pull ghcr.io/benhook1013/$service:latest || true
             docker buildx build \
+              --cache-from type=registry,ref=ghcr.io/benhook1013/$service:latest \
               --cache-from type=gha \
               --cache-to type=gha,mode=max \
               --load \


### PR DESCRIPTION
## Summary
- remove redundant Node modules cache step so setup-node cache is used before installs
- reuse registry layers in preview workflow to avoid rebuilding unchanged service images
- pull previous `latest` images as build cache for Docker image workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/docker-images.yml .github/workflows/preview.yml`


------
https://chatgpt.com/codex/tasks/task_e_689ae536de7883309cffa4bb8bce3daa