### PR TITLE
Enable file scheme for local link checking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,6 +161,7 @@ tasks.register<NpxTask>("lintMarkdownFix") {
 
 tasks.register<Exec>("linkCheck") {
     commandLine("bash", "./dev-tools/docs/link-check.sh")
+    environment("CHECK_EXTERNAL_LINKS", if (fullCheck) "1" else "0")
 }
 
 tasks.named("lintMarkdown") {

--- a/dev-tools/docs/link-check.sh
+++ b/dev-tools/docs/link-check.sh
@@ -19,8 +19,7 @@ mapfile -t FILES < <(
 )
 
 OPTIONS=(
-  --scheme https
-  --scheme http
+  --scheme file
   --exclude-path node_modules
   --exclude-path build
   --exclude-path .gradle
@@ -28,5 +27,9 @@ OPTIONS=(
   --max-retries 3
   --retry-wait-time 2
 )
+
+if [[ "${CHECK_EXTERNAL_LINKS:-}" == 1 ]]; then
+  OPTIONS+=(--scheme https --scheme http)
+fi
 
 "$BIN" --no-progress --verbose "${OPTIONS[@]}" "${FILES[@]}"


### PR DESCRIPTION
## Summary
- include file:// scheme in link-check script so local Markdown links are validated
- add CHECK_EXTERNAL_LINKS env var to optionally enable HTTP/HTTPS link checks

## Testing
- `pre-commit run --files dev-tools/docs/link-check.sh` *(fails: 259 link errors)*
- `CHECK_EXTERNAL_LINKS=0 ./gradlew lintMarkdown linkCheck -PfullCheck` *(fails: Process 'command 'bash'' finished with non-zero exit value 2)*

------
https://chatgpt.com/codex/tasks/task_e_689f08edd1c88330b41b8980bd0e43fa