### PR TITLE
ci: decouple lint jobs from buf-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
   docker-lint:
     name: Dockerfile Lint
     runs-on: ubuntu-latest
-    needs: buf-check
     steps:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v3
@@ -71,7 +70,6 @@ jobs:
 
   shellcheck:
     name: ShellCheck
-    needs: buf-check
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout Code


### PR DESCRIPTION
## Summary
- run docker and shell lint jobs in parallel to buf-check
- keep build-and-test waiting on all lint jobs

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689beb8d65a48330ae6535c730c73434