### PR TITLE
ci: install node deps for trivy license scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,20 @@ jobs:
       - name: ⬇️ Checkout Code
         uses: actions/checkout@v5
 
+      - name: ⚙️ Set Up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            config/openapi/package-lock.json
+            web-client/package-lock.json
+
+      - name: 📦 Install Node Dependencies
+        run: |
+          npm --prefix config/openapi ci
+          npm --prefix web-client ci
+
       - name: 💾 Cache Trivy DB
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- set up Node and install dependencies before running Trivy so license info is included

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a9b11a68c48330ba14fb91baa7be28