### PR TITLE
Suppress SpotBugs EI_EXPOSE_REP2 in game session service

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the Entity Management Service. */
 @Component
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public final class EntityManagementClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the Game Logic Service using mTLS. */
 @Component
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public final class GameLogicClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the World Management Service. */
 @Component
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public final class WorldManagementClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import net.firedevops.firemud.client.EntityManagementClient;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Default implementation of {@link GameInstanceService}. */
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 @Service
 public final class GameInstanceServiceImpl implements GameInstanceService {
   private static final Logger logger = LoggingUtil.getLogger(GameInstanceServiceImpl.class);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -42,8 +43,13 @@ public final class GameSessionGrpcService
   private final PingService pingService;
   private final GameInstanceService gameInstanceService;
   private final FeatureFlagService featureFlagService;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final TickService tickService;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final MeterRegistry meterRegistry;
+
   private final IpConnectionLimiter ipConnectionLimiter;
   private final SessionRateLimiter sessionRateLimiter;
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public final class SessionStateServiceImpl implements SessionStateService {
   private static final Logger logger = LoggingUtil.getLogger(SessionStateServiceImpl.class);
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final RedisTemplate<String, Object> redisTemplate;
 
   @Override

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /** Periodically processes ticks for all running sessions. */
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 @Component
 @RequiredArgsConstructor
 public final class TickScheduler {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -26,6 +27,7 @@ import org.springframework.scripting.support.ResourceScriptSource;
 import org.springframework.stereotype.Service;
 
 /** Default Redis-backed implementation of {@link TickService}. */
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 @Service
 @RequiredArgsConstructor
 public class TickServiceImpl implements TickService {


### PR DESCRIPTION
## Summary
- silence SpotBugs EI_EXPOSE_REP2 false positives in game session service components and clients

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68a9b1b2349083309488ee9057cf332d