### PR TITLE
Add daily PostgreSQL backup retention

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -191,7 +191,7 @@ runbooks. Velero schedules back up only Kubernetes manifests.
 
 The Docker Compose stack includes a `pg-dump-cron` service that runs
 `dev-tools/backups/pg-dump-rotate.sh` every 15 minutes. Dumps are written to the
-`./backups` directory and follow the same daily/weekly/monthly rotation policy as
+`./backups` directory and follow the same 15min/daily/weekly/monthly rotation policy as
 production. Set `PG_DUMP_BUCKET` and `PG_DUMP_ENDPOINT` to automatically upload
 the files to your object store.
 

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -10,10 +10,11 @@ This document defines the backup schedule and disaster recovery procedures for F
 - The production Terraform modules automatically deploy this CronJob. See [`k8s/terraform-production`](../../k8s/terraform-production).
 - Retention policy:
   - **24 hours** of 15‑minute dumps
+  - **10 days** of daily dumps
   - **3 weekly** dumps
   - **3 monthly** dumps
 - The CronJob writes to a persistent volume claim `firemud-pg-dumps` and runs
-  a script (`pg-dump.sh`) that enforces the retention policy. The environment
+  a script (`pg-dump.sh`) that enforces the retention policy. Dumps are stored under `15min`, `daily`, `weekly`, and `monthly` directories. The environment
   variables `PG_DUMP_BUCKET` **and** `PG_DUMP_ENDPOINT` must both be set;
   otherwise uploads are skipped. When defined, the script also uploads each
   dump to the specified S3/MinIO bucket. The same script is available for local use as `dev-tools/backups/pg-dump-rotate.sh`.

--- a/dev-tools/backups/pg-dump-rotate.sh
+++ b/dev-tools/backups/pg-dump-rotate.sh
@@ -15,9 +15,9 @@ if [[ -n "$BUCKET" || -n "$ENDPOINT" ]]; then
 fi
 PREFIX=firemud
 
-mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
+mkdir -p "$BACKUP_DIR/15min" "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
 TS=$(date +%Y%m%d%H%M%S)
-DUMP="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"
+DUMP="$BACKUP_DIR/15min/${PREFIX}_${TS}.sql.gz"
 
 # Install awscli if bucket upload is enabled and aws command missing
 if [ -n "$BUCKET" ] && ! command -v aws >/dev/null 2>&1; then
@@ -26,12 +26,20 @@ fi
 
 pg_dump -h "$FIREMUD_POSTGRES_HOST" -U "$FIREMUD_POSTGRES_USER" -d "$FIREMUD_POSTGRES_DB" | gzip > "$DUMP"
 
-# keep last 96 daily dumps
-cd "$BACKUP_DIR/daily"
+HOUR=$(date +%H)
+# keep last 96 15min dumps
+cd "$BACKUP_DIR/15min"
 find . -maxdepth 1 -name "${PREFIX}_*.sql.gz" -printf '%T@ %p\n' | sort -nr | tail -n +97 | cut -d' ' -f2- | xargs -r rm --
 
 DOW=$(date +%u) # 1-7 (Mon-Sun)
 DOM=$(date +%d)
+
+if [ "$HOUR" = "00" ]; then
+  DAILY_DEST="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"
+  cp "$DUMP" "$DAILY_DEST"
+  cd "$BACKUP_DIR/daily"
+  find . -maxdepth 1 -name "${PREFIX}_*.sql.gz" -printf '%T@ %p\n' | sort -nr | tail -n +11 | cut -d' ' -f2- | xargs -r rm --
+fi
 
 if [ "$DOW" = "7" ]; then
   WEEKLY_DEST="$BACKUP_DIR/weekly/${PREFIX}_${TS}.sql.gz"
@@ -53,9 +61,15 @@ if [ -n "$BUCKET" ]; then
     AWS_ARGS="--endpoint-url $ENDPOINT"
   fi
   echo "Uploading $DUMP to s3://$BUCKET"
-  if ! aws s3 cp "$DUMP" "s3://$BUCKET/daily/" "$AWS_ARGS"; then
-    echo "Failed to upload daily dump" >&2
+  if ! aws s3 cp "$DUMP" "s3://$BUCKET/15min/" "$AWS_ARGS"; then
+    echo "Failed to upload 15min dump" >&2
     exit 1
+  fi
+  if [ "$HOUR" = "00" ]; then
+    if ! aws s3 cp "$DUMP" "s3://$BUCKET/daily/" "$AWS_ARGS"; then
+      echo "Failed to upload daily dump" >&2
+      exit 1
+    fi
   fi
   if [ "$DOW" = "7" ]; then
     if ! aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" "$AWS_ARGS"; then

--- a/dev-tools/backups/verify-backups.sh
+++ b/dev-tools/backups/verify-backups.sh
@@ -26,7 +26,7 @@ if [ -n "${PG_DUMP_BUCKET:-}" ]; then
     exit 1
   }
   KEY=$(aws s3api list-objects-v2 --bucket "$PG_DUMP_BUCKET" \
-        --prefix "daily/" \
+        --prefix "15min/" \
         --endpoint-url "${PG_DUMP_ENDPOINT:-}" \
         --query 'sort_by(Contents,&LastModified)[-1].Key' --output text 2>/dev/null || echo None)
   if [ "$KEY" = "None" ]; then

