### PR TITLE
chore: split npm dependabot configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,17 @@ updates:
       timezone: "Pacific/Auckland"
 
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/config/openapi"
     schedule:
       interval: "weekly"
       day: "sunday"
       time: "04:00"
       timezone: "Pacific/Auckland"
 
-  # - package-ecosystem: "npm"
-  #   directory: "/frontend"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "sunday"
-  #     time: "04:00"
-  #     timezone: "Pacific/Auckland"
+  - package-ecosystem: "npm"
+    directory: "/web-client"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "04:00"
+      timezone: "Pacific/Auckland"


### PR DESCRIPTION
## Summary
- track npm dependencies separately for config/openapi and web-client

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_689beb9a328083308f718996af848ee0