### PR TITLE
ci: use shared Buf workspace config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,11 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: protos
         run: |
-          buf breaking --against "../.git#ref=${{ github.event.pull_request.base.sha }},subdir=protos"
+          buf breaking --against "../.git#ref=${{ github.event.pull_request.base.sha }},subdir=protos" --config ../config/protobuf/buf.work.yaml
 
       - name: ⚙️ Generate Protobufs
         working-directory: protos
-        run: buf generate --template ../config/protobuf/buf.gen.yaml
+        run: buf generate --template ../config/protobuf/buf.gen.yaml --config ../config/protobuf/buf.work.yaml
 
   docker-lint:
     name: Dockerfile Lint


### PR DESCRIPTION
## Summary
- ensure buf breaking and generation use shared workspace config

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `BUF_WORKSPACE_CONFIG=../config/protobuf/buf.work.yaml buf generate --template ../config/protobuf/buf.gen.yaml`

------
https://chatgpt.com/codex/tasks/task_e_689bf512d94c8330b94ad31e9ed90287