### PR TITLE
docs: embed kibana and grafana dashboards in admin service

### DIFF
--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -7,13 +7,13 @@ Centralized logging and administration tools for the platform. Collects log data
 ### Responsibilities
 
 - Aggregate logs from every microservice via Fluent Bit sidecars and expose search APIs.
-- Offer dashboards and search for operators and moderators.
+- Offer dashboards and search for operators and moderators by embedding Kibana and Grafana views.
 - Enforce moderation actions such as bans via secured APIs
 - Record audit trails for feature flag changes and account events.
 
 ## Architecture / Design Notes
 
-Uses the common stack outlined in [Logging & Monitoring](../../system-architecture-logging-monitoring.md) and exposes admin endpoints for reviewing logs and applying moderation actions.
+Uses the common stack outlined in [Logging & Monitoring](../../system-architecture-logging-monitoring.md) and exposes admin endpoints for reviewing logs and applying moderation actions. It consumes Kibana and Grafana APIs to embed existing dashboards within the admin interface.
 All admin APIs are secured via role-based access control integrated with the Account Service.
 
 - gRPC connections to this service require mTLS. JWT validation is required for admin or user-facing endpoints; internal gameplay and system calls are authenticated solely via mTLS.
@@ -28,7 +28,7 @@ All admin APIs are secured via role-based access control integrated with the Acc
 ## Key Features
 
 - Central log search for entries collected via Fluent Bit sidecars.
-- [Analytics dashboards](./analytics-dashboards.md) for operators.
+- [Analytics dashboards](./analytics-dashboards.md) for operators, embedding Kibana and Grafana panels.
 - Tools for banning or restricting accounts.
 - [Role-based admin UI](./admin-ui.md) for moderators.
 - Saga workflows coordinate moderation tasks across services. See [Transaction Strategies](../system-architecture-transactions.md).
@@ -95,7 +95,7 @@ grpcurl -plaintext -d '{"tenant_id":1,"reporter_account_id":1,"target_account_id
   - Account Service forwards account events and payment notifications.
   - Game Session Service streams session lifecycle metrics.
   - Social & Groups Service delivers chat logs for moderation.
-  - **External:** Elasticsearch, Prometheus, Grafana, and Alertmanager for storage, visualization, and alerting.
+  - **External:** Elasticsearch, Prometheus, Kibana, Grafana, and Alertmanager for storage, visualization, embedding, and alerting.
 
 > See [**Gateway Architecture**](../system-architecture-gateway.md),
 [**Deployment Environments**](../infrastructure/deployment-environments.md),

--- a/design/architecture/system-architecture-diagram.md
+++ b/design/architecture/system-architecture-diagram.md
@@ -73,13 +73,15 @@ flowchart TD
     Prom -- metrics --> Logging
     Jaeger -- traces --> Logging
     Alertmgr -- alerts --> Logging
+    Kibana -- dashboards --> Logging
+    Grafana -- dashboards --> Logging
 
 ```
 
 The Web client is built with React and Material‑UI. For component layout and state management details see [Frontend Architecture](./system-architecture-frontend.md).
 
 Fluent Bit, Prometheus, and the OpenTelemetry Collector work together so logs, metrics, and traces share the same `traceId`. This makes it easy to correlate game events across Kibana, Grafana, and Jaeger dashboards.
-The Logging & Admin Service queries Elasticsearch, Prometheus, and Jaeger and consumes Alertmanager notifications to power dashboards and moderation workflows.
+The Logging & Admin Service queries Elasticsearch, Prometheus, and Jaeger and consumes Alertmanager notifications. It also embeds Kibana and Grafana dashboards via their APIs to power moderation workflows.
 
 Only the **TCP Proxy Service** and **Spring Cloud Gateway** are reachable from the internet. They operate in the network DMZ while the remaining microservices run on the internal network. See [Security Architecture](./system-architecture-security.md#🌐-network-security--boundary-design) for details.
 
@@ -113,10 +115,10 @@ The diagram also illustrates the monitoring stack shared by every service:
 - **Elasticsearch** – Stores logs for search and troubleshooting.
 - **Prometheus** – Scrapes metrics and forwards alerts to **Alertmanager**.
 - **Alertmanager** – Routes alerts and notifies the Logging & Admin Service.
-- **Grafana** – Visualizes dashboards based on Prometheus data.
+- **Grafana** – Visualizes dashboards based on Prometheus data and exposes an API that the Logging & Admin Service uses for embedding.
 - **OpenTelemetry Collector** – Aggregates distributed traces.
 - **Jaeger** – Provides a UI for end‑to‑end trace analysis.
-- **Kibana** – Queries and visualizes Elasticsearch logs.
+- **Kibana** – Queries and visualizes Elasticsearch logs and exposes an API that the Logging & Admin Service uses for embedding.
 
 See [Logging & Monitoring](./system-architecture-logging-monitoring.md) for deployment details.
 

--- a/design/architecture/system-architecture-logging-monitoring.md
+++ b/design/architecture/system-architecture-logging-monitoring.md
@@ -8,7 +8,7 @@ This document consolidates the platform's observability architecture.
 
 - **Fluent Bit** sidecars collect service logs from every microservice.
 - Logs are stored in **Elasticsearch** and explored through **Kibana** dashboards.
-- The **Logging & Admin Service** exposes moderation tools and log queries.
+- The **Logging & Admin Service** exposes moderation tools and log queries and embeds Kibana dashboards via its API for richer visualization.
 - Logs are emitted in JSON with request tracing fields (e.g., `traceId`) and the active `playerId` for moderation context.
 - Kibana dashboards filter by both `traceId` and `playerId` to narrow investigations quickly.
 - gRPC services use the shared `LoggingInterceptor` to include `traceId` and `correlationId` in every log entry. See [Shared Libraries](./system-architecture-shared-libraries.md).
@@ -22,6 +22,7 @@ This document consolidates the platform's observability architecture.
 - **Prometheus** scrapes metrics from all services and triggers alerts via **Alertmanager**.
 - **Grafana** dashboards visualize performance data.
 - The Logging & Admin Service queries Prometheus for metrics and Jaeger for trace analysis to power moderation dashboards and investigations. See [Operator Dashboards](./microservices/logging-admin-service/analytics-dashboards.md) for examples.
+- It calls the Grafana API to embed existing dashboards alongside Kibana views for a unified operator experience.
 - The service consumes Alertmanager notifications so operators can triage alerts inside the admin UI.
 - **OpenTelemetry** spans provide distributed tracing across ticks and requests. Traces are collected by an OpenTelemetry Collector and visualized with Jaeger. See [Tracing](./system-architecture-tracing.md) for deployment details.
 - Sample Kubernetes manifests under [`k8s/monitoring`](../../k8s/monitoring) deploy the collector and Jaeger (`otel-collector.yaml`, `jaeger.yaml`).


### PR DESCRIPTION
## Summary
- show Logging & Admin Service consuming Kibana and Grafana in system architecture diagram
- document embedding of Kibana/Grafana dashboards in admin service and monitoring overview

## Testing
- `python3 -m pre_commit run --files design/architecture/system-architecture-diagram.md design/architecture/system-architecture-logging-monitoring.md design/architecture/microservices/logging-admin-service/README.md`

------
https://chatgpt.com/codex/tasks/task_e_689c058d002c83308005e9c9cfd22103