### PR TITLE
chore: cache link check results

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Cache link check results
+        uses: actions/cache@v3
+        with:
+          path: .lychee_cache
+          key: lychee-${{ runner.os }}-${{ hashFiles('**/*.md') }}
       - name: Check links
         uses: lycheeverse/lychee-action@v2.4.1
+        env:
+          LYCHEE_CACHE: true
         with:
           args: --no-progress --verbose --exclude-file config/lychee/.lycheeignore './**/*.md' --exclude './**/node_modules/**' --exclude './**/build/**' --exclude './**/.gradle/**'
           fail: true


### PR DESCRIPTION
## Summary
- cache lychee link check in docs workflow

## Testing
- `pre-commit run --files .github/workflows/docs.yml`


------
https://chatgpt.com/codex/tasks/task_e_689be99ed7b48330bfb5940dd56a33da