### PR TITLE
refactor: address spotbugs warnings

### DIFF
--- a/services/game-design-service/build.gradle.kts
+++ b/services/game-design-service/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     runtimeOnly(libs.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
 }
 
 

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/config/AssetStoreConfig.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/config/AssetStoreConfig.java
@@ -1,7 +1,6 @@
 package net.firedevops.firemud.config;
 
 import java.net.URI;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -11,12 +10,10 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 @Configuration
-@RequiredArgsConstructor
 public class AssetStoreConfig {
-  private final AssetStoreProperties properties;
 
   @Bean
-  public S3Client s3Client() {
+  public S3Client s3Client(AssetStoreProperties properties) {
     AwsBasicCredentials creds =
         AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey());
     return S3Client.builder()

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java
@@ -4,6 +4,7 @@ import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.firedevops.firemud.client.AutomationScriptingClient;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class VersionServiceImpl implements VersionService {
   private static final Logger logger = LoggingUtil.getLogger(VersionServiceImpl.class);
 


### PR DESCRIPTION
## Summary
- avoid retaining mutable AssetStoreProperties by injecting via method in AssetStoreConfig
- suppress false positive for AssetExportService injection in VersionServiceImpl
- add SpotBugs annotations dependency

## Testing
- `./gradlew :game-design-service:spotBugsMain --rerun-tasks -PfullCheck`
- `./gradlew :game-design-service:test`


------
https://chatgpt.com/codex/tasks/task_e_68a938c645f08330a9ebc2ebb699d175