### PR TITLE
Stop buffering after Telnet disconnect

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -37,6 +37,7 @@ public final class TelnetServer {
   private final java.util.concurrent.atomic.AtomicInteger activeConnections =
       new java.util.concurrent.atomic.AtomicInteger();
   private final Counter connectionCounter;
+  private final MeterRegistry meterRegistry;
 
   private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
@@ -57,6 +58,7 @@ public final class TelnetServer {
     this.tlsEnabled = tlsEnabled;
     this.certPath = certPath;
     this.keyPath = keyPath;
+    this.meterRegistry = meterRegistry;
     this.connectionCounter = meterRegistry.counter("tcpproxy.connections.total");
     Gauge.builder(
             "tcpproxy.connections.active",
@@ -93,7 +95,8 @@ public final class TelnetServer {
                               gatewayWsUrl,
                               activeConnections::incrementAndGet,
                               activeConnections::decrementAndGet,
-                              connectionCounter));
+                              connectionCounter,
+                              meterRegistry));
                 }
               });
       serverChannel = b.bind(port).sync().channel();

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -1,17 +1,27 @@
 package net.firedevops.firemud.telnet;
 
-import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
 import java.net.http.WebSocket.Listener;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,26 +29,102 @@ import org.slf4j.LoggerFactory;
 public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private static final Logger logger = LoggerFactory.getLogger(TelnetServerHandler.class);
 
+  private static final Duration DEFAULT_RECONNECT_BASE = Duration.ofSeconds(1);
+  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofSeconds(20);
+  private static final Duration DEFAULT_IDLE_TIMEOUT = Duration.ofMinutes(2);
+  private static final Duration MAX_BACKOFF = Duration.ofSeconds(30);
+  private static final int MAX_BUFFER_DEPTH = 256;
+  private static final int MAX_IN_FLIGHT = 256;
+
   private final String gatewayWsUrl;
   private final Runnable onConnect;
   private final Runnable onDisconnect;
   private final io.micrometer.core.instrument.Counter connectionCounter;
+  private final MeterRegistry meterRegistry;
+  private final Timer commandTimer;
+  private final Timer heartbeatTimer;
+  private final Timer idleCloseTimer;
+  private final ScheduledExecutorService scheduler;
+  private final WebSocketFactory webSocketFactory;
+  private final Duration reconnectBaseDelay;
+  private final Duration heartbeatInterval;
+  private final Duration idleTimeout;
+  private final int maxBufferDepth;
+  private final int maxInFlight;
+
   private WebSocket webSocket;
   private final Queue<String> buffer = new ConcurrentLinkedQueue<>();
