### PR TITLE
Enable Gradle cache writes for docs and ERD jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
 
       - name: 🧹 Lint Docs and Links
         run: |
@@ -423,6 +425,8 @@ jobs:
 
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
 
       - name: 🖼️ Generate ERD diagrams
         run: ./dev-tools/docs/generate-erd.sh


### PR DESCRIPTION
## Summary
- allow docs lint job to save Gradle caches
- allow ERD generation job to save Gradle caches

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68aadd3ee6288330bb87ce79d0b453ff