### PR TITLE
Guard gRPC tracing interceptor on Tracer bean

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/config/GrpcConfig.java
@@ -6,6 +6,7 @@ import net.firedevops.firemud.common.grpc.LoggingInterceptor;
 import net.firedevops.firemud.common.grpc.MetricsInterceptor;
 import net.firedevops.firemud.common.grpc.TracingInterceptor;
 import org.lognet.springboot.grpc.GRpcGlobalInterceptor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,6 +26,7 @@ public class GrpcConfig {
 
   @Bean
   @GRpcGlobalInterceptor
+  @ConditionalOnBean(Tracer.class)
   public TracingInterceptor tracingInterceptor(Tracer tracer) {
     return new TracingInterceptor(tracer);
   }

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/config/GrpcConfigTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/config/GrpcConfigTest.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.trace.Tracer;
+import net.firedevops.firemud.common.grpc.TracingInterceptor;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/** Unit tests for {@link GrpcConfig} verifying conditional bean creation. */
+class GrpcConfigTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withBean(MeterRegistry.class, SimpleMeterRegistry::new)
+          .withUserConfiguration(GrpcConfig.class);
+
+  @Test
+  void tracingInterceptorNotLoadedWhenTracerMissing() {
+    contextRunner.run(ctx -> assertThat(ctx).doesNotHaveBean(TracingInterceptor.class));
+  }
+
+  @Test
+  void tracingInterceptorLoadedWhenTracerPresent() {
+    contextRunner
+        .withBean(Tracer.class, () -> Mockito.mock(Tracer.class))
+        .run(ctx -> assertThat(ctx).hasSingleBean(TracingInterceptor.class));
+  }
+}


### PR DESCRIPTION
## Summary
- make tracing interceptor conditional on Tracer bean
- add unit test verifying conditional bean registration

## Testing
- `./gradlew :tcp-proxy-service:check`

------
https://chatgpt.com/codex/tasks/task_e_68a9b3aa7e788330af51f2d736e525de