### PR TITLE
Add log-only boot run task for TCP proxy service

### DIFF
--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -37,12 +37,13 @@ tasks.named<BootRun>("bootRun") {
     }
 }
 
-tasks.register<BootRun>("runTcpProxyDev") {
+tasks.register<BootRun>("bootRunLogOnly") {
     group = "application"
-    description = "Start the TCP proxy in dev with the local echo WebSocket bridge"
+    description = "Start the TCP proxy in dev with log-only Telnet handling"
     mainClass.set("net.firedevops.firemud.TcpProxyServiceApplication")
     classpath = sourceSets.main.get().runtimeClasspath
     systemProperty("spring.profiles.active", "dev")
+    environment("TCP_PROXY_LOG_ONLY", "true")
     environment("GATEWAY_WS_URL", "ws://localhost:8080/dev/echo")
 }
 

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -32,6 +32,7 @@ public final class TelnetServer {
   private final int port;
   private final String gatewayWsUrl;
   private final boolean tlsEnabled;
+  private final boolean logOnly;
   private final String certPath;
   private final String keyPath;
   private final java.util.concurrent.atomic.AtomicInteger activeConnections =
@@ -48,6 +49,7 @@ public final class TelnetServer {
       @Value("${TCP_PROXY_PORT:2323}") int port,
       @Value("${GATEWAY_WS_URL:ws://localhost:8080/dev/echo}") String gatewayWsUrl,
       @Value("${TCP_PROXY_TLS_ENABLED:false}") boolean tlsEnabled,
+      @Value("${TCP_PROXY_LOG_ONLY:false}") boolean logOnly,
       @Value("${TCP_PROXY_TLS_CERT:}") String certPath,
       @Value("${TCP_PROXY_TLS_KEY:}") String keyPath,
       MeterRegistry meterRegistry)
@@ -55,6 +57,7 @@ public final class TelnetServer {
     this.port = port;
     this.gatewayWsUrl = gatewayWsUrl;
     this.tlsEnabled = tlsEnabled;
+    this.logOnly = logOnly;
     this.certPath = certPath;
     this.keyPath = keyPath;
     this.connectionCounter = meterRegistry.counter("tcpproxy.connections.total");
@@ -91,6 +94,7 @@ public final class TelnetServer {
                       .addLast(
                           new TelnetServerHandler(
                               gatewayWsUrl,
+                              logOnly,
                               activeConnections::incrementAndGet,
                               activeConnections::decrementAndGet,
                               connectionCounter));

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -20,6 +20,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private static final Logger logger = LoggerFactory.getLogger(TelnetServerHandler.class);
 
   private final String gatewayWsUrl;
+  private final boolean logOnly;
   private final Runnable onConnect;
   private final Runnable onDisconnect;
   private final io.micrometer.core.instrument.Counter connectionCounter;
@@ -28,10 +29,12 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
 
   public TelnetServerHandler(
       String gatewayWsUrl,
+      boolean logOnly,
       Runnable onConnect,
       Runnable onDisconnect,
       io.micrometer.core.instrument.Counter connectionCounter) {
     this.gatewayWsUrl = gatewayWsUrl;
+    this.logOnly = logOnly;
     this.onConnect = onConnect;
     this.onDisconnect = onDisconnect;
     this.connectionCounter = connectionCounter;
@@ -69,6 +72,10 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     connectionCounter.increment();
     onConnect.run();
     logger.info("Telnet client connected from {} targeting {}", ip != null ? ip : remote, gatewayWsUrl);
+    if (logOnly) {
+      logger.info("Log-only mode enabled; skipping WebSocket bridge for {}", gatewayWsUrl);
+      return;
+    }
     HttpClient client = HttpClient.newHttpClient();
     var builder = client.newWebSocketBuilder();
     if (ip != null) {
@@ -109,6 +116,10 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
 
     logger.info("Received Telnet input: {}", sanitized);
+
+    if (logOnly) {
+      return;
+    }
 
     if (webSocket != null) {
       webSocket.sendText(sanitized, true);

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -22,6 +22,7 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
@@ -50,6 +51,7 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
@@ -70,6 +72,7 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
@@ -94,6 +97,7 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
@@ -118,6 +122,7 @@ class TelnetServerHandlerTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
@@ -135,5 +140,25 @@ class TelnetServerHandlerTest {
     handler.channelRead0(ctx, msg);
 
     verify(ws, times(0)).sendText(anyString(), eq(true));
+  }
+
+  @Test
+  void logOnlyModeSkipsWebSocketTraffic() {
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            true,
+            () -> {},
+            () -> {},
+            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "say hello");
+
+    assertEquals(0, handler.getBufferedSize());
   }
 }

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
@@ -22,6 +22,7 @@ class TelnetServerTest {
             0,
             "ws://localhost/ws",
             false,
+            false,
             "",
             "",
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry());


### PR DESCRIPTION
## Summary
- rename the TCP proxy dev boot run task to `bootRunLogOnly` and enable log-only settings
- add a log-only switch to the Telnet server/handler to skip WebSocket bridging when requested
- update Telnet handler tests to cover the new log-only behavior and constructor changes

## Testing
- ./gradlew :tcp-proxy-service:test --no-daemon --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692565fd6ee08330b3faaec8561502a0)