### PR TITLE
Handle null remote address in TelnetServerHandler

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -61,7 +61,10 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     var remote = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
     String ip = null;
     if (remote instanceof java.net.InetSocketAddress address) {
-      ip = address.getAddress().getHostAddress();
+      var inetAddress = address.getAddress();
+      if (inetAddress != null) {
+        ip = inetAddress.getHostAddress();
+      }
     }
     connectionCounter.increment();
     onConnect.run();


### PR DESCRIPTION
## Summary
- guard against null `InetAddress` when extracting client IP in TelnetServerHandler

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :tcp-proxy-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68aade5d1a5483308bfda3d996232714