### PR TITLE
Use Argon2 hashing and keep login JWT server-side

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -93,7 +93,7 @@ resolved during authentication.
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | `GET`  | `/ping` | Simple health check |
-| `POST` | `/auth/login` | Authenticate and return JWT |
+| `POST` | `/auth/login` | Authenticate and establish a session; JWT is kept server-side |
 | `POST` | `/auth/request-password-reset` | Request password reset |
 | `POST` | `/auth/complete-password-reset` | Complete password reset |
 | `POST` | `/auth/request-email-verification` | Send verification email |
@@ -216,7 +216,7 @@ Two-factor authentication is optional and applies only when a `two_factor_secret
 - `POST /accounts` – create a new account and profile.
 - `GET /accounts/{accountId}/export` – export all account data.
 - `DELETE /accounts/{accountId}` – remove an account permanently.
-- `POST /auth/login` – authenticate and establish a session. The JWT returned is for internal service calls.
+- `POST /auth/login` – authenticate and establish a session. JWTs are stored for internal service calls and never returned to clients.
 - `GET /.well-known/jwks.json` – JWKS for verifying issued JWT tokens.
 - `POST /auth/request-email-verification` – send a verification email for the account.
 - `POST /auth/verify-email` – confirm the verification token.
@@ -255,9 +255,7 @@ Example login response:
 ```json
 {
   "status": "SUCCESS",
-  "data": {
-    "authToken": "<token>"
-  }
+  "data": null
 }
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ opentelemetry = "1.53.0"
 micrometer = "1.15.3"
 jjwt = "0.12.6"
 aws-sdk = "2.32.21"
+argon2 = "2.11"
 
 [libraries]
 # Spring Boot Starters
@@ -54,6 +55,7 @@ micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-p
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
 jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
+argon2 = { module = "de.mkammerer:argon2-jvm", version.ref = "argon2" }
 
 grpc-spring-boot-starter = { module = "io.github.lognet:grpc-spring-boot-starter", version = "5.2.0" }
 postgresql = { module = "org.postgresql:postgresql", version = "42.7.7" }

--- a/services/account-service/build.gradle.kts
+++ b/services/account-service/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.otlp)
+    implementation(libs.argon2)
     compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
     implementation(libs.stripe.java)
     implementation(libs.otp.java)

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -3,7 +3,6 @@ package net.firedevops.firemud.controller;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AccountRefRequest;
-import net.firedevops.firemud.dto.AuthTokenDto;
 import net.firedevops.firemud.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.dto.LoginRequest;
 import net.firedevops.firemud.dto.PasswordResetRequest;
@@ -26,11 +25,10 @@ public class AuthController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<ApiResponse<AuthTokenDto>> login(@Valid @RequestBody LoginRequest request) {
-    String token =
-        accountService.authenticate(
-            request.tenantId(), request.username(), request.password(), request.otp());
-    return ResponseEntity.ok(ApiResponse.success(new AuthTokenDto(token)));
+  public ResponseEntity<ApiResponse<Void>> login(@Valid @RequestBody LoginRequest request) {
+    accountService.authenticate(
+        request.tenantId(), request.username(), request.password(), request.otp());
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 
   @PostMapping("/request-password-reset")

--- a/services/account-service/src/main/java/net/firedevops/firemud/dto/AuthTokenDto.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/dto/AuthTokenDto.java
@@ -1,3 +1,0 @@
-package net.firedevops.firemud.dto;
-
-public record AuthTokenDto(String authToken) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -1,10 +1,9 @@
 package net.firedevops.firemud.service.impl;
 
 import com.bastiaanjansen.otp.TOTPGenerator;
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
 import io.micrometer.core.annotation.Timed;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Optional;
 import net.firedevops.firemud.client.LoggingAdminClient;
@@ -146,8 +145,7 @@ public class AccountServiceImpl implements AccountService {
     Optional<Account> accountOpt = accountRepository.findByTenantIdAndUsername(tenantId, username);
     Account account =
         accountOpt.orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
-    String hash = hashPassword(password);
-    if (!hash.equals(account.getPasswordHash())) {
+    if (!verifyPassword(password, account.getPasswordHash())) {
       throw new IllegalArgumentException("Invalid credentials");
     }
     if (account.getTwoFactorSecret() != null
@@ -347,17 +345,13 @@ public class AccountServiceImpl implements AccountService {
   }
 
   private String hashPassword(String password) {
-    try {
-      MessageDigest md = MessageDigest.getInstance("SHA-256");
-      byte[] hash = md.digest(password.getBytes(StandardCharsets.UTF_8));
-      StringBuilder sb = new StringBuilder();
-      for (byte b : hash) {
-        sb.append(String.format("%02x", b));
-      }
-      return sb.toString();
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException("SHA-256 not available", e);
-    }
+    Argon2 argon2 = Argon2Factory.create();
+    return argon2.hash(2, 65536, 1, password.toCharArray());
+  }
+
+  private boolean verifyPassword(String password, String hash) {
+    Argon2 argon2 = Argon2Factory.create();
+    return argon2.verify(hash, password.toCharArray());
   }
 
   private String readTemplate(String name) {

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/controller/AuthControllerTest.java
@@ -25,7 +25,7 @@ class AuthControllerTest {
   @MockitoBean private AccountService accountService;
 
   @Test
-  void loginReturnsToken() throws Exception {
+  void loginDoesNotExposeToken() throws Exception {
     LoginRequest request = new LoginRequest(1L, "demo", "password", null);
     when(accountService.authenticate(1L, "demo", "password", null)).thenReturn("tok123");
 
@@ -36,7 +36,7 @@ class AuthControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))
-        .andExpect(jsonPath("$.data.authToken").value("tok123"));
+        .andExpect(jsonPath("$.data.authToken").doesNotExist());
   }
 
   @Test

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import de.mkammerer.argon2.Argon2;
+import de.mkammerer.argon2.Argon2Factory;
 import java.util.Optional;
 import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.saga.SagaRunner;
@@ -260,16 +262,7 @@ class AccountServiceImplTest {
   }
 
   private static String hash(String password) {
-    try {
-      java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
-      byte[] hash = md.digest(password.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-      StringBuilder sb = new StringBuilder();
-      for (byte b : hash) {
-        sb.append(String.format("%02x", b));
-      }
-      return sb.toString();
-    } catch (java.security.NoSuchAlgorithmException e) {
-      throw new IllegalStateException(e);
-    }
+    Argon2 argon2 = Argon2Factory.create();
+    return argon2.hash(2, 65536, 1, password.toCharArray());
   }
 }


### PR DESCRIPTION
## Summary
- secure account passwords with Argon2 hashes and verification
- avoid exposing JWTs from the `/auth/login` endpoint and update design docs accordingly

## Testing
- `./gradlew :account-service:check`

------
https://chatgpt.com/codex/tasks/task_e_689c28c29b7c8330be971cb029ab7f55