### PR TITLE
chore: refine frontend cache paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            package-lock.json
             web-client/package-lock.json
             config/openapi/package-lock.json
 


### PR DESCRIPTION
## Summary
- remove unused root package-lock from frontend checks dependency cache

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689bfc7764e88330bafab6285d8eded0