### PR TITLE
Handle watch service closure

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtSecretWatcher.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtSecretWatcher.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.common.security;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
@@ -54,6 +55,9 @@ public class JwtSecretWatcher implements AutoCloseable {
         key = watchService.take();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        return;
+      } catch (ClosedWatchServiceException e) {
+        // Watch service closed while waiting; exit loop
         return;
       }
       boolean changed = false;

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/JwtUtil.java
@@ -30,9 +30,6 @@ public class JwtUtil {
   }
 
   public Jws<Claims> parseToken(String token) {
-    return Jwts.parser()
-        .verifyWith(Keys.hmacShaKeyFor(key))
-        .build()
-        .parseSignedClaims(token);
+    return Jwts.parser().verifyWith(Keys.hmacShaKeyFor(key)).build().parseSignedClaims(token);
   }
 }


### PR DESCRIPTION
## Summary
- handle `ClosedWatchServiceException` in `JwtSecretWatcher` to stop watcher thread cleanly when closed
- format `JwtUtil` per Spotless rules

## Testing
- `./gradlew :common-library:check -PfullCheck`
- `./gradlew spotBugsMain -PfullCheck`


------
https://chatgpt.com/codex/tasks/task_e_68aad966930483308bd4f5bd764282c7