### PR TITLE
fix: use workspace config for buf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,15 @@ jobs:
       - name: ⚠️ Buf Breaking
         if: github.event_name == 'pull_request'
         working-directory: protos
-        run: |
-          buf breaking --against "../.git#ref=${{ github.event.pull_request.base.sha }},subdir=protos" --config ../config/protobuf/buf.work.yaml
+        env:
+          BUF_WORKSPACE_CONFIG: ../config/protobuf/buf.work.yaml
+        run: buf breaking --against "../.git#ref=${{ github.event.pull_request.base.sha }},subdir=protos"
 
       - name: ⚙️ Generate Protobufs
         working-directory: protos
-        run: buf generate --template ../config/protobuf/buf.gen.yaml --config ../config/protobuf/buf.work.yaml
+        env:
+          BUF_WORKSPACE_CONFIG: ../config/protobuf/buf.work.yaml
+        run: buf generate --template ../config/protobuf/buf.gen.yaml
 
   docker-lint:
     name: Dockerfile Lint


### PR DESCRIPTION
## Summary
- fix buf breaking step using correct workspace config env var
- ensure protobuf generation uses workspace config

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: PveEncounterServiceImpl.java has formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_689c124852488330813e7ab917b0e82b