### PR TITLE
Fix broken documentation links

### DIFF
--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -206,7 +206,7 @@ Authentication generates a JWT that is stored **server-side** in Redis for inter
 
 ### Two-Factor Authentication
 
-Two-factor authentication is optional and applies only when a `two_factor_secret` is configured on an account. This is typically enabled for administrator or moderator accounts. When present, the `/auth/login` endpoint requires an `otp` field. Codes are validated using the Base32 secret as outlined in the [Security Architecture](../../../design/architecture/system-architecture-security.md).
+Two-factor authentication is optional and applies only when a `two_factor_secret` is configured on an account. This is typically enabled for administrator or moderator accounts. When present, the `/auth/login` endpoint requires an `otp` field. Codes are validated using the Base32 secret as outlined in the [Security Architecture](../../system-architecture-security.md).
 
 ### REST & gRPC Endpoints
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -147,7 +147,7 @@ grpcurl -plaintext localhost:6565 entity_management.v1.EntityManagementService/P
 
 ### Tick Locking
 
-This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:lock:{tenantId}:{entityId}` key described in the [Redis Architecture](../../../design/architecture/system-architecture-redis.md) document. Locks expire after `game.tick-duration-ms` (default 1000 ms) to ensure stalled ticks can be retried.
+This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:lock:{tenantId}:{entityId}` key described in the [Redis Architecture](../../system-architecture-redis.md) document. Locks expire after `game.tick-duration-ms` (default 1000 ms) to ensure stalled ticks can be retried.
 
 - [System Architecture Diagram](../../system-architecture-diagram.md)
 - [System Context Diagram](../../system-context-diagram.md)

--- a/design/architecture/microservices/game-design-service/feature-flags.md
+++ b/design/architecture/microservices/game-design-service/feature-flags.md
@@ -21,6 +21,6 @@ Feature flags can control optional UI layout tweaks, status effect experiments o
 ## Related Documentation
 
 - [Versioning & Runtime Configuration](../../system-architecture-versioning-runtime.md)
-- [Game Customization Options](../game-customization-options.md)
-- [Game Session Service](./game-session-service/README.md)
-- [Logging & Admin Service](./logging-admin-service/README.md)
+- [Game Customization Options](../../game-customization-options.md)
+- [Game Session Service](../game-session-service/README.md)
+- [Logging & Admin Service](../logging-admin-service/README.md)

--- a/design/architecture/microservices/game-design-service/item-equipment-balancing.md
+++ b/design/architecture/microservices/game-design-service/item-equipment-balancing.md
@@ -25,7 +25,7 @@ These capabilities are available in the current implementation.
 - [Game Design Service Architecture](README.md)
 - [World Editing & Customization Tools](world-editing-tools.md)
 - [Version Control for Design Assets](version-control.md)
-- [Game Design Service gRPC API](../../../../../protos/game-design/v1/README.md)
+- [Game Design Service gRPC API](../../../../protos/game-design/v1/README.md)
 - [Entity Management Service](../entity-management-service/README.md)
 - [Ability & Action Design Tools](ability-action-tools.md)
 - [Web-Based Visual Design Interface](web-visual-interface.md)

--- a/design/architecture/microservices/service-template.md
+++ b/design/architecture/microservices/service-template.md
@@ -38,13 +38,13 @@
 - **Internal:** {{ Other FireMUD services this one relies on. }}
 - **External:** {{ Databases, caches, or third-party systems. }}
 
-> See [**Gateway Architecture**](../../system-architecture-gateway.md), [**Deployment Environments**](../../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../../system-architecture-protocol-bridging.md) for details on shared infrastructure components.
+> See [**Gateway Architecture**](../system-architecture-gateway.md), [**Deployment Environments**](../infrastructure/deployment-environments.md), and [**Protocol Bridging**](../system-architecture-protocol-bridging.md) for details on shared infrastructure components.
 
 ## Operational Notes
 
-- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../../infrastructure/deployment-environments.md).
-- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../../system-architecture-logging-monitoring.md) pipeline.
-The OpenTelemetry collector endpoint can be overridden via `OTEL_ENDPOINT` (see [Environment Variables & Secrets Management](../../infrastructure/environment-and-secrets.md)).
+- Runs as a Kubernetes Deployment (Docker Compose for local dev) with `/actuator/health` probes. See [Deployment Environments](../infrastructure/deployment-environments.md).
+- Logging, metrics, and tracing follow the standard [Logging & Monitoring](../system-architecture-logging-monitoring.md) pipeline.
+The OpenTelemetry collector endpoint can be overridden via `OTEL_ENDPOINT` (see [Environment Variables & Secrets Management](../infrastructure/environment-and-secrets.md)).
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- correct broken links in microservice design docs
- ensure service template uses proper relative paths

## Testing
- `./gradlew linkCheck -PfullCheck`
- `./gradlew check -PfullCheck` *(fails: SpotBugs missing classes)*

------
https://chatgpt.com/codex/tasks/task_e_68a993c6fdf48330bb0a7ed3cc472a43