### PR TITLE
docs: clarify ci workflow details

### DIFF
--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -8,7 +8,7 @@ GitHub Actions fully automates Kubernetes deployments.
 
 ## 🎯 Goals
 
-- **Automate builds and tests** for all microservices whenever code changes are pushed.
+- **Automate builds and tests** for all microservices whenever code changes are pushed by running the [`ci.yml`](../../.github/workflows/ci.yml) workflow.
 - **Build Docker images** and push them to GitHub Container Registry (GHCR).
 - **Deploy to Kubernetes manually** via the [`manual-helm-deploy.yml`](../../.github/workflows/manual-helm-deploy.yml) workflow, which applies the Helm charts under [`k8s/helm`](../../k8s/helm) using `values-local.yaml` by default. Full automation handles this automatically.
 - Keep the workflow configuration easy to maintain and extensible for additional security scans or nightly jobs.
@@ -20,7 +20,7 @@ GitHub Actions fully automates Kubernetes deployments.
 - **Generate database ERD diagrams** as build artifacts after each run. The [`dev-tools/docs/generate-erd.sh`](../../dev-tools/docs/generate-erd.sh) script writes them to `design/erd/`, and the workflow uploads this directory as artifacts.
 - **Cancel previous runs for the same branch** using a concurrency group so CI resources are conserved.
 
-The CI job first performs a **Buf breaking change check** to ensure protobuf APIs remain compatible. It then runs formatting and lint steps followed by a matrix of Gradle `check` tasks—one per microservice—which compile and test each module while running Spotless, Checkstyle, and SpotBugs. **Hadolint** checks Dockerfiles and **ShellCheck** validates shell scripts. Coverage reports are generated with JaCoCo and a Trivy security scan runs on the workspace. Node 20 is also configured so the pipeline can lint OpenAPI definitions, run the React client’s linters, and execute an accessibility audit using headless Chrome. After the scan, the job executes [`dev-tools/docs/generate-erd.sh`](../../dev-tools/docs/generate-erd.sh) to build ERD diagrams from the service migrations and uploads them as artifacts. Documentation links are verified in the `docs.yml` workflow before publishing to GitHub Pages. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
+The main [`ci.yml`](../../.github/workflows/ci.yml) workflow first performs a **Buf breaking change check** to ensure protobuf APIs remain compatible. It then runs formatting and lint steps followed by a matrix of Gradle `check` tasks—one per microservice—which compile and test each module while running Spotless, Checkstyle, and SpotBugs. **Hadolint** checks Dockerfiles and **ShellCheck** validates shell scripts. Coverage reports are generated with JaCoCo and a Trivy security scan runs on the workspace. Node 20 is also configured so the pipeline can lint OpenAPI definitions, run the React client’s linters, and execute an accessibility audit using headless Chrome. After the `build-and-test` and `trivy-scan` jobs finish, a dedicated `generate-erd` job runs [`dev-tools/docs/generate-erd.sh`](../../dev-tools/docs/generate-erd.sh) to build ERD diagrams from the service migrations and uploads them as artifacts. Documentation links are verified in the `docs.yml` workflow before publishing to GitHub Pages. Docker images are built in a separate workflow. See [System Architecture Testing](./system-architecture-testing.md) for additional details.
 A GitHub Actions step posts a summary comment on pull requests showing whether tests passed and what the overall coverage percentage was.
 
 ---


### PR DESCRIPTION
## Summary
- reference `ci.yml` as the primary workflow
- describe ERD generation running after build-and-test and Trivy jobs

## Testing
- `pre-commit run --files design/architecture/system-architecture-cicd.md` *(fails: automation-scripting-service formatting, shellcheck missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c30661b1083308aecb42d9d81638a