### PR TITLE
chore(ci): configure buf subdir and template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: protos
         run: |
-          buf breaking --against "../.git#ref=${{ github.event.pull_request.base.sha }}"
+          buf breaking --against "../.git#ref=${{ github.event.pull_request.base.sha }},subdir=protos"
 
       - name: ⚙️ Generate Protobufs
         working-directory: protos
-        run: buf generate
+        run: buf generate --template ../config/protobuf/buf.gen.yaml
 
   docker-lint:
     name: Dockerfile Lint


### PR DESCRIPTION
## Summary
- scope buf breaking comparison to the protos subdirectory
- run buf generate with repository buf.gen.yaml template

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_689be64be0448330b027c426f4cbaeb6