### PR TITLE
Document observability feeds for Logging & Admin Service

### DIFF
--- a/design/architecture/system-architecture-diagram.md
+++ b/design/architecture/system-architecture-diagram.md
@@ -69,12 +69,17 @@ flowchart TD
     Prom --> Grafana
     OTel --> Jaeger
     ES --> Kibana
+    ES -- logs --> Logging
+    Prom -- metrics --> Logging
+    Jaeger -- traces --> Logging
+    Alertmgr -- alerts --> Logging
 
 ```
 
 The Web client is built with React and Material‑UI. For component layout and state management details see [Frontend Architecture](./system-architecture-frontend.md).
 
 Fluent Bit, Prometheus, and the OpenTelemetry Collector work together so logs, metrics, and traces share the same `traceId`. This makes it easy to correlate game events across Kibana, Grafana, and Jaeger dashboards.
+The Logging & Admin Service queries Elasticsearch, Prometheus, and Jaeger and consumes Alertmanager notifications to power dashboards and moderation workflows.
 
 Only the **TCP Proxy Service** and **Spring Cloud Gateway** are reachable from the internet. They operate in the network DMZ while the remaining microservices run on the internal network. See [Security Architecture](./system-architecture-security.md#🌐-network-security--boundary-design) for details.
 
@@ -98,7 +103,7 @@ The diagram covers every microservice in the repository:
 - **[Game Design Service](./microservices/game-design-service/README.md)** – Provides authoring tools for game data and feature flags with version publishing copy steps and a web-based editor.
 - **[Automation & Scripting Service](./microservices/automation-scripting-service/README.md)** – Executes AI behaviors and custom scripts.
 - **[Social & Groups Service](./microservices/social-groups-service/README.md)** – Manages chat, guilds, and social networking.
-- **[Logging & Admin Service](./microservices/logging-admin-service/README.md)** – Centralizes logging, metrics, and admin tools with advanced analytics dashboards.
+- **[Logging & Admin Service](./microservices/logging-admin-service/README.md)** – Centralizes logging, metrics, and admin tools with dashboards built from Elasticsearch logs, Prometheus metrics, and Jaeger traces to support moderation.
 
 ## 🔍 Observability Components
 
@@ -107,6 +112,7 @@ The diagram also illustrates the monitoring stack shared by every service:
 - **Fluent Bit** – Collects structured logs from each container.
 - **Elasticsearch** – Stores logs for search and troubleshooting.
 - **Prometheus** – Scrapes metrics and forwards alerts to **Alertmanager**.
+- **Alertmanager** – Routes alerts and notifies the Logging & Admin Service.
 - **Grafana** – Visualizes dashboards based on Prometheus data.
 - **OpenTelemetry Collector** – Aggregates distributed traces.
 - **Jaeger** – Provides a UI for end‑to‑end trace analysis.

--- a/design/architecture/system-architecture-logging-monitoring.md
+++ b/design/architecture/system-architecture-logging-monitoring.md
@@ -21,6 +21,8 @@ This document consolidates the platform's observability architecture.
 
 - **Prometheus** scrapes metrics from all services and triggers alerts via **Alertmanager**.
 - **Grafana** dashboards visualize performance data.
+- The Logging & Admin Service queries Prometheus for metrics and Jaeger for trace analysis to power moderation dashboards and investigations. See [Operator Dashboards](./microservices/logging-admin-service/analytics-dashboards.md) for examples.
+- The service consumes Alertmanager notifications so operators can triage alerts inside the admin UI.
 - **OpenTelemetry** spans provide distributed tracing across ticks and requests. Traces are collected by an OpenTelemetry Collector and visualized with Jaeger. See [Tracing](./system-architecture-tracing.md) for deployment details.
 - Sample Kubernetes manifests under [`k8s/monitoring`](../../k8s/monitoring) deploy the collector and Jaeger (`otel-collector.yaml`, `jaeger.yaml`).
 - Metrics are recorded with Micrometer. The shared `MetricsInterceptor` tracks `grpc.server.requests` for each call. Services increment the `grpc.app_error` counter in their `error()` helpers as described in the [gRPC API Style guidelines](./system-architecture-grpc.md).

--- a/design/project-management/task-list-logging-admin-service.md
+++ b/design/project-management/task-list-logging-admin-service.md
@@ -6,6 +6,9 @@
 - [x] Deploy Fluent Bit sidecars to forward logs to Elasticsearch
 - [x] Integrate Alertmanager for automated alerts
 - [x] Provide analytics dashboards for operators
+- [ ] Integrate Prometheus metrics into admin dashboards
+- [ ] Surface Jaeger trace data within admin dashboards
+- [ ] Display Alertmanager notifications in the admin UI
 - [ ] Support dashboard filtering by `playerId`
 - [ ] Implement real-time analytics on game performance
 - [ ] Provide real-time saga workflow state charts


### PR DESCRIPTION
## Summary
- link Elasticsearch, Prometheus, Jaeger, and Alertmanager outputs to the Logging & Admin Service in the system diagram
- describe how the admin service queries metrics, traces, and alerts in logging/monitoring docs
- track tasks for integrating metrics, traces, and alerts in the logging-admin service task list

## Testing
- `pre-commit run --files design/architecture/system-architecture-diagram.md design/architecture/system-architecture-logging-monitoring.md design/project-management/task-list-logging-admin-service.md`


------
https://chatgpt.com/codex/tasks/task_e_689bfbe416048330921e026ac2c80c4a