### PR TITLE
Make Redis and saga utilities optional

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -5,12 +5,14 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 /** Records conflict metadata in Redis for hotspot detection. */
 @Component
 @RequiredArgsConstructor
+@ConditionalOnBean(StringRedisTemplate.class)
 @SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
     justification = "Injected dependencies are safe to store without defensive copies")

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/saga/SagaRunner.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/saga/SagaRunner.java
@@ -11,10 +11,12 @@ import net.firedevops.firemud.common.saga.persistence.SagaStep;
 import net.firedevops.firemud.common.saga.persistence.SagaStepRepository;
 import net.firedevops.firemud.metrics.SagaMetrics;
 import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 /** Executes sagas with correlation ID handling and metrics. */
 @Component
+@ConditionalOnBean({SagaInstanceRepository.class, SagaStepRepository.class})
 @SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
     justification = "Repositories and metrics are injected and immutable")


### PR DESCRIPTION
## Summary
- Avoid creating Redis conflict tracker when no `StringRedisTemplate` is present
- Only register saga runner when JPA repositories exist

## Testing
- `./gradlew :tcp-proxy-service:test --rerun-tasks`
- `./gradlew :common-library:test --rerun-tasks`
- `./gradlew check` *(fails: process killed; environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b3aa7e788330af51f2d736e525de