### PR TITLE
docs: remove plan wording

### DIFF
--- a/design/architecture/infrastructure/deployment-environments.md
+++ b/design/architecture/infrastructure/deployment-environments.md
@@ -134,7 +134,7 @@ Select the desired profile via the `SPRING_PROFILES_ACTIVE` environment variable
 ## 🎮 Staging Environment for Playtesting
 
 A dedicated staging cluster mirrors production using smaller node sizes. Pull requests spin up a short-lived Docker Compose stack via [preview.yml](../../../.github/workflows/preview.yml) so playtesters can evaluate changes. Test data resets nightly once the staging cluster is available.
-For details on collecting tester feedback see [Playtesting & Feedback Plan](../../project-management/playtesting-feedback.md).
+For details on collecting tester feedback see [Playtesting & Feedback](../../project-management/playtesting-feedback.md).
 
 ---
 

--- a/design/architecture/system-architecture-testing.md
+++ b/design/architecture/system-architecture-testing.md
@@ -34,7 +34,7 @@ The repository uses a hierarchical Gradle setup. The root `build.gradle.kts` del
 
 Unit and integration tests run automatically in GitHub Actions through a matrix of `:service-name:check` tasks. Cross-service tests run via the `crossServiceTest` Gradle task.
 
-## 💡 Cross-Service Integration Plan
+## 💡 Cross-Service Integration Testing
 
 For workflows that span multiple services, such as account creation and world provisioning, the suite starts several containers at once using **Testcontainers**. Each container joins a shared network so gRPC calls function just like in production.
 

--- a/design/architecture/user-journeys.md
+++ b/design/architecture/user-journeys.md
@@ -278,7 +278,7 @@ favicons, and theme overrides before applying them in the UI. See
 
 ## 16. Playtesting & Analytics
 
-Before launch or after major updates, creators invite testers to staged environments. Feedback is collected per the [Playtesting & Feedback Plan](../project-management/playtesting-feedback.md) and telemetry is reviewed using the [Analytics Dashboards](./microservices/logging-admin-service/analytics-dashboards.md).
+Before launch or after major updates, creators invite testers to staged environments. Feedback is collected per the [Playtesting & Feedback](../project-management/playtesting-feedback.md) and telemetry is reviewed using the [Analytics Dashboards](./microservices/logging-admin-service/analytics-dashboards.md).
 
 ---
 
@@ -412,7 +412,7 @@ These flows complement the architecture diagrams in [System Architecture Overvie
 - [Multi-Tenancy](./system-architecture-multi-tenancy.md)
 - [Operational Runbooks](./system-architecture-runbooks.md)
 - [Performance Optimization Guidelines](./performance-optimization.md)
-- [Playtesting & Feedback Plan](../project-management/playtesting-feedback.md)
+- [Playtesting & Feedback](../project-management/playtesting-feedback.md)
 - [Procedural Generation](./system-architecture-procedural-generation.md)
 - [Protocol Bridging](./system-architecture-protocol-bridging.md)
 - [Reconnection Strategy](./system-architecture-reconnection.md)

--- a/design/project-management/playtesting-feedback.md
+++ b/design/project-management/playtesting-feedback.md
@@ -1,4 +1,4 @@
-# 🔄 Playtesting & Feedback Plan
+# 🔄 Playtesting & Feedback
 
 Early adopters can try new features in short-lived environments created by the
 [`preview.yml`](../../.github/workflows/preview.yml) workflow. Pull requests


### PR DESCRIPTION
## Summary
- rename cross-service integration plan section to cross-service integration testing
- remove "Plan" wording from playtesting feedback docs and update references

## Testing
- ⚠️ `pre-commit run --all-files` *(fails: automation-scripting-service:spotlessJavaCheck formatting issue)*

------
https://chatgpt.com/codex/tasks/task_e_689c0e7d04588330a7cdbd8be0f0bf1f