### PR TITLE
Add justifications for SpotBugs suppressions

### DIFF
--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -135,3 +135,4 @@ Monetization:
 - gRPC endpoints must return `ErrorDetail` objects for application errors. Wrap response observers to log warnings, increment `grpc.app_error` with the error code, and tag spans. Only call `onError()` for transport or infrastructure failures.
 - Run `pre-commit run --all-files` or `./gradlew check` before committing to verify formatting, tests, and coverage.
 - Avoid returning nulls; use transactions for DB consistency.
+- When suppressing SpotBugs warnings, use `@SuppressFBWarnings(value = "<WARNING>", justification = "<reason>")`.

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AccountController.java
@@ -23,7 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
   private final AccountService accountService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "AccountService is injected and not exposed")
   public AccountController(AccountService accountService) {
     this.accountService = accountService;
   }

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/AuthController.java
@@ -21,7 +21,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
   private final AccountService accountService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "AccountService is injected and not exposed")
   public AuthController(AccountService accountService) {
     this.accountService = accountService;
   }

--- a/services/account-service/src/main/java/net/firedevops/firemud/controller/ProfileController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/controller/ProfileController.java
@@ -17,7 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/profiles")
 public class ProfileController {
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "AccountService is injected and not exposed")
   private final AccountService accountService;
 
   public ProfileController(AccountService accountService) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/EmailVerificationToken.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/EmailVerificationToken.java
