### PR TITLE
refactor: avoid exposing telnet metrics state

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 
 /** Simple Netty-based Telnet server that forwards input to the gateway via WebSocket. */
 @Component
-public class TelnetServer {
+public final class TelnetServer {
   private static final Logger logger = LoggerFactory.getLogger(TelnetServer.class);
 
   private final int port;
@@ -88,7 +88,10 @@ public class TelnetServer {
                     .addLast(new StringDecoder())
                     .addLast(
                         new TelnetServerHandler(
-                            gatewayWsUrl, activeConnections, connectionCounter));
+                            gatewayWsUrl,
+                            activeConnections::incrementAndGet,
+                            activeConnections::decrementAndGet,
+                            connectionCounter));
               }
             });
     serverChannel = b.bind(port).sync().channel();

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -20,17 +20,20 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private static final Logger logger = LoggerFactory.getLogger(TelnetServerHandler.class);
 
   private final String gatewayWsUrl;
-  private final java.util.concurrent.atomic.AtomicInteger activeConnections;
+  private final Runnable onConnect;
+  private final Runnable onDisconnect;
   private final io.micrometer.core.instrument.Counter connectionCounter;
   private WebSocket webSocket;
   private final Queue<String> buffer = new ConcurrentLinkedQueue<>();
 
   public TelnetServerHandler(
       String gatewayWsUrl,
-      java.util.concurrent.atomic.AtomicInteger activeConnections,
+      Runnable onConnect,
+      Runnable onDisconnect,
       io.micrometer.core.instrument.Counter connectionCounter) {
     this.gatewayWsUrl = gatewayWsUrl;
-    this.activeConnections = activeConnections;
+    this.onConnect = onConnect;
+    this.onDisconnect = onDisconnect;
     this.connectionCounter = connectionCounter;
   }
 
@@ -61,7 +64,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       ip = address.getAddress().getHostAddress();
     }
     connectionCounter.increment();
-    activeConnections.incrementAndGet();
+    onConnect.run();
     HttpClient client = HttpClient.newHttpClient();
     var builder = client.newWebSocketBuilder();
     if (ip != null) {
@@ -107,7 +110,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "bye");
       webSocket = null;
     }
-    activeConnections.decrementAndGet();
+    onDisconnect.run();
     buffer.clear();
   }
 

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -22,7 +22,8 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
-            new java.util.concurrent.atomic.AtomicInteger(),
+            () -> {},
+            () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
@@ -49,7 +50,8 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
-            new java.util.concurrent.atomic.AtomicInteger(),
+            () -> {},
+            () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
@@ -68,7 +70,8 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
-            new java.util.concurrent.atomic.AtomicInteger(),
+            () -> {},
+            () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
@@ -91,7 +94,8 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
-            new java.util.concurrent.atomic.AtomicInteger(),
+            () -> {},
+            () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
@@ -114,7 +118,8 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
-            new java.util.concurrent.atomic.AtomicInteger(),
+            () -> {},
+            () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);


### PR DESCRIPTION
## Summary
- encapsulate telnet connection counters behind callbacks
- seal TelnetServer and pass increment/decrement handlers
- adjust TelnetServerHandler tests for new constructor

## Testing
- `./gradlew :tcp-proxy-service:check :world-management-service:check`
- `./gradlew spotBugsMain -PfullCheck`


------
https://chatgpt.com/codex/tasks/task_e_68a951d4aecc8330a8354e1bfcd6cf5c