### PR TITLE
fix: load Flyway PostgreSQL plugin for ERD generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,8 @@ buildscript {
     }
     dependencies {
         classpath("com.fasterxml.jackson.core:jackson-databind:2.19.2")
+        classpath("org.flywaydb:flyway-database-postgresql:11.11.2")
+        classpath("org.postgresql:postgresql:42.7.7")
     }
 }
 
@@ -53,6 +55,8 @@ subprojects {
     group = "net.firedevops.firemud"
     version = project.property("version") as String
 
+    val libs = rootProject.extensions.getByType<VersionCatalogsExtension>().named("libs")
+
     plugins.withId("java") {
         the<JavaPluginExtension>().toolchain.languageVersion.set(JavaLanguageVersion.of(21))
         tasks.withType<JavaCompile>().configureEach {
@@ -63,9 +67,13 @@ subprojects {
     if (projectDir.parentFile.name == "services" && name != "common-library") {
         apply(plugin = "org.springframework.boot")
         apply(plugin = "org.flywaydb.flyway")
-    }
 
-    val libs = rootProject.extensions.getByType<VersionCatalogsExtension>().named("libs")
+        dependencies {
+            implementation(libs.findLibrary("flyway-core").get())
+            implementation(libs.findLibrary("flyway-database-postgresql").get())
+            implementation(libs.findLibrary("postgresql").get())
+        }
+    }
 
     dependencies {
         implementation(libs.findLibrary("protobuf-java").get())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ spring-boot-starter-websocket = { module = "org.springframework.boot:spring-boot
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "spring-boot" }
 
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 
 mapstruct = { module = "org.mapstruct:mapstruct", version.ref = "mapstruct" }
 mapstruct-processor = { module = "org.mapstruct:mapstruct-processor", version.ref = "mapstruct" }


### PR DESCRIPTION
## Summary
- load PostgreSQL Flyway database plugin in buildscript
- add Flyway database and JDBC driver dependencies to service subprojects

## Testing
- `./gradlew check`
- `./dev-tools/docs/generate-erd.sh` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68aa96d085cc83309b82da2632dff0b0