### PR TITLE
feat(common): ensure session context stores immutable role data

### DIFF
--- a/services/common-library/src/main/java/net/firedevops/firemud/common/security/SessionContext.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/security/SessionContext.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.common.security;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Thread-local storage for JWT claims extracted by {@link AuthTokenInterceptor}. */
 public final class SessionContext {
@@ -12,7 +13,16 @@ public final class SessionContext {
 
   public static void setContext(
       String accountId, List<String> globalRoles, Map<String, List<String>> scopedRoles) {
-    HOLDER.set(new ClaimsData(accountId, globalRoles, scopedRoles));
+    List<String> immutableGlobals =
+        globalRoles == null ? List.of() : List.copyOf(globalRoles);
+    Map<String, List<String>> immutableScoped =
+        scopedRoles == null
+            ? Map.of()
+            : scopedRoles.entrySet().stream()
+                .collect(
+                    Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey, e -> List.copyOf(e.getValue())));
+    HOLDER.set(new ClaimsData(accountId, immutableGlobals, immutableScoped));
   }
 
   public static void clear() {


### PR DESCRIPTION
## Summary
- store defensive copies of role lists and maps in `SessionContext`
- run SpotBugs with full check
- run `gradlew check`

## Testing
- `./gradlew :common-library:spotbugsMain --rerun-tasks -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68aaea0ce6008330ba544e998b508c59