### PR TITLE
Clarify procedural generation tick budget

### DIFF
--- a/design/architecture/system-architecture-procedural-generation.md
+++ b/design/architecture/system-architecture-procedural-generation.md
@@ -95,7 +95,7 @@ In **sparse mode**, only selected POIs and waypoints are emitted.
 
 The following rules align generators with the core runtime and tooling:
 
-1. **Solo Tick Scheduling** – Runtime generation is queued like any other command but includes `requiresSoloTick: true`. The Game Session Service executes it in an isolated tick with an extended 500&nbsp;ms budget.
+1. **Solo Tick Scheduling** – Runtime generation is queued like any other command but includes `requiresSoloTick: true`. The Game Session Service executes it in an isolated tick with an extended, configurable time budget.
 2. **Seed Metadata** – All requests specify a seed. During world creation these values are persisted by the World Management Service and reused at runtime to ensure reproducible layouts.
 3. **Sparse Traversal Rules** – Sparse rooms exist on the map. A `spacingMultiplier` value on each region influences movement cost and travel time between them.
 4. **Post-generation Population** – After rooms are created, the Automation & Scripting Service triggers population scripts based on room tags, biome, and difficulty zone.


### PR DESCRIPTION
## Summary
- make procedural generation tick budget configurable in docs

## Testing
- `pre-commit run --files design/architecture/system-architecture-procedural-generation.md` *(fails: PveEncounterServiceImpl.java needs formatting; shellcheck missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c23bcf71c83309430175d0fc50ced