### PR TITLE
docs: reference dev-tools scripts

### DIFF
--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -179,5 +179,6 @@ These can be added as separate workflows or additional jobs in the main pipeline
 - [Infrastructure Overview](./infrastructure/README.md)
 - [Deployment Environments](./infrastructure/deployment-environments.md)
 - [Testing Strategy](./system-architecture-testing.md)
+- [Developer Tools & Scripting](./system-architecture-scripting.md)
 - [Backup & Disaster Recovery](./system-architecture-backup-recovery.md)
 - [User Journeys – Testing & Continuous Delivery](./user-journeys.md#17-testing--continuous-delivery)

--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -100,10 +100,10 @@ By constraining scripts to curated components and enforcing strict quotas, FireM
 
 ## 🛠️ Developer Tools
 
-Several helper scripts live under `dev-tools/` to streamline common tasks:
+Several helper scripts streamline common tasks:
 
-- `firemud-cli.sh` – command-line utility for starting and stopping the local stack.
-- `docs/generate-erd.sh` – produces Entity Relationship Diagrams for each service.
-- `docs/generate-grpc-docs.sh` – generates Markdown documentation from protobuf definitions.
+- `dev-tools/firemud-cli.sh` – command-line utility for starting and stopping the local stack.
+- `dev-tools/docs/generate-erd.sh` – produces Entity Relationship Diagrams for each service.
+- `dev-tools/docs/generate-grpc-docs.sh` – generates Markdown documentation from protobuf definitions.
 
 These scripts complement the web-based editor and allow creators to automate routine actions.


### PR DESCRIPTION
## Summary
- clarify dev-tools script paths
- link CI/CD design to scripting docs

## Testing
- `pre-commit run --files design/architecture/system-architecture-cicd.md design/architecture/system-architecture-scripting.md` *(fails: :automation-scripting-service:spotlessJavaCheck)*
- `pre-commit run markdownlint --files design/architecture/system-architecture-cicd.md design/architecture/system-architecture-scripting.md`


------
https://chatgpt.com/codex/tasks/task_e_689c30661b1083308aecb42d9d81638a