### PR TITLE
fix: defensively copy world room configuration

### DIFF
--- a/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/config/WorldProperties.java
@@ -13,11 +13,8 @@ public class WorldProperties {
   /** Properties related to room behaviour. */
   private Room room = new Room();
 
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-      value = "EI_EXPOSE_REP2",
-      justification = "Configuration object stored without defensive copy")
   public void setRoom(Room room) {
-    this.room = room;
+    this.room = new Room(room);
   }
 
   @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
@@ -30,5 +27,11 @@ public class WorldProperties {
   public static class Room {
     /** TTL in seconds for room cache entries. */
     @Getter @Setter private long cacheTtlSeconds = 60;
+
+    public Room() {}
+
+    public Room(Room other) {
+      this.cacheTtlSeconds = other.cacheTtlSeconds;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- avoid exposing internal WorldProperties.Room by defensively copying in setter
- add Room copy constructor for safe configuration mutations

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68aae5c7eb8883309d6a4bbc13a63320