### PR TITLE
Defensively copy gRPC client properties

### DIFF
--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/AccountClient.java
@@ -29,8 +29,29 @@ public class AccountClient implements AutoCloseable {
   private TlsCertificateWatcher watcher;
 
   public AccountClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
-    this.endpoints = endpoints;
-    this.tlsProps = tlsProps;
+    this.endpoints = copyEndpoints(endpoints);
+    this.tlsProps = copyTlsProps(tlsProps);
+  }
+
+  private static ServiceEndpointsProperties copyEndpoints(ServiceEndpointsProperties src) {
+    var copy = new ServiceEndpointsProperties();
+    copy.setAccountService(src.getAccountService());
+    copy.setGameSessionService(src.getGameSessionService());
+    copy.setGameDesignService(src.getGameDesignService());
+    copy.setGameLogicService(src.getGameLogicService());
+    copy.setWorldManagementService(src.getWorldManagementService());
+    copy.setEntityManagementService(src.getEntityManagementService());
+    copy.setLoggingAdminService(src.getLoggingAdminService());
+    copy.setAutomationScriptingService(src.getAutomationScriptingService());
+    return copy;
+  }
+
+  private static GrpcClientProperties copyTlsProps(GrpcClientProperties src) {
+    var copy = new GrpcClientProperties();
+    copy.setCertChain(src.getCertChain());
+    copy.setPrivateKey(src.getPrivateKey());
+    copy.setCaCert(src.getCaCert());
+    return copy;
   }
 
   @PostConstruct

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.client;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -23,7 +22,6 @@ import net.firedevops.firemud.gamesession.v1.StopSessionResponse;
 import org.springframework.stereotype.Component;
 
 /** gRPC client for communicating with the Game Session Service. */
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Component
 public class GameSessionClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
@@ -33,8 +31,29 @@ public class GameSessionClient implements AutoCloseable {
   private TlsCertificateWatcher watcher;
 
   public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
-    this.endpoints = endpoints;
-    this.tlsProps = tlsProps;
+    this.endpoints = copyEndpoints(endpoints);
+    this.tlsProps = copyTlsProps(tlsProps);
+  }
+
+  private static ServiceEndpointsProperties copyEndpoints(ServiceEndpointsProperties src) {
+    var copy = new ServiceEndpointsProperties();
+    copy.setAccountService(src.getAccountService());
+    copy.setGameSessionService(src.getGameSessionService());
+    copy.setGameDesignService(src.getGameDesignService());
+    copy.setGameLogicService(src.getGameLogicService());
+    copy.setWorldManagementService(src.getWorldManagementService());
+    copy.setEntityManagementService(src.getEntityManagementService());
+    copy.setLoggingAdminService(src.getLoggingAdminService());
+    copy.setAutomationScriptingService(src.getAutomationScriptingService());
+    return copy;
+  }
+
+  private static GrpcClientProperties copyTlsProps(GrpcClientProperties src) {
+    var copy = new GrpcClientProperties();
+    copy.setCertChain(src.getCertChain());
+    copy.setPrivateKey(src.getPrivateKey());
+    copy.setCaCert(src.getCaCert());
+    return copy;
   }
 
   @PostConstruct

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -1,6 +1,5 @@
 package net.firedevops.firemud.client;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -21,7 +20,6 @@ import net.firedevops.firemud.gamesession.v1.PingResponse;
 import org.springframework.stereotype.Component;
 
 /** gRPC client for communicating with the Game Session Service. */
-@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Component
 public class GameSessionClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
@@ -31,8 +29,29 @@ public class GameSessionClient implements AutoCloseable {
   private TlsCertificateWatcher watcher;
 
   public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
-    this.endpoints = endpoints;
-    this.tlsProps = tlsProps;
+    this.endpoints = copyEndpoints(endpoints);
+    this.tlsProps = copyTlsProps(tlsProps);
+  }
+
+  private static ServiceEndpointsProperties copyEndpoints(ServiceEndpointsProperties src) {
+    var copy = new ServiceEndpointsProperties();
+    copy.setAccountService(src.getAccountService());
+    copy.setGameSessionService(src.getGameSessionService());
+    copy.setGameDesignService(src.getGameDesignService());
+    copy.setGameLogicService(src.getGameLogicService());
+    copy.setWorldManagementService(src.getWorldManagementService());
+    copy.setEntityManagementService(src.getEntityManagementService());
+    copy.setLoggingAdminService(src.getLoggingAdminService());
+    copy.setAutomationScriptingService(src.getAutomationScriptingService());
+    return copy;
+  }
+
+  private static GrpcClientProperties copyTlsProps(GrpcClientProperties src) {
+    var copy = new GrpcClientProperties();
+    copy.setCertChain(src.getCertChain());
+    copy.setPrivateKey(src.getPrivateKey());
+    copy.setCaCert(src.getCaCert());
+    return copy;
   }
 
   @PostConstruct


### PR DESCRIPTION
## Summary
- prevent gRPC client configuration objects from exposing mutable state by copying values in constructors
- drop unnecessary SpotBugs suppressions on GameSessionClient implementations

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a9572f7e8c8330bb68a0602ac7ef00