### PR TITLE
Fix SpotBugs configuration and suppress false positives

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,8 +104,15 @@ subprojects {
         // Exclude generated sources and protobuf-generated packages from analysis
         val generatedDir = "${File.separator}generated${File.separator}"
         val protoPackages = listOf("net/firedevops/firemud/**/v1/**")
+        // Capture original class directories before filtering so we can supply them on the
+        // auxiliary classpath. Without this SpotBugs fails with missing class errors when our
+        // analyzed classes reference generated protobuf classes that were excluded from
+        // analysis. Providing the original directories on the auxiliary classpath allows
+        // SpotBugs to resolve those references while still skipping analysis of the generated
+        // sources.
+        val originalClassDirs = classDirs.files
         classDirs.setFrom(
-            classDirs.files
+            originalClassDirs
                 .filterNot { it.path.contains(generatedDir) }
                 .map { fileTree(it) { exclude(protoPackages) } }
         )
@@ -114,15 +121,16 @@ subprojects {
                 .filterNot { it.path.contains(generatedDir) }
                 .map { fileTree(it) { exclude(protoPackages) } }
         )
+        auxClassPaths.from(originalClassDirs)
     }
 
     // SpotBugs analyzes the compiled classes, so ensure it runs after Java
     // compilation to avoid implicit dependency issues reported by Gradle.
     tasks.named("spotbugsMain") {
-        dependsOn("compileJava")
+        dependsOn("compileJava", "processResources")
     }
     tasks.named("spotbugsTest") {
-        dependsOn("compileTestJava")
+        dependsOn("compileTestJava", "processTestResources")
     }
 
     tasks.test {

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ReportGrpcService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ReportGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
@@ -18,6 +19,9 @@ public class ReportGrpcService extends ReportServiceGrpc.ReportServiceImplBase {
   private final ReportService reportService;
   private final MeterRegistry meterRegistry;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Spring injects ReportService and MeterRegistry beans")
   public ReportGrpcService(ReportService reportService, MeterRegistry meterRegistry) {
     this.reportService = reportService;
     this.meterRegistry = meterRegistry;

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/SagaDashboardServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/SagaDashboardServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import net.firedevops.firemud.dto.SagaInstanceDto;
@@ -19,6 +20,9 @@ public class SagaDashboardServiceImpl implements SagaDashboardService {
   private final SagaMapper mapper;
   private final SagaMetrics metrics;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Spring manages dependencies and metrics bean")
   public SagaDashboardServiceImpl(
       SagaInstanceRepository instanceRepository,
       SagaStepRepository stepRepository,

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/FriendController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AddFriendRequest;
@@ -16,6 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
   private final FriendService friendService;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Spring manages FriendService bean lifecycle")
   public FriendController(FriendService friendService) {
     this.friendService = friendService;
   }

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/controller/GuildController.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import net.firedevops.firemud.common.ApiResponse;
 import net.firedevops.firemud.dto.AddGuildMemberRequest;
@@ -23,6 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class GuildController {
   private final GuildService guildService;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Spring manages GuildService bean lifecycle")
   public GuildController(GuildService guildService) {
     this.guildService = guildService;
   }


### PR DESCRIPTION
## Summary
- avoid missing class errors by supplying generated classes on SpotBugs aux classpath
- ensure SpotBugs runs after resource processing
- suppress false EI_EXPOSE_REP2 reports for Spring-managed beans

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a9aed9c5408330bb39aa1ac78abfe5