### PR TITLE
feat: gate heavy checks behind flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,17 +192,17 @@ jobs:
           ./gradlew spotlessCheck
           echo "::endgroup::"
 
-      - name: 🧹 Fix Markdown Lint
+      - name: 🧹 Lint Docs
         run: |
-          echo "::group::Lint Markdown"
-          ./gradlew lintMarkdown
+          echo "::group::Lint Markdown and Links"
+          ./gradlew lintMarkdown linkCheck -PfullCheck
           echo "::endgroup::"
 
       - name: 🧪 Run Unit Tests
         id: checks
         run: |
           echo "::group::Run Tests"
-          ./gradlew :${{ matrix.service }}:check
+          ./gradlew :${{ matrix.service }}:check -PfullCheck
           echo "::endgroup::"
 
       - name: 📈 Parse Coverage %

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -58,10 +58,16 @@ version from GitHub Container Registry.
 
 ## ✅ Markdown Linting via Gradle
 
-This project uses `markdownlint-cli2` to lint Markdown files. The `check` task automatically runs linting in check-only mode:
+This project uses `markdownlint-cli2` to lint Markdown files. To speed up local builds, `./gradlew check` skips Markdown lint and other heavy analysis unless the `fullCheck` property is supplied:
 
 ```bash
-./gradlew check
+./gradlew check -PfullCheck
+```
+
+You can also run the lint task directly:
+
+```bash
+./gradlew lintMarkdown
 ```
 
 To manually fix correctable issues, run:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.github.gradle.node.npm.task.NpxTask
 import com.github.spotbugs.snom.SpotBugsTask
+import org.gradle.api.plugins.quality.Checkstyle
 import java.io.File
 
 buildscript {
@@ -28,6 +29,8 @@ node {
     // Don't download Node in CI; use the version provided by the environment
     download.set(System.getenv("CI") == null)
 }
+
+val fullCheck = project.hasProperty("fullCheck") || System.getenv("CI") != null
 
 allprojects {
     repositories {
@@ -81,7 +84,12 @@ subprojects {
         toolVersion.set("4.9.3")
     }
 
+    tasks.withType<Checkstyle>().configureEach {
+        enabled = fullCheck
+    }
+
     tasks.withType<SpotBugsTask>().configureEach {
+        enabled = fullCheck
         excludeFilter.set(rootProject.file("config/spotbugs/spotbugs-exclude.xml"))
         setIgnoreFailures(true)
         // Exclude generated sources such as Protobuf classes from analysis
@@ -101,10 +109,11 @@ subprojects {
 
     tasks.test {
         useJUnitPlatform()
-        finalizedBy("jacocoTestReport")
+        if (fullCheck) finalizedBy("jacocoTestReport")
     }
 
     tasks.jacocoTestReport {
+        enabled = fullCheck
         dependsOn(tasks.test)
         reports {
             xml.required.set(true)
@@ -145,14 +154,24 @@ tasks.register<Exec>("linkCheck") {
     commandLine("bash", "./dev-tools/docs/link-check.sh")
 }
 
+tasks.named("lintMarkdown") {
+    enabled = fullCheck
+}
+
+tasks.named("linkCheck") {
+    enabled = fullCheck
+}
+
 tasks.named("check") {
-    dependsOn(
-        "lintMarkdown",
-        "checkstyleMain",
-        "spotbugsMain",
-        "jacocoTestReport",
-        "linkCheck"
-    )
+    if (fullCheck) {
+        dependsOn(
+            "lintMarkdown",
+            "checkstyleMain",
+            "spotbugsMain",
+            "jacocoTestReport",
+            "linkCheck"
+        )
+    }
 }
 
 tasks.register<Exec>("buildBaseImage") {

--- a/gradle/proto-convention.gradle
+++ b/gradle/proto-convention.gradle
@@ -41,3 +41,8 @@ protobuf {
 tasks.named('compileJava') {
     dependsOn('generateProto')
 }
+
+// Spotless needs generated sources available when formatting runs
+tasks.named('spotlessJava') {
+    dependsOn('generateProto')
+}


### PR DESCRIPTION
## Summary
- gate markdown lint, link checking, checkstyle, spotbugs, and jacoco behind `fullCheck`
- run full checks in CI via `-PfullCheck`
- document how to enable full checks locally
- ensure Spotless runs after protobuf code generation

## Testing
- `./gradlew check`
- `./gradlew check -PfullCheck`


------
https://chatgpt.com/codex/tasks/task_e_689bfef2d26c833081a516b54f0fb689