### PR TITLE
chore: suppress spotbugs exposure warnings

### DIFF
--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 @Entity
@@ -15,6 +18,8 @@ public class Revision {
   @Column(nullable = false, length = 36)
   private String tenantId;
 
+  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
+  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "tenant_id", nullable = false)
   private Game game;

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.entity;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Data
 @Entity
@@ -15,6 +18,8 @@ public class Version {
   @Column(nullable = false, length = 36)
   private String tenantId;
 
+  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
+  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "tenant_id", nullable = false)
   private Game game;

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
@@ -30,6 +31,8 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   private final PingService pingService;
   private final RevisionService revisionService;
   private final VersionService versionService;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   private final MeterRegistry meterRegistry;
 
   private ErrorDetail error(String code, String message) {


### PR DESCRIPTION
## Summary
- prevent SpotBugs from flagging game entity relationships as exposing internal state
- mark GameDesign gRPC service's MeterRegistry dependency as safe to store

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :game-design-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68a9b9c716cc8330a1824b52905c267d