### PR TITLE
chore: suppress spotbugs exposure warnings

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/Profile.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/Profile.java
@@ -1,9 +1,13 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "profiles")
 public class Profile {
@@ -13,6 +17,8 @@ public class Profile {
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.NONE)
   private Account account;
 
   @Column(nullable = false)
@@ -23,4 +29,18 @@ public class Profile {
 
   @Column(length = 255)
   private String bio;
+
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "Account reference is managed by JPA and intentionally exposed")
+  public Account getAccount() {
+    return account;
+  }
+
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Account reference is managed by JPA and intentionally stored")
+  public void setAccount(Account account) {
+    this.account = account;
+  }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/VirtualCurrencyGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/VirtualCurrencyGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import net.firedevops.firemud.account.v1.AddCurrencyRequest;
@@ -15,6 +16,7 @@ import org.lognet.springboot.grpc.GRpcService;
 @GRpcService
 public class VirtualCurrencyGrpcService
     extends VirtualCurrencyServiceGrpc.VirtualCurrencyServiceImplBase {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final VirtualCurrencyService currencyService;
 
   public VirtualCurrencyGrpcService(VirtualCurrencyService currencyService) {

--- a/services/entity-management-service/build.gradle.kts
+++ b/services/entity-management-service/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     runtimeOnly(libs.jjwt.impl)
     runtimeOnly(libs.jjwt.jackson)
     runtimeOnly(libs.postgresql)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/InventoryController.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/InventoryController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.ApiResponse;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/characters/{characterId}/inventory")
 @RequiredArgsConstructor
 public class InventoryController {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final InventoryService inventoryService;
 
   @GetMapping

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
@@ -31,7 +32,9 @@ public class EntityManagementGrpcService
     extends EntityManagementServiceGrpc.EntityManagementServiceImplBase {
   private final PingService pingService;
   private final CharacterService characterService;
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final InventoryService inventoryService;
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final MeterRegistry meterRegistry;
 
   public EntityManagementGrpcService(

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -16,7 +17,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class TickLockServiceImpl implements TickLockService {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final StringRedisTemplate redisTemplate;
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final MeterRegistry meterRegistry;
   private final ConflictTracker conflictTracker;
 

--- a/services/game-logic-service/build.gradle.kts
+++ b/services/game-logic-service/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":common-library"))
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
 }
 
 

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/SimpleCommandProcessor.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/SimpleCommandProcessor.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.logic.command;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.firedevops.firemud.common.ErrorDetail;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.logic.dto.CommandResult;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class SimpleCommandProcessor implements CommandProcessor {
   private static final Logger logger = LoggingUtil.getLogger(SimpleCommandProcessor.class);
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final EventDispatcher dispatcher;
   private final ScriptingHook scriptingHook;
 

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -19,6 +20,7 @@ import org.lognet.springboot.grpc.GRpcService;
 public class GameLogicGrpcService extends GameLogicServiceGrpc.GameLogicServiceImplBase {
   private final PingService pingService;
   private final CommandService commandService;
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final MeterRegistry meterRegistry;
 
   public GameLogicGrpcService(

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     runtimeOnly(libs.postgresql)
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.4")
 }
 
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link IpConnectionLimiter}. */
 @Service
 public class IpConnectionLimiterImpl implements IpConnectionLimiter {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final StringRedisTemplate redisTemplate;
   private final int maxConnectionsPerIp;
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import net.firedevops.firemud.service.SessionRateLimiter;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link SessionRateLimiter}. */
 @Service
 public class SessionRateLimiterImpl implements SessionRateLimiter {
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final StringRedisTemplate redisTemplate;
   private final int maxMessagesPerSecond;
 

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
@@ -18,6 +19,7 @@ public class LoggingAdminGrpcService extends LoggingAdminServiceGrpc.LoggingAdmi
   private final FeatureFlagService featureFlagService;
   private final LogQueryService logQueryService;
   private final ModerationService moderationService;
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final MeterRegistry meterRegistry;
 
   public LoggingAdminGrpcService(


### PR DESCRIPTION
## Summary
- suppress SpotBugs EI_EXPOSE_REP warnings across services and controllers
- include spotbugs-annotations dependency in service builds

## Testing
- `./gradlew spotBugsMain -PfullCheck` *(fails: remaining SpotBugs issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a99585faf08330843f79be504c073c