### PR TITLE
Suppress MapStruct warnings in mappers

### DIFF
--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CharacterMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CharacterMapper.java
@@ -3,10 +3,14 @@ package net.firedevops.firemud.mapper;
 import net.firedevops.firemud.dto.CharacterDto;
 import net.firedevops.firemud.entity.Character;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CharacterMapper {
   CharacterDto toDto(Character entity);
 
+  @Mapping(target = "inventoryEntries", ignore = true)
+  @Mapping(target = "lastLoginAt", ignore = true)
+  @Mapping(target = "version", ignore = true)
   Character toEntity(CharacterDto dto);
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CraftingIngredientMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CraftingIngredientMapper.java
@@ -1,0 +1,17 @@
+package net.firedevops.firemud.mapper;
+
+import net.firedevops.firemud.dto.CraftingIngredientDto;
+import net.firedevops.firemud.entity.CraftingIngredient;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CraftingIngredientMapper {
+  @Mapping(target = "itemId", source = "item.id")
+  CraftingIngredientDto toDto(CraftingIngredient entity);
+
+  @Mapping(target = "item.id", source = "itemId")
+  @Mapping(target = "recipe", ignore = true)
+  @Mapping(target = "id", ignore = true)
+  CraftingIngredient toEntity(CraftingIngredientDto dto);
+}

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CraftingRecipeMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/CraftingRecipeMapper.java
@@ -5,7 +5,7 @@ import net.firedevops.firemud.entity.CraftingRecipe;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = CraftingIngredientMapper.class)
 public interface CraftingRecipeMapper {
   @Mapping(target = "resultItemId", source = "resultItem.id")
   CraftingRecipeDto toDto(CraftingRecipe entity);

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/ItemMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/ItemMapper.java
@@ -3,10 +3,12 @@ package net.firedevops.firemud.mapper;
 import net.firedevops.firemud.dto.ItemDto;
 import net.firedevops.firemud.entity.Item;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ItemMapper {
   ItemDto toDto(Item entity);
 
+  @Mapping(target = "version", ignore = true)
   Item toEntity(ItemDto dto);
 }

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/NpcMapper.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/mapper/NpcMapper.java
@@ -17,5 +17,6 @@ public interface NpcMapper {
       target = "lastDefeatedAt",
       expression =
           "java(dto.lastDefeatedAtEpochMs() == null ? null : java.time.Instant.ofEpochMilli(dto.lastDefeatedAtEpochMs()))")
+  @Mapping(target = "version", ignore = true)
   Npc toEntity(NpcDto dto);
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/RevisionMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/RevisionMapper.java
@@ -3,10 +3,12 @@ package net.firedevops.firemud.mapper;
 import net.firedevops.firemud.dto.RevisionDto;
 import net.firedevops.firemud.entity.Revision;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface RevisionMapper {
   RevisionDto toDto(Revision entity);
 
+  @Mapping(target = "game", ignore = true)
   Revision toEntity(RevisionDto dto);
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/VersionMapper.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/mapper/VersionMapper.java
@@ -3,10 +3,12 @@ package net.firedevops.firemud.mapper;
 import net.firedevops.firemud.dto.VersionDto;
 import net.firedevops.firemud.entity.Version;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface VersionMapper {
   VersionDto toDto(Version entity);
 
+  @Mapping(target = "game", ignore = true)
   Version toEntity(VersionDto dto);
 }


### PR DESCRIPTION
## Summary
- add CraftingIngredientMapper to support ingredient mappings
- ignore unneeded fields in mapper interfaces to satisfy MapStruct

## Testing
- `./gradlew spotbugsMain -PfullCheck --rerun-tasks`
- `./gradlew :entity-management-service:check :game-design-service:check -PfullCheck`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ad6be248330a529e01c59e16d97