### PR TITLE
chore(ci): cache openapi deps and install in build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,10 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             web-client/package-lock.json
+            config/openapi/package-lock.json
 
       - name: 📦 Install Root Dependencies
-        run: npm ci
+        run: npm --prefix config/openapi ci
 
       - name: 📑 Lint OpenAPI Specs
         run: npm --prefix config/openapi run openapi:lint


### PR DESCRIPTION
## Summary
- cache config/openapi package-lock in build-and-test
- install OpenAPI root dependencies during build

## Testing
- `./gradlew check` *(fails: Task ':account-service:spotlessJava' uses output of ':account-service:generateProto' without explicit dependency)*
- `pre-commit run --all-files` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689beb87e7cc83308f08f524e0486b15