### PR TITLE
Handle invalid watch keys in JwtSecretWatcher

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtSecretWatcher.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtSecretWatcher.java
@@ -65,10 +65,13 @@ public class JwtSecretWatcher implements AutoCloseable {
           break;
         }
       }
-      key.reset();
+      boolean valid = key.reset();
       if (changed) {
         logger.info("JWT secret change detected; reloading");
         onChange.run();
+      }
+      if (!valid) {
+        break;
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure JwtSecretWatcher stops processing when the watched directory becomes invalid

## Testing
- `./gradlew :common-library:spotbugsMain -PfullCheck --rerun-tasks`
- `./gradlew :common-library:test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68aaaa8bf7248330b2dac480910f49c4