### PR TITLE
Fix SpotBugs warnings and remove unnecessary suppressions

### DIFF
--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -30,7 +30,6 @@ public class GameSessionClient implements AutoCloseable {
   private GameSessionServiceGrpc.GameSessionServiceBlockingStub stub;
   private TlsCertificateWatcher watcher;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
   public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = copyEndpoints(endpoints);
     this.tlsProps = copyTlsProps(tlsProps);

--- a/services/social-groups-service/build.gradle.kts
+++ b/services/social-groups-service/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     runtimeOnly(libs.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
 }
 
 

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/ChatServiceImpl.java
@@ -1,11 +1,11 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import java.time.Instant;
-import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.client.LoggingAdminClient;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.config.ChatProperties;
@@ -23,7 +23,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected services are managed by Spring")
 public class ChatServiceImpl implements ChatService {
   private static final Logger logger = LoggingUtil.getLogger(ChatServiceImpl.class);
 
@@ -37,6 +39,33 @@ public class ChatServiceImpl implements ChatService {
 
   private Counter publishCounter;
   private Counter redisErrorCounter;
+
+  public ChatServiceImpl(
+      ChatMessageRepository repository,
+      ChatMessageMapper mapper,
+      ProfanityFilter profanityFilter,
+      LoggingAdminClient loggingAdminClient,
+      RedisTemplate<String, Object> redisTemplate,
+      MeterRegistry meterRegistry,
+      ChatProperties chatProperties) {
+    this.repository = repository;
+    this.mapper = mapper;
+    this.profanityFilter = profanityFilter;
+    this.loggingAdminClient = loggingAdminClient;
+    this.redisTemplate = redisTemplate;
+    this.meterRegistry = meterRegistry;
+    this.chatProperties = copyProps(chatProperties);
+  }
+
+  private static ChatProperties copyProps(ChatProperties src) {
+    var copy = new ChatProperties();
+    copy.setSays(src.getSays());
+    copy.setTells(src.getTells());
+    copy.setGuild(src.getGuild());
+    copy.setCity(src.getCity());
+    copy.setAccount(src.getAccount());
+    return copy;
+  }
 
   @PostConstruct
   void init() {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/SocialGroupsGrpcService.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/service/impl/SocialGroupsGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,9 @@ import org.lognet.springboot.grpc.GRpcService;
 /** gRPC service implementation for the SocialGroupsService API. */
 @GRpcService
 @RequiredArgsConstructor
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected services are managed by Spring")
 public class SocialGroupsGrpcService extends SocialGroupsServiceGrpc.SocialGroupsServiceImplBase {
   private final PingService pingService;
   private final ChatService chatService;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameSessionClient.java
@@ -28,7 +28,6 @@ public class GameSessionClient implements AutoCloseable {
   private GameSessionServiceGrpc.GameSessionServiceBlockingStub stub;
   private TlsCertificateWatcher watcher;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
   public GameSessionClient(ServiceEndpointsProperties endpoints, GrpcClientProperties tlsProps) {
     this.endpoints = copyEndpoints(endpoints);
     this.tlsProps = copyTlsProps(tlsProps);


### PR DESCRIPTION
## Summary
- remove redundant SpotBugs suppressions in GameSessionClient
- add SpotBugs annotations to social-groups-service and copy ChatProperties defensively
- suppress false positives for Spring-managed dependencies in social groups service

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a98ff208248330a3533ff07bc0cef4