### PR TITLE
Include Buf config files in cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/buf
-          key: buf-mod-${{ runner.os }}-${{ hashFiles('protos/buf.yaml', 'protos/**/*.proto') }}
+          key: buf-mod-${{ runner.os }}-${{ hashFiles('protos/buf.yaml', 'protos/**/*.proto', 'config/protobuf/buf.gen.yaml', 'config/protobuf/buf.work.yaml') }}
           restore-keys: buf-mod-${{ runner.os }}-
 
       - name: 🛠️ Fetch Base Commit for Buf Breaking


### PR DESCRIPTION
## Summary
- include buf.gen.yaml and buf.work.yaml in Buf cache key

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_689bfc7d19b4833085f97f2df375273f