### PR TITLE
fix: remove invalid database config exclusion in tcp proxy app

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/TcpProxyServiceApplication.java
@@ -2,7 +2,6 @@ package net.firedevops.firemud;
 
 import jakarta.annotation.PreDestroy;
 import net.firedevops.firemud.common.config.CommonAutoConfiguration;
-import net.firedevops.firemud.common.config.DatabaseAutoConfiguration;
 import net.firedevops.firemud.telnet.TelnetServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,11 +12,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.event.EventListener;
 
 @SpringBootApplication(
-    exclude = {
-      DataSourceAutoConfiguration.class,
-      RedisAutoConfiguration.class,
-      DatabaseAutoConfiguration.class
-    })
+    exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
 @Import(CommonAutoConfiguration.class)
 public class TcpProxyServiceApplication {
   private final TelnetServer telnetServer;


### PR DESCRIPTION
## Summary
- fix TcpProxyServiceApplication annotation to stop excluding DatabaseAutoConfiguration, which is not an auto-configuration class

## Testing
- `./gradlew :tcp-proxy-service:check --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68b3e8d0f58483309aa3010e4df7bb60