### PR TITLE
Refactor entity IDs to reduce SpotBugs warnings

### DIFF
--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Character.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/Character.java
@@ -8,10 +8,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Entity
 @Table(name = "characters")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NamedEntityGraph(
     name = "character.inventory",
     attributeNodes = {
@@ -21,6 +23,7 @@ import lombok.Data;
 public class Character {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @EqualsAndHashCode.Include
   private Long id;
 
   @Column(nullable = false)

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CharacterFriend.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CharacterFriend.java
@@ -23,4 +23,25 @@ public class CharacterFriend {
 
   @Column(nullable = false)
   private Instant createdAt = Instant.now();
+
+  public CharacterFriendKey getId() {
+    if (id == null) {
+      return null;
+    }
+    CharacterFriendKey copy = new CharacterFriendKey();
+    copy.setCharacterId(id.getCharacterId());
+    copy.setFriendId(id.getFriendId());
+    return copy;
+  }
+
+  public void setId(CharacterFriendKey id) {
+    if (id == null) {
+      this.id = null;
+    } else {
+      CharacterFriendKey copy = new CharacterFriendKey();
+      copy.setCharacterId(id.getCharacterId());
+      copy.setFriendId(id.getFriendId());
+      this.id = copy;
+    }
+  }
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CraftingIngredient.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CraftingIngredient.java
@@ -19,4 +19,25 @@ public class CraftingIngredient {
 
   @Column(nullable = false)
   private int quantity;
+
+  public CraftingIngredientKey getId() {
+    if (id == null) {
+      return null;
+    }
+    CraftingIngredientKey copy = new CraftingIngredientKey();
+    copy.setRecipeId(id.getRecipeId());
+    copy.setItemId(id.getItemId());
+    return copy;
+  }
+
+  public void setId(CraftingIngredientKey id) {
+    if (id == null) {
+      this.id = null;
+    } else {
+      CraftingIngredientKey copy = new CraftingIngredientKey();
+      copy.setRecipeId(id.getRecipeId());
+      copy.setItemId(id.getItemId());
+      this.id = copy;
+    }
+  }
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CraftingRecipe.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/entity/CraftingRecipe.java
@@ -5,16 +5,19 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Entity
 @Table(name = "crafting_recipes")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NamedEntityGraph(
     name = "recipe.ingredients",
     attributeNodes = {@NamedAttributeNode("ingredients"), @NamedAttributeNode("ingredients.item")})
 public class CraftingRecipe {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @EqualsAndHashCode.Include
   private Long id;
 
   @Column(nullable = false)


### PR DESCRIPTION
## Summary
- limit `equals`/`hashCode` for `Character` and `CraftingRecipe` to explicitly included fields
- defensively copy embedded IDs in `CharacterFriend` and `CraftingIngredient`

## Testing
- `./gradlew --rerun-tasks spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68aa863ebe308330a3bc7c1a0e81a635