### PR TITLE
Protect gateway route lists and suppress SpotBugs warnings

### DIFF
--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.time.Instant;
 import net.firedevops.firemud.client.AccountClient;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class ModerationServiceImpl implements ModerationService {
   private static final Logger logger = LoggingUtil.getLogger(ModerationServiceImpl.class);
 

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     annotationProcessor(libs.lombok)
     annotationProcessor(libs.lombok.mapstruct.binding)
     compileOnly(libs.lombok)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
     implementation(libs.flyway.core)
     implementation(libs.mapstruct)
     implementation(libs.spring.boot.starter)

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/controller/GatewayController.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/controller/GatewayController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.service.GatewayRoute;
 import net.firedevops.firemud.service.GatewayRouteService;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GatewayController {
   private final GatewayRouteService routeService;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public GatewayController(GatewayRouteService routeService) {
     this.routeService = routeService;
   }

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/GatewayRoute.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/GatewayRoute.java
@@ -4,4 +4,13 @@ import java.util.List;
 
 /** Simple DTO representing a dynamic gateway route. */
 public record GatewayRoute(
-    String routeId, String uri, List<String> predicates, List<String> filters) {}
+    String routeId, String uri, List<String> predicates, List<String> filters) {
+  /**
+   * Canonical constructor that defensively copies predicate and filter lists to avoid exposing
+   * internal mutable state.
+   */
+  public GatewayRoute {
+    predicates = predicates != null ? List.copyOf(predicates) : null;
+    filters = filters != null ? List.copyOf(filters) : null;
+  }
+}

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayManagementGrpcService.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayManagementGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.gateway.v1.GatewayManagementServiceGrpc;
@@ -15,6 +16,7 @@ import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC implementation for remote gateway management. */
 @GRpcService
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class GatewayManagementGrpcService
     extends GatewayManagementServiceGrpc.GatewayManagementServiceImplBase {
   private final GatewayRouteService routeService;

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayRouteServiceImpl.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayRouteServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.net.URI;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 /** Implementation of {@link GatewayRouteService} that updates Spring Cloud Gateway at runtime. */
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 @Service
 public class GatewayRouteServiceImpl implements GatewayRouteService {
   private static final Logger logger = LoggingUtil.getLogger(GatewayRouteServiceImpl.class);


### PR DESCRIPTION
## Summary
- defensively copy predicate and filter lists in `GatewayRoute`
- suppress SpotBugs EI_EXPOSE_REP2 warnings in gateway and moderation services
- add SpotBugs annotations dependency for spring-cloud-gateway module

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a9929f35308330aea27a33e22e21cb