### PR TITLE
fix: prevent GameAssetDto exposing internal array

### DIFF
--- a/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameAssetDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/dto/GameAssetDto.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 
 public record GameAssetDto(
     Long id,
@@ -10,4 +11,25 @@ public record GameAssetDto(
     @NotNull @Size(max = 255) String fileName,
     @NotNull @Size(max = 100) String contentType,
     byte[] data,
-    LocalDateTime createdAt) {}
+    LocalDateTime createdAt) {
+
+  public GameAssetDto(
+      Long id,
+      @NotNull @Size(max = 36) String tenantId,
+      @NotNull @Size(max = 255) String fileName,
+      @NotNull @Size(max = 100) String contentType,
+      byte[] data,
+      LocalDateTime createdAt) {
+    this.id = id;
+    this.tenantId = tenantId;
+    this.fileName = fileName;
+    this.contentType = contentType;
+    this.data = data != null ? Arrays.copyOf(data, data.length) : null;
+    this.createdAt = createdAt;
+  }
+
+  @Override
+  public byte[] data() {
+    return data != null ? Arrays.copyOf(data, data.length) : null;
+  }
+}


### PR DESCRIPTION
## Summary
- protect `GameAssetDto`'s internal byte array via defensive copies

## Testing
- `./gradlew --no-daemon --console=plain :game-design-service:spotbugsMain -PfullCheck --rerun-tasks`
- `./gradlew --no-daemon --console=plain check`


------
https://chatgpt.com/codex/tasks/task_e_68a951d4aecc8330a8354e1bfcd6cf5c