### PR TITLE
Fix tcp-proxy README Gradle path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Please read the following documents before using AI tooling or submitting code c
 - [Global AI Rules](design/project-management/ai-rules-global.md)
 - [Local AI Rules](design/project-management/ai-rules-local.md)
 
+Gradle project paths do **not** include the `services:` prefix even though the modules live under the `services/` directory. Use commands like `./gradlew :tcp-proxy-service:test` instead of `./gradlew :services:tcp-proxy-service:test` when running or referencing tasks.
+
 Do not manually wrap lines. Let lines flow naturally so content displays cleanly on GitHub and in
 editors.
 

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -42,6 +42,17 @@ Build all modules with:
 
 Gradle compiles the services and prepares Docker images using the included Dockerfiles.
 
+### Running Tests for a Single Service
+
+Gradle project paths map directly to the names defined in `settings.gradle.kts`, so they do **not** include the `services:` prefix even though the source lives under `services/`. To run just one service's tests, use the project name from `settings.gradle.kts`:
+
+```bash
+# Example: tcp-proxy-service
+./gradlew :tcp-proxy-service:test
+```
+
+Using a `services:` prefix (for example `:services:tcp-proxy-service:test`) will fail because no such project path exists in the Gradle settings.
+
 ## 🐳 Building Docker Images
 
 Use the aggregated task to build container images for all services:

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -102,7 +102,7 @@ details on how Telnet connections are integrated into the platform.
 
 Use the bundled `/dev/echo` WebSocket endpoint under the `dev` profile to validate the Telnet -> WebSocket bridge without running the full gateway stack:
 
-1. Start the service: `./gradlew :services:tcp-proxy-service:bootRun`. The task defaults to the `dev` profile for local runs. Override with `SPRING_PROFILES_ACTIVE=<profile>` or `-Dspring.profiles.active=<profile>` when needed.
+1. Start the service: `./gradlew :tcp-proxy-service:bootRun`. The task defaults to the `dev` profile for local runs. Override with `SPRING_PROFILES_ACTIVE=<profile>` or `-Dspring.profiles.active=<profile>` when needed.
 2. The dev profile disables gRPC TLS by default. Enable it with `GRPC_SERVER_TLS_ENABLED=true` to use the sample certificates in `src/main/resources/certs`.
 3. For non-dev profiles (including production), TLS and mutual auth remain enabled unless explicitly disabled, and the `/dev/echo` WebSocket is not exposed.
 4. Point the bridge at the local echo when running with the dev profile: `GATEWAY_WS_URL=ws://localhost:8080/dev/echo`.


### PR DESCRIPTION
## Summary
- correct the tcp-proxy README to use the root-level Gradle project path when running the service locally

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925695699cc833095180fb79b36f9b5)