### PR TITLE
Add codex setup and maintenance scripts

### DIFF
--- a/codex-maintenance.sh
+++ b/codex-maintenance.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# --- Refresh system packages needed by the repo ---
+apt-get update
+apt-get install -y --only-upgrade \
+    docker.io \
+    docker-compose \
+    postgresql-client \
+    redis-tools \
+    chromium-browser
+
+# --- Python tooling ---
+pip install --upgrade pre-commit
+
+# --- Node workspaces (needed before any Gradle tasks) ---
+npm --prefix config/openapi ci
+npm --prefix web-client ci
+
+# --- Java/Gradle bootstrap ---
+./gradlew build
+
+# Optional sanity checks
+docker --version
+psql --version
+redis-cli --version
+npm --version
+

--- a/codex-setup.sh
+++ b/codex-setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# --- System dependencies needed by the repo ---
+apt-get update
+apt-get install -y --no-install-recommends \
+    docker.io \
+    docker-compose \
+    postgresql-client \
+    redis-tools \
+    chromium-browser
+
+# --- Python tooling ---
+pip install --upgrade pip pre-commit
+
+# --- Node workspaces (needed before the Gradle build) ---
+npm --prefix config/openapi ci
+npm --prefix web-client ci
+
+# --- Java/Gradle bootstrap ---
+./gradlew build
+
+# Optional sanity checks (fail early if a tool is missing)
+docker --version
+psql --version
+redis-cli --version
+npm --version
+


### PR DESCRIPTION
## Summary
- add `codex-setup.sh` for container setup with system dependencies and tooling
- add `codex-maintenance.sh` for updating dependencies in cached containers

## Testing
- `pre-commit run --files codex-setup.sh codex-maintenance.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa9807452483309daca349a29fab92