### PR TITLE
fix(ci): correct ERD generation script path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: 🖼️ Generate ERD diagrams
-        run: ./dev-tools/generate-erd.sh
+        run: ./dev-tools/docs/generate-erd.sh
 
       - name: 📤 Upload ERD artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow to call the correct ERD generation script

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_68aa887a9b3c8330a64b3ebd3c6bceeb