### PR TITLE
ci: remove redundant Spotless step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,12 +212,6 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: 🎨 Check Spotless Formatting
-        run: |
-          echo "::group::Run Spotless"
-          ./gradlew :${{ matrix.service }}:spotlessCheck
-          echo "::endgroup::"
-
       - name: 🧪 Run Gradle Checks
         id: checks
         run: |


### PR DESCRIPTION
## Summary
- inline Spotless into Gradle checks and drop dedicated step

## Testing
- `pre-commit run --files .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a9b04382c88330b4ed032fbc09bd40