### PR TITLE
Ensure GameAsset data safety

### DIFF
--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/GameAsset.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/GameAsset.java
@@ -27,4 +27,22 @@ public class GameAsset {
 
   @Column(nullable = false)
   private LocalDateTime createdAt = LocalDateTime.now();
+
+  /**
+   * Returns a defensive copy of the asset data to avoid exposing the internal representation.
+   *
+   * @return copy of the asset data or {@code null} if no data is present
+   */
+  public byte[] getData() {
+    return data == null ? null : data.clone();
+  }
+
+  /**
+   * Stores a defensive copy of the provided data to protect the internal representation.
+   *
+   * @param data raw asset bytes
+   */
+  public void setData(byte[] data) {
+    this.data = data == null ? null : data.clone();
+  }
 }


### PR DESCRIPTION
## Summary
- prevent exposing GameAsset's internal byte array by cloning on get/set

## Testing
- `./gradlew --no-daemon :game-design-service:spotbugsMain -PspotbugsOnlyAnalyze=net.firedevops.firemud.entity.GameAsset -PfullCheck` *(fails: SpotBugs ended with exit code 3 for other classes)*
- `pre-commit run --all-files` *(fails: shellcheck not installed and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9572f7e8c8330bb68a0602ac7ef00