### PR TITLE
ci: parallelize trivy scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
   trivy-scan:
     name: Trivy Security Scan
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [buf-check, docker-lint, shellcheck]
     steps:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v3
@@ -344,7 +344,7 @@ jobs:
   generate-erd:
     name: Generate ERD Diagrams
     runs-on: ubuntu-latest
-    needs: trivy-scan
+    needs: [build-and-test, trivy-scan]
     steps:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- run Trivy scan after initial lint jobs instead of after build
- ensure ERD generation waits for both build and security scan

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_689bf1473414833098ece5c967cce210