### PR TITLE
Align dev echo WebSocket metrics with gateway conventions

### DIFF
--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.otlp)
+    testImplementation("io.projectreactor:reactor-test:3.6.8")
+    testRuntimeOnly("io.grpc:grpc-netty:1.77.0")
 }
 
 

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/DevWebSocketConfig.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/config/DevWebSocketConfig.java
@@ -1,0 +1,34 @@
+package net.firedevops.firemud.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import net.firedevops.firemud.websocket.DevEchoWebSocketHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+
+@Configuration
+@Profile("dev")
+public class DevWebSocketConfig {
+
+  @Bean
+  public DevEchoWebSocketHandler devEchoWebSocketHandler(MeterRegistry meterRegistry) {
+    return new DevEchoWebSocketHandler(meterRegistry);
+  }
+
+  @Bean
+  public HandlerMapping devWebSocketMapping(DevEchoWebSocketHandler devEchoWebSocketHandler) {
+    SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+    mapping.setOrder(-1);
+    mapping.setUrlMap(Map.of("/dev/echo", devEchoWebSocketHandler));
+    return mapping;
+  }
+
+  @Bean
+  public WebSocketHandlerAdapter webSocketHandlerAdapter() {
+    return new WebSocketHandlerAdapter();
+  }
+}

--- a/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/websocket/DevEchoWebSocketHandler.java
+++ b/services/spring-cloud-gateway/src/main/java/net/firedevops/firemud/websocket/DevEchoWebSocketHandler.java
@@ -1,0 +1,90 @@
+package net.firedevops.firemud.websocket;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.firedevops.firemud.common.LoggingUtil;
+import org.slf4j.Logger;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+
+/**
+ * Development-only echo handler for verifying the TCP proxy <-> gateway WebSocket bridge.
+ */
+public class DevEchoWebSocketHandler implements WebSocketHandler {
+  private static final String ENDPOINT_TAG_VALUE = "dev-echo";
+  private static final String METRIC_CONNECTIONS_ACTIVE = "gateway.connections.active";
+  private static final String METRIC_CONNECTIONS_TOTAL = "gateway.connections.total";
+  private static final String METRIC_MESSAGES = "gateway.websocket.messages";
+  private static final Logger logger = LoggingUtil.getLogger(DevEchoWebSocketHandler.class);
+
+  private final AtomicInteger activeConnections = new AtomicInteger();
+  private final Counter connectionCounter;
+  private final Counter messageCounter;
+
+  public DevEchoWebSocketHandler(MeterRegistry meterRegistry) {
+    this.connectionCounter =
+        Counter.builder(METRIC_CONNECTIONS_TOTAL)
+            .description("Total WebSocket connections for a gateway endpoint")
+            .tag("endpoint", ENDPOINT_TAG_VALUE)
+            .register(meterRegistry);
+    this.messageCounter =
+        Counter.builder(METRIC_MESSAGES)
+            .description("WebSocket messages processed for a gateway endpoint")
+            .tag("endpoint", ENDPOINT_TAG_VALUE)
+            .register(meterRegistry);
+    Gauge.builder(METRIC_CONNECTIONS_ACTIVE, activeConnections, AtomicInteger::get)
+        .description("Active WebSocket connections for a gateway endpoint")
+        .tag("endpoint", ENDPOINT_TAG_VALUE)
+        .register(meterRegistry);
+  }
+
+  @Override
+  public Mono<Void> handle(WebSocketSession session) {
+    connectionCounter.increment();
+    activeConnections.incrementAndGet();
+
+    logger.info(
+        "Dev echo session {} connected from {}",
+        session.getId(),
+        session.getHandshakeInfo().getRemoteAddress());
+
+    Flux<WebSocketMessage> outbound =
+        session.receive()
+            .doOnNext(
+                message -> {
+                  String payload = message.getPayloadAsText();
+                  logger.info("Dev echo session {} received: {}", session.getId(), payload);
+                  messageCounter.increment();
+                })
+            .doOnError(
+                throwable ->
+                    logger.warn(
+                        "Dev echo session {} closed due to error", session.getId(), throwable))
+            .map(message -> session.textMessage(message.getPayloadAsText()));
+
+    return session
+        .send(outbound)
+        .doFinally(
+            signalType -> {
+              activeConnections.decrementAndGet();
+              if (signalType != SignalType.CANCEL) {
+                logger.info(
+                    "Dev echo session {} closed via {} (active={})",
+                    session.getId(),
+                    signalType,
+                    activeConnections.get());
+              } else {
+                logger.debug(
+                    "Dev echo session {} cancelled (active={})",
+                    session.getId(),
+                    activeConnections.get());
+              }
+            });
+  }
+}

