### PR TITLE
docs: split scheduled jobs into CI and cluster sections

### DIFF
--- a/design/architecture/infrastructure/schedule.md
+++ b/design/architecture/infrastructure/schedule.md
@@ -1,12 +1,19 @@
-# ⏰ Scheduled CI/CD Jobs
+# ⏰ Scheduled Jobs
 
-This document lists automated jobs that run on a schedule. Each entry links to the main design reference and the configuration that defines the schedule.
+This document lists automated jobs that run on a schedule. Each entry links to the main design reference and the configuration that defines the schedule. Jobs are grouped by the environment where they run.
+
+## GitHub CI
 
 | Scheduled Item | Frequency (UTC) | Documentation | Configuration |
 |----------------|-----------------|---------------|---------------|
 | CI — Build and Security | Daily at 03:00 | [CI/CD Pipeline](../system-architecture-cicd.md) | [.github/workflows/ci.yml](../../../.github/workflows/ci.yml) |
 | CodeQL Analysis | Weekly on Sundays at 00:00 | [CI/CD Pipeline](../system-architecture-cicd.md) | [.github/workflows/codeql.yml](../../../.github/workflows/codeql.yml) |
 | Weekly Security Scan | Weekly on Sundays at 03:00 | [CI/CD Pipeline](../system-architecture-cicd.md) | [.github/workflows/weekly-security-scan.yml](../../../.github/workflows/weekly-security-scan.yml) |
+
+## Kubernetes Cluster
+
+| Scheduled Item | Frequency (UTC) | Documentation | Configuration |
+|----------------|-----------------|---------------|---------------|
 | PostgreSQL pg_dump | Every 15 minutes | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/postgres/pg-dump-cronjob.yaml](../../../k8s/postgres/pg-dump-cronjob.yaml) |
 | Velero backup verification | Daily at 04:00 | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/velero/verify-backups-cronjob.yaml](../../../k8s/velero/verify-backups-cronjob.yaml) |
-| Velero manifest backups | 15 min, weekly, monthly | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/velero/schedule.yaml](../../../k8s/velero/schedule.yaml) |
+| Velero manifest backups | Every 15 minutes, weekly on Sundays at 02:00, monthly on the 1st at 03:00 | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/velero/schedule.yaml](../../../k8s/velero/schedule.yaml) |


### PR DESCRIPTION
## Summary
- group scheduled jobs by environment in infrastructure schedule doc
- clarify frequencies and link to GitHub Actions and Kubernetes manifests

## Testing
- `pre-commit run --files design/architecture/infrastructure/schedule.md`


------
https://chatgpt.com/codex/tasks/task_e_689bf9ad9ab08330b8112fcd31e40579