### PR TITLE
docs: clarify MCP case sensitivity and handshake

### DIFF
--- a/design/architecture/system-architecture-mcp-support.md
+++ b/design/architecture/system-architecture-mcp-support.md
@@ -10,7 +10,7 @@ This document outlines how FireMUD incorporates the Mud Client Protocol (MCP) to
 
 ## 📘 MCP Basics
 
-The MCP 2.1 specification defines a simple, 7-bit ASCII, line-based protocol for sending out-of-band messages on the same channel as normal Telnet traffic. Both connection endpoints are treated symmetrically, and the protocol itself maintains no state; higher-level packages define application behavior. Lines beginning with the `#$#` marker are interpreted as MCP messages, while other lines remain in-band for legacy clients.
+The MCP 2.1 specification defines a simple, 7-bit ASCII, line-based protocol for sending out-of-band messages on the same channel as normal Telnet traffic. Lines are delimited with `\r\n` and there is no fixed line-length limit. Both connection endpoints are treated symmetrically, and the protocol itself maintains no state; higher-level packages define application behavior. Message names and keywords are case-insensitive, while authentication keys and data tags must preserve their exact case. Lines beginning with the `#$#` marker are interpreted as MCP messages, while other lines remain in-band for legacy clients.
 
 ## Overview
 
@@ -25,6 +25,8 @@ When a client connects, the server begins with an `mcp` version line advertising
 
 Each endpoint then advertises its capabilities using `mcp-negotiate-can package: <name> min-version: <x> max-version: <y>` messages and finishes with `mcp-negotiate-end`. FireMUD uses version 2.0 of the `mcp-negotiate` package, so the package must be advertised explicitly and `mcp-negotiate-end` terminates negotiation. A package is considered active only after both sides have sent `mcp-negotiate-can` for it and both have sent `mcp-negotiate-end`. Implementations may defer using a package until receipt of the other side’s `mcp-negotiate-end`. Unknown packages are ignored so legacy clients remain unaffected.
 
+No other MCP traffic should be sent until both sides have exchanged their initial `mcp` lines and completed negotiation. Every subsequent message must include the agreed `authentication-key`.
+
 Example handshake:
 
 ```text
@@ -37,7 +39,7 @@ Example handshake:
 
 ## 📨 Message Format
 
-MCP treats any line starting with `#$#` as an out-of-band message. Other lines remain in-band Telnet traffic. Lines beginning with `#$#` or `#$"` must be quoted with the prefix `#$"` to preserve their literal content. Each message contains a case-insensitive name, the session’s case-sensitive authentication key, and keyword/value pairs. Values may be simple or multiline; simple values containing spaces or special characters require quoting, while multiline values append `*` to the keyword and include an `_data-tag` argument whose value is echoed on subsequent `* datatag keyword:` lines and closed with `#: datatag`. MCP places no limit on line length and relies on the underlying session for ordering and reliability. Malformed or unrecognized messages are silently discarded, allowing traditional Telnet clients to coexist with MCP-aware tooling.
+MCP treats any line starting with `#$#` as an out-of-band message. Other lines remain in-band Telnet traffic. Lines beginning with `#$#` or `#$"` must be quoted with the prefix `#$"` to preserve their literal content. Each message contains a case-insensitive name, the session’s authentication key, and case-insensitive keywords. Authentication keys and data tags are case-sensitive. Values may be simple or multiline; simple values containing spaces or special characters require quoting, while multiline values append `*` to the keyword and include an `_data-tag` argument whose value is echoed on subsequent `* datatag keyword:` lines and closed with `#: datatag`. MCP relies on the underlying session for ordering and reliability. Malformed or unrecognized messages are silently discarded, allowing traditional Telnet clients to coexist with MCP-aware tooling.
 
 Example multiline message:
 


### PR DESCRIPTION
## Summary
- describe MCP line delimiters and case sensitivity rules
- state that no other MCP messages are exchanged until after `mcp-negotiate`

## Testing
- `pre-commit run --files design/architecture/system-architecture-mcp-support.md` *(fails: automation-scripting-service:spotlessJavaCheck)*

------
https://chatgpt.com/codex/tasks/task_e_689c1fbc9af08330a2e1555d926f500f