### PR TITLE
chore(ci): add registry cache for docker builds

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -42,6 +42,9 @@ jobs:
             ghcr.io/benhook1013/${{ matrix.service }}:latest
             ghcr.io/benhook1013/${{ matrix.service }}:${{ github.ref_name }}
           cache-from: |
+            type=registry,ref=ghcr.io/benhook1013/${{ matrix.service }}:buildcache
             type=registry,ref=ghcr.io/benhook1013/${{ matrix.service }}:latest
             type=gha
-          cache-to: type=gha,mode=max
+          cache-to: |
+            type=registry,ref=ghcr.io/benhook1013/${{ matrix.service }}:buildcache,mode=max
+            type=gha,mode=max

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -52,8 +52,10 @@ jobs:
           for service in $services; do
             docker pull ghcr.io/benhook1013/$service:latest || true
             docker buildx build \
+              --cache-from type=registry,ref=ghcr.io/benhook1013/$service:buildcache \
               --cache-from type=registry,ref=ghcr.io/benhook1013/$service:latest \
               --cache-from type=gha \
+              --cache-to type=registry,ref=ghcr.io/benhook1013/$service:buildcache,mode=max \
               --cache-to type=gha,mode=max \
               --load \
               -t firemud-$service \


### PR DESCRIPTION
## Summary
- cache Docker builds to ghcr registry for workflow build reuse

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689bfc93ee1c8330b62d5845ebc358fe