### PR TITLE
Defensively copy generator params

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GeneratedRoom.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GeneratedRoom.java
@@ -1,13 +1,35 @@
 package net.firedevops.firemud.service.generator;
 
+import java.util.List;
+import java.util.Map;
+
 /** DTO representing a procedurally generated room with metadata for editor overlays. */
 public record GeneratedRoom(
     long roomId,
     long connectedTo,
     int x,
     int y,
-    java.util.Map<String, Long> exitMap,
-    java.util.List<String> tags,
+    Map<String, Long> exitMap,
+    List<String> tags,
     String biome,
     int elevation,
-    Long regionId) {}
+    Long regionId) {
+  /**
+   * Creates a generated room. The provided collections are defensively copied to avoid exposing
+   * mutable internal state to callers.
+   *
+   * @param roomId unique room identifier
+   * @param connectedTo adjacent room identifier
+   * @param x x-coordinate within the generated map
+   * @param y y-coordinate within the generated map
+   * @param exitMap mapping of exits to neighboring room ids
+   * @param tags list of metadata tags
+   * @param biome biome type name
+   * @param elevation elevation relative to map origin
+   * @param regionId optional region identifier
+   */
+  public GeneratedRoom {
+    exitMap = Map.copyOf(exitMap);
+    tags = List.copyOf(tags);
+  }
+}

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationParams.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/generator/GenerationParams.java
@@ -3,4 +3,16 @@ package net.firedevops.firemud.service.generator;
 import java.util.Map;
 
 /** Parameters for procedural generation. */
-public record GenerationParams(long seed, int rooms, Map<String, String> params) {}
+public record GenerationParams(long seed, int rooms, Map<String, String> params) {
+  /**
+   * Creates generation parameters. The provided map is defensively copied to avoid exposing mutable
+   * internal state.
+   *
+   * @param seed random seed for generation
+   * @param rooms number of rooms to create
+   * @param params additional arbitrary parameters
+   */
+  public GenerationParams {
+    params = Map.copyOf(params);
+  }
+}


### PR DESCRIPTION
## Summary
- avoid exposing mutable map and list from `GeneratedRoom`
- defensively copy procedural generation params

## Testing
- `./gradlew :automation-scripting-service:spotbugsMain -PfullCheck --rerun-tasks --console=plain`
- `./gradlew :automation-scripting-service:check --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68a9b45a49cc83308299d4844370d8b0