### PR TITLE
fix: disable DB auto-config in tcp proxy

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud;
 
 import jakarta.annotation.PreDestroy;
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
+import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.telnet.TelnetServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -11,7 +12,12 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.event.EventListener;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+@SpringBootApplication(
+    exclude = {
+      DataSourceAutoConfiguration.class,
+      RedisAutoConfiguration.class,
+      DatabaseAutoConfiguration.class
+    })
 @Import(CommonAutoConfiguration.class)
 public class TcpProxyServiceApplication {
   private final TelnetServer telnetServer;


### PR DESCRIPTION
## Summary
- avoid starting unused database and flyway beans in TcpProxyService
- prevent cross-service tests from attempting DB connections

## Testing
- `./gradlew :tcp-proxy-service:test`
- `./gradlew :tcp-proxy-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68aad880a4f8833098341d43ab3de052