### PR TITLE
Handle Redis expire return results

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/quota/ScriptQuotaServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/quota/ScriptQuotaServiceImpl.java
@@ -7,6 +7,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service;
     value = "EI_EXPOSE_REP2",
     justification = "Dependencies are injected and not exposed")
 public class ScriptQuotaServiceImpl implements ScriptQuotaService {
+  private static final Logger logger = LoggingUtil.getLogger(ScriptQuotaServiceImpl.class);
   private final RedisTemplate<String, Object> redisTemplate;
   private final MeterRegistry meterRegistry;
 
@@ -42,7 +45,11 @@ public class ScriptQuotaServiceImpl implements ScriptQuotaService {
     String key = quotaKey(tenantId, scriptId);
     Long count = redisTemplate.opsForValue().increment(key);
     if (count != null && count == 1L) {
-      redisTemplate.expire(key, Duration.ofSeconds(windowSeconds));
+      boolean expirationSet =
+          Boolean.TRUE.equals(redisTemplate.expire(key, Duration.ofSeconds(windowSeconds)));
+      if (!expirationSet) {
+        logger.warn("Failed to set expiration for {}", key);
+      }
     }
     boolean allowed = count != null && count <= limit;
     if (allowed) {

--- a/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.common.LoggingUtil;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
     value = "EI_EXPOSE_REP2",
     justification = "Injected dependencies are safe to store without defensive copies")
 public class RedisConflictTracker implements ConflictTracker {
+  private static final Logger logger = LoggingUtil.getLogger(RedisConflictTracker.class);
   private final StringRedisTemplate redisTemplate;
   private final MeterRegistry meterRegistry;
 
@@ -27,7 +30,11 @@ public class RedisConflictTracker implements ConflictTracker {
   public void recordConflict(String key) {
     String redisKey = "conflict:" + key;
     redisTemplate.opsForValue().increment(redisKey);
-    redisTemplate.expire(redisKey, Duration.ofSeconds(ttlSeconds));
+    boolean expirationSet =
+        Boolean.TRUE.equals(redisTemplate.expire(redisKey, Duration.ofSeconds(ttlSeconds)));
+    if (!expirationSet) {
+      logger.warn("Failed to set expiration for {}", redisKey);
+    }
     meterRegistry.counter("tick_conflict_hotspot_detected_total").increment();
   }
 }


### PR DESCRIPTION
## Summary
- log failed Redis TTL updates
- detect expiration failures in script quota service

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68aaed54f0108330ab898eab9bbec17e