### PR TITLE
chore: suppress SpotBugs warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,10 +101,19 @@ subprojects {
         enabled = fullCheck
         excludeFilter.set(rootProject.file("config/spotbugs/spotbugs-exclude.xml"))
         setIgnoreFailures(true)
-        // Exclude generated sources such as Protobuf classes from analysis
+        // Exclude generated sources and protobuf-generated packages from analysis
         val generatedDir = "${File.separator}generated${File.separator}"
-        classDirs.setFrom(classDirs.files.filterNot { it.path.contains(generatedDir) })
-        sourceDirs.setFrom(sourceDirs.files.filterNot { it.path.contains(generatedDir) })
+        val protoPackages = listOf("net/firedevops/firemud/**/v1/**")
+        classDirs.setFrom(
+            classDirs.files
+                .filterNot { it.path.contains(generatedDir) }
+                .map { fileTree(it) { exclude(protoPackages) } }
+        )
+        sourceDirs.setFrom(
+            sourceDirs.files
+                .filterNot { it.path.contains(generatedDir) }
+                .map { fileTree(it) { exclude(protoPackages) } }
+        )
     }
 
     // SpotBugs analyzes the compiled classes, so ensure it runs after Java

--- a/config/spotbugs/spotbugs-exclude.xml
+++ b/config/spotbugs/spotbugs-exclude.xml
@@ -7,19 +7,15 @@
     
     <!-- Exclude all protobuf-generated classes in versioned packages -->
     <Match>
-        <Package name="net.firedevops.firemud.account.v1" />
-        <Bug pattern=".*" />
+        <Class name="~net\\.firedevops\\.firemud\\.account\\.v1\\..*" />
     </Match>
     <Match>
-        <Package name="net.firedevops.firemud.entitymanagement.v1" />
-        <Bug pattern=".*" />
+        <Class name="~net\\.firedevops\\.firemud\\.entitymanagement\\.v1\\..*" />
     </Match>
     <Match>
-        <Package name="net.firedevops.firemud.gamesession.v1" />
-        <Bug pattern=".*" />
+        <Class name="~net\\.firedevops\\.firemud\\.gamesession\\.v1\\..*" />
     </Match>
     <Match>
-        <Package name="net.firedevops.firemud.socialgroups.v1" />
-        <Bug pattern=".*" />
+        <Class name="~net\\.firedevops\\.firemud\\.socialgroups\\.v1\\..*" />
     </Match>
 </FindBugsFilter>

--- a/services/logging-admin-service/build.gradle.kts
+++ b/services/logging-admin-service/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     annotationProcessor(libs.lombok)
     annotationProcessor(libs.lombok.mapstruct.binding)
     compileOnly(libs.lombok)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
     implementation(libs.flyway.core)
     implementation(libs.mapstruct)
     implementation(libs.spring.boot.starter)

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -22,6 +23,7 @@ import net.firedevops.firemud.gamesession.v1.StopSessionResponse;
 import org.springframework.stereotype.Component;
 
 /** gRPC client for communicating with the Game Session Service. */
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Component
 public class GameSessionClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -20,6 +21,7 @@ import net.firedevops.firemud.gamesession.v1.PingResponse;
 import org.springframework.stereotype.Component;
 
 /** gRPC client for communicating with the Game Session Service. */
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Component
 public class GameSessionClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Instance.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Instance.java
@@ -1,9 +1,11 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
 
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Data
 @Entity
 @Table(name = "instance")

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Room.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Room.java
@@ -1,8 +1,10 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Data
 @Entity
 @Table(name = "room")

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/RoomExit.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/RoomExit.java
@@ -1,8 +1,10 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Data
 @Entity
 @Table(name = "room_exit")

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RegionServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RegionServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import net.firedevops.firemud.service.RegionService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 @Service
 @RequiredArgsConstructor
 public class RegionServiceImpl implements RegionService {

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RoomServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RoomServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -14,6 +15,7 @@ import net.firedevops.firemud.service.RoomService;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 @Service
 @RequiredArgsConstructor
 public class RoomServiceImpl implements RoomService {


### PR DESCRIPTION
## Summary
- exclude protobuf-generated packages from SpotBugs
- add SpotBugs annotations to world management and logging admin classes
- wire SpotBugs annotations dependency into logging admin service

## Testing
- `./gradlew spotBugsMain -PfullCheck --no-configuration-cache --rerun-tasks`
- `./gradlew check -x test` *(fails: spotless formatting for VersionServiceImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68a940fbcdf483308b1ec029de03e24d