### PR TITLE
fix: harden generation result and suppress quota service SpotBugs

### DIFF
--- a/services/automation-scripting-service/build.gradle.kts
+++ b/services/automation-scripting-service/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.otlp)
     implementation(libs.jjwt.api)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
     runtimeOnly(libs.jjwt.impl)
     runtimeOnly(libs.jjwt.jackson)
     runtimeOnly(libs.postgresql)

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationResult.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationResult.java
@@ -3,4 +3,17 @@ package net.firedevops.firemud.service.generator;
 import java.util.List;
 
 /** Result of procedural generation. */
-public record GenerationResult(List<GeneratedRoom> rooms, GenerationErrorDetail error) {}
+public record GenerationResult(List<GeneratedRoom> rooms, GenerationErrorDetail error) {
+  /**
+   * Creates a new generation result.
+   *
+   * <p>The provided list is defensively copied to avoid exposing internal mutable state.
+   *
+   * @param rooms generated rooms
+   * @param error optional generation error
+   */
+  public GenerationResult(List<GeneratedRoom> rooms, GenerationErrorDetail error) {
+    this.rooms = List.copyOf(rooms);
+    this.error = error;
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/quota/ScriptQuotaServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/quota/ScriptQuotaServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.quota;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -13,6 +14,9 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link ScriptQuotaService}. */
 @Service
 @RequiredArgsConstructor
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Dependencies are injected and not exposed")
 public class ScriptQuotaServiceImpl implements ScriptQuotaService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;


### PR DESCRIPTION
## Summary
- defensively copy generated rooms in GenerationResult
- suppress SpotBugs false positive in ScriptQuotaServiceImpl and add annotations dependency

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :automation-scripting-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68a940fbcdf483308b1ec029de03e24d