### PR TITLE
Remove unnecessary SpotBugs suppressions and make chat config immutable

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/CurrencyBalance.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/CurrencyBalance.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.entity;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -12,7 +11,6 @@ public class CurrencyBalance {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.entity;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -12,7 +11,6 @@ public class PaymentTransaction {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/config/ChatProperties.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/config/ChatProperties.java
@@ -1,9 +1,7 @@
 package net.firedevops.firemud.config;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Data
 @ConfigurationProperties(prefix = "firemud.chat")
 public class ChatProperties {
   private ChatCacheSettings says = new ChatCacheSettings(7200L, 50);
@@ -12,16 +10,45 @@ public class ChatProperties {
   private ChatCacheSettings city = new ChatCacheSettings(172800L, 50);
   private ChatCacheSettings account = new ChatCacheSettings(172800L, 50);
 
-  @Data
-  public static class ChatCacheSettings {
-    private long historyTtlSeconds;
-    private int maxMessages;
-
-    public ChatCacheSettings() {}
-
-    public ChatCacheSettings(long ttl, int max) {
-      this.historyTtlSeconds = ttl;
-      this.maxMessages = max;
-    }
+  public ChatCacheSettings getSays() {
+    return says;
   }
+
+  public void setSays(ChatCacheSettings says) {
+    this.says = says;
+  }
+
+  public ChatCacheSettings getTells() {
+    return tells;
+  }
+
+  public void setTells(ChatCacheSettings tells) {
+    this.tells = tells;
+  }
+
+  public ChatCacheSettings getGuild() {
+    return guild;
+  }
+
+  public void setGuild(ChatCacheSettings guild) {
+    this.guild = guild;
+  }
+
+  public ChatCacheSettings getCity() {
+    return city;
+  }
+
+  public void setCity(ChatCacheSettings city) {
+    this.city = city;
+  }
+
+  public ChatCacheSettings getAccount() {
+    return account;
+  }
+
+  public void setAccount(ChatCacheSettings account) {
+    this.account = account;
+  }
+
+  public record ChatCacheSettings(long historyTtlSeconds, int maxMessages) {}
 }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
@@ -87,8 +87,8 @@ public class ChatServiceImpl implements ChatService {
       }
 
       redisTemplate.opsForList().leftPush(key, saved.getContent());
-      redisTemplate.expire(key, java.time.Duration.ofSeconds(settings.getHistoryTtlSeconds()));
-      redisTemplate.opsForList().trim(key, 0, settings.getMaxMessages() - 1);
+      redisTemplate.expire(key, java.time.Duration.ofSeconds(settings.historyTtlSeconds()));
+      redisTemplate.opsForList().trim(key, 0, settings.maxMessages() - 1);
     } catch (Exception e) {
       redisErrorCounter.increment();
       logger.warn("Failed to publish chat message to Redis", e);

--- a/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
+++ b/services/social-groups-service/src/test/java/unit/net/firedevops/firemud/service/impl/ChatServiceImplTest.java
@@ -71,8 +71,8 @@ class ChatServiceImplTest {
     assertEquals(1L, dto.id());
     verify(listOps).leftPush("say:1:1", "hello");
     verify(redisTemplate)
-        .expire("say:1:1", Duration.ofSeconds(props.getSays().getHistoryTtlSeconds()));
-    verify(listOps).trim("say:1:1", 0, props.getSays().getMaxMessages() - 1);
+        .expire("say:1:1", Duration.ofSeconds(props.getSays().historyTtlSeconds()));
+    verify(listOps).trim("say:1:1", 0, props.getSays().maxMessages() - 1);
     assertEquals(1.0, meterRegistry.get("chat_messages_published_total").counter().count(), 0.001);
     assertEquals(0.0, meterRegistry.get("chat_redis_errors_total").counter().count(), 0.001);
   }


### PR DESCRIPTION
## Summary
- Drop redundant SpotBugs suppression annotations from account entities
- Make chat caching configuration immutable via record and adjust usage
- Update chat service and tests for new configuration API

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a951d4aecc8330a8354e1bfcd6cf5c