@@ -15,8 +15,16 @@ public class EmailVerificationToken {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
-  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
+  @Getter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP",
+              justification = "JPA association is intentionally exposed"))
+  @Setter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP2",
+              justification = "JPA association stored directly"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/ExternalAccount.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/ExternalAccount.java
@@ -27,12 +27,14 @@ public class ExternalAccount {
   @Column(name = "external_id", nullable = false, length = 100)
   private String externalId;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA association is intentionally exposed")
   public Account getAccount() {
     return account;
   }
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "JPA association stored directly")
   public void setAccount(Account account) {
     this.account = account;
   }

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PasswordResetToken.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PasswordResetToken.java
@@ -15,8 +15,16 @@ public class PasswordResetToken {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
-  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
+  @Getter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP",
+              justification = "JPA association is intentionally exposed"))
+  @Setter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP2",
+              justification = "JPA association stored directly"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/PaymentTransaction.java
@@ -14,8 +14,16 @@ public class PaymentTransaction {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
-  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
+  @Getter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP",
+              justification = "JPA association is intentionally exposed"))
+  @Setter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP2",
+              justification = "JPA association stored directly"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/entity/Subscription.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/entity/Subscription.java
@@ -15,8 +15,16 @@ public class Subscription {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
-  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
+  @Getter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP",
+              justification = "JPA association is intentionally exposed"))
+  @Setter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP2",
+              justification = "JPA association stored directly"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "account_id", nullable = false)
   private Account account;

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountGrpcService.java
@@ -32,7 +32,9 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
   private final PingService pingService;
   private final AccountService accountService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Services are injected and remain internal")
   public AccountGrpcService(PingService pingService, AccountService accountService) {
     this.pingService = pingService;
     this.accountService = accountService;

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -63,7 +63,9 @@ public class AccountServiceImpl implements AccountService {
   private final net.firedevops.firemud.service.session.SessionService sessionService;
   private final SagaRunner sagaRunner;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Dependencies are injected and kept internal")
   public AccountServiceImpl(
       AccountRepository accountRepository,
       AccountMapper accountMapper,

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/EmailServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/EmailServiceImpl.java
@@ -17,7 +17,9 @@ public class EmailServiceImpl implements EmailService {
   private final JavaMailSender mailSender;
   private final MailProperties mailProperties;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Dependencies are injected and not exposed")
   public EmailServiceImpl(JavaMailSender mailSender, MailProperties mailProperties) {
     this.mailSender = mailSender;
     this.mailProperties = mailProperties;

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/PaymentServiceImpl.java
@@ -27,7 +27,9 @@ public class PaymentServiceImpl implements PaymentService {
   private final SubscriptionRepository subscriptionRepository;
   private final StripeClient stripeClient;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Repositories and client are injected and not exposed")
   public PaymentServiceImpl(
       AccountRepository accountRepository,
       PaymentTransactionRepository paymentTransactionRepository,

--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/VirtualCurrencyGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/VirtualCurrencyGrpcService.java
@@ -16,7 +16,9 @@ import org.lognet.springboot.grpc.GRpcService;
 @GRpcService
 public class VirtualCurrencyGrpcService
     extends VirtualCurrencyServiceGrpc.VirtualCurrencyServiceImplBase {
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "CurrencyService is injected and not exposed")
   private final VirtualCurrencyService currencyService;
 
   public VirtualCurrencyGrpcService(VirtualCurrencyService currencyService) {

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/controller/NpcFormationController.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/controller/NpcFormationController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/formations")
 @RequiredArgsConstructor
-@SuppressFBWarnings(value = "EI2", justification = "Service dependency is not exposed")
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Service dependency is not exposed")
 public class NpcFormationController {
   private final NpcFormationService formationService;
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/advanced/NpcMoraleServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/advanced/NpcMoraleServiceImpl.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 /** Simple morale-based AI module. */
 @Service
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Service dependency is not exposed")
 public class NpcMoraleServiceImpl implements NpcMoraleService {
   private final NpcAggressionService aggressionService;
 

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/AutomationQueueServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/AutomationQueueServiceImpl.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link AutomationQueueService}. */
 @Service
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Service dependency is not exposed")
 public class AutomationQueueServiceImpl implements AutomationQueueService {
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/NpcFormationGrpcService.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/NpcFormationGrpcService.java
@@ -1,9 +1,11 @@
 package net.firedevops.firemud.service.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import java.util.List;
+import java.util.Objects;
 import net.firedevops.firemud.automationscripting.v1.AddFormationMemberRequest;
 import net.firedevops.firemud.automationscripting.v1.AddFormationMemberResponse;
 import net.firedevops.firemud.automationscripting.v1.AutomationScriptingServiceGrpc;
@@ -19,10 +21,12 @@ import org.lognet.springboot.grpc.GRpcService;
 @GRpcService
 public class NpcFormationGrpcService
     extends AutomationScriptingServiceGrpc.AutomationScriptingServiceImplBase {
+
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Service dependency is not exposed")
   private final NpcFormationService formationService;
 
   public NpcFormationGrpcService(NpcFormationService formationService) {
-    this.formationService = formationService;
+    this.formationService = Objects.requireNonNull(formationService);
   }
 
   @Override

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @SuppressFBWarnings(
-    value = "EI2",
+    value = "EI_EXPOSE_REP2",
     justification = "Injected dependencies are not exposed externally")
 public class ScriptTickServiceImpl implements ScriptTickService {
   private static final Logger logger = LoggingUtil.getLogger(ScriptTickServiceImpl.class);

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/InventoryController.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/controller/InventoryController.java
@@ -17,7 +17,9 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/characters/{characterId}/inventory")
 @RequiredArgsConstructor
 public class InventoryController {
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Spring injects InventoryService; storing reference is safe")
   private final InventoryService inventoryService;
 
   @GetMapping

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/CharacterServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/CharacterServiceImpl.java
@@ -20,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@SuppressFBWarnings(value = "EI2", justification = "Injected dependencies are not exposed")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected dependencies are not exposed")
 public class CharacterServiceImpl implements CharacterService {
 
   private final CharacterRepository characterRepository;

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/EntityManagementGrpcService.java
@@ -33,10 +33,14 @@ public class EntityManagementGrpcService
   private final PingService pingService;
   private final CharacterService characterService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Injected InventoryService is not exposed externally")
   private final InventoryService inventoryService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry is thread-safe and stored as injected")
   private final MeterRegistry meterRegistry;
 
   public EntityManagementGrpcService(

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
@@ -17,10 +17,14 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class TickLockServiceImpl implements TickLockService {
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "RedisTemplate is injected and used safely")
   private final StringRedisTemplate redisTemplate;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry is thread-safe and injected by Spring")
   private final MeterRegistry meterRegistry;
 
   private final ConflictTracker conflictTracker;

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Revision.java
@@ -18,8 +18,16 @@ public class Revision {
   @Column(nullable = false, length = 36)
   private String tenantId;
 
-  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
-  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
+  @Getter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP",
+              justification = "JPA association is intentionally exposed"))
+  @Setter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP2",
+              justification = "JPA association stored directly"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "tenant_id", nullable = false)
   private Game game;

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/entity/Version.java
@@ -18,8 +18,16 @@ public class Version {
   @Column(nullable = false, length = 36)
   private String tenantId;
 
-  @Getter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP"))
-  @Setter(onMethod_ = @SuppressFBWarnings("EI_EXPOSE_REP2"))
+  @Getter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP",
+              justification = "JPA association is intentionally exposed"))
+  @Setter(
+      onMethod_ =
+          @SuppressFBWarnings(
+              value = "EI_EXPOSE_REP2",
+              justification = "JPA association stored directly"))
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "tenant_id", nullable = false)
   private Game game;

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/GameDesignGrpcService.java
@@ -32,7 +32,9 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   private final RevisionService revisionService;
   private final VersionService versionService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry is injected and not exposed")
   private final MeterRegistry meterRegistry;
 
   private ErrorDetail error(String code, String message) {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/service/impl/VersionServiceImpl.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected dependencies are not exposed")
 public class VersionServiceImpl implements VersionService {
   private static final Logger logger = LoggingUtil.getLogger(VersionServiceImpl.class);
 

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/SimpleCommandProcessor.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/logic/command/SimpleCommandProcessor.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Service;
 public class SimpleCommandProcessor implements CommandProcessor {
   private static final Logger logger = LoggingUtil.getLogger(SimpleCommandProcessor.class);
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "EventDispatcher is injected and not exposed")
   private final EventDispatcher dispatcher;
 
   private final ScriptingHook scriptingHook;

--- a/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
+++ b/services/game-logic-service/src/main/java/net/firedevops/firemud/service/impl/GameLogicGrpcService.java
@@ -21,7 +21,9 @@ public class GameLogicGrpcService extends GameLogicServiceGrpc.GameLogicServiceI
   private final PingService pingService;
   private final CommandService commandService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry is thread-safe and only stored")
   private final MeterRegistry meterRegistry;
 
   public GameLogicGrpcService(

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/EntityManagementClient.java
@@ -17,7 +17,9 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the Entity Management Service. */
 @Component
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Configuration and channel references remain internal")
 public final class EntityManagementClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/GameLogicClient.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the Game Logic Service using mTLS. */
 @Component
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Configuration and channel references remain internal")
 public final class GameLogicClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/client/WorldManagementClient.java
@@ -17,7 +17,9 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for the World Management Service. */
 @Component
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Configuration and channel references remain internal")
 public final class WorldManagementClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Default implementation of {@link GameInstanceService}. */
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected dependencies are not exposed externally")
 @Service
 public final class GameInstanceServiceImpl implements GameInstanceService {
   private static final Logger logger = LoggingUtil.getLogger(GameInstanceServiceImpl.class);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -44,10 +44,14 @@ public final class GameSessionGrpcService
   private final GameInstanceService gameInstanceService;
   private final FeatureFlagService featureFlagService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "TickService is injected and not exposed")
   private final TickService tickService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry is thread-safe and only stored")
   private final MeterRegistry meterRegistry;
 
   private final IpConnectionLimiter ipConnectionLimiter;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link IpConnectionLimiter}. */
 @Service
 public class IpConnectionLimiterImpl implements IpConnectionLimiter {
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "RedisTemplate is injected and not exposed")
   private final StringRedisTemplate redisTemplate;
 
   private final int maxConnectionsPerIp;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Service;
 /** Redis-backed implementation of {@link SessionRateLimiter}. */
 @Service
 public class SessionRateLimiterImpl implements SessionRateLimiter {
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "RedisTemplate is injected and not exposed")
   private final StringRedisTemplate redisTemplate;
 
   private final int maxMessagesPerSecond;

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionStateServiceImpl.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Service;
 public final class SessionStateServiceImpl implements SessionStateService {
   private static final Logger logger = LoggingUtil.getLogger(SessionStateServiceImpl.class);
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "RedisTemplate is injected and not exposed")
   private final RedisTemplate<String, Object> redisTemplate;
 
   @Override

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickScheduler.java
@@ -11,7 +11,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /** Periodically processes ticks for all running sessions. */
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected repository and service are not exposed")
 @Component
 @RequiredArgsConstructor
 public final class TickScheduler {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -27,7 +27,9 @@ import org.springframework.scripting.support.ResourceScriptSource;
 import org.springframework.stereotype.Service;
 
 /** Default Redis-backed implementation of {@link TickService}. */
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected dependencies are kept internal")
 @Service
 @RequiredArgsConstructor
 public class TickServiceImpl implements TickService {

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/LoggingAdminGrpcService.java
@@ -20,7 +20,9 @@ public class LoggingAdminGrpcService extends LoggingAdminServiceGrpc.LoggingAdmi
   private final LogQueryService logQueryService;
   private final ModerationService moderationService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "MeterRegistry is thread-safe and only stored")
   private final MeterRegistry meterRegistry;
 
   public LoggingAdminGrpcService(

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/service/impl/ModerationServiceImpl.java
@@ -20,7 +20,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected clients and repositories remain internal")
 public class ModerationServiceImpl implements ModerationService {
   private static final Logger logger = LoggingUtil.getLogger(ModerationServiceImpl.class);
 

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/controller/GatewayController.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/controller/GatewayController.java
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class GatewayController {
   private final GatewayRouteService routeService;
 
-  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "RouteService is injected and not exposed externally")
   public GatewayController(GatewayRouteService routeService) {
     this.routeService = routeService;
   }

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayManagementGrpcService.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayManagementGrpcService.java
@@ -16,7 +16,9 @@ import org.lognet.springboot.grpc.GRpcService;
 
 /** gRPC implementation for remote gateway management. */
 @GRpcService
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected route service is kept internal")
 public class GatewayManagementGrpcService
     extends GatewayManagementServiceGrpc.GatewayManagementServiceImplBase {
   private final GatewayRouteService routeService;

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayRouteServiceImpl.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/service/impl/GatewayRouteServiceImpl.java
@@ -19,7 +19,9 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 /** Implementation of {@link GatewayRouteService} that updates Spring Cloud Gateway at runtime. */
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected writer and publisher references are not exposed")
 @Service
 public class GatewayRouteServiceImpl implements GatewayRouteService {
   private static final Logger logger = LoggingUtil.getLogger(GatewayRouteServiceImpl.class);

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/client/GameDesignClient.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Component;
 
 /** gRPC client for communicating with the Game Design Service. */
 @Component
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected configuration and channel references are not exposed")
 public class GameDesignClient implements AutoCloseable {
   private final ServiceEndpointsProperties endpoints;
   private final GrpcClientProperties tlsProps;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
@@ -13,12 +13,16 @@ public class WorldProperties {
   /** Properties related to room behaviour. */
   private Room room = new Room();
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Configuration object stored without defensive copy")
   public void setRoom(Room room) {
     this.room = room;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "Room properties are mutable and returned directly")
   public Room getRoom() {
     return room;
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/data/TestDataSeeder.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/data/TestDataSeeder.java
@@ -20,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Profile("dev")
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Repositories are injected for seeding and not exposed")
 public class TestDataSeeder implements ApplicationRunner {
   private final RegionRepository regionRepository;
   private final ZoneRepository zoneRepository;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Instance.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Instance.java
@@ -30,12 +30,16 @@ public class Instance {
 
   @Version private int version;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA association is intentionally exposed")
   public Zone getZone() {
     return zone;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JPA association stored directly")
   public void setZone(Zone zone) {
     this.zone = zone;
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Room.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Room.java
@@ -18,12 +18,16 @@ public class Room {
   @JoinColumn(name = "region_id", nullable = false)
   private Region region;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA relationship is intentionally exposed")
   public Region getRegion() {
     return region;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JPA relationship is stored directly")
   public void setRegion(Region region) {
     this.region = region;
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/RoomExit.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/RoomExit.java
@@ -27,22 +27,30 @@ public class RoomExit {
 
   @Version private int version;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA association is intentionally exposed")
   public Room getFromRoom() {
     return fromRoom;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JPA association stored directly")
   public void setFromRoom(Room fromRoom) {
     this.fromRoom = fromRoom;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA association is intentionally exposed")
   public Room getToRoom() {
     return toRoom;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JPA association stored directly")
   public void setToRoom(Room toRoom) {
     this.toRoom = toRoom;
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/WorldEvent.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/WorldEvent.java
@@ -35,12 +35,16 @@ public class WorldEvent {
 
   @Version private int version;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA association is intentionally exposed")
   public Region getRegion() {
     return region;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JPA association stored directly")
   public void setRegion(Region region) {
     this.region = region;
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Zone.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/entity/Zone.java
@@ -23,12 +23,16 @@ public class Zone {
 
   @Version private int version;
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "JPA association is intentionally exposed")
   public Region getRegion() {
     return region;
   }
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("EI_EXPOSE_REP2")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "JPA association stored directly")
   public void setRegion(Region region) {
     this.region = region;
   }

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RegionServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RegionServiceImpl.java
@@ -11,7 +11,9 @@ import net.firedevops.firemud.service.RegionService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected dependencies are not exposed")
 @Service
 @RequiredArgsConstructor
 public class RegionServiceImpl implements RegionService {

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RoomServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/RoomServiceImpl.java
@@ -15,7 +15,9 @@ import net.firedevops.firemud.service.RoomService;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Spring-managed dependencies are stored internally")
 @Service
 @RequiredArgsConstructor
 public class RoomServiceImpl implements RoomService {

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldCreationServiceImpl.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Dependencies are injected and remain internal")
 public class WorldCreationServiceImpl implements WorldCreationService {
   private final RegionRepository regionRepository;
   private final MeterRegistry meterRegistry;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldEventServiceImpl.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldEventServiceImpl.java
@@ -24,7 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected repositories and metrics remain internal")
 public class WorldEventServiceImpl implements WorldEventService {
   private final WorldEventRepository eventRepository;
   private final RegionRepository regionRepository;

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldManagementGrpcService.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/service/impl/WorldManagementGrpcService.java
@@ -26,7 +26,9 @@ import org.lognet.springboot.grpc.GRpcService;
 /** gRPC endpoints for the World Management Service. */
 @GRpcService
 @RequiredArgsConstructor
-@SuppressFBWarnings("EI_EXPOSE_REP2")
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected services and registry remain internal")
 public class WorldManagementGrpcService
     extends WorldManagementServiceGrpc.WorldManagementServiceImplBase {
   private final PingService pingService;


### PR DESCRIPTION
## Summary
- include explicit `value` and `justification` on all `@SuppressFBWarnings` usages
- fix suppression codes to use explicit `EI_EXPOSE_REP2` where appropriate

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68aa8f915b588330ac08a327dfe98b98