### PR TITLE
Normalize telnet framing and newline handling

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -34,9 +34,11 @@ public final class TelnetServer {
   private final boolean tlsEnabled;
   private final String certPath;
   private final String keyPath;
+  private final boolean advertiseMcp;
   private final java.util.concurrent.atomic.AtomicInteger activeConnections =
       new java.util.concurrent.atomic.AtomicInteger();
   private final Counter connectionCounter;
+  private final Counter discardedCommandCounter;
 
   private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
@@ -50,6 +52,7 @@ public final class TelnetServer {
       @Value("${TCP_PROXY_TLS_ENABLED:false}") boolean tlsEnabled,
       @Value("${TCP_PROXY_TLS_CERT:}") String certPath,
       @Value("${TCP_PROXY_TLS_KEY:}") String keyPath,
+      @Value("${TCP_PROXY_MCP_ENABLED:false}") boolean advertiseMcp,
       MeterRegistry meterRegistry)
       throws SSLException {
     this.port = port;
@@ -57,7 +60,9 @@ public final class TelnetServer {
     this.tlsEnabled = tlsEnabled;
     this.certPath = certPath;
     this.keyPath = keyPath;
+    this.advertiseMcp = advertiseMcp;
     this.connectionCounter = meterRegistry.counter("tcpproxy.connections.total");
+    this.discardedCommandCounter = meterRegistry.counter("tcpproxy.telnet.discarded");
     Gauge.builder(
             "tcpproxy.connections.active",
             activeConnections,
@@ -86,14 +91,16 @@ public final class TelnetServer {
                     pipeline.addLast(sslContext.newHandler(ch.alloc()));
                   }
                   pipeline
-                      .addLast(new LineBasedFrameDecoder(1024))
-                      .addLast(new StringDecoder(StandardCharsets.UTF_8))
+                      .addLast(new LineBasedFrameDecoder(1024, false, true))
+                      .addLast(new StringDecoder(StandardCharsets.ISO_8859_1))
                       .addLast(
                           new TelnetServerHandler(
                               gatewayWsUrl,
                               activeConnections::incrementAndGet,
                               activeConnections::decrementAndGet,
-                              connectionCounter));
+                              connectionCounter,
+                              discardedCommandCounter,
+                              advertiseMcp));
                 }
               });
       serverChannel = b.bind(port).sync().channel();

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -1,6 +1,8 @@
 package net.firedevops.firemud.telnet;
 
 import io.micrometer.core.annotation.Timed;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import java.net.URI;
@@ -23,6 +25,9 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private final Runnable onConnect;
   private final Runnable onDisconnect;
   private final io.micrometer.core.instrument.Counter connectionCounter;
+  private final io.micrometer.core.instrument.Counter discardedCommandCounter;
+  private final boolean advertiseMcp;
+  private volatile boolean mcpNegotiated;
   private WebSocket webSocket;
   private final Queue<String> buffer = new ConcurrentLinkedQueue<>();
 
@@ -30,11 +35,15 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       String gatewayWsUrl,
       Runnable onConnect,
       Runnable onDisconnect,
