### PR TITLE
ci: run Spotless and markdown lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,13 @@ jobs:
       - name: 🎨 Apply Spotless Formatting
         run: |
           echo "::group::Run Spotless"
-          ./gradlew spotlessApply
+          ./gradlew spotlessCheck
           echo "::endgroup::"
 
       - name: 🧹 Fix Markdown Lint
         run: |
           echo "::group::Lint Markdown"
-          ./gradlew lintMarkdownFix
+          ./gradlew lintMarkdown
           echo "::endgroup::"
 
       - name: 🧪 Run Unit Tests


### PR DESCRIPTION
## Summary
- use `spotlessCheck` to verify formatting instead of applying it
- switch markdown lint command to `lintMarkdown`

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689beb8482ac833082e687154d8d3968