### PR TITLE
Handle missing IP addresses and improve RNG

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/PveEncounterServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/PveEncounterServiceImpl.java
@@ -2,7 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import io.micrometer.core.annotation.Timed;
 import java.util.List;
-import java.util.Random;
+import java.util.SplittableRandom;
 import lombok.extern.slf4j.Slf4j;
 import net.firedevops.firemud.model.PveEvent;
 import net.firedevops.firemud.service.PveEncounterService;
@@ -23,7 +23,7 @@ public class PveEncounterServiceImpl implements PveEncounterService {
   @Override
   @Timed(value = "pve.generateEvent")
   public PveEvent generateEvent(String region, long seed) {
-    Random rnd = new Random(seed);
+    SplittableRandom rnd = new SplittableRandom(seed);
     List<String> pool;
     switch (region.toLowerCase()) {
       case "forest" -> pool = FOREST_EVENTS;

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/ClientIpHeaderFilter.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/filter/ClientIpHeaderFilter.java
@@ -13,8 +13,14 @@ public class ClientIpHeaderFilter implements WebFilter, Ordered {
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
     String headerIp = exchange.getRequest().getHeaders().getFirst("X-Client-IP");
-    if (headerIp == null && exchange.getRequest().getRemoteAddress() != null) {
-      headerIp = exchange.getRequest().getRemoteAddress().getAddress().getHostAddress();
+    if (headerIp == null) {
+      var remote = exchange.getRequest().getRemoteAddress();
+      if (remote != null) {
+        var address = remote.getAddress();
+        if (address != null) {
+          headerIp = address.getHostAddress();
+        }
+      }
     }
     if (headerIp != null) {
       final String ip = headerIp;

--- a/services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/ClientIpHeaderFilterTest.java
+++ b/services/spring-cloud-gateway/src/test/java/unit/net/firedevops/firemud/filter/ClientIpHeaderFilterTest.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
@@ -26,5 +27,40 @@ class ClientIpHeaderFilterTest {
         };
     filter.filter(exchange, chain).block();
     assertEquals("1.2.3.4", ref.get().getRequest().getHeaders().getFirst("X-Client-IP"));
+  }
+
+  @Test
+  void noHeaderWhenRemoteAddressMissing() {
+    ClientIpHeaderFilter filter = new ClientIpHeaderFilter();
+    MockServerHttpRequest request = MockServerHttpRequest.get("/").build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    java.util.concurrent.atomic.AtomicReference<ServerWebExchange> ref =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    WebFilterChain chain =
+        e -> {
+          ref.set(e);
+          return Mono.empty();
+        };
+    filter.filter(exchange, chain).block();
+    assertNull(ref.get().getRequest().getHeaders().getFirst("X-Client-IP"));
+  }
+
+  @Test
+  void noHeaderWhenAddressUnresolved() {
+    ClientIpHeaderFilter filter = new ClientIpHeaderFilter();
+    MockServerHttpRequest request =
+        MockServerHttpRequest.get("/")
+            .remoteAddress(java.net.InetSocketAddress.createUnresolved("example.com", 0))
+            .build();
+    MockServerWebExchange exchange = MockServerWebExchange.from(request);
+    java.util.concurrent.atomic.AtomicReference<ServerWebExchange> ref =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    WebFilterChain chain =
+        e -> {
+          ref.set(e);
+          return Mono.empty();
+        };
+    filter.filter(exchange, chain).block();
+    assertNull(ref.get().getRequest().getHeaders().getFirst("X-Client-IP"));
   }
 }


### PR DESCRIPTION
## Summary
- prevent `ClientIpHeaderFilter` from dereferencing null remote addresses
- test missing/invalid remote addresses
- use `SplittableRandom` in PvE encounter generation

## Testing
- `./gradlew :spring-cloud-gateway:check :automation-scripting-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68a98ff208248330a3533ff07bc0cef4