### PR TITLE
fix(ci): use valid shellcheck action tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v5
-      - uses: ludeeus/action-shellcheck@2
+      - uses: ludeeus/action-shellcheck@master
         with:
           scandir: dev-tools
 


### PR DESCRIPTION
## Summary
- switch ShellCheck GitHub action to master tag

## Testing
- `pre-commit run --all-files` *(fails: Spotless format violations in automation-scripting-service)*

------
https://chatgpt.com/codex/tasks/task_e_689c1225fcc883309ece61168d55b387