### PR TITLE
Add note-only guidance for nonstandard code

### DIFF
--- a/design/project-management/ai-rules-global.md
+++ b/design/project-management/ai-rules-global.md
@@ -48,6 +48,7 @@
 
 - When reviewing or refactoring code:
   - Identify bugs, anti-patterns, and improvements
+  - Note strange or nonstandard implementations and suggest better alternatives in your output, but do not apply fixes unless explicitly requested
   - Do not change functionality unless requested
   - Avoid touching unrelated code
   - Update or remove outdated comments


### PR DESCRIPTION
## Summary
- Add instruction to AI rules directing contributors to note strange or nonstandard code patterns with suggested alternatives without applying fixes

## Testing
- `pre-commit run --files design/project-management/ai-rules-global.md`

------
https://chatgpt.com/codex/tasks/task_e_68aaaa558f808330aea466d914be135b