### PR TITLE
ci: run frontend checks once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,44 +78,17 @@ jobs:
         with:
           scandir: dev-tools
 
-  build-and-test:
-    name: Build and Test (${{ matrix.service }})
-    needs: [buf-check, docker-lint, shellcheck]
+  frontend-checks:
+    name: Frontend Checks
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version: [21]
-        node-version: [20]
-        service:
-          - account-service
-          - automation-scripting-service
-          - entity-management-service
-          - game-design-service
-          - game-logic-service
-          - game-session-service
-          - logging-admin-service
-          - social-groups-service
-          - spring-cloud-gateway
-          - tcp-proxy-service
-          - world-management-service
-
     steps:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v3
 
-      - name: ⚙️ Set Up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java-version }}
-          cache: gradle
-
       - name: ⚙️ Set Up Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -159,6 +132,39 @@ jobs:
         run: |
           cd web-client
           npm run accessibility
+
+  build-and-test:
+    name: Build and Test (${{ matrix.service }})
+    needs: [buf-check, docker-lint, shellcheck, frontend-checks]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [21]
+        service:
+          - account-service
+          - automation-scripting-service
+          - entity-management-service
+          - game-design-service
+          - game-logic-service
+          - game-session-service
+          - logging-admin-service
+          - social-groups-service
+          - spring-cloud-gateway
+          - tcp-proxy-service
+          - world-management-service
+
+    steps:
+      - name: ⬇️ Checkout Code
+        uses: actions/checkout@v3
+
+      - name: ⚙️ Set Up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: gradle
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
## Summary
- split frontend checks into a dedicated job
- remove node setup and frontend lint from build-and-test

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_689bf17f55488330b4422bf99324f722