--- a/services/spring-cloud-gateway/src/main/resources/application.yml
+++ b/services/spring-cloud-gateway/src/main/resources/application.yml
@@ -128,6 +128,8 @@ firemud:
     jwt-secret-path: ${FIREMUD_AUTH_JWT_SECRET_PATH:}
     jwt-secret: ${FIREMUD_AUTH_JWT_SECRET}
 
+---
+
 server:
   compression:
     enabled: true

--- a/services/spring-cloud-gateway/src/test/java/net/firedevops/firemud/config/DevWebSocketConfigTest.java
+++ b/services/spring-cloud-gateway/src/test/java/net/firedevops/firemud/config/DevWebSocketConfigTest.java
@@ -1,0 +1,55 @@
+package net.firedevops.firemud.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import net.firedevops.firemud.websocket.DevEchoWebSocketHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+
+class DevWebSocketConfigTest {
+
+  private final ReactiveWebApplicationContextRunner contextRunner =
+      new ReactiveWebApplicationContextRunner()
+          .withUserConfiguration(DevWebSocketConfig.class, MeterRegistryConfig.class);
+
+  @Test
+  void createsBeansWhenDevProfileActive() {
+    contextRunner
+        .withPropertyValues("spring.profiles.active=dev")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(DevEchoWebSocketHandler.class);
+              assertThat(context).hasSingleBean(SimpleUrlHandlerMapping.class);
+              SimpleUrlHandlerMapping handlerMapping =
+                  context.getBean(SimpleUrlHandlerMapping.class);
+              Object handler = context.getBean(DevEchoWebSocketHandler.class);
+
+              assertThat(handlerMapping.getUrlMap().get("/dev/echo")).isSameAs(handler);
+            });
+  }
+
+  @Test
+  void doesNotRegisterBeansOutsideDevProfile() {
+    contextRunner
+        .withPropertyValues("spring.profiles.active=prod")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(DevEchoWebSocketHandler.class);
+              assertThat(context).doesNotHaveBean(HandlerMapping.class);
+            });
+  }
+
+  @Configuration
+  static class MeterRegistryConfig {
+    @Bean
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+}

--- a/services/spring-cloud-gateway/src/test/java/net/firedevops/firemud/websocket/DevEchoWebSocketIntegrationTest.java
+++ b/services/spring-cloud-gateway/src/test/java/net/firedevops/firemud/websocket/DevEchoWebSocketIntegrationTest.java
@@ -1,0 +1,74 @@
+package net.firedevops.firemud.websocket;
+
+import java.net.URI;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+@SpringBootTest(
+    classes = net.firedevops.firemud.SpringCloudGatewayApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "spring.flyway.enabled=false",
+        "firemud.database.enabled=false",
+        "spring.cloud.gateway.default-filters[0]=",
+        "grpc.server.security.enabled=false",
+        "spring.autoconfigure.exclude=org.springframework.cloud.gateway.config.GatewayClassPathWarningAutoConfiguration",
+        "spring.main.web-application-type=reactive"
+    })
+@ActiveProfiles("dev")
+class DevEchoWebSocketIntegrationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private ReactorNettyWebSocketClient client;
+
+  @Test
+  void echoesPayloads() {
+    URI uri = URI.create("ws://localhost:" + port + "/dev/echo");
+    Sinks.One<String> replySink = Sinks.one();
+
+    Mono<Void> sessionMono =
+        client.execute(
+            uri,
+            session ->
+                session
+                    .send(Mono.just(session.textMessage("hello")))
+                    .then(
+                        session
+                            .receive()
+                            .take(1)
+                            .map(message -> message.getPayloadAsText())
+                            .doOnNext(replySink::tryEmitValue)
+                            .then()));
+
+    Mono<String> response =
+        sessionMono
+            .onErrorResume(
+                ex -> {
+                  replySink.tryEmitError(ex);
+                  return Mono.empty();
+                })
+            .then(replySink.asMono())
+            .timeout(Duration.ofSeconds(5));
+
+    StepVerifier.create(response).expectNext("hello").verifyComplete();
+  }
+
+  @TestConfiguration
+  static class ClientConfig {
+    @Bean
+    ReactorNettyWebSocketClient reactorNettyWebSocketClient() {
+      return new ReactorNettyWebSocketClient();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enhance the dev-only WebSocket echo handler with connection lifecycle logging, error visibility, and shared gateway metric naming/tags
- verify the dev profile gating and URL mapping via a reactive context runner test

## Testing
- ./gradlew :spring-cloud-gateway:test --console=plain --no-daemon


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692575a69cd0833086662a6199a56014)