### PR TITLE
Specify UTF-8 for redis WAIT command

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.PostConstruct;
@@ -105,7 +106,10 @@ public class ScriptTickServiceImpl implements ScriptTickService {
       redisTemplate.execute(
           (RedisCallback<Object>)
               connection -> {
-                connection.execute("WAIT", "1".getBytes(), "100".getBytes());
+                connection.execute(
+                    "WAIT",
+                    "1".getBytes(StandardCharsets.UTF_8),
+                    "100".getBytes(StandardCharsets.UTF_8));
                 return null;
               });
     } catch (Exception e) {


### PR DESCRIPTION
## Summary
- ensure ScriptTickServiceImpl uses UTF-8 encoding when waiting for Redis replication

## Testing
- `./gradlew :automation-scripting-service:spotbugsMain -PfullCheck`
- `./gradlew :automation-scripting-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68a938c645f08330a9ebc2ebb699d175