### PR TITLE
feat(session): add TTL for IP connection limiter

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.service.impl;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Duration;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,11 +17,15 @@ public class IpConnectionLimiterImpl implements IpConnectionLimiter {
 
   private final int maxConnectionsPerIp;
 
+  private final Duration entryTtl;
+
   public IpConnectionLimiterImpl(
       StringRedisTemplate redisTemplate,
-      @Value("${GAME_SESSION_MAX_CONNECTIONS_PER_IP:5}") int maxConnectionsPerIp) {
+      @Value("${GAME_SESSION_MAX_CONNECTIONS_PER_IP:5}") int maxConnectionsPerIp,
+      @Value("${GAME_SESSION_CONN_TTL_SEC:3600}") long entryTtlSeconds) {
     this.redisTemplate = redisTemplate;
     this.maxConnectionsPerIp = maxConnectionsPerIp;
+    this.entryTtl = Duration.ofSeconds(entryTtlSeconds);
   }
 
   @Override
@@ -33,8 +38,12 @@ public class IpConnectionLimiterImpl implements IpConnectionLimiter {
 
   @Override
   public void register(String ip, long sessionId) {
-    redisTemplate.opsForValue().increment(ipKey(ip));
-    redisTemplate.opsForValue().set(sessionKey(sessionId), ip);
+    String ipKey = ipKey(ip);
+    Long count = redisTemplate.opsForValue().increment(ipKey);
+    if (count != null && count == 1L) {
+      redisTemplate.expire(ipKey, entryTtl);
+    }
+    redisTemplate.opsForValue().set(sessionKey(sessionId), ip, entryTtl);
   }
 
   @Override

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/IpConnectionLimiterImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/IpConnectionLimiterImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -44,7 +45,7 @@ class IpConnectionLimiterImplTest {
               return null;
             })
         .when(ops)
-        .set(anyString(), anyString());
+        .set(anyString(), anyString(), any());
     doAnswer(
             inv -> {
               store.remove(inv.getArgument(0));
@@ -53,7 +54,7 @@ class IpConnectionLimiterImplTest {
         .when(redis)
         .delete(anyString());
 
-    IpConnectionLimiterImpl limiter = new IpConnectionLimiterImpl(redis, 1);
+    IpConnectionLimiterImpl limiter = new IpConnectionLimiterImpl(redis, 1, 60);
     assertTrue(limiter.canAccept("1.2.3.4"));
     limiter.register("1.2.3.4", 1L);
     assertFalse(limiter.canAccept("1.2.3.4"));


### PR DESCRIPTION
## Summary
- expire Redis tracking keys for IP connections after configurable TTL
- update unit test for connection limiter

## Testing
- `./gradlew :game-session-service:spotbugsMain -PfullCheck`
- `./gradlew :game-session-service:check`

------
https://chatgpt.com/codex/tasks/task_e_68aad966930483308bd4f5bd764282c7