### PR TITLE
docs: expand mcp spec details

### DIFF
--- a/design/architecture/system-architecture-mcp-support.md
+++ b/design/architecture/system-architecture-mcp-support.md
@@ -17,24 +17,34 @@ These commands are wrapped in MCP messages so external tools, including AI assis
 
 ## 🔌 Protocol Handshake
 
-When a client connects, the server begins with an `mcp` version line advertising a minimum and maximum supported protocol version. The client replies with its own `mcp` line that includes the session’s `authentication-key` along with its version range. Both sides pick the highest overlapping version and tag all subsequent messages with the agreed key. After the version exchange, each side advertises optional packages with `mcp-negotiate-can` and may confirm a version for a package using `mcp-negotiate-set` before concluding with `mcp-negotiate-end`. Unknown packages are ignored so legacy clients remain unaffected.
+When a client connects, the server begins with an `mcp` version line advertising a minimum and maximum supported protocol version. The client replies with its own `mcp` line that includes the session’s `authentication-key` along with its version range. Both sides pick the highest overlapping version and tag all subsequent messages with the agreed key. After the version exchange, each side sends `mcp-negotiate-can` for every package it supports—including `mcp-negotiate` itself—and concludes with `mcp-negotiate-end`. A package becomes usable only after both sides have advertised it and both have sent `mcp-negotiate-end`. Unknown packages are ignored so legacy clients remain unaffected.
 
 Example handshake:
 
 ```text
 #$#mcp version: 2.1 to: 2.1
 #$#mcp authentication-key: 18972163558 version: 2.1 to: 2.1
+#$#mcp-negotiate-can package: mcp-negotiate min-version: 1.0 max-version: 2.0
 #$#mcp-negotiate-can package: mcp-cord min-version: 1.0 max-version: 1.0
 #$#mcp-negotiate-end
 ```
 
 ## 📨 Message Format
 
-MCP treats any line starting with `#$#` as an out-of-band message. Other lines remain in-band Telnet traffic. Lines beginning with `#$#` or `#$"` must be quoted with the prefix `#$"` to preserve their literal content. Each message contains a case-insensitive name, the session’s case-sensitive authentication key, and keyword/value pairs. Values may be simple or multiline; simple values containing spaces or special characters require quoting, while multiline values span additional lines prefixed with `* datatag` and terminate with `: datatag`.
+MCP treats any line starting with `#$#` as an out-of-band message. Other lines remain in-band Telnet traffic. Lines beginning with `#$#` or `#$"` must be quoted with the prefix `#$"` to preserve their literal content. Each message contains a case-insensitive name, the session’s case-sensitive authentication key, and keyword/value pairs. Values may be simple or multiline; simple values containing spaces or special characters require quoting, while multiline values append `*` to the keyword and include an `_data-tag` argument whose value is echoed on subsequent `* datatag keyword:` lines and closed with `#: datatag`. Malformed or unrecognized messages are silently discarded, allowing traditional Telnet clients to coexist with MCP-aware tooling.
+
+Example multiline message:
+
+```text
+#$#firemud-create-room 18972163558 name: "Hall" description*: "" _data-tag: desc1
+#$#* desc1 description: First line
+#$#* desc1 description: Second line
+#$#: desc1
+```
 
 ## 📦 Optional Packages
 
-FireMUD supports the `mcp-cord` package to multiplex additional channels over the same connection. Cords allow stateful conversations—such as room editing sessions—to be tied to specific client windows. Additional packages can be negotiated as needed.
+FireMUD supports the `mcp-cord` package to multiplex additional channels over the same connection. The package defines `mcp-cord-open`, `mcp-cord`, and `mcp-cord-closed` messages to manage cord lifecycles so stateful conversations—such as room editing sessions—can be tied to specific client windows. Additional packages can be negotiated as needed.
 
 ## Example Workflow
 


### PR DESCRIPTION
## Summary
- clarify MCP negotiation by removing non-spec messages and detailing package activation rules
- document multiline value `_data-tag` usage and cord lifecycle messages

## Testing
- `pre-commit run --all-files` *(fails: automation-scripting-service:spotlessJavaCheck format violations)*

------
https://chatgpt.com/codex/tasks/task_e_689c106a4f0483309b795067412f56aa