### PR TITLE
fix: remove duplicate gradle cache configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: gradle
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -205,7 +204,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-          cache: gradle
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -422,7 +420,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-          cache: gradle
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-          cache: gradle
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-          cache: gradle
 
       - name: ⚙️ Set Up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-          cache: gradle
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
## Summary
- avoid conflicting Gradle cache setup by relying solely on `gradle/actions/setup-gradle` in CI workflows

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/preview.yml .github/workflows/license-scan.yml`

------
https://chatgpt.com/codex/tasks/task_e_68aa8b7527f88330b51e211c30f48a5d