### PR TITLE
ci: remove frontend checks dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
   build-and-test:
     name: Build and Test (${{ matrix.service }})
-    needs: [buf-check, docker-lint, shellcheck, frontend-checks]
+    needs: [buf-check, docker-lint, shellcheck]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
## Summary
- remove `frontend-checks` requirement from `build-and-test` job
- ensure downstream ERD generation still depends on build and security scans

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_689bfc4ac3d8833081706178eeb7a730