-      io.micrometer.core.instrument.Counter connectionCounter) {
+      io.micrometer.core.instrument.Counter connectionCounter,
+      io.micrometer.core.instrument.Counter discardedCommandCounter,
+      boolean advertiseMcp) {
     this.gatewayWsUrl = gatewayWsUrl;
     this.onConnect = onConnect;
     this.onDisconnect = onDisconnect;
     this.connectionCounter = connectionCounter;
+    this.discardedCommandCounter = discardedCommandCounter;
+    this.advertiseMcp = advertiseMcp;
   }
 
   void setWebSocket(WebSocket webSocket) {
@@ -103,7 +112,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   @Override
   @Timed(value = "tcpproxy.command")
   protected void channelRead0(ChannelHandlerContext ctx, String msg) {
-    String sanitized = sanitize(msg);
+    String sanitized = sanitize(ctx, msg);
     if (sanitized == null) {
       return;
     }
@@ -135,30 +144,139 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
 
   private static final byte IAC = (byte) 255;
 
+  private static final byte WILL = (byte) 251;
+  private static final byte WONT = (byte) 252;
+  private static final byte DO = (byte) 253;
+  private static final byte DONT = (byte) 254;
+  private static final byte SB = (byte) 250;
+  private static final byte SE = (byte) 240;
+  private static final String MCP_PREFIX = "#$#";
+
   private static final Set<Byte> ALLOWED_COMMANDS =
       Set.of((byte) 240, (byte) 241, (byte) 249, (byte) 251, (byte) 252, (byte) 253, (byte) 254);
 
-  private String sanitize(String msg) {
+  private static final Set<Byte> SUPPORTED_OPTIONS = Set.of((byte) 1, (byte) 3);
+
+  boolean isMcpNegotiated() {
+    return mcpNegotiated;
+  }
+
+  private String sanitize(ChannelHandlerContext ctx, String msg) {
     byte[] bytes = msg.getBytes(StandardCharsets.ISO_8859_1);
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < bytes.length; i++) {
       byte b = bytes[i];
       if (b == IAC) {
-        if (i + 1 < bytes.length) {
-          byte cmd = bytes[++i];
-          if (!ALLOWED_COMMANDS.contains(cmd)) {
-            continue;
-          }
-          // drop allowed Telnet commands rather than forwarding
-          continue;
+        i = handleIacSequence(ctx, bytes, i + 1, sb);
+        continue;
+      }
+      if (b == '\r') {
+        if (i + 1 < bytes.length && bytes[i + 1] == '\n') {
+          i++;
         }
+        sb.append('\n');
+        continue;
+      }
+      if (b == '\n') {
+        sb.append('\n');
         continue;
       }
       if (b >= 32 && b <= 126) {
         sb.append((char) b);
       }
     }
-    String cleaned = sb.toString().trim();
-    return cleaned.isEmpty() ? null : cleaned;
+    String cleaned = sb.toString();
+    String negotiationCandidate = cleaned.stripLeading();
+    if (!negotiationCandidate.isEmpty() && negotiationCandidate.startsWith(MCP_PREFIX)) {
+      boolean initialNegotiation = !mcpNegotiated;
+      mcpNegotiated = true;
+      if (advertiseMcp && initialNegotiation) {
+        ctx.writeAndFlush("#$#mcp version:2.1\r\n");
+      }
+    }
+    return cleaned.isBlank() ? null : cleaned;
+  }
+
+  private int handleIacSequence(ChannelHandlerContext ctx, byte[] bytes, int index, StringBuilder sb) {
+    if (index >= bytes.length) {
+      discardedCommandCounter.increment();
+      return bytes.length;
+    }
+    byte command = bytes[index];
+    if (command == IAC) {
+      sb.append((char) IAC);
+      return index;
+    }
+    switch (command) {
+      case DO:
+      case DONT:
+        return negotiate(ctx, command, bytes, index);
+      case WILL:
+      case WONT:
+        return negotiate(ctx, command, bytes, index);
+      case SB:
+        return handleSubNegotiation(ctx, bytes, index);
+      default:
+        if (!ALLOWED_COMMANDS.contains(command)) {
+          discardedCommandCounter.increment();
+        }
+        return index;
+    }
+  }
+
+  private int negotiate(ChannelHandlerContext ctx, byte command, byte[] bytes, int index) {
+    if (index + 1 >= bytes.length) {
+      discardedCommandCounter.increment();
+      return bytes.length;
+    }
+    byte option = bytes[index + 1];
+    boolean supported = SUPPORTED_OPTIONS.contains(option);
+    byte response;
+    if (command == DO) {
+      response = supported ? WILL : WONT;
+    } else if (command == DONT) {
+      response = WONT;
+    } else if (command == WILL) {
+      response = supported ? DO : DONT;
+    } else {
+      response = DONT;
+    }
+    if (!supported) {
+      discardedCommandCounter.increment();
+    }
+    writeNegotiationResponse(ctx, response, option);
+    return index + 1;
+  }
+
+  private int handleSubNegotiation(ChannelHandlerContext ctx, byte[] bytes, int index) {
+    if (index + 1 >= bytes.length) {
+      discardedCommandCounter.increment();
+      return bytes.length;
+    }
+    byte option = bytes[index + 1];
+    int cursor = index + 2;
+    while (cursor < bytes.length - 1) {
+      if (bytes[cursor] == IAC && bytes[cursor + 1] == SE) {
+        break;
+      }
+      cursor++;
+    }
+    if (cursor >= bytes.length - 1) {
+      discardedCommandCounter.increment();
+      return bytes.length;
+    }
+    if (!SUPPORTED_OPTIONS.contains(option)) {
+      discardedCommandCounter.increment();
+      writeNegotiationResponse(ctx, DONT, option);
+    }
+    return cursor + 1;
+  }
+
+  private void writeNegotiationResponse(ChannelHandlerContext ctx, byte response, byte option) {
+    ByteBuf responseBuf = Unpooled.buffer(3);
+    responseBuf.writeByte(IAC);
+    responseBuf.writeByte(response);
+    responseBuf.writeByte(option);
+    ctx.writeAndFlush(responseBuf);
   }
 }

--- a/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TelnetPipelineIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TelnetPipelineIntegrationTest.java
@@ -1,0 +1,85 @@
+package net.firedevops.firemud.telnet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.string.StringDecoder;
+import java.net.http.WebSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TelnetPipelineIntegrationTest {
+
+  @Test
+  void rawBytesFlowThroughPipelineWithNegotiationResponses() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("connections"),
+            registry.counter("discarded"),
+            false);
+
+    WebSocket ws = Mockito.mock(WebSocket.class);
+    CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
+    Mockito.when(ws.sendText(Mockito.anyString(), Mockito.eq(true))).thenReturn(future);
+    handler.setWebSocket(ws);
+
+    EmbeddedChannel channel =
+        new EmbeddedChannel(
+            new LineBasedFrameDecoder(1024, false, true),
+            new StringDecoder(StandardCharsets.ISO_8859_1),
+            handler);
+
+    byte[] payload = {(byte) 255, (byte) 253, (byte) 1, 'l', 'i', 'n', 'e', '\r', '\n'};
+    channel.writeInbound(Unpooled.wrappedBuffer(payload));
+
+    ByteBuf response = channel.readOutbound();
+    assertEquals((byte) 255, response.readByte());
+    assertEquals((byte) 251, response.readByte());
+    assertEquals((byte) 1, response.readByte());
+    response.release();
+
+    Mockito.verify(ws).sendText("line\n", true);
+  }
+
+  @Test
+  void unsupportedSubNegotiationInPipelineIncrementsMetric() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("connections"),
+            registry.counter("discarded"),
+            false);
+
+    WebSocket ws = Mockito.mock(WebSocket.class);
+    CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
+    Mockito.when(ws.sendText(Mockito.anyString(), Mockito.eq(true))).thenReturn(future);
+    handler.setWebSocket(ws);
+
+    EmbeddedChannel channel =
+        new EmbeddedChannel(
+            new LineBasedFrameDecoder(1024, false, true),
+            new StringDecoder(StandardCharsets.ISO_8859_1),
+            handler);
+
+    byte[] payload = {
+      (byte) 255, (byte) 250, (byte) 99, 'x', (byte) 255, (byte) 240, 'c', 'm', 'd', '\r', '\n'
+    };
+    channel.writeInbound(Unpooled.wrappedBuffer(payload));
+
+    assertEquals(1.0, registry.counter("discarded").count());
+    Mockito.verify(ws).sendText("cmd\n", true);
+  }
+}

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -1,30 +1,45 @@
 package net.firedevops.firemud.telnet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.string.StringDecoder;
 import java.net.InetSocketAddress;
 import java.net.http.WebSocket;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 class TelnetServerHandlerTest {
 
+  private TelnetServerHandler newHandler(SimpleMeterRegistry registry, boolean advertiseMcp) {
+    return new TelnetServerHandler(
+        "ws://localhost/ws",
+        () -> {},
+        () -> {},
+        registry.counter("test"),
+        registry.counter("discarded"),
+        advertiseMcp);
+  }
+
   @Test
   void bufferedInputFlushedOnWebSocketConnect() {
-    TelnetServerHandler handler =
-        new TelnetServerHandler(
-            "ws://localhost/ws",
-            () -> {},
-            () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -47,12 +62,8 @@ class TelnetServerHandlerTest {
 
   @Test
   void bufferClearedOnDisconnect() {
-    TelnetServerHandler handler =
-        new TelnetServerHandler(
-            "ws://localhost/ws",
-            () -> {},
-            () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -67,12 +78,8 @@ class TelnetServerHandlerTest {
 
   @Test
   void unsupportedTelnetCommandsAreDropped() {
-    TelnetServerHandler handler =
-        new TelnetServerHandler(
-            "ws://localhost/ws",
-            () -> {},
-            () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -91,12 +98,8 @@ class TelnetServerHandlerTest {
 
   @Test
   void controlCharactersAreRemoved() {
-    TelnetServerHandler handler =
-        new TelnetServerHandler(
-            "ws://localhost/ws",
-            () -> {},
-            () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -115,12 +118,8 @@ class TelnetServerHandlerTest {
 
   @Test
   void emptyAfterSanitizeIsIgnored() {
-    TelnetServerHandler handler =
-        new TelnetServerHandler(
-            "ws://localhost/ws",
-            () -> {},
-            () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -135,5 +134,110 @@ class TelnetServerHandlerTest {
     handler.channelRead0(ctx, msg);
 
     verify(ws, times(0)).sendText(anyString(), eq(true));
+  }
+
+  @Test
+  void repliesToSupportedDoWithWill() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Mockito.when(ctx.writeAndFlush(any())).thenReturn(null);
+
+    byte[] bytes = {(byte) 255, (byte) 253, (byte) 1, 'g', 'o'};
+    String msg = new String(bytes, java.nio.charset.StandardCharsets.ISO_8859_1);
+    handler.channelRead0(ctx, msg);
+
+    ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+    verify(ctx).writeAndFlush(captor.capture());
+    ByteBuf buf = captor.getValue();
+    assertEquals((byte) 255, buf.readByte());
+    assertEquals((byte) 251, buf.readByte());
+    assertEquals((byte) 1, buf.readByte());
+    buf.release();
+    assertEquals(1, handler.getBufferedSize());
+  }
+
+  @Test
+  void unsupportedSubNegotiationIsDroppedAndCounted() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Mockito.when(ctx.writeAndFlush(any())).thenReturn(null);
+    WebSocket ws = mock(WebSocket.class);
+    CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
+    org.mockito.Mockito.when(ws.sendText(anyString(), eq(true))).thenReturn(future);
+    handler.setWebSocket(ws);
+
+    byte[] bytes = {(byte) 255, (byte) 250, (byte) 99, 'x', (byte) 255, (byte) 240, 'l', 'o', 'o', 'k'};
+    String msg = new String(bytes, java.nio.charset.StandardCharsets.ISO_8859_1);
+    handler.channelRead0(ctx, msg);
+
+    assertEquals(1.0, registry.counter("discarded").count());
+    verify(ws).sendText("look", true);
+  }
+
+  @Test
+  void mcpNegotiationAdvertisedWhenEnabled() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, true);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Mockito.when(ctx.writeAndFlush(any())).thenReturn(null);
+
+    handler.channelRead0(ctx, "#$#mcp-negotiate\r\n");
+
+    assertTrue(handler.isMcpNegotiated());
+    verify(ctx).writeAndFlush("#$#mcp version:2.1\r\n");
+  }
+
+  @Test
+  void unsupportedDoNegotiationRespondsWithWontAndCounts() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Mockito.when(ctx.writeAndFlush(any())).thenReturn(null);
+    WebSocket ws = mock(WebSocket.class);
+    CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
+    org.mockito.Mockito.when(ws.sendText(anyString(), eq(true))).thenReturn(future);
+    handler.setWebSocket(ws);
+
+    byte[] bytes = {(byte) 255, (byte) 253, (byte) 99, 'c', 'm', 'd'};
+    String msg = new String(bytes, java.nio.charset.StandardCharsets.ISO_8859_1);
+    handler.channelRead0(ctx, msg);
+
+    ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+    verify(ctx).writeAndFlush(captor.capture());
+    ByteBuf buf = captor.getValue();
+    assertEquals((byte) 255, buf.readByte());
+    assertEquals((byte) 252, buf.readByte());
+    assertEquals((byte) 99, buf.readByte());
+    buf.release();
+    assertEquals(1.0, registry.counter("discarded").count());
+    verify(ws).sendText("cmd", true);
+  }
+
+  @Test
+  void unsupportedWillNegotiationRespondsWithDontAndCounts() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Mockito.when(ctx.writeAndFlush(any())).thenReturn(null);
+    WebSocket ws = mock(WebSocket.class);
+    CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
+    org.mockito.Mockito.when(ws.sendText(anyString(), eq(true))).thenReturn(future);
+    handler.setWebSocket(ws);
+
+    byte[] bytes = {(byte) 255, (byte) 251, (byte) 99, 'c', 'm', 'd'};
+    String msg = new String(bytes, java.nio.charset.StandardCharsets.ISO_8859_1);
+    handler.channelRead0(ctx, msg);
+
+    ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+    verify(ctx).writeAndFlush(captor.capture());
+    ByteBuf buf = captor.getValue();
+    assertEquals((byte) 255, buf.readByte());
+    assertEquals((byte) 254, buf.readByte());
+    assertEquals((byte) 99, buf.readByte());
+    buf.release();
+    assertEquals(1.0, registry.counter("discarded").count());
+    verify(ws).sendText("cmd", true);
   }
 }

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
@@ -24,6 +24,7 @@ class TelnetServerTest {
             false,
             "",
             "",
+            false,
             new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
     server.start();
     server.stop();


### PR DESCRIPTION
## Summary
- add tests covering unsupported DO/WILL telnet negotiations to ensure WONT/DONT replies and discarded metric increments
- verify telnet handler still forwards sanitized commands after rejecting unsupported options

## Testing
- ./gradlew :tcp-proxy-service:test --console=plain --no-daemon

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256715dcfc83308b6aa6940d803319)