--- a/dev-tools/restores/restore-latest-db.sh
+++ b/dev-tools/restores/restore-latest-db.sh
@@ -14,7 +14,7 @@ command -v aws >/dev/null 2>&1 || {
 TMP_DIR=$(mktemp -d)
 FILE="$TMP_DIR/latest.sql.gz"
 
-KEY=$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "daily/" \
+KEY=$(aws s3api list-objects-v2 --bucket "$BUCKET" --prefix "15min/" \
       --endpoint-url "$ENDPOINT" \
       --query 'sort_by(Contents,&LastModified)[-1].Key' --output text)
 

--- a/k8s/postgres/pg-dump-cronjob.yaml
+++ b/k8s/postgres/pg-dump-cronjob.yaml
@@ -68,9 +68,9 @@ data:
       fi
     fi
 
-    mkdir -p "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
+    mkdir -p "$BACKUP_DIR/15min" "$BACKUP_DIR/daily" "$BACKUP_DIR/weekly" "$BACKUP_DIR/monthly"
     TS=$(date +%Y%m%d%H%M%S)
-    DUMP="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"
+    DUMP="$BACKUP_DIR/15min/${PREFIX}_${TS}.sql.gz"
 
     # Install awscli if bucket upload is enabled and aws command missing
     if [ -n "$BUCKET" ] && ! command -v aws >/dev/null 2>&1; then
@@ -79,12 +79,20 @@ data:
 
     pg_dump -h "$FIREMUD_POSTGRES_HOST" -U "$FIREMUD_POSTGRES_USER" -d "$FIREMUD_POSTGRES_DB" | gzip > "$DUMP"
 
-    # keep last 96 daily dumps
-    cd "$BACKUP_DIR/daily"
+    HOUR=$(date +%H)
+    # keep last 96 15min dumps
+    cd "$BACKUP_DIR/15min"
     ls -1t ${PREFIX}_*.sql.gz | tail -n +97 | xargs -r rm --
 
     DOW=$(date +%u) # 1-7 (Mon-Sun)
     DOM=$(date +%d)
+
+    if [ "$HOUR" = "00" ]; then
+      DAILY_DEST="$BACKUP_DIR/daily/${PREFIX}_${TS}.sql.gz"
+      cp "$DUMP" "$DAILY_DEST"
+      cd "$BACKUP_DIR/daily"
+      ls -1t ${PREFIX}_*.sql.gz | tail -n +11 | xargs -r rm --
+    fi
 
     if [ "$DOW" = "7" ]; then
       WEEKLY_DEST="$BACKUP_DIR/weekly/${PREFIX}_${TS}.sql.gz"
@@ -106,9 +114,15 @@ data:
         AWS_ARGS="--endpoint-url $ENDPOINT"
       fi
       echo "Uploading $DUMP to s3://$BUCKET"
-      if ! aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS; then
-        echo "Failed to upload daily dump" >&2
+      if ! aws s3 cp "$DUMP" "s3://$BUCKET/15min/" $AWS_ARGS; then
+        echo "Failed to upload 15min dump" >&2
         exit 1
+      fi
+      if [ "$HOUR" = "00" ]; then
+        if ! aws s3 cp "$DUMP" "s3://$BUCKET/daily/" $AWS_ARGS; then
+          echo "Failed to upload daily dump" >&2
+          exit 1
+        fi
       fi
       if [ "$DOW" = "7" ]; then
         if ! aws s3 cp "$DUMP" "s3://$BUCKET/weekly/" $AWS_ARGS; then

--- a/k8s/velero/README.md
+++ b/k8s/velero/README.md
@@ -79,6 +79,6 @@ dev-tools/backups/setup-local-backup.sh
 
 Velero backups exclude PostgreSQL and Redis data. PostgreSQL dumps are created by
 the `firemud-pg-dump` CronJob defined under `k8s/postgres/pg-dump-cronjob.yaml`.
-The CronJob's script rotates daily/weekly/monthly dumps and can upload them to a
+The CronJob's script rotates 15min/daily/weekly/monthly dumps and can upload them to a
 bucket when `PG_DUMP_BUCKET` is set. Redis is intentionally ephemeral and
 repopulates from the database on startup.

--- a/k8s/velero/verify-backups-cronjob.yaml
+++ b/k8s/velero/verify-backups-cronjob.yaml
@@ -57,7 +57,7 @@ data:
         exit 1
       }
       KEY=$(aws s3api list-objects-v2 --bucket "$PG_DUMP_BUCKET" \
-            --prefix "daily/" \
+            --prefix "15min/" \
             --endpoint-url "${PG_DUMP_ENDPOINT:-}" \
             --query 'sort_by(Contents,&LastModified)[-1].Key' --output text 2>/dev/null || echo None)
       if [ "$KEY" = "None" ]; then


### PR DESCRIPTION
## Summary
- document 10-day daily backup tier between 15‑minute and weekly dumps
- rotate and upload 15min/daily/weekly/monthly PostgreSQL dumps
- update verification and restore scripts for new 15min prefix

## Testing
- `./gradlew check` *(fails: SpotlessTask uses generateProto outputs without dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689bef01120c83308dcb8980d07dc565