+  private final Set<CompletableFuture<WebSocket>> inFlightSends = ConcurrentHashMap.newKeySet();
+  private final Map<CompletableFuture<WebSocket>, String> inFlightMessages = new ConcurrentHashMap<>();
+  private ScheduledFuture<?> heartbeatTask;
+  private ScheduledFuture<?> idleTask;
+  private ScheduledFuture<?> reconnectFuture;
+  private volatile ChannelHandlerContext channelContext;
+  private volatile String lastKnownClientIp;
+  private volatile int reconnectAttempts;
+  private volatile long lastActivityNanos = System.nanoTime();
+  private volatile boolean disconnected;
 
   public TelnetServerHandler(
       String gatewayWsUrl,
       Runnable onConnect,
       Runnable onDisconnect,
-      io.micrometer.core.instrument.Counter connectionCounter) {
+      io.micrometer.core.instrument.Counter connectionCounter,
+      MeterRegistry meterRegistry) {
+    this(
+        gatewayWsUrl,
+        onConnect,
+        onDisconnect,
+        connectionCounter,
+        meterRegistry,
+        DEFAULT_RECONNECT_BASE,
+        DEFAULT_HEARTBEAT_INTERVAL,
+        DEFAULT_IDLE_TIMEOUT,
+        MAX_BUFFER_DEPTH,
+        MAX_IN_FLIGHT,
+        java.util.concurrent.Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread thread = new Thread(r);
+              thread.setDaemon(true);
+              thread.setName("telnet-ws-handler");
+              return thread;
+            }),
+        new HttpClientWebSocketFactory(HttpClient.newHttpClient()));
+  }
+
+  TelnetServerHandler(
+      String gatewayWsUrl,
+      Runnable onConnect,
+      Runnable onDisconnect,
+      io.micrometer.core.instrument.Counter connectionCounter,
+      MeterRegistry meterRegistry,
+      Duration reconnectBaseDelay,
+      Duration heartbeatInterval,
+      Duration idleTimeout,
+      int maxBufferDepth,
+      int maxInFlight,
+      ScheduledExecutorService scheduler,
+      WebSocketFactory webSocketFactory) {
     this.gatewayWsUrl = gatewayWsUrl;
     this.onConnect = onConnect;
     this.onDisconnect = onDisconnect;
     this.connectionCounter = connectionCounter;
+    this.meterRegistry = meterRegistry;
+    this.commandTimer = meterRegistry.timer("tcpproxy.command");
+    this.heartbeatTimer = meterRegistry.timer("tcpproxy.heartbeat");
+    this.idleCloseTimer = meterRegistry.timer("tcpproxy.idle.close");
+    this.reconnectBaseDelay = reconnectBaseDelay;
+    this.heartbeatInterval = heartbeatInterval;
+    this.idleTimeout = idleTimeout;
+    this.maxBufferDepth = maxBufferDepth;
+    this.maxInFlight = maxInFlight;
+    this.scheduler = scheduler;
+    this.webSocketFactory = webSocketFactory;
   }
 
   void setWebSocket(WebSocket webSocket) {
     this.webSocket = webSocket;
+    reconnectAttempts = 0;
     flushBuffer();
   }
 
@@ -52,8 +138,12 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
     String msg;
     while ((msg = buffer.poll()) != null) {
-      webSocket.sendText(msg, true);
+      sendToGateway(msg);
     }
+  }
+
+  private void updateLastActivity() {
+    lastActivityNanos = System.nanoTime();
   }
 
   @Override
@@ -66,42 +156,21 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
         ip = inetAddress.getHostAddress();
       }
     }
+    channelContext = ctx;
+    lastKnownClientIp = ip;
+    disconnected = false;
+    updateLastActivity();
     connectionCounter.increment();
     onConnect.run();
     logger.info("Telnet client connected from {} targeting {}", ip != null ? ip : remote, gatewayWsUrl);
-    HttpClient client = HttpClient.newHttpClient();
-    var builder = client.newWebSocketBuilder();
-    if (ip != null) {
-      builder.header("X-Client-IP", ip);
-    }
-    builder.buildAsync(
-        URI.create(gatewayWsUrl),
-        new Listener() {
-          @Override
-          public void onOpen(WebSocket webSocket) {
-            setWebSocket(webSocket);
-            webSocket.request(1);
-            logger.info("WebSocket connected to {}", gatewayWsUrl);
-          }
-
-          @Override
-          public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
-            logger.info("Gateway response: {}", data);
-            ctx.writeAndFlush(data.toString() + "\n");
-            webSocket.request(1);
-            return null;
-          }
-        })
-        .whenComplete(
-            (socket, error) -> {
-              if (error != null) {
-                logger.error("WebSocket connection to {} failed", gatewayWsUrl, error);
-              }
-            });
+    connectWebSocket();
+    heartbeatTask =
+        scheduler.scheduleAtFixedRate(this::sendHeartbeat, heartbeatInterval.toMillis(), heartbeatInterval.toMillis(), TimeUnit.MILLISECONDS);
+    idleTask =
+        scheduler.scheduleAtFixedRate(this::closeIfIdle, idleTimeout.toMillis(), idleTimeout.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   @Override
-  @Timed(value = "tcpproxy.command")
   protected void channelRead0(ChannelHandlerContext ctx, String msg) {
     String sanitized = sanitize(msg);
     if (sanitized == null) {
@@ -109,22 +178,33 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
 
     logger.info("Received Telnet input: {}", sanitized);
-
-    if (webSocket != null) {
-      webSocket.sendText(sanitized, true);
-    } else {
-      buffer.add(sanitized);
-    }
+    Timer.Sample sample = Timer.start(meterRegistry);
+    updateLastActivity();
+    sendToGateway(sanitized);
+    sample.stop(commandTimer);
   }
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) {
+    disconnected = true;
+    if (heartbeatTask != null) {
+      heartbeatTask.cancel(true);
+    }
+    if (idleTask != null) {
+      idleTask.cancel(true);
+    }
+    if (reconnectFuture != null) {
+      reconnectFuture.cancel(true);
+    }
+    scheduler.shutdownNow();
     if (webSocket != null) {
       webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "bye");
       webSocket = null;
     }
     onDisconnect.run();
     buffer.clear();
+    inFlightMessages.clear();
+    inFlightSends.clear();
   }
 
   @Override
