### PR TITLE
Securely wipe password arrays

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/service/impl/AccountServiceImpl.java
@@ -350,12 +350,22 @@ public class AccountServiceImpl implements AccountService {
 
   private String hashPassword(String password) {
     Argon2 argon2 = Argon2Factory.create();
-    return argon2.hash(2, 65536, 1, password.toCharArray());
+    char[] chars = password.toCharArray();
+    try {
+      return argon2.hash(2, 65536, 1, chars);
+    } finally {
+      argon2.wipeArray(chars);
+    }
   }
 
   private boolean verifyPassword(String password, String hash) {
     Argon2 argon2 = Argon2Factory.create();
-    return argon2.verify(hash, password.toCharArray());
+    char[] chars = password.toCharArray();
+    try {
+      return argon2.verify(hash, chars);
+    } finally {
+      argon2.wipeArray(chars);
+    }
   }
 
   private String readTemplate(String name) {

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/service/impl/AccountServiceImplTest.java
@@ -263,6 +263,11 @@ class AccountServiceImplTest {
 
   private static String hash(String password) {
     Argon2 argon2 = Argon2Factory.create();
-    return argon2.hash(2, 65536, 1, password.toCharArray());
+    char[] chars = password.toCharArray();
+    try {
+      return argon2.hash(2, 65536, 1, chars);
+    } finally {
+      argon2.wipeArray(chars);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- ensure Argon2 password hashing and verification wipe char arrays after use
- clear test helper password arrays to avoid lingering sensitive data

## Testing
- `./gradlew :account-service:spotBugsMain -PfullCheck --info`
- `./gradlew :account-service:check`


------
https://chatgpt.com/codex/tasks/task_e_68aae28122348330b9f800d72f006caa