### PR TITLE
fix: specify charset for Telnet StringDecoder

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -16,6 +16,7 @@ import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.net.ssl.SSLException;
 import org.slf4j.Logger;
@@ -86,7 +87,7 @@ public final class TelnetServer {
                   }
                   pipeline
                       .addLast(new LineBasedFrameDecoder(1024))
-                      .addLast(new StringDecoder())
+                      .addLast(new StringDecoder(StandardCharsets.UTF_8))
                       .addLast(
                           new TelnetServerHandler(
                               gatewayWsUrl,


### PR DESCRIPTION
## Summary
- avoid deprecated StringDecoder constructor by specifying UTF-8 charset

## Testing
- `pre-commit run --files services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java`
- `./gradlew :tcp-proxy-service:test`
- `./gradlew spotBugsMain -PfullCheck`


------
https://chatgpt.com/codex/tasks/task_e_68aae28122348330b9f800d72f006caa