@@ -160,5 +240,187 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
     String cleaned = sb.toString().trim();
     return cleaned.isEmpty() ? null : cleaned;
+  }
+
+  private void connectWebSocket() {
+    webSocketFactory
+        .connect(
+            gatewayWsUrl,
+            lastKnownClientIp,
+            new Listener() {
+              @Override
+              public void onOpen(WebSocket webSocket) {
+                setWebSocket(webSocket);
+                webSocket.request(1);
+                logger.info("WebSocket connected to {}", gatewayWsUrl);
+              }
+
+              @Override
+              public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                logger.info("Gateway response: {}", data);
+                updateLastActivity();
+                channelContext.writeAndFlush(data.toString() + "\n");
+                webSocket.request(1);
+                return null;
+              }
+
+              @Override
+              public CompletionStage<?> onPong(WebSocket webSocket, ByteBuffer message) {
+                updateLastActivity();
+                webSocket.request(1);
+                return Listener.super.onPong(webSocket, message);
+              }
+
+              @Override
+              public void onError(WebSocket webSocket, Throwable error) {
+                logger.warn("WebSocket connection to {} failed", gatewayWsUrl, error);
+                handleGatewayDisconnect();
+              }
+
+              @Override
+              public CompletionStage<?> onClose(
+                  WebSocket webSocket, int statusCode, String reason) {
+                logger.info("WebSocket closed from gateway: {} - {}", statusCode, reason);
+                handleGatewayDisconnect();
+                return Listener.super.onClose(webSocket, statusCode, reason);
+              }
+            })
+        .whenComplete(
+            (socket, error) -> {
+              if (error != null) {
+                logger.error("WebSocket connection to {} failed", gatewayWsUrl, error);
+                handleGatewayDisconnect();
+              }
+            });
+  }
+
+  private void sendHeartbeat() {
+    if (webSocket == null) {
+      return;
+    }
+    Timer.Sample sample = Timer.start(meterRegistry);
+    CompletableFuture<WebSocket> future = webSocket.sendPing(ByteBuffer.wrap(new byte[] {0x0}));
+    registerSendFuture("__heartbeat__", future);
+    future.whenComplete(
+        (ws, error) -> {
+          sample.stop(heartbeatTimer);
+          if (error != null) {
+            logger.warn("Heartbeat ping failed", error);
+            handleGatewayDisconnect();
+          }
+        });
+  }
+
+  private void closeIfIdle() {
+    Duration idleDuration = Duration.ofNanos(System.nanoTime() - lastActivityNanos);
+    if (idleDuration.compareTo(idleTimeout) <= 0) {
+      return;
+    }
+    Timer.Sample sample = Timer.start(meterRegistry);
+    logger.warn("Closing idle Telnet session after {}", idleDuration);
+    sample.stop(idleCloseTimer);
+    if (channelContext != null) {
+      channelContext.close();
+    }
+  }
+
+  private void handleGatewayDisconnect() {
+    if (disconnected) {
+      inFlightMessages.clear();
+      inFlightSends.clear();
+      buffer.clear();
+      return;
+    }
+    webSocket = null;
+    if (!inFlightMessages.isEmpty()) {
+      var pendingMessages = new ArrayList<>(inFlightMessages.values());
+      inFlightMessages.clear();
+      inFlightSends.clear();
+      pendingMessages.stream()
+          .filter(message -> message != null && !"__heartbeat__".equals(message))
+          .forEach(this::bufferMessage);
+    }
+    if (channelContext == null || scheduler.isShutdown()) {
+      return;
+    }
+    if (reconnectFuture != null && !reconnectFuture.isDone()) {
+      return;
+    }
+    long backoffMillis =
+        Math.min(
+                reconnectBaseDelay.toMillis() * (long) Math.pow(2, reconnectAttempts),
+                MAX_BACKOFF.toMillis());
+    reconnectAttempts++;
+    reconnectFuture =
+        scheduler.schedule(
+            this::connectWebSocket,
+            backoffMillis,
+            TimeUnit.MILLISECONDS);
+    logger.info("Scheduling gateway reconnect in {} ms", backoffMillis);
+  }
+
+  private void sendToGateway(String sanitized) {
+    if (webSocket == null) {
+      bufferMessage(sanitized);
+      return;
+    }
+    if (inFlightSends.size() >= maxInFlight) {
+      logger.warn("In-flight send limit exceeded; closing session to protect memory");
+      if (channelContext != null) {
+        channelContext.close();
+      }
+      return;
+    }
+    CompletableFuture<WebSocket> future = webSocket.sendText(sanitized, true);
+    registerSendFuture(sanitized, future);
+  }
+
+  private void bufferMessage(String sanitized) {
+    if (disconnected) {
+      return;
+    }
+    if (buffer.size() >= maxBufferDepth) {
+      logger.warn("Buffer depth {} exceeded; closing Telnet session to avoid memory pressure", maxBufferDepth);
+      if (channelContext != null) {
+        channelContext.close();
+      }
+      return;
+    }
+    buffer.add(sanitized);
+  }
+
+  private void registerSendFuture(String payload, CompletableFuture<WebSocket> future) {
+    inFlightSends.add(future);
+    inFlightMessages.put(future, payload);
+    future.whenComplete(
+        (ws, error) -> {
+          inFlightSends.remove(future);
+          String message = inFlightMessages.remove(future);
+          if (error != null && message != null && !"__heartbeat__".equals(message)) {
+            bufferMessage(message);
+            handleGatewayDisconnect();
+          }
+        });
+  }
+
+  interface WebSocketFactory {
+    CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener);
+  }
+
+  private static final class HttpClientWebSocketFactory implements WebSocketFactory {
+    private final HttpClient httpClient;
+
+    private HttpClientWebSocketFactory(HttpClient httpClient) {
+      this.httpClient = httpClient;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      var builder = httpClient.newWebSocketBuilder();
+      if (clientIp != null) {
+        builder.header("X-Client-IP", clientIp);
+      }
+      return builder.buildAsync(URI.create(gatewayWsUrl), listener);
+    }
   }
 }

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -1,30 +1,40 @@
 package net.firedevops.firemud.telnet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import java.nio.ByteBuffer;
 import java.net.InetSocketAddress;
 import java.net.http.WebSocket;
