### PR TITLE
Replace deprecated JJWT parser usage in JwtUtil

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
@@ -30,6 +30,9 @@ public class JwtUtil {
   }
 
   public Jws<Claims> parseToken(String token) {
-    return Jwts.parser().setSigningKey(Keys.hmacShaKeyFor(key)).build().parseClaimsJws(token);
+    return Jwts.parser()
+        .verifyWith(Keys.hmacShaKeyFor(key))
+        .build()
+        .parseSignedClaims(token);
   }
 }


### PR DESCRIPTION
## Summary
- use modern JJWT parser API with verifyWith and parseSignedClaims to avoid deprecated calls

## Testing
- `./gradlew spotBugsMain -PfullCheck --rerun-tasks`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68aaaa8bf7248330b2dac480910f49c4