### PR TITLE
feat: harden dto and entity collections

### DIFF
--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/CraftingRecipeDto.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/dto/CraftingRecipeDto.java
@@ -9,4 +9,9 @@ public record CraftingRecipeDto(
     @NotNull String name,
     @NotNull Long resultItemId,
     int resultQuantity,
-    List<CraftingIngredientDto> ingredients) {}
+    List<CraftingIngredientDto> ingredients) {
+
+  public CraftingRecipeDto {
+    ingredients = List.copyOf(ingredients);
+  }
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Character.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Character.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Data;
@@ -65,4 +66,12 @@ public class Character {
   private Instant lastLoginAt;
 
   @Version private int version;
+
+  public Set<InventoryEntry> getInventoryEntries() {
+    return Collections.unmodifiableSet(inventoryEntries);
+  }
+
+  public void setInventoryEntries(Set<InventoryEntry> inventoryEntries) {
+    this.inventoryEntries = new HashSet<>(inventoryEntries);
+  }
 }


### PR DESCRIPTION
## Summary
- prevent CraftingRecipeDto from exposing internal ingredient list
- avoid leaking Character.inventoryEntries via defensive copies

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :entity-management-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68aa68c8e94083309e698f043a1f0e8f