+import java.net.http.WebSocket.Listener;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class TelnetServerHandlerTest {
 
   @Test
   void bufferedInputFlushedOnWebSocketConnect() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
             () -> {},
             () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+            registry.counter("test"),
+            registry);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -47,12 +57,14 @@ class TelnetServerHandlerTest {
 
   @Test
   void bufferClearedOnDisconnect() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
             () -> {},
             () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+            registry.counter("test"),
+            registry);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -66,13 +78,55 @@ class TelnetServerHandlerTest {
   }
 
   @Test
-  void unsupportedTelnetCommandsAreDropped() {
+  void pendingGatewayFailuresAreDroppedAfterDisconnect() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PendingWebSocketFactory factory = new PendingWebSocketFactory();
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
             () -> {},
             () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(10),
+            java.time.Duration.ofSeconds(30),
+            java.time.Duration.ofSeconds(30),
+            10,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "north");
+    assertEquals(0, handler.getBufferedSize());
+
+    handler.channelInactive(ctx);
+
+    factory.failPending();
+
+    assertEquals(0, handler.getBufferedSize());
+  }
+
+  @Test
+  void unsupportedTelnetCommandsAreDropped() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -91,12 +145,14 @@ class TelnetServerHandlerTest {
 
   @Test
   void controlCharactersAreRemoved() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
             () -> {},
             () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+            registry.counter("test"),
+            registry);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -115,12 +171,14 @@ class TelnetServerHandlerTest {
 
   @Test
   void emptyAfterSanitizeIsIgnored() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
             () -> {},
             () -> {},
-            new io.micrometer.core.instrument.simple.SimpleMeterRegistry().counter("test"));
+            registry.counter("test"),
+            registry);
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     when(ctx.channel()).thenReturn(channel);
@@ -135,5 +193,540 @@ class TelnetServerHandlerTest {
     handler.channelRead0(ctx, msg);
 
     verify(ws, times(0)).sendText(anyString(), eq(true));
+  }
+
+  @Test
+  void bufferedCommandsAreReplayedAfterGatewayReconnect() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    RecordingFactory factory = new RecordingFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(100),
+            java.time.Duration.ofSeconds(30),
+            java.time.Duration.ofSeconds(30),
+            10,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+
+    RecordingWebSocket firstSocket = factory.lastSocket.get();
+    handler.channelRead0(ctx, "say hi");
+    assertEquals(1, firstSocket.sentMessages.size());
+
+    factory.lastListener.get().onClose(firstSocket, WebSocket.NORMAL_CLOSURE, "bye");
+
+    handler.channelRead0(ctx, "look");
+    assertEquals(1, handler.getBufferedSize());
+
+    Thread.sleep(200);
+
+    RecordingWebSocket secondSocket = factory.lastSocket.get();
+    Thread.sleep(100);
+
+    assertEquals(0, handler.getBufferedSize());
+    assertEquals(1, secondSocket.sentMessages.size());
+    assertEquals("look", secondSocket.sentMessages.get(0));
+    handler.channelInactive(ctx);
+  }
+
+  @Test
+  void closesSessionWhenBufferDepthExceeded() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    FailingConnectFactory failingFactory = new FailingConnectFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(10),
+            java.time.Duration.ofSeconds(30),
+            java.time.Duration.ofSeconds(30),
+            1,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            failingFactory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "north");
+    handler.channelRead0(ctx, "south");
+
+    verify(ctx, times(1)).close();
+    handler.channelInactive(ctx);
+  }
+
+  @Test
+  void closesSessionWhenInFlightLimitExceeded() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PendingWebSocketFactory factory = new PendingWebSocketFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(10),
+            java.time.Duration.ofSeconds(30),
+            java.time.Duration.ofSeconds(30),
+            10,
+            1,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "cast spell");
+    handler.channelRead0(ctx, "look");
+
+    verify(ctx, times(1)).close();
+    factory.completePending();
+    handler.channelInactive(ctx);
+  }
+
+  @Test
+  void failedSendIsBufferedAndReplayedAfterReconnect() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    FailingOnceFactory factory = new FailingOnceFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(20),
+            java.time.Duration.ofSeconds(30),
+            java.time.Duration.ofSeconds(30),
+            10,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "attack goblin");
+
+    Thread.sleep(60);
+
+    RecordingWebSocket reconnectSocket = factory.lastSocket.get();
+    assertEquals(1, reconnectSocket.sentMessages.size());
+    assertEquals("attack goblin", reconnectSocket.sentMessages.get(0));
+
+    handler.channelInactive(ctx);
+  }
+
+  @Test
+  void pendingInFlightMessagesAreBufferedOnDisconnect() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PendingThenRecordingFactory factory = new PendingThenRecordingFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(10),
+            java.time.Duration.ofSeconds(30),
+            java.time.Duration.ofSeconds(2),
+            10,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "who");
+
+    factory.firstListener.get().onClose(factory.firstSocket.get(), WebSocket.NORMAL_CLOSURE, "bye");
+
+    Thread.sleep(60);
+
+    RecordingWebSocket reconnectSocket = factory.recordingSocket.get();
+    assertEquals(1, reconnectSocket.sentMessages.size());
+    assertEquals("who", reconnectSocket.sentMessages.get(0));
+
+    handler.channelInactive(ctx);
+  }
+
+  @Test
+  void heartbeatPingsGatewayOnSchedule() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    HeartbeatRecordingFactory factory = new HeartbeatRecordingFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(5),
+            java.time.Duration.ofMillis(20),
+            java.time.Duration.ofSeconds(30),
+            10,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+
+    HeartbeatRecordingWebSocket socket = factory.lastSocket.get();
+    Thread.sleep(60);
+
+    assertTrue(socket.pingCount.get() > 0, "Expected at least one heartbeat ping");
+    handler.channelInactive(ctx);
+  }
+
+  @Test
+  void idleSessionsCloseAfterTimeout() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    RecordingFactory factory = new RecordingFactory();
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry,
+            java.time.Duration.ofMillis(5),
+            java.time.Duration.ofMillis(50),
+            java.time.Duration.ofMillis(30),
+            10,
+            10,
+            Executors.newSingleThreadScheduledExecutor(
+                r -> {
+                  Thread thread = new Thread(r);
+                  thread.setDaemon(true);
+                  return thread;
+                }),
+            factory);
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    when(ctx.channel()).thenReturn(channel);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    Thread.sleep(60);
+
+    verify(ctx, atLeastOnce()).close();
+    handler.channelInactive(ctx);
+  }
+
+  private static class RecordingFactory implements TelnetServerHandler.WebSocketFactory {
+    private final AtomicReference<Listener> lastListener = new AtomicReference<>();
+    private final AtomicReference<RecordingWebSocket> lastSocket = new AtomicReference<>();
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      lastListener.set(listener);
+      RecordingWebSocket socket = new RecordingWebSocket();
+      lastSocket.set(socket);
+      listener.onOpen(socket);
+      return CompletableFuture.completedFuture(socket);
+    }
+  }
+
+  private static class HeartbeatRecordingFactory implements TelnetServerHandler.WebSocketFactory {
+    private final AtomicReference<HeartbeatRecordingWebSocket> lastSocket = new AtomicReference<>();
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      HeartbeatRecordingWebSocket socket = new HeartbeatRecordingWebSocket();
+      lastSocket.set(socket);
+      listener.onOpen(socket);
+      return CompletableFuture.completedFuture(socket);
+    }
+  }
+
+  private static class PendingWebSocketFactory implements TelnetServerHandler.WebSocketFactory {
+    private final AtomicReference<PendingWebSocket> lastSocket = new AtomicReference<>();
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      PendingWebSocket socket = new PendingWebSocket();
+      lastSocket.set(socket);
+      listener.onOpen(socket);
+      return CompletableFuture.completedFuture(socket);
+    }
+
+    void completePending() {
+      PendingWebSocket socket = lastSocket.get();
+      if (socket != null) {
+        socket.completeAll();
+      }
+    }
+
+    void failPending() {
+      PendingWebSocket socket = lastSocket.get();
+      if (socket != null) {
+        socket.completeAllExceptionally();
+      }
+    }
+  }
+
+  private static class PendingWebSocket implements WebSocket {
+    private final java.util.List<CompletableFuture<WebSocket>> pendingFutures =
+        new java.util.ArrayList<>();
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      CompletableFuture<WebSocket> pending = new CompletableFuture<>();
+      pendingFutures.add(pending);
+      return pending;
+    }
+
+    void completeAll() {
+      pendingFutures.forEach(f -> f.complete(this));
+      pendingFutures.clear();
+    }
+
+    void completeAllExceptionally() {
+      pendingFutures.forEach(f -> f.completeExceptionally(new RuntimeException("send failed")));
+      pendingFutures.clear();
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendBinary(java.nio.ByteBuffer data, boolean last) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPing(java.nio.ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPong(java.nio.ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+      completeAll();
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public void request(long n) {}
+
+    @Override
+    public String getSubprotocol() {
+      return null;
+    }
+
+    @Override
+    public boolean isOutputClosed() {
+      return false;
+    }
+
+    @Override
+    public boolean isInputClosed() {
+      return false;
+    }
+
+    @Override
+    public void abort() {}
+  }
+
+  private static class FailingOnceFactory implements TelnetServerHandler.WebSocketFactory {
+    private final AtomicReference<RecordingWebSocket> lastSocket = new AtomicReference<>();
+    private boolean failNextSend = true;
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      FailingRecordingWebSocket socket = new FailingRecordingWebSocket(failNextSend);
+      failNextSend = false;
+      lastSocket.set(socket);
+      listener.onOpen(socket);
+      return CompletableFuture.completedFuture(socket);
+    }
+  }
+
+  private static class FailingRecordingWebSocket extends RecordingWebSocket {
+    private boolean shouldFail;
+
+    private FailingRecordingWebSocket(boolean shouldFail) {
+      this.shouldFail = shouldFail;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      if (shouldFail) {
+        shouldFail = false;
+        CompletableFuture<WebSocket> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("send failed"));
+        return failed;
+      }
+      return super.sendText(data, last);
+    }
+  }
+
+  private static class FailingConnectFactory implements TelnetServerHandler.WebSocketFactory {
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      return CompletableFuture.failedFuture(new RuntimeException("connect failed"));
+    }
+  }
+
+  private static class PendingThenRecordingFactory implements TelnetServerHandler.WebSocketFactory {
+    private final AtomicInteger connects = new AtomicInteger();
+    private final AtomicReference<Listener> firstListener = new AtomicReference<>();
+    private final AtomicReference<PendingRecordingWebSocket> firstSocket = new AtomicReference<>();
+    private final AtomicReference<RecordingWebSocket> recordingSocket = new AtomicReference<>();
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener) {
+      if (connects.incrementAndGet() == 1) {
+        PendingRecordingWebSocket socket = new PendingRecordingWebSocket();
+        firstListener.set(listener);
+        firstSocket.set(socket);
+        listener.onOpen(socket);
+        return CompletableFuture.completedFuture(socket);
+      }
+      RecordingWebSocket socket = new RecordingWebSocket();
+      recordingSocket.set(socket);
+      listener.onOpen(socket);
+      return CompletableFuture.completedFuture(socket);
+    }
+  }
+
+  private static class PendingRecordingWebSocket extends RecordingWebSocket {
+    private final java.util.List<CompletableFuture<WebSocket>> pendingFutures =
+        new java.util.ArrayList<>();
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      CompletableFuture<WebSocket> pending = new CompletableFuture<>();
+      pendingFutures.add(pending);
+      return pending;
+    }
+  }
+
+  private static class RecordingWebSocket implements WebSocket {
+    private final java.util.List<String> sentMessages = new java.util.ArrayList<>();
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      sentMessages.add(data.toString());
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendBinary(java.nio.ByteBuffer data, boolean last) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPing(java.nio.ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPong(java.nio.ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public void request(long n) {}
+
+    @Override
+    public String getSubprotocol() {
+      return null;
+    }
+
+    @Override
+    public boolean isOutputClosed() {
+      return false;
+    }
+
+    @Override
+    public boolean isInputClosed() {
+      return false;
+    }
+
+    @Override
+    public void abort() {}
+  }
+
+  private static class HeartbeatRecordingWebSocket extends RecordingWebSocket {
+    private final AtomicInteger pingCount = new AtomicInteger();
+
+    @Override
+    public CompletableFuture<WebSocket> sendPing(ByteBuffer message) {
+      pingCount.incrementAndGet();
+      return CompletableFuture.completedFuture(this);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- avoid requeuing in-flight gateway messages once the Telnet session disconnects so buffers are cleared instead of replayed
- extend pending WebSocket test doubles to emit failures and add coverage ensuring gateway send failures after disconnect do not rebuild the buffer

## Testing
- ./gradlew :tcp-proxy-service:test --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256740ca2c83308b379199010f4211)