### PR TITLE
Fix SpotBugs findings in game session service

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the Entity Management Service. */
 @Component
-public class EntityManagementClient implements AutoCloseable {
+public final class EntityManagementClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the Game Logic Service using mTLS. */
 @Component
-public class GameLogicClient implements AutoCloseable {
+public final class GameLogicClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the World Management Service. */
 @Component
-public class WorldManagementClient implements AutoCloseable {
+public final class WorldManagementClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;
   private ManagedChannel channel;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** Default implementation of {@link GameInstanceService}. */
 @Service
-public class GameInstanceServiceImpl implements GameInstanceService {
+public final class GameInstanceServiceImpl implements GameInstanceService {
   private static final Logger logger = LoggingUtil.getLogger(GameInstanceServiceImpl.class);
 
   private final GameInstanceRepository repository;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -37,7 +37,8 @@ import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC endpoints for the Game Session Service. */
 @GRpcService
-public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionServiceImplBase {
+public final class GameSessionGrpcService
+    extends GameSessionServiceGrpc.GameSessionServiceImplBase {
   private final PingService pingService;
   private final GameInstanceService gameInstanceService;
   private final FeatureFlagService featureFlagService;
@@ -165,7 +166,7 @@ public class GameSessionGrpcService extends GameSessionServiceGrpc.GameSessionSe
   public void enqueueCommand(
       EnqueueCommandRequest request, StreamObserver<EnqueueCommandResponse> responseObserver) {
     try {
-      long sessionId = Long.valueOf(request.getSessionId());
+      long sessionId = Long.parseLong(request.getSessionId());
       if (!sessionRateLimiter.allow(sessionId)) {
         EnqueueCommandResponse response =
             EnqueueCommandResponse.newBuilder()

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 /** Default Redis-backed implementation of {@link SessionStateService}. */
 @Service
 @RequiredArgsConstructor
-public class SessionStateServiceImpl implements SessionStateService {
+public final class SessionStateServiceImpl implements SessionStateService {
   private static final Logger logger = LoggingUtil.getLogger(SessionStateServiceImpl.class);
 
   private final RedisTemplate<String, Object> redisTemplate;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 /** Periodically processes ticks for all running sessions. */
 @Component
 @RequiredArgsConstructor
-public class TickScheduler {
+public final class TickScheduler {
   private final GameInstanceRepository repository;
   private final TickService tickService;
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -4,6 +4,7 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -112,7 +113,10 @@ public class TickServiceImpl implements TickService {
       redisTemplate.execute(
           (RedisCallback<Object>)
               connection -> {
-                connection.execute("WAIT", "1".getBytes(), "100".getBytes());
+                connection.execute(
+                    "WAIT",
+                    "1".getBytes(StandardCharsets.UTF_8),
+                    "100".getBytes(StandardCharsets.UTF_8));
                 return null;
               });
     } catch (Exception e) {


### PR DESCRIPTION
## Summary
- Use explicit UTF-8 encoding when executing Redis WAIT command
- Avoid boxing by using `Long.parseLong` for session IDs
- Declare service and client classes `final` to reduce SpotBugs exposure warnings

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :game-session-service:check`

------
https://chatgpt.com/codex/tasks/task_e_68a9482c78308330b218d4ce25418a9e