### PR TITLE
Gracefully skip tcp proxy cross-service test without Docker

### DIFF
--- a/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TcpProxyCrossServiceIntegrationTest.java
@@ -49,13 +49,21 @@ class TcpProxyCrossServiceIntegrationTest {
   private static boolean gatewayStarted = false;
 
   static {
-    if (DockerClientFactory.instance().isDockerAvailable()) {
+    if (isDockerAvailable()) {
       try {
         gateway.start();
         gatewayStarted = true;
       } catch (Exception e) {
         gatewayStarted = false;
       }
+    }
+  }
+
+  private static boolean isDockerAvailable() {
+    try {
+      return DockerClientFactory.instance().isDockerAvailable();
+    } catch (Exception e) {
+      return false;
     }
   }
 
@@ -86,7 +94,7 @@ class TcpProxyCrossServiceIntegrationTest {
   @Test
   void proxyStartsAlongsideGateway() throws Exception {
     Assumptions.assumeTrue(
-        DockerClientFactory.instance().isDockerAvailable() && gatewayStarted,
+        isDockerAvailable() && gatewayStarted,
         "Gateway container not available, skipping cross-service test");
     assertThat(gateway.isRunning()).isTrue();
 


### PR DESCRIPTION
## Summary
- Handle IllegalStateException when checking Docker availability in `TcpProxyCrossServiceIntegrationTest`
- Skip test when Docker isn't accessible instead of failing during static initialization

## Testing
- `./gradlew :tcp-proxy-service:test --rerun-tasks`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68abeee45ba483308f2d1b3e014118da