### PR TITLE
Ensure Gradle toolchains auto-provision JDK 21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=true
+# DO NOT set org.gradle.java.home (remove it if present)
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 version=0.1.0


### PR DESCRIPTION
## Summary
- Document that `org.gradle.java.home` must not be set so Gradle can auto-provision JDK 21
- Verify Gradle toolchains resolve Java 21 and build succeeds

## Testing
- `./gradlew --version`
- `./gradlew -q javaToolchains`
- `./gradlew --info help`
- `./gradlew clean build --console=plain`
- `./gradlew check --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_689c59dcf9c883308fb6af02cde13368