### PR TITLE
fix: repair microservice doc links

### DIFF
--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -42,7 +42,7 @@ For cross-service systems (e.g., networking, infrastructure), refer to:
 For new services, start from the [Service Template](./service-template.md) so documentation follows the same layout.
 
 All gRPC schema files are organized under the top-level
-[`protos/`](../../protos) directory. Individual service documents link to their
+[`protos/`](../../../protos) directory. Individual service documents link to their
 corresponding versioned proto folders.
 
 ## 📚 Related Documentation

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -24,22 +24,22 @@ Manages user accounts and authentication for the platform. It stores profile dat
 - Account-to-character relationships allow players to own characters across multiple games.
 - All tables include a `tenantId` column so the same platform account can join
   multiple games without data leakage. Every query enforces this tenant filter as
-  described in the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+  described in the [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
   design.
 - Provides a JWKS endpoint for other services to validate tokens. Keys are rotated
-  via cert-manager as described in the [Security Architecture](../system-architecture-security.md).
+  via cert-manager as described in the [Security Architecture](../../system-architecture-security.md).
 - All service-to-service communication is protected by mutual TLS.
 - Client authentication is initiated via the `LOGIN` command flow described in
-  [Authentication & Authorization](../system-architecture-authentication.md).
+  [Authentication & Authorization](../../system-architecture-authentication.md).
   Session tokens stored in Redis allow seamless reconnection by the Game Session
   Service without re-entering credentials.
 - Sends notification emails when the Game Session Service reports suspicious
   login activity. See
-  [Security Architecture](../system-architecture-security.md#brute-force-defense-and-abuse-handling).
+  [Security Architecture](../../system-architecture-security.md#brute-force-defense-and-abuse-handling).
 - Non-gameplay workflows such as account creation or billing updates are
   orchestrated using the Saga pattern outlined in
-  [Transaction Strategies](../system-architecture-transactions.md).
-- Leverages the [Shared Libraries](../system-architecture-shared-libraries.md) for common DTOs, logging interceptors, and Micrometer metrics.
+  [Transaction Strategies](../../system-architecture-transactions.md).
+- Leverages the [Shared Libraries](../../system-architecture-shared-libraries.md) for common DTOs, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -114,14 +114,14 @@ resolved during authentication.
   - Game Session Service consumes tokens to create gameplay sessions.
 - **External:** PostgreSQL for account data, Redis for transient session data.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -161,31 +161,31 @@ The gRPC schemas for this service live in
 
 ## 📚 Related Documentation
 
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Sign Up](../user-journeys.md#1-sign-up)
-- [User Journeys](../user-journeys.md#11-purchases-and-subscriptions) – payment and subscription workflow.
-- [User Journeys – Account Data Export & Deletion](../user-journeys.md#18-account-data-export--deletion)
-- [Redis Architecture](../system-architecture-redis.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Database Migrations](../system-architecture-database-migrations.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Sign Up](../../user-journeys.md#1-sign-up)
+- [User Journeys](../../user-journeys.md#11-purchases-and-subscriptions) – payment and subscription workflow.
+- [User Journeys – Account Data Export & Deletion](../../user-journeys.md#18-account-data-export--deletion)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Database Migrations](../../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ## Additional Details
 
 ### Monetization Design
 
-The Account Service also manages billing records for purchases and subscriptions. Payment processing is handled through **Stripe** as outlined in the [Core Requirements](../../../design/project-management/core-requirements.md#2.8-moderation-administration--monetization). Entities include `payment_transaction` and `subscription` tables with Flyway migrations. gRPC endpoints and REST controllers expose operations for creating payment intents and managing subscriptions. The proto definitions live in [`payment_service.proto`](../../../protos/account/v1/payment_service.proto).
+The Account Service also manages billing records for purchases and subscriptions. Payment processing is handled through **Stripe** as outlined in the [Core Requirements](../../../project-management/core-requirements.md#2.8-moderation-administration--monetization). Entities include `payment_transaction` and `subscription` tables with Flyway migrations. gRPC endpoints and REST controllers expose operations for creating payment intents and managing subscriptions. The proto definitions live in [`payment_service.proto`](../../../../protos/account/v1/payment_service.proto).
 Donations are stored as one-time `payment_transaction` records with the `donation` flag set to `true`. A dedicated `CreateDonation` gRPC method issues a Stripe payment intent for these cases. Refunds call Stripe's API and update the `payment_transaction` `status` to `refunded`, enabling chargeback handling workflows.
 
 ### Virtual Currency & Revenue Sharing
@@ -198,7 +198,7 @@ Premium hosting tiers are modeled as subscription plans with higher resource lim
 
 ### Email & Notification Design
 
-This service sends verification and password reset emails using a configured SMTP provider. Notifications for suspicious logins or account events are queued for asynchronous delivery via a gRPC `NotificationService`. Sample templates live under `resources/templates/` and environment variables configure `spring.mail.*` along with `firemud.mail.from`, `firemud.mail.verification-url`, and `firemud.mail.reset-url`. The gRPC API is defined in [`notification_service.proto`](../../../protos/account/v1/notification_service.proto).
+This service sends verification and password reset emails using a configured SMTP provider. Notifications for suspicious logins or account events are queued for asynchronous delivery via a gRPC `NotificationService`. Sample templates live under `resources/templates/` and environment variables configure `spring.mail.*` along with `firemud.mail.from`, `firemud.mail.verification-url`, and `firemud.mail.reset-url`. The gRPC API is defined in [`notification_service.proto`](../../../../protos/account/v1/notification_service.proto).
 
 ### Session Management
 
@@ -261,7 +261,7 @@ Example login response:
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`account_service.proto`](../../../protos/account/v1/account_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`account_service.proto`](../../../../protos/account/v1/account_service.proto).
 - `CreateAccount(CreateAccountRequest) returns (CreateAccountResponse)` – registers a new user.
 - `SendNotification(SendNotificationRequest) returns (SendNotificationResponse)` – deliver account notifications asynchronously.
 - `ExportAccount(ExportAccountRequest) returns (ExportAccountResponse)` – export account data.
@@ -306,7 +306,7 @@ Account creation uses the shared `SagaBuilder` from `firemud-common` to persist
 the account record, create the profile, and log creation in the Logging & Admin
 Service. If any step fails, compensation actions roll back the database writes
 so the workflow remains consistent across services. See the
-[Transaction Strategies](../system-architecture-transactions.md) document for
+[Transaction Strategies](../../system-architecture-transactions.md) document for
 details on the saga pattern.
 
 Purchase workflows (one-time payments or donations) reuse this same runner. The
@@ -328,4 +328,4 @@ images are available:
 ./gradlew :account-service:test --tests "*CrossServiceIntegrationTest"
 ```
 
-See [System Architecture Testing](../system-architecture-testing.md) for more details.
+See [System Architecture Testing](../../system-architecture-testing.md) for more details.

--- a/design/architecture/microservices/automation-scripting-service/README.md
+++ b/design/architecture/microservices/automation-scripting-service/README.md
@@ -11,7 +11,7 @@ The Automation & Scripting Service drives non-player character (NPC) behavior an
 - Stores persistent NPC memory and automation queues
 - Integrates with Game Session and World Management services for real-time updates
 
-For details on how scripts are authored and executed safely, see [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
+For details on how scripts are authored and executed safely, see [System Architecture: Scripting & Automation](../../system-architecture-scripting.md).
 
 An OpenAPI specification for the REST endpoints is available at `src/main/resources/openapi.yaml` in the service repository.
 
@@ -23,7 +23,7 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
   designers can build behaviors without coding.
 - AI computations are optimized for large worlds by evaluating scripts on a separate schedule and batching the resulting commands before handing them to the tick system.
 - Script definitions are versioned and can be hot reloaded without downtime as
-  described in [System Architecture: Scripting & Automation](../system-architecture-scripting.md).
+  described in [System Architecture: Scripting & Automation](../../system-architecture-scripting.md).
 - The service listens for a `NotifyScriptVersionUpdate` event and reloads the
   specified scripts in memory, validating compatibility before updating the
   runtime registry.
@@ -31,11 +31,11 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
     can be rolled back. The service uses the shared `SagaBuilder` and
     `SagaRunner` helpers to persist the script and emit `sagas.active` metrics
     with a `correlationId` for troubleshooting. See
-    [Transaction Strategies](../system-architecture-transactions.md).
+    [Transaction Strategies](../../system-architecture-transactions.md).
 - Each game's scripts live in tables keyed by `tenantId`, ensuring automation for
   one game cannot access another's data. Redis queues also include the tenant
-  prefix; see [Multi-Tenancy](../system-architecture-multi-tenancy.md).
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+  prefix; see [Multi-Tenancy](../../system-architecture-multi-tenancy.md).
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -79,7 +79,7 @@ interaction.
   runaway behavior.
 - The service uses `ScriptTickService` to stage, commit, and roll back events in Redis.
   This runs independently of the main game tick loop. Locks `tick:lock:{tenantId}:{scriptId}`
-  ensure only one script tick operates at a time. See [Tick System and Runtime Design](../system-architecture-ticks.md) for how queued commands are processed.
+  ensure only one script tick operates at a time. See [Tick System and Runtime Design](../../system-architecture-ticks.md) for how queued commands are processed.
 
 ### gRPC APIs
 
@@ -110,14 +110,14 @@ values fall below configurable thresholds the NPC may become `FLEEING` or
   - World Management Service receives world-state updates from scripts.
 - **External:** PostgreSQL for script storage and Redis for queuing automation tasks.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -149,26 +149,26 @@ stubs.
 
 ## 📚 Related Documentation
 
-- [System Architecture: Scripting & Automation](../system-architecture-scripting.md)
-- [Tick System and Runtime Design](../system-architecture-ticks.md)
-- [Redis Architecture](../system-architecture-redis.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Add Automation & Scripting](../user-journeys.md#4-add-automation--scripting)
-- [System Architecture Overview](../system-architecture-overview.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Database Migrations](../system-architecture-database-migrations.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture: Scripting & Automation](../../system-architecture-scripting.md)
+- [Tick System and Runtime Design](../../system-architecture-ticks.md)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Add Automation & Scripting](../../user-journeys.md#4-add-automation--scripting)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Database Migrations](../../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
 ### Configuration
 
-PostgreSQL and Redis connections are configured via the common `DatabaseAutoConfiguration` and `RedisProperties` classes. Refer to [Deployment Environments](../infrastructure/deployment-environments.md) for default values. Local development typically uses the settings from `.env.sample`.
+PostgreSQL and Redis connections are configured via the common `DatabaseAutoConfiguration` and `RedisProperties` classes. Refer to [Deployment Environments](../../infrastructure/deployment-environments.md) for default values. Local development typically uses the settings from `.env.sample`.
 
 ### REST & gRPC Endpoints
 
@@ -182,7 +182,7 @@ curl http://localhost:8080/ping
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`automation_scripting_service.proto`](../../../protos/automation-scripting/v1/automation_scripting_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`automation_scripting_service.proto`](../../../../protos/automation-scripting/v1/automation_scripting_service.proto).
 
 ```bash
 grpcurl -plaintext localhost:6565 automation_scripting.v1.AutomationScriptingService/Ping
@@ -204,5 +204,5 @@ configurable window. Counters are stored in Redis using keys of the form
 ignored and `script_quota_denied_total` is incremented. Enforcement metrics are
 exported via the standard `sagas.active` gauge.
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -21,19 +21,19 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
 - This design reduces write frequency and contention, making optimistic locking a natural fit — most entities are updated by only one process at a time, and conflicts are rare.
 - Item transfers and other gameplay actions span services but execute within ticks
   using Redis scripts for rollback. Sagas are reserved for non-gameplay
-  workflows. See [Transaction Strategies](../system-architecture-transactions.md).
+  workflows. See [Transaction Strategies](../../system-architecture-transactions.md).
   This service does not participate in any saga workflows.
 - All entity tables include a `tenantId` column. Service methods always filter on
   this value so character data for different games remains isolated; Redis keys
-  mirror this prefix. Details are in the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+  mirror this prefix. Details are in the [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
   document.
 - Gameplay-facing gRPC endpoints do not parse JWT tokens. The Game Session Service
   injects identity context using `SessionContext` and may request a new JWT from
   the Account Service if a player's roles change. It does not validate tokens for
   gameplay. Traffic between services still uses mutual TLS certificates as outlined in the
-  [Security Architecture](../system-architecture-security.md).
+  [Security Architecture](../../system-architecture-security.md).
 
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 - Service methods are annotated with `@Timed` so inventory and character operations emit Prometheus metrics.
 
 ## Key Features
@@ -72,14 +72,14 @@ Handles player characters, NPCs, items, and inventory. Provides CRUD operations 
   - Game Session Service coordinates runtime updates via Redis queues.
 - **External:** PostgreSQL for entity data.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -106,21 +106,21 @@ proto files, run `./gradlew generateProto` to update generated sources.
 
 ## 📚 Related Documentation
 
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Tick System and Runtime Design](../system-architecture-ticks.md)
-- [Redis Architecture](../system-architecture-redis.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – World and Entity Design](../user-journeys.md#3-world-and-entity-design)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Database Migrations](../system-architecture-database-migrations.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Tick System and Runtime Design](../../system-architecture-ticks.md)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – World and Entity Design](../../user-journeys.md#3-world-and-entity-design)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Database Migrations](../../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
@@ -136,7 +136,7 @@ curl http://localhost:8080/ping
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`entity_management_service.proto`](../../../protos/entity-management/v1/entity_management_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`entity_management_service.proto`](../../../../protos/entity-management/v1/entity_management_service.proto).
 - `CreateCharacter(CreateCharacterRequest) returns (CreateCharacterResponse)` – builds a new player character.
 - `UpdateEntity(UpdateEntityRequest) returns (UpdateEntityResponse)` – updates stats or equipment.
 - `QueryInventory(QueryInventoryRequest) returns (QueryInventoryResponse)` – lists items for an entity.
@@ -149,5 +149,5 @@ grpcurl -plaintext localhost:6565 entity_management.v1.EntityManagementService/P
 
 This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:lock:{tenantId}:{entityId}` key described in the [Redis Architecture](../../../design/architecture/system-architecture-redis.md) document. Locks expire after `game.tick-duration-ms` (default 1000 ms) to ensure stalled ticks can be retried.
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)

--- a/design/architecture/microservices/game-design-service/README.md
+++ b/design/architecture/microservices/game-design-service/README.md
@@ -26,17 +26,17 @@ manifest files.
 - Maintains history of revisions so designers can roll back to prior versions.
 - Publishing a new game version triggers a Saga that copies data to other
   services as outlined in
-  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
-  and [Transaction Strategies](../system-architecture-transactions.md).
+  [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)
+  and [Transaction Strategies](../../system-architecture-transactions.md).
   The workflow is implemented using the Saga utilities from `firemud-common`
   with compensation steps to roll back if downstream copies fail. The workflow
   persists the new version and copies data to downstream services.
 - Design assets are stored per `tenantId` so multiple games can coexist in the
   same database schema. Queries and version publishing workflows enforce this
-  tenant filter. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+  tenant filter. See [Multi-Tenancy](../../system-architecture-multi-tenancy.md).
 - All gRPC APIs require JWT authentication between services. REST authentication is supported.
-  Tokens are parsed by a shared `AuthTokenInterceptor` configured in `GrpcConfig`, which stores claims in `SessionContext` for role checks. Service-to-service traffic uses mutual TLS certificates managed by cert-manager as described in the [Security Architecture](../system-architecture-security.md).
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+  Tokens are parsed by a shared `AuthTokenInterceptor` configured in `GrpcConfig`, which stores claims in `SessionContext` for role checks. Service-to-service traffic uses mutual TLS certificates managed by cert-manager as described in the [Security Architecture](../../system-architecture-security.md).
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -93,14 +93,14 @@ manifest files.
   - Logging & Admin Service records publishing audits.
 - **External:** PostgreSQL for storing design assets.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -139,15 +139,15 @@ stubs with `./gradlew generateProto` whenever these files are updated.
 
 ## 📚 Related Documentation
 
-See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) for how published versions are promoted to runtime.
+See [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md) for how published versions are promoted to runtime.
 
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Game Creation](../user-journeys.md#2-game-creation)
-- [User Journeys – World and Entity Design](../user-journeys.md#3-world-and-entity-design)
-- [User Journeys – Publish and Start a Game Instance](../user-journeys.md#5-publish-and-start-a-game-instance)
-- [User Journeys – Patch and Update a Live Game](../user-journeys.md#10-patch-and-update-a-live-game)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Game Creation](../../user-journeys.md#2-game-creation)
+- [User Journeys – World and Entity Design](../../user-journeys.md#3-world-and-entity-design)
+- [User Journeys – Publish and Start a Game Instance](../../user-journeys.md#5-publish-and-start-a-game-instance)
+- [User Journeys – Patch and Update a Live Game](../../user-journeys.md#10-patch-and-update-a-live-game)
 - [Asset Storage Setup](asset-storage.md)
 - [World Editing & Customization Tools](world-editing-tools.md)
 - [Ability & Action Design Tools](ability-action-tools.md)
@@ -155,18 +155,18 @@ See [Versioning & Runtime Configuration](../system-architecture-versioning-runti
 - [Web-Based Visual Design Interface](web-visual-interface.md)
 - [Version Control for Design Assets](version-control.md)
 - [In-Game Modding and Plugin Framework](modding-framework.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Database Migrations](../system-architecture-database-migrations.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Database Migrations](../../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ## Additional Details
 
@@ -190,7 +190,7 @@ Detailed request and response schemas are defined in the
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_design_service.proto`](../../../protos/game-design/v1/game_design_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_design_service.proto`](../../../../protos/game-design/v1/game_design_service.proto).
 - `SaveRevision(SaveRevisionRequest) returns (SaveRevisionResponse)` – persists a design change.
 - `PublishVersion(PublishVersionRequest) returns (PublishVersionResponse)` – publishes a frozen version.
 - `PublishScriptPatchVersion(PublishScriptPatchVersionRequest) returns (PublishScriptPatchVersionResponse)` – publishes a script-only patch version.
@@ -202,7 +202,7 @@ grpcurl -plaintext localhost:6565 game_design.v1.GameDesignService/Ping
 
 ### Saga Participation
 
-Publishing a game version is coordinated using the Saga utilities from `firemud-common`. The `VersionServiceImpl` builds a workflow that first persists the new version and then copies design data to downstream services. If any step fails, previously executed actions are compensated so the database remains consistent. See the [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) document for the overall flow.
+Publishing a game version is coordinated using the Saga utilities from `firemud-common`. The `VersionServiceImpl` builds a workflow that first persists the new version and then copies design data to downstream services. If any step fails, previously executed actions are compensated so the database remains consistent. See the [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md) document for the overall flow.
 
 ## Local Development Notes
 

--- a/design/architecture/microservices/game-design-service/ability-action-tools.md
+++ b/design/architecture/microservices/game-design-service/ability-action-tools.md
@@ -2,7 +2,7 @@
 
 This document outlines the editors for defining abilities, actions, and combat mechanics. The tooling is part of the Game Design Service and pushes finalized data to the [Game Logic Service](../game-logic-service/README.md) during version publishing.
 
-The publish workflow is part of the cross‑service saga described in [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
+The publish workflow is part of the cross‑service saga described in [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md).
 
 Data entered in these editors is stored as revisions using the `SaveRevision` gRPC call defined in [`game_design_service.proto`](../../../../protos/game-design/v1/game_design_service.proto).
 Finalized versions are published with `PublishVersion` so the Game Logic Service can load the rules as part of the cross‑service saga described in the [Game Design Service Architecture](README.md).

--- a/design/architecture/microservices/game-design-service/feature-flags.md
+++ b/design/architecture/microservices/game-design-service/feature-flags.md
@@ -20,7 +20,7 @@ Feature flags can control optional UI layout tweaks, status effect experiments o
 
 ## Related Documentation
 
-- [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
+- [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)
 - [Game Customization Options](../game-customization-options.md)
 - [Game Session Service](./game-session-service/README.md)
 - [Logging & Admin Service](./logging-admin-service/README.md)

--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -1,6 +1,6 @@
 # Item & Equipment Balancing Tools
 
-Game balance relies heavily on item statistics and equipment progression. This document outlines tools for tuning those values. Balancing data follows the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. Designers store changes via the `SaveRevision` gRPC endpoint and publish them with `PublishVersion`. These operations participate in the cross-service saga described in [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md). See [Version Control for Design Assets](version-control.md) for more detail.
+Game balance relies heavily on item statistics and equipment progression. This document outlines tools for tuning those values. Balancing data follows the same revision and version publishing workflow used throughout the Game Design Service so that stats remain consistent across releases. Designers store changes via the `SaveRevision` gRPC endpoint and publish them with `PublishVersion`. These operations participate in the cross-service saga described in [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md). See [Version Control for Design Assets](version-control.md) for more detail.
 
 Balancing records are scoped by `tenantId` so multiple games can maintain independent item definitions.
 
@@ -25,7 +25,7 @@ These capabilities are available in the current implementation.
 - [Game Design Service Architecture](README.md)
 - [World Editing & Customization Tools](world-editing-tools.md)
 - [Version Control for Design Assets](version-control.md)
-- [Game Design Service gRPC API](../../../../protos/game-design/v1/README.md)
+- [Game Design Service gRPC API](../../../../../protos/game-design/v1/README.md)
 - [Entity Management Service](../entity-management-service/README.md)
 - [Ability & Action Design Tools](ability-action-tools.md)
 - [Web-Based Visual Design Interface](web-visual-interface.md)

--- a/design/architecture/microservices/game-design-service/modding-framework.md
+++ b/design/architecture/microservices/game-design-service/modding-framework.md
@@ -29,8 +29,8 @@ Plugin bundles are uploaded through the Game Design Service and stored in the sa
 
 - [Automation & Scripting Service](../automation-scripting-service/README.md)
 - [Game Design Service Architecture](README.md)
-- [User Journeys – Extensibility & External Tools](../user-journeys.md#21-extensibility--external-tools)
-- [System Architecture – Scripting & Automation](../system-architecture-scripting.md)
+- [User Journeys – Extensibility & External Tools](../../user-journeys.md#21-extensibility--external-tools)
+- [System Architecture – Scripting & Automation](../../system-architecture-scripting.md)
 - [Asset Storage Setup](asset-storage.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)

--- a/design/architecture/microservices/game-design-service/version-control.md
+++ b/design/architecture/microservices/game-design-service/version-control.md
@@ -21,4 +21,4 @@ Design assets are versioned to enable rollback and collaborative workflows. This
 ## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
-- [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
+- [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)

--- a/design/architecture/microservices/game-design-service/world-editing-tools.md
+++ b/design/architecture/microservices/game-design-service/world-editing-tools.md
@@ -20,5 +20,5 @@ Game creators use these interfaces to craft rooms, items and NPCs without modify
 ## 📚 Related Documentation
 
 - [Game Design Service Architecture](README.md)
-- [System Architecture – Transactions](../system-architecture-transactions.md)
-- [User Journeys – World and Entity Design](../user-journeys.md#3-world-and-entity-design)
+- [System Architecture – Transactions](../../system-architecture-transactions.md)
+- [User Journeys – World and Entity Design](../../user-journeys.md#3-world-and-entity-design)

--- a/design/architecture/microservices/game-logic-service/README.md
+++ b/design/architecture/microservices/game-logic-service/README.md
@@ -14,7 +14,7 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Forward chat actions to the Social & Groups Service for delivery and
   profanity checks after verifying room context via the World Management
   Service and character state via the Entity Management Service
-- See the [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- See the [Service Responsibility Matrix](../../service-responsibility-matrix.md)
   for how this service fits into the overall architecture.
 
 ## Architecture / Design Notes
@@ -25,17 +25,17 @@ Executes the core gameplay rules and command parsing. It processes player action
 - Fetches contextual world and entity data on demand via gRPC.
 - Gameplay rules are imported from the Game Design Service when a version is
   published; the runtime service does not query design databases.
-- Integrates with the tick system described in [Tick System and Runtime Design](../system-architecture-ticks.md) to ensure deterministic command ordering.
-- Cross-service combat or trade operations run within ticks and rely on Redis-based rollback, not sagas. See [Transaction Strategies](../system-architecture-transactions.md).
+- Integrates with the tick system described in [Tick System and Runtime Design](../../system-architecture-ticks.md) to ensure deterministic command ordering.
+- Cross-service combat or trade operations run within ticks and rely on Redis-based rollback, not sagas. See [Transaction Strategies](../../system-architecture-transactions.md).
 - All commands are scoped by `tenantId` so that rules execute only against data
   for the active game instance. The Game Session Service passes this context on
-  every request. See [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+  every request. See [Multi-Tenancy](../../system-architecture-multi-tenancy.md).
 - Gameplay gRPC requests do not include JWTs. The Game Session Service provides
   player identity from Redis via `SessionContext`. It may refresh a JWT from the
   Account Service if roles change but does not validate tokens for gameplay.
   Communications use mutual TLS certificates as outlined in the
-  [Security Architecture](../system-architecture-security.md).
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+  [Security Architecture](../../system-architecture-security.md).
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 - Flyway is enabled for consistency with other services, but the initial migration is empty because no tables are required.
 
 ## Key Features
@@ -87,14 +87,14 @@ This service is largely stateless. It relies on:
   - Automation & Scripting Service triggers additional effects during rule execution.
   - Social & Groups Service handles chat delivery and profanity filtering.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -126,19 +126,19 @@ the generated code with `./gradlew generateProto` after making changes.
 
 ## 📚 Related Documentation
 
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Tick System and Runtime Design](../system-architecture-ticks.md)
-- [Redis Architecture](../system-architecture-redis.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Tick System and Runtime Design](../../system-architecture-ticks.md)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [User Journeys – Player Login and Gameplay](../../user-journeys.md#7-player-login-and-gameplay)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
@@ -188,10 +188,10 @@ grpcurl -plaintext -d '{"tenant_id":"demo","session_id":"demo","command":"look"}
   localhost:6565 game_logic.v1.GameLogicService/ExecuteCommand
 ```
 
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ### Local Development Notes
 

--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -20,25 +20,25 @@ Orchestrates live game sessions, including tick execution, player input validati
 - Ensures atomic command execution using Redis transactions and Lua scripts.
 - Crash recovery replays ticks stored in Redis using AOF persistence and `WAIT`
   semantics, ensuring deterministic recovery as described in
-  [Tick System and Runtime Design](../system-architecture-ticks.md#crash-recovery-and-replay).
+  [Tick System and Runtime Design](../../system-architecture-ticks.md#crash-recovery-and-replay).
 - Every session record includes a `tenantId` identifying the game instance.
   Redis keys and database tables prefix this value so sessions from different
   games remain isolated. The platform may enforce per-game resource quotas at this level so one tenant cannot exhaust cluster capacity.
-  See the [Multi-Tenancy](../system-architecture-multi-tenancy.md) document.
+  See the [Multi-Tenancy](../../system-architecture-multi-tenancy.md) document.
   Session state for reconnect recovery lives in Redis using keys of the form
   `session:{tenantId}:{sessionId}` and is purged when the session ends. All tick queues, locks and pending sets share this tenant-prefixed scheme.
   - Restores sessions after disconnects and enforces single-session control as outlined in the Reconnection Strategy.
 - Certain operations such as game startup and shutdown are implemented as Sagas
   so that all dependent services remain in sync. See
-  [Transaction Strategies](../system-architecture-transactions.md).
+  [Transaction Strategies](../../system-architecture-transactions.md).
 - Saga workflows use the shared `SagaBuilder` and emit metrics with correlation
   IDs via `SagaRunner`.
 - Monitors login attempts per IP and temporarily blacklists repeat
   offenders. Global spikes introduce small delays and suspicious activity
   triggers notification emails to the account holder. See
-  [Security Architecture](../system-architecture-security.md#brute-force-defense-and-abuse-handling).
+  [Security Architecture](../../system-architecture-security.md#brute-force-defense-and-abuse-handling).
 - Session objects are created as soon as a client connects. They remain unauthenticated until the Account Service verifies credentials and issues a token.
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -49,7 +49,7 @@ Orchestrates live game sessions, including tick execution, player input validati
   sessions can reload updated scripts without restarting.
 - **Termination Handling** — cleans up resources and logs results when a game ends.
 - **Instance Initialization** — starts new games from published templates.
-- **Reconnection Handling** — resumes gameplay via Redis-backed session state as described in [Reconnection Strategy](../system-architecture-reconnection.md).
+- **Reconnection Handling** — resumes gameplay via Redis-backed session state as described in [Reconnection Strategy](../../system-architecture-reconnection.md).
 - **State Queries** — exposes gRPC methods to retrieve current game or player state for the web UI.
 
 ### Data Model
@@ -91,11 +91,11 @@ Orchestrates live game sessions, including tick execution, player input validati
 - gRPC clients discover endpoints via `ServiceEndpointsProperties` and secure
   connections with mTLS certificates issued by cert-manager.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md), [**Deployment Environments**](../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for details on shared infrastructure components.
+> See [**Gateway Architecture**](../../system-architecture-gateway.md), [**Deployment Environments**](../../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -127,24 +127,24 @@ Service definitions reside in
 
 ## 📚 Related Documentation
 
-- [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md) — how game instances load published versions and runtime flags.
-- [Reconnection Strategy](../system-architecture-reconnection.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Tick System and Runtime Design](../system-architecture-ticks.md)
-- [Redis Architecture](../system-architecture-redis.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md) — how game instances load published versions and runtime flags.
+- [Reconnection Strategy](../../system-architecture-reconnection.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Tick System and Runtime Design](../../system-architecture-ticks.md)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
 ### Configuration
 
-Environment variables configure the PostgreSQL and Redis connections via `DatabaseAutoConfiguration` and `RedisProperties`. Refer to [Deployment Environments](../infrastructure/deployment-environments.md) for details. The `.env.sample` file contains example values.
+Environment variables configure the PostgreSQL and Redis connections via `DatabaseAutoConfiguration` and `RedisProperties`. Refer to [Deployment Environments](../../infrastructure/deployment-environments.md) for details. The `.env.sample` file contains example values.
 
-The service enforces multi-tenant isolation. All tables include a `tenant_id` column and Redis keys are prefixed with this value as outlined in the [Multi-Tenancy design](../system-architecture-multi-tenancy.md).
+The service enforces multi-tenant isolation. All tables include a `tenant_id` column and Redis keys are prefixed with this value as outlined in the [Multi-Tenancy design](../../system-architecture-multi-tenancy.md).
 
 ### REST & gRPC Endpoints
 
@@ -173,7 +173,7 @@ curl -X POST http://localhost:8080/sessions \
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_session_service.proto`](../../../protos/game-session/v1/game_session_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`game_session_service.proto`](../../../../protos/game-session/v1/game_session_service.proto).
 - `StartSession(StartSessionRequest) returns (StartSessionResponse)` – creates a new game instance.
 - `StopSession(StopSessionRequest) returns (StopSessionResponse)` – stops a running session.
 - `RestartSession(RestartSessionRequest) returns (RestartSessionResponse)` – restarts a stopped session.
@@ -195,31 +195,31 @@ grpcurl -plaintext -d '{"tenantId":"demo","runtimeVersion":"v42","scriptPatchVer
 ### Additional Notes
 
 - See [Cross-Region Sharding and Session Handoff](#cross-region-sharding-and-session-handoff) for how sessions migrate between clusters.
-- Metrics emitted by this service feed the operator [Analytics Dashboards](../microservices/logging-admin-service/analytics-dashboards.md). Prometheus scrapes metrics from `/actuator/prometheus`.
+- Metrics emitted by this service feed the operator [Analytics Dashboards](../logging-admin-service/analytics-dashboards.md). Prometheus scrapes metrics from `/actuator/prometheus`.
 - Logs and metrics include a `script_patch_version` label so operators know which
   hotfix revision is active.
 
 ### Runtime Feature Flags
 
-Feature flags are stored in the `feature_flag` table and can be toggled through the Logging & Admin Service. The Game Session Service exposes a gRPC `ToggleFeatureFlag` method so administrators can enable or disable experimental behavior without restarting a session. See [Game Design Service Feature Flags](../microservices/game-design-service/feature-flags.md) for how definitions are created and published.
+Feature flags are stored in the `feature_flag` table and can be toggled through the Logging & Admin Service. The Game Session Service exposes a gRPC `ToggleFeatureFlag` method so administrators can enable or disable experimental behavior without restarting a session. See [Game Design Service Feature Flags](../game-design-service/feature-flags.md) for how definitions are created and published.
 
 ### Saga Participation
 
-Game startup and shutdown are coordinated using the shared `Saga` helpers from `firemud-common`. Each dependent service (World Management, Entity Management and Game Logic) confirms its part of the workflow before the session becomes active. Failures trigger compensating steps, ensuring consistent rollbacks. See [Transaction Strategies](../system-architecture-transactions.md) for background.
+Game startup and shutdown are coordinated using the shared `Saga` helpers from `firemud-common`. Each dependent service (World Management, Entity Management and Game Logic) confirms its part of the workflow before the session becomes active. Failures trigger compensating steps, ensuring consistent rollbacks. See [Transaction Strategies](../../system-architecture-transactions.md) for background.
 
 ### Redis Keys
 
 Session state needed for reconnect recovery is stored under `session:{tenantId}:{sessionId}`. Tick queues, locks and pending sets use the same prefix. Keys are removed when a session stops.
 
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Publish and Start a Game Instance](../user-journeys.md#5-publish-and-start-a-game-instance)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Publish and Start a Game Instance](../../user-journeys.md#5-publish-and-start-a-game-instance)
+- [User Journeys – Player Login and Gameplay](../../user-journeys.md#7-player-login-and-gameplay)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ### Cross-Service Integration Test
 
@@ -231,7 +231,7 @@ the dependent Docker images are built:
 ./gradlew :game-session-service:test --tests "*CrossServiceIntegrationTest"
 ```
 
-See [System Architecture Testing](../system-architecture-testing.md) for more
+See [System Architecture Testing](../../system-architecture-testing.md) for more
 details.
 
 ## Additional Features
@@ -255,5 +255,5 @@ domains isolated.
 The service emits Prometheus metrics for tick timing, queue lengths and command
 latency. Logs include the `tenantId` and `traceId` fields so operators can build
 dashboards in the Logging & Admin Service. These metrics feed the default
-[Analytics Dashboards](../microservices/logging-admin-service/analytics-dashboards.md)
+[Analytics Dashboards](../logging-admin-service/analytics-dashboards.md)
 to monitor game health and player activity.

--- a/design/architecture/microservices/logging-admin-service/README.md
+++ b/design/architecture/microservices/logging-admin-service/README.md
@@ -21,9 +21,9 @@ All admin APIs are secured via role-based access control integrated with the Acc
   network-layer isolation for admin endpoints.
 - Moderation data and log indices include a `tenantId` field so administrators
   only see information for the games they manage. Cross-tenant queries are
-  rejected per the [Multi-Tenancy](../system-architecture-multi-tenancy.md)
+  rejected per the [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
   strategy.
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -31,15 +31,15 @@ All admin APIs are secured via role-based access control integrated with the Acc
 - [Analytics dashboards](./analytics-dashboards.md) for operators, embedding Kibana and Grafana panels.
 - Tools for banning or restricting accounts.
 - [Role-based admin UI](./admin-ui.md) for moderators.
-- Saga workflows coordinate moderation tasks across services. See [Transaction Strategies](../system-architecture-transactions.md).
+- Saga workflows coordinate moderation tasks across services. See [Transaction Strategies](../../system-architecture-transactions.md).
 - [Moderation policies](./moderation-policies.md) including profanity filters.
-- UI for toggling runtime feature flags. Backend APIs are available. See [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md).
+- UI for toggling runtime feature flags. Backend APIs are available. See [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md).
 - Audit trail for account actions and world changes.
 - Transaction logs for purchases and subscription events.
 - Captures failed login attempts and suspicious activity reported by the Game
   Session Service for operator review.
 - Works with Saga workflows to record state changes across services. See
-  [Transaction Strategies](../system-architecture-transactions.md).
+  [Transaction Strategies](../../system-architecture-transactions.md).
 - Automated alerts for suspicious activity via Alertmanager.
 - Real-time analytics on game performance.
 - Optional TOTP-based two-factor authentication for administrator accounts.
@@ -76,7 +76,7 @@ curl http://localhost:8080/ping
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`logging_admin_service.proto`](../../../protos/logging-admin/v1/logging_admin_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`logging_admin_service.proto`](../../../../protos/logging-admin/v1/logging_admin_service.proto).
 - `QueryLogs(QueryLogsRequest) returns (QueryLogsResponse)` – searches collected logs.
 - `ApplyModerationAction(ApplyModerationActionRequest) returns (ApplyModerationActionResponse)` – records a moderation event.
 - `CreateReport(CreateReportRequest) returns (CreateReportResponse)` – ingest a player report.
@@ -97,14 +97,14 @@ grpcurl -plaintext -d '{"tenant_id":1,"reporter_account_id":1,"target_account_id
   - Social & Groups Service delivers chat logs for moderation.
   - **External:** Elasticsearch, Prometheus, Kibana, Grafana, and Alertmanager for storage, visualization, embedding, and alerting.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 - REST endpoints listen on port `8080` and gRPC on port `6565`.
 
@@ -137,20 +137,20 @@ these change, run `./gradlew generateProto` to refresh generated sources.
 
 See [Logging & Monitoring](../../system-architecture-logging-monitoring.md) for details on the shared observability stack.
 
-- [Security Architecture](../system-architecture-security.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Monitoring and Moderation](../user-journeys.md#9-monitoring-and-moderation)
-- [User Journeys – Purchases and Subscriptions](../user-journeys.md#11-purchases-and-subscriptions)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Monitoring and Moderation](../../user-journeys.md#9-monitoring-and-moderation)
+- [User Journeys – Purchases and Subscriptions](../../user-journeys.md#11-purchases-and-subscriptions)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ## Additional Details
 
@@ -160,5 +160,5 @@ The service exposes `/sagas` and `/sagas/{id}/steps` endpoints for operators to 
 long-running workflows coordinated via the shared Saga library. The dashboard reads from
 the `saga_instance` and `saga_step` tables and publishes a `sagas.active` Prometheus gauge.
 
-See [Transaction Strategies](../system-architecture-transactions.md) for an overview of
+See [Transaction Strategies](../../system-architecture-transactions.md) for an overview of
 Saga usage across FireMUD.

--- a/design/architecture/microservices/logging-admin-service/moderation-policies.md
+++ b/design/architecture/microservices/logging-admin-service/moderation-policies.md
@@ -22,7 +22,7 @@ Operators can customize the word list per tenant, and the filter flags attempts 
 
 1. Offending logs or reports are flagged in the Logging & Admin Service dashboards. These dashboards are described in [Analytics Dashboards](./analytics-dashboards.md).
 2. Moderators review the context and determine the severity.
-3. Actions are recorded via `ApplyModerationAction` gRPC calls (see [`logging_admin_service.proto`](../../../protos/logging-admin/v1/logging_admin_service.proto)). The service coordinates a saga to delete the account, terminate active sessions, and apply temporary suspensions with recorded durations in the `moderation_actions` table.
+3. Actions are recorded via `ApplyModerationAction` gRPC calls (see [`logging_admin_service.proto`](../../../../protos/logging-admin/v1/logging_admin_service.proto)). The service coordinates a saga to delete the account, terminate active sessions, and apply temporary suspensions with recorded durations in the `moderation_actions` table.
 4. Notifications are sent to affected players with reason and duration through the Account Service `NotificationService`.
 
 ## Appeals

--- a/design/architecture/microservices/service-template.md
+++ b/design/architecture/microservices/service-template.md
@@ -38,13 +38,13 @@
 - **Internal:** {{ Other FireMUD services this one relies on. }}
 - **External:** {{ Databases, caches, or third-party systems. }}
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md), [**Deployment Environments**](../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for details on shared infrastructure components.
+> See [**Gateway Architecture**](../../system-architecture-gateway.md), [**Deployment Environments**](../../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
-The OpenTelemetry collector endpoint can be overridden via `OTEL_ENDPOINT` (see [Environment Variables & Secrets Management](../infrastructure/environment-and-secrets.md)).
+The OpenTelemetry collector endpoint can be overridden via `OTEL_ENDPOINT` (see [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)).
 
 ## Environment Variables
 

--- a/design/architecture/microservices/social-groups-service/README.md
+++ b/design/architecture/microservices/social-groups-service/README.md
@@ -34,15 +34,15 @@ An OpenAPI specification for the REST endpoints is available at `src/main/resour
   - Account messages: 48 hours or 50 messages
   Older messages remain in PostgreSQL for moderation and historical logs.
 - Guild creation and membership changes participate in Saga workflows so other
-  services remain consistent. See [Transaction Strategies](../system-architecture-transactions.md).
+  services remain consistent. See [Transaction Strategies](../../system-architecture-transactions.md).
 - Chat history and guild data are stored with a `tenantId` so conversations are
   isolated per game. Redis list keys also include this prefix. See
-  [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+  [Multi-Tenancy](../../system-architecture-multi-tenancy.md).
 - Cross-service calls always forward the `tenantId` so features remain isolated;
-  see [Multi-Tenancy](../system-architecture-multi-tenancy.md) for details.
+  see [Multi-Tenancy](../../system-architecture-multi-tenancy.md) for details.
 - APIs require authenticated JWTs from the Account Service for role checks.
-  These tokens are exchanged only between services. All inter-service communication is encrypted via mutual TLS, following the [Security Architecture](../system-architecture-security.md).
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+  These tokens are exchanged only between services. All inter-service communication is encrypted via mutual TLS, following the [Security Architecture](../../system-architecture-security.md).
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -97,7 +97,7 @@ temporary WebRTC tokens via the REST endpoint `/voice/token` (see
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -138,20 +138,20 @@ files change.
 
 ## 📚 Related Documentation
 
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Social Interaction](../user-journeys.md#8-social-interaction)
-- [Redis Architecture](../system-architecture-redis.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Database Migrations](../system-architecture-database-migrations.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Social Interaction](../../user-journeys.md#8-social-interaction)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Database Migrations](../../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
@@ -177,7 +177,7 @@ curl http://localhost:8080/ping
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`social_groups_service.proto`](../../../protos/social-groups/v1/social_groups_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – connectivity check defined in [`social_groups_service.proto`](../../../../protos/social-groups/v1/social_groups_service.proto).
 
 ```bash
 grpcurl -plaintext localhost:6565 social_groups.v1.SocialGroupsService/Ping
@@ -207,8 +207,8 @@ curl -X POST http://localhost:8080/voice/token \
   -d '{"tenantId":"tenant-abc","accountId":100,"channelId":"guild-10"}'
 ```
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ### Cross-Service Integration Test
 
@@ -220,5 +220,5 @@ images are available:
 ./gradlew :social-groups-service:test --tests "*CrossServiceIntegrationTest"
 ```
 
-Refer to [System Architecture Testing](../system-architecture-testing.md) for
+Refer to [System Architecture Testing](../../system-architecture-testing.md) for
 guidance.

--- a/design/architecture/microservices/spring-cloud-gateway/README.md
+++ b/design/architecture/microservices/spring-cloud-gateway/README.md
@@ -8,7 +8,7 @@ An OpenAPI specification for these REST endpoints lives in `services/spring-clou
 
 ### Responsibilities
 
-- Enforce authentication for admin routes. TLS termination occurs at the load balancer as described in the [Security Architecture](../system-architecture-security.md)
+- Enforce authentication for admin routes. TLS termination occurs at the load balancer as described in the [Security Architecture](../../system-architecture-security.md)
 - Upgrade WebSocket connections and forward them to backend services
 - Apply rate limits and basic abuse protections
 - Relay traffic to the Game Session Service and other backends
@@ -18,13 +18,13 @@ An OpenAPI specification for these REST endpoints lives in `services/spring-clou
 
 - Handles persistent WebSocket connections and supports raw TCP through the TCP Proxy Service.
 - Event-driven updates synchronize game state across connected players.
-- Relies on the Game Session Service to restore sessions when clients reconnect as described in the [Reconnection Strategy](../system-architecture-reconnection.md).
+- Relies on the Game Session Service to restore sessions when clients reconnect as described in the [Reconnection Strategy](../../system-architecture-reconnection.md).
 - Gateway restarts are transparent thanks to the layered reconnection model
-  outlined in [Reconnection Strategy](../system-architecture-reconnection.md).
+  outlined in [Reconnection Strategy](../../system-architecture-reconnection.md).
 - Applies rate limiting and authentication filters for admin endpoints.
 - Relies on the Game Session Service for gameplay login and session management.
-- External TLS is terminated by the load balancer and traffic to backend services uses mutual TLS as described in the [Security Architecture](../system-architecture-security.md).
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+- External TLS is terminated by the load balancer and traffic to backend services uses mutual TLS as described in the [Security Architecture](../../system-architecture-security.md).
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 - gRPC endpoints use `LoggingInterceptor`, `MetricsInterceptor`, and `TracingInterceptor` for consistent observability.
 
 ## Key Features
@@ -73,14 +73,14 @@ for the core services so Docker Compose environments work out of the box.
   - TCP Proxy Service forwards Telnet traffic into the gateway.
 - **External:** Spring Cloud Gateway infrastructure.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -117,16 +117,16 @@ adding or removing routes at runtime.
 
 ## 📚 Related Documentation
 
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Reconnection Strategy](../system-architecture-reconnection.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Reconnection Strategy](../../system-architecture-reconnection.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Player Login and Gameplay](../../user-journeys.md#7-player-login-and-gameplay)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
@@ -166,11 +166,11 @@ curl -X DELETE http://localhost:8080/routes/demo
 grpcurl -plaintext localhost:6565 spring_cloud_gateway.v1.GatewayManagementService/Ping
 ```
 
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ## Scalability
 

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -18,18 +18,18 @@ The OpenAPI specification for the `/ping` health endpoint lives in `services/tcp
 - Buffers incoming input while the client remains connected and discards it if the
   TCP session drops. After reconnect, buffered commands are resent automatically.
 - Handles Telnet negotiation and character encoding quirks.
-- Negotiates the Mud Client Protocol (MCP) when supported. See [MCP Support](../system-architecture-mcp-support.md).
+- Negotiates the Mud Client Protocol (MCP) when supported. See [MCP Support](../../system-architecture-mcp-support.md).
 - Works with the Reconnection Strategy to resume sessions transparently.
 - Can optionally terminate Telnet-over-TLS. Forwarding to the gateway uses
   WebSocket connections and supports mutual TLS.
-  See [Security Architecture](../system-architecture-security.md).
+  See [Security Architecture](../../system-architecture-security.md).
 - Runs in the network DMZ and never contacts internal services directly.
 - Sanitizes incoming Telnet data and enforces a whitelist of
    **Telnet protocol commands** as described in the
-   [Security Architecture](../system-architecture-security.md#telnet-command-handling-and-controls).
+   [Security Architecture](../../system-architecture-security.md#telnet-command-handling-and-controls).
 - Forwards client IPs via `X-Client-IP` so central throttling occurs in the Game Session Service. Optional TLS termination is controlled by `TCP_PROXY_TLS_ENABLED`.
 - Performs basic sanitization but defers connection and rate limits to downstream services.
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 
 ## Key Features
 
@@ -57,13 +57,13 @@ for internal coordination:
 
 These events let the Game Session Service resume suspended sessions and deliver
 buffered commands. Their definitions live in
-[`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
+[`tcp_proxy_service.proto`](../../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
 
 ### Telnet Command Handling
 
 The proxy sanitizes incoming bytes and allows only a safe subset of
 **Telnet protocol commands** as described in the
-[Security Architecture](../system-architecture-security.md#telnet-command-handling-and-controls).
+[Security Architecture](../../system-architecture-security.md#telnet-command-handling-and-controls).
 This avoids implementing the full Telnet specification while still protecting
 against malformed negotiation sequences and other legacy edge cases.
 
@@ -87,14 +87,14 @@ Commands outside this list are discarded and only sanitized printable characters
 The proxy is stateless. Any buffered input lives only in memory until forwarded
 to the Spring Cloud Gateway.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on how Telnet connections are integrated into the platform.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 - A simple `smoke-test.sh` script in the service directory checks the REST and gRPC endpoints.
 
@@ -132,16 +132,16 @@ regenerated via `./gradlew generateProto` when the proto files change.
 
 ## 📚 Related Documentation
 
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Reconnection Strategy](../system-architecture-reconnection.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – Player Login and Gameplay](../user-journeys.md#7-player-login-and-gameplay)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Reconnection Strategy](../../system-architecture-reconnection.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – Player Login and Gameplay](../../user-journeys.md#7-player-login-and-gameplay)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
@@ -161,7 +161,7 @@ curl http://localhost:8080/ping
 - `NotifyDisconnect(NotifyDisconnectRequest) returns (NotifyDisconnectResponse)` – informs the Game Session Service a Telnet client disconnected.
 - `PushBufferedInput(PushBufferedInputRequest) returns (PushBufferedInputResponse)` – delivers queued commands after a reconnect.
 
-All RPC definitions live in [`tcp_proxy_service.proto`](../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
+All RPC definitions live in [`tcp_proxy_service.proto`](../../../../protos/tcp-proxy/v1/tcp_proxy_service.proto).
 
 ```bash
 grpcurl -plaintext localhost:6565 tcp_proxy.v1.TcpProxyService/Ping
@@ -169,11 +169,11 @@ grpcurl -plaintext localhost:6565 tcp_proxy.v1.TcpProxyService/Ping
 
 Prometheus scrapes metrics from `/actuator/prometheus`. OpenTelemetry spans are exported to the collector service so traces can be viewed in Jaeger.
 
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ### Cross-Service Integration Test
 
@@ -187,5 +187,5 @@ This test requires the Spring Cloud Gateway Docker image to be available. Build 
 ./gradlew :tcp-proxy-service:test --tests "*CrossServiceIntegrationTest"
 ```
 
-See [System Architecture Testing](../system-architecture-testing.md) for more
+See [System Architecture Testing](../../system-architecture-testing.md) for more
 information.

--- a/design/architecture/microservices/world-management-service/README.md
+++ b/design/architecture/microservices/world-management-service/README.md
@@ -23,19 +23,19 @@ The World Management Service stores and manages game world data such as rooms, r
 - Publishes world event notifications for NPC scripts and game logic processing.
 - During version publishing the service participates in a Saga that copies design
   data into its schema, ensuring world data matches the active version. See
-  [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
-  and [Transaction Strategies](../system-architecture-transactions.md).
+  [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)
+  and [Transaction Strategies](../../system-architecture-transactions.md).
 - World creation for new games runs as a Saga, inserting a starter region and copying
   full design data. See [World Creation Workflow](world-creation-workflow.md).
 - All world tables are keyed by `tenantId`; background jobs and gRPC queries
   include this filter so one game's world data never mixes with another's. See
-  [Multi-Tenancy](../system-architecture-multi-tenancy.md).
+  [Multi-Tenancy](../../system-architecture-multi-tenancy.md).
 - Gameplay gRPC operations do not validate JWTs directly. The Game Session
   Service binds player identity from Redis into `SessionContext`. It may request
   an updated JWT from the Account Service when roles change but does not perform
   token validation during gameplay. All traffic still uses mutual TLS as described in the
-  [Security Architecture](../system-architecture-security.md).
-- Utilizes the [Shared Libraries](../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
+  [Security Architecture](../../system-architecture-security.md).
+- Utilizes the [Shared Libraries](../../system-architecture-shared-libraries.md) for DTO definitions, logging interceptors, and Micrometer metrics.
 - gRPC endpoints include the shared `LoggingInterceptor`, `MetricsInterceptor`, and
   `TracingInterceptor` so logs, metrics, and traces are emitted consistently.
 
@@ -95,14 +95,14 @@ specified region.
   - Automation & Scripting Service reacts to scheduled world changes.
 - **External:** PostgreSQL for world data, Redis for transient active state.
 
-> See [**Gateway Architecture**](../system-architecture-gateway.md),
-[**Deployment Environments**](../infrastructure/deployment-environments.md),
-and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for
+> See [**Gateway Architecture**](../../system-architecture-gateway.md),
+[**Deployment Environments**](../../infrastructure/deployment-environments.md),
+and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for
 details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
 - Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
 
 ## Environment Variables
@@ -131,22 +131,22 @@ Run `./gradlew generateProto` to regenerate sources after editing these files.
 
 ## 📚 Related Documentation
 
-- [System Architecture Overview](../system-architecture-overview.md)
-- [Versioning & Runtime Configuration](../system-architecture-versioning-runtime.md)
-- [Tick System and Runtime Design](../system-architecture-ticks.md)
-- [Redis Architecture](../system-architecture-redis.md)
-- [Multi-Tenancy](../system-architecture-multi-tenancy.md)
-- [Service Responsibility Matrix](../service-responsibility-matrix.md)
-- [User Journeys – World and Entity Design](../user-journeys.md#3-world-and-entity-design)
-- [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md)
-- [Shared Libraries Overview](../system-architecture-shared-libraries.md)
-- [Database Migrations](../system-architecture-database-migrations.md)
-- [Backup & Disaster Recovery](../system-architecture-backup-recovery.md)
-- [Logging & Monitoring](../system-architecture-logging-monitoring.md)
-- [Authentication & Authorization](../system-architecture-authentication.md)
-- [Security Architecture](../system-architecture-security.md)
-- [Testing Strategy](../system-architecture-testing.md)
-- [CI/CD Pipeline](../system-architecture-cicd.md)
+- [System Architecture Overview](../../system-architecture-overview.md)
+- [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)
+- [Tick System and Runtime Design](../../system-architecture-ticks.md)
+- [Redis Architecture](../../system-architecture-redis.md)
+- [Multi-Tenancy](../../system-architecture-multi-tenancy.md)
+- [Service Responsibility Matrix](../../service-responsibility-matrix.md)
+- [User Journeys – World and Entity Design](../../user-journeys.md#3-world-and-entity-design)
+- [gRPC API Style & Versioning Guidelines](../../system-architecture-grpc.md)
+- [Shared Libraries Overview](../../system-architecture-shared-libraries.md)
+- [Database Migrations](../../system-architecture-database-migrations.md)
+- [Backup & Disaster Recovery](../../system-architecture-backup-recovery.md)
+- [Logging & Monitoring](../../system-architecture-logging-monitoring.md)
+- [Authentication & Authorization](../../system-architecture-authentication.md)
+- [Security Architecture](../../system-architecture-security.md)
+- [Testing Strategy](../../system-architecture-testing.md)
+- [CI/CD Pipeline](../../system-architecture-cicd.md)
 
 ## Additional Details
 
@@ -168,11 +168,11 @@ curl http://localhost:8080/ping
 
 Requests to this service come from other internal services. Player identity is
 established by the Game Session Service, so no JWT header is required here. See
-the [Security Architecture](../system-architecture-security.md) for details.
+the [Security Architecture](../../system-architecture-security.md) for details.
 
 #### gRPC
 
-- `Ping(PingRequest) returns (PingResponse)` – basic connectivity check defined in [`world_management_service.proto`](../../../protos/world-management/v1/world_management_service.proto).
+- `Ping(PingRequest) returns (PingResponse)` – basic connectivity check defined in [`world_management_service.proto`](../../../../protos/world-management/v1/world_management_service.proto).
 - `GetRoom(GetRoomRequest) returns (GetRoomResponse)` – fetches a room's JSON representation.
 - `UpdateWorldState(UpdateWorldStateRequest) returns (UpdateWorldStateResponse)` – applies pending world updates and notifies other services.
 
@@ -198,8 +198,8 @@ World events are persisted in the `world_event` table and processed periodically
 
 World creation for a new tenant runs as a Saga using the helper utilities from `firemud-common`. Each step is described in [world-creation-workflow.md](world-creation-workflow.md) and can be rolled back if a later step fails. This ensures worlds are created consistently even when the workflow spans multiple services.
 
-- [System Architecture Diagram](../system-architecture-diagram.md)
-- [System Context Diagram](../system-context-diagram.md)
+- [System Architecture Diagram](../../system-architecture-diagram.md)
+- [System Context Diagram](../../system-context-diagram.md)
 
 ## Procedural Generation Rules API
 

--- a/design/architecture/microservices/world-management-service/world-creation-workflow.md
+++ b/design/architecture/microservices/world-management-service/world-creation-workflow.md
@@ -25,4 +25,4 @@ The saga state is stored in the `saga_instance` and `saga_step` tables defined i
 
 See [World Management Service](README.md) for additional service context.
 
-See [Transaction Strategies](../system-architecture-transactions.md) for background on how sagas are used across FireMUD.
+See [Transaction Strategies](../../system-architecture-transactions.md) for background on how sagas are used across FireMUD.

--- a/design/architecture/system-architecture-runbooks.md
+++ b/design/architecture/system-architecture-runbooks.md
@@ -70,7 +70,7 @@ For local development, use `./gradlew devUp` to start Docker Compose and
    - A manual workflow `manual-backup-restore.yml` can verify backups and
      perform an optional restore test in a temporary namespace. Trigger it
      from the GitHub Actions UI when needed.
-   - **Maintain dump volume**: the [`firemud-pg-dump` CronJob](k8s/postgres/pg-dump-cronjob.yaml) rotates files automatically,
+   - **Maintain dump volume**: the [`firemud-pg-dump` CronJob](../../k8s/postgres/pg-dump-cronjob.yaml) rotates files automatically,
     but long-lived persistent volumes can still fill up. The Docker Compose
     stack includes a `pg-dump-cron` service that runs the same rotation script
     every 15 minutes. Periodically check the `firemud-pg-dumps` PVC and prune


### PR DESCRIPTION
## Summary
- fix broken relative links in microservice design docs
- correct runbook link to pg-dump CronJob manifest

## Testing
- `./gradlew --rerun-tasks lintMarkdown linkCheck`

------
https://chatgpt.com/codex/tasks/task_e_68a954921330833092f3b786e644abcd