### PR TITLE
Clarify password hashing in gRPC docs and track implementation

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -17,7 +17,7 @@ Manages user accounts and authentication for the platform. It stores profile dat
 ## Architecture / Design Notes
 
 - Stateless authentication uses short-lived JWT tokens strictly for service-to-service authorization. Gameplay clients never see these tokens.
-- Passwords are hashed with strong salts and stored only in PostgreSQL.
+- The service hashes raw passwords with a strong algorithm such as Argon2 and unique salts before storing them in PostgreSQL.
 - Session information is stored in Redis as transient data for quick reconnections.
 - Creation events are logged to the Logging & Admin Service via a saga step.
 - Ban and recovery events are logged to the Logging & Admin Service for auditability.

--- a/design/grpc-docs/grpc-api.md
+++ b/design/grpc-docs/grpc-api.md
@@ -317,7 +317,7 @@ Parameters required to register a new account.
 | ----- | ---- | ----- | ----------- |
 | username | [string](#string) |  | Desired username for login and display. |
 | email | [string](#string) |  | Email address used for notifications and password recovery. |
-| password | [string](#string) |  | Raw password that will be hashed before storage. |
+| password | [string](#string) |  | Raw password that the server hashes before storage. |
 
 
 

--- a/design/project-management/task-list-account-service.md
+++ b/design/project-management/task-list-account-service.md
@@ -12,6 +12,7 @@
 - [x] Use saga orchestrator for account creation workflow
 - [x] Implement self-service account recovery
 - [x] Add optional 2FA for admin and moderator roles
+- [ ] Hash user passwords before storage using a strong algorithm like Argon2
 - [ ] Track character ownership per account
 - [ ] Implement account ban and suspension workflows with audit logging
 - [ ] Provide web form and endpoints for players to submit ban appeals

--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -39,7 +39,7 @@ message CreateAccountRequest {
   string username = 1;
   // Email address used for notifications and password recovery.
   string email = 2;
-  // Raw password that will be hashed before storage.
+  // Raw password that the server hashes before storage.
   string password = 3;
 }
 


### PR DESCRIPTION
## Summary
- Describe account signup password hashing in account proto comment
- Regenerate gRPC API docs to reflect server-side hashing
- Track password hashing work in account service task list
- Note Argon2-based password hashing in account service design docs

## Testing
- `SKIP=frontend-lint,shellcheck pre-commit run --files design/architecture/microservices/account-service/README.md design/project-management/task-list-account-service.md design/grpc-docs/grpc-api.md protos/account/v1/account_service.proto`


------
https://chatgpt.com/codex/tasks/task_e_689bee60fed0833080693d4718d9065a