### PR TITLE
Configure Gradle toolchain for Java 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,10 @@ subprojects {
     group = "net.firedevops.firemud"
     version = project.property("version") as String
 
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
+    plugins.withId("java") {
+        the<JavaPluginExtension>().toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+        tasks.withType<JavaCompile>().configureEach {
+            options.release.set(21)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,8 @@ org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m
+org.gradle.java.installations.auto-detect=true
+org.gradle.java.installations.auto-download=true
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 version=0.1.0

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/PveEncounterServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/PveEncounterServiceImpl.java
@@ -9,8 +9,8 @@ import net.firedevops.firemud.service.PveEncounterService;
 import org.springframework.stereotype.Service;
 
 /**
- * Basic PvE encounter generator that uses a predefined set of events per region.
- * Encounters are seeded so results can be reproduced during testing.
+ * Basic PvE encounter generator that uses a predefined set of events per region. Encounters are
+ * seeded so results can be reproduced during testing.
  */
 @Service
 @Slf4j


### PR DESCRIPTION
## Summary
- Enable automatic Java toolchain detection and download and increase JVM memory
- Enforce Java 21 toolchain and release level across all subprojects
- Format PveEncounterServiceImpl to satisfy Spotless

## Testing
- `./gradlew --version`
- `./gradlew -q --console=plain javaToolchains`
- `./gradlew --info --console=plain help`
- `./gradlew --console=plain clean build`


------
https://chatgpt.com/codex/tasks/task_e_689c3936d56c8330bc19c7dd5d0c0f3a