### PR TITLE
Apply defensive copies and suppress SpotBugs warnings

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.common.security.RequireAdminRole;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
   private final AccountService accountService;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public AccountController(AccountService accountService) {
     this.accountService = accountService;
   }

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AccountRefRequest;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
   private final AccountService accountService;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public AuthController(AccountService accountService) {
     this.accountService = accountService;
   }

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/ExternalAccount.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/ExternalAccount.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -25,4 +26,14 @@ public class ExternalAccount {
 
   @Column(name = "external_id", nullable = false, length = 100)
   private String externalId;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP")
+  public Account getAccount() {
+    return account;
+  }
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public void setAccount(Account account) {
+    this.account = account;
+  }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.account.v1.AccountServiceGrpc;
@@ -31,6 +32,7 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
   private final PingService pingService;
   private final AccountService accountService;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public AccountGrpcService(PingService pingService, AccountService accountService) {
     this.pingService = pingService;
     this.accountService = accountService;

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.service.impl;
 import com.bastiaanjansen.otp.TOTPGenerator;
 import de.mkammerer.argon2.Argon2;
 import de.mkammerer.argon2.Argon2Factory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.util.Map;
 import java.util.Optional;
@@ -62,6 +63,7 @@ public class AccountServiceImpl implements AccountService {
   private final net.firedevops.firemud.service.session.SessionService sessionService;
   private final SagaRunner sagaRunner;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public AccountServiceImpl(
       AccountRepository accountRepository,
       AccountMapper accountMapper,

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/EmailServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/EmailServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.config.MailProperties;
@@ -16,6 +17,7 @@ public class EmailServiceImpl implements EmailService {
   private final JavaMailSender mailSender;
   private final MailProperties mailProperties;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public EmailServiceImpl(JavaMailSender mailSender, MailProperties mailProperties) {
     this.mailSender = mailSender;
     this.mailProperties = mailProperties;

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.time.LocalDateTime;
 import net.firedevops.firemud.client.StripeClient;
@@ -26,6 +27,7 @@ public class PaymentServiceImpl implements PaymentService {
   private final SubscriptionRepository subscriptionRepository;
   private final StripeClient stripeClient;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public PaymentServiceImpl(
       AccountRepository accountRepository,
       PaymentTransactionRepository paymentTransactionRepository,

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationResult.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationResult.java
@@ -3,4 +3,9 @@ package net.firedevops.firemud.service.generator;
 import java.util.List;
 
 /** Result of procedural generation. */
-public record GenerationResult(List<GeneratedRoom> rooms, GenerationErrorDetail error) {}
+public record GenerationResult(List<GeneratedRoom> rooms, GenerationErrorDetail error) {
+
+  public GenerationResult {
+    rooms = rooms == null ? List.of() : List.copyOf(rooms);
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationServiceImpl.java
@@ -2,19 +2,22 @@ package net.firedevops.firemud.service.generator;
 
 import io.micrometer.core.annotation.Timed;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 /** Default implementation invoking a generator then running hooks. */
 @Service
-@RequiredArgsConstructor
 public class GenerationServiceImpl implements GenerationService {
   private static final Logger logger = LoggerFactory.getLogger(GenerationServiceImpl.class);
 
   private final GeneratorRegistry registry;
   private final List<GenerationHook> hooks;
+
+  public GenerationServiceImpl(GeneratorRegistry registry, List<GenerationHook> hooks) {
+    this.registry = registry;
+    this.hooks = hooks == null ? List.of() : List.copyOf(hooks);
+  }
 
   @Override
   @Timed(value = "generation.generate")


### PR DESCRIPTION
## Summary
- Guard generated rooms list in `GenerationResult`
- Copy hook lists in `GenerationServiceImpl` and suppress exposure of injected dependencies across services and controllers

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check` *(fails: The following files had format violations: src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java)*

------
https://chatgpt.com/codex/tasks/task_e_68a940fbcdf483308b1ec029de03e24d