### PR TITLE
Suppress SpotBugs EI warnings in account service

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/EmailVerificationToken.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/EmailVerificationToken.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 @Entity
@@ -12,6 +15,8 @@ public class EmailVerificationToken {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
+  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PasswordResetToken.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PasswordResetToken.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 @Entity
@@ -12,6 +15,8 @@ public class PasswordResetToken {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
+  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -1,7 +1,10 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 @Entity
@@ -11,6 +14,8 @@ public class PaymentTransaction {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
+  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/Subscription.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/Subscription.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 @Entity
@@ -12,6 +15,8 @@ public class Subscription {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
+  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/session/SessionServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.session;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.time.Duration;
 import net.firedevops.firemud.config.AuthProperties;
@@ -11,6 +12,9 @@ public class SessionServiceImpl implements SessionService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final AuthProperties authProperties;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Dependencies are injected and managed by Spring")
   public SessionServiceImpl(
       RedisTemplate<String, Object> redisTemplate, AuthProperties authProperties) {
     this.redisTemplate = redisTemplate;


### PR DESCRIPTION
## Summary
- suppress SpotBugs EI warnings on account relationships
- annotate SessionServiceImpl constructor to justify dependency references

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :account-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68a9aed9c5408330bb39aa1ac78abfe5