### PR TITLE
Suppress SpotBugs warnings in automation scripting service

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/mapper/ScriptDefinitionMapper.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/mapper/ScriptDefinitionMapper.java
@@ -11,5 +11,6 @@ public interface ScriptDefinitionMapper {
   ScriptDefinitionDto toDto(ScriptDefinition entity);
 
   @Mapping(source = "version", target = "scriptVersion")
+  @Mapping(target = "rowVersion", ignore = true)
   ScriptDefinition toEntity(ScriptDefinitionDto dto);
 }

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/advanced/NpcMoraleServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/advanced/NpcMoraleServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.advanced;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.model.AggressionState;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 /** Simple morale-based AI module. */
 @Service
 @RequiredArgsConstructor
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class NpcMoraleServiceImpl implements NpcMoraleService {
   private final NpcAggressionService aggressionService;
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/AutomationQueueServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/AutomationQueueServiceImpl.java
@@ -1,5 +1,6 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link AutomationQueueService}. */
 @Service
 @RequiredArgsConstructor
+@SuppressFBWarnings("EI_EXPOSE_REP2")
 public class AutomationQueueServiceImpl implements AutomationQueueService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;


### PR DESCRIPTION
## Summary
- ignore `rowVersion` in `ScriptDefinitionMapper`
- suppress SpotBugs EI_EXPOSE_REP2 warnings in `AutomationQueueServiceImpl` and `NpcMoraleServiceImpl`

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68aa88accae883308e7bbc6e5530ad74