### PR TITLE
fix tcp-proxy cross-service test configuration

### DIFF
--- a/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.telnet.TelnetServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -33,7 +34,11 @@ import org.testcontainers.utility.DockerImageName;
     classes = TcpProxyServiceApplication.class,
     properties = {"TCP_PROXY_PORT=2323"})
 @EnableAutoConfiguration(
-    exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+    exclude = {
+      DataSourceAutoConfiguration.class,
+      RedisAutoConfiguration.class,
+      DatabaseAutoConfiguration.class
+    })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TcpProxyCrossServiceIntegrationTest {
   static GenericContainer<?> gateway =


### PR DESCRIPTION
## Summary
- exclude DatabaseAutoConfiguration from TcpProxyCrossServiceIntegrationTest to prevent unwanted DB setup during cross-service integration tests

## Testing
- `./gradlew :tcp-proxy-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68aadd7eec108330a14473dfd5576e10