### PR TITLE
fix: address spotbugs reported exposures

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -29,8 +29,29 @@ public class LoggingAdminClient implements AutoCloseable {
   private TlsCertificateWatcher watcher;
 
   public LoggingAdminClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
-    this.endpoints = endpoints;
-    this.tlsProps = tlsProps;
+    this.endpoints = copyEndpoints(endpoints);
+    this.tlsProps = copyTlsProps(tlsProps);
+  }
+
+  private static ServiceEndpointsProperties copyEndpoints(ServiceEndpointsProperties src) {
+    var copy = new ServiceEndpointsProperties();
+    copy.setAccountService(src.getAccountService());
+    copy.setGameSessionService(src.getGameSessionService());
+    copy.setGameDesignService(src.getGameDesignService());
+    copy.setGameLogicService(src.getGameLogicService());
+    copy.setWorldManagementService(src.getWorldManagementService());
+    copy.setEntityManagementService(src.getEntityManagementService());
+    copy.setLoggingAdminService(src.getLoggingAdminService());
+    copy.setAutomationScriptingService(src.getAutomationScriptingService());
+    return copy;
+  }
+
+  private static GrpcClientProperties copyTlsProps(GrpcClientProperties src) {
+    var copy = new GrpcClientProperties();
+    copy.setCertChain(src.getCertChain());
+    copy.setPrivateKey(src.getPrivateKey());
+    copy.setCaCert(src.getCaCert());
+    return copy;
   }
 
   @PostConstruct

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/ProfileController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/ProfileController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.ProfileDto;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/profiles")
 public class ProfileController {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final AccountService accountService;
 
   public ProfileController(AccountService accountService) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/CurrencyBalance.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/CurrencyBalance.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -11,6 +12,7 @@ public class CurrencyBalance {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -11,6 +12,7 @@ public class PaymentTransaction {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/client/LoggingAdminClient.java
@@ -28,8 +28,29 @@ public class LoggingAdminClient implements AutoCloseable {
   private TlsCertificateWatcher watcher;
 
   public LoggingAdminClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
-    this.endpoints = endpoints;
-    this.tlsProps = tlsProps;
+    this.endpoints = copyEndpoints(endpoints);
+    this.tlsProps = copyTlsProps(tlsProps);
+  }
+
+  private static ServiceEndpointsProperties copyEndpoints(ServiceEndpointsProperties src) {
+    var copy = new ServiceEndpointsProperties();
+    copy.setAccountService(src.getAccountService());
+    copy.setGameSessionService(src.getGameSessionService());
+    copy.setGameDesignService(src.getGameDesignService());
+    copy.setGameLogicService(src.getGameLogicService());
+    copy.setWorldManagementService(src.getWorldManagementService());
+    copy.setEntityManagementService(src.getEntityManagementService());
+    copy.setLoggingAdminService(src.getLoggingAdminService());
+    copy.setAutomationScriptingService(src.getAutomationScriptingService());
+    return copy;
+  }
+
+  private static GrpcClientProperties copyTlsProps(GrpcClientProperties src) {
+    var copy = new GrpcClientProperties();
+    copy.setCertChain(src.getCertChain());
+    copy.setPrivateKey(src.getPrivateKey());
+    copy.setCaCert(src.getCaCert());
+    return copy;
   }
 
   @PostConstruct


### PR DESCRIPTION
## Summary
- avoid leaking mutable config objects in LoggingAdminClient by making defensive copies
- suppress false positive internal representation warnings on entities and controller

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a9482c78308330b218d4ce25418a9e