### PR TITLE
Use value equality for Redis counters

### DIFF
--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/quota/ScriptQuotaServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/quota/ScriptQuotaServiceImpl.java
@@ -44,7 +44,7 @@ public class ScriptQuotaServiceImpl implements ScriptQuotaService {
   public boolean tryAcquire(Long tenantId, Long scriptId) {
     String key = quotaKey(tenantId, scriptId);
     Long count = redisTemplate.opsForValue().increment(key);
-    if (count != null && count == 1L) {
+    if (Long.valueOf(1L).equals(count)) {
       boolean expirationSet =
           Boolean.TRUE.equals(redisTemplate.expire(key, Duration.ofSeconds(windowSeconds)));
       if (!expirationSet) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
@@ -40,7 +40,7 @@ public class IpConnectionLimiterImpl implements IpConnectionLimiter {
   public void register(String ip, long sessionId) {
     String ipKey = ipKey(ip);
     Long count = redisTemplate.opsForValue().increment(ipKey);
-    if (count != null && count == 1L) {
+    if (Long.valueOf(1L).equals(count)) {
       redisTemplate.expire(ipKey, entryTtl);
     }
     redisTemplate.opsForValue().set(sessionKey(sessionId), ip, entryTtl);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
@@ -28,7 +28,7 @@ public class SessionRateLimiterImpl implements SessionRateLimiter {
   public boolean allow(long sessionId) {
     String key = key(sessionId);
     Long count = redisTemplate.opsForValue().increment(key);
-    if (count != null && count == 1L) {
+    if (Long.valueOf(1L).equals(count)) {
       redisTemplate.expire(key, Duration.ofSeconds(1));
     }
     return count != null && count <= maxMessagesPerSecond;


### PR DESCRIPTION
## Summary
- avoid object identity comparison when initializing Redis counters
- ensure counters expire only when newly created

## Testing
- `./gradlew spotBugsMain -PfullCheck`
- `./gradlew :automation-scripting-service:compileJava :game-session-service:compileJava`
- `./gradlew :automation-scripting-service:spotbugsMain :game-session-service:spotbugsMain -PfullCheck`
- `./gradlew :automation-scripting-service:check :game-session-service:check -PfullCheck` *(fails: process hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68abf2ca721c833087cc2406ae08aece