### PR TITLE
Harden telnet reconnect buffering

### DIFF
--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -40,6 +40,7 @@ public final class TelnetServer {
       new java.util.concurrent.atomic.AtomicInteger();
   private final Counter connectionCounter;
   private final Counter discardedCommandCounter;
+  private final MeterRegistry meterRegistry;
 
   private final EventLoopGroup bossGroup = new NioEventLoopGroup(1);
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
@@ -64,6 +65,7 @@ public final class TelnetServer {
     this.certPath = certPath;
     this.keyPath = keyPath;
     this.advertiseMcp = advertiseMcp;
+    this.meterRegistry = meterRegistry;
     this.connectionCounter = meterRegistry.counter("tcpproxy.connections.total");
     this.discardedCommandCounter = meterRegistry.counter("tcpproxy.telnet.discarded");
     Gauge.builder(
@@ -104,7 +106,8 @@ public final class TelnetServer {
                               activeConnections::decrementAndGet,
                               connectionCounter,
                               discardedCommandCounter,
-                              advertiseMcp));
+                              advertiseMcp,
+                              meterRegistry));
                 }
               });
       serverChannel = b.bind(port).sync().channel();

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -1,6 +1,8 @@
 package net.firedevops.firemud.telnet;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -9,17 +11,28 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
 import java.net.http.WebSocket.Listener;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Handler that forwards Telnet lines to the gateway via WebSocket. */
 public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private static final Logger logger = LoggerFactory.getLogger(TelnetServerHandler.class);
+  private static final Duration INITIAL_RECONNECT_DELAY = Duration.ofSeconds(1);
+  private static final Duration MAX_RECONNECT_DELAY = Duration.ofSeconds(30);
+  private static final Duration HEARTBEAT_INTERVAL = Duration.ofSeconds(30);
+  private static final Duration IDLE_TIMEOUT = Duration.ofMinutes(5);
+  private static final int MAX_BUFFER_DEPTH = 512;
 
   private final String gatewayWsUrl;
   private final boolean logOnly;
@@ -28,9 +41,25 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private final io.micrometer.core.instrument.Counter connectionCounter;
   private final io.micrometer.core.instrument.Counter discardedCommandCounter;
   private final boolean advertiseMcp;
+  private final MeterRegistry meterRegistry;
+  private final Timer commandTimer;
+  private final Timer heartbeatTimer;
+  private final Timer idleCloseTimer;
+  private final WebSocketConnector webSocketConnector;
+  private volatile ChannelHandlerContext context;
+  private volatile boolean closing;
+  private volatile boolean reconnecting;
+  private volatile int reconnectAttempts;
+  private volatile ScheduledFuture<?> heartbeatFuture;
+  private volatile ScheduledFuture<?> idleFuture;
+  private volatile long lastActivityNanos;
   private volatile boolean mcpNegotiated;
   private WebSocket webSocket;
   private final Queue<String> buffer = new ConcurrentLinkedQueue<>();
+  private final Set<CompletableFuture<WebSocket>> outstandingSends =
+      ConcurrentHashMap.newKeySet();
+  private volatile CompletableFuture<WebSocket> inFlightSend;
+  private String clientIp;
 
   public TelnetServerHandler(
       String gatewayWsUrl,
@@ -39,7 +68,30 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       Runnable onDisconnect,
       io.micrometer.core.instrument.Counter connectionCounter,
       io.micrometer.core.instrument.Counter discardedCommandCounter,
-      boolean advertiseMcp) {
+      boolean advertiseMcp,
+      MeterRegistry meterRegistry) {
+    this(
+        gatewayWsUrl,
+        logOnly,
+        onConnect,
+        onDisconnect,
+        connectionCounter,
+        discardedCommandCounter,
+        advertiseMcp,
+        meterRegistry,
+        TelnetServerHandler::createWebSocket);
+  }
+
+  TelnetServerHandler(
+      String gatewayWsUrl,
+      boolean logOnly,
+      Runnable onConnect,
+      Runnable onDisconnect,
+      io.micrometer.core.instrument.Counter connectionCounter,
+      io.micrometer.core.instrument.Counter discardedCommandCounter,
+      boolean advertiseMcp,
+      MeterRegistry meterRegistry,
+      WebSocketConnector webSocketConnector) {
     this.gatewayWsUrl = gatewayWsUrl;
     this.logOnly = logOnly;
     this.onConnect = onConnect;
@@ -47,104 +99,355 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     this.connectionCounter = connectionCounter;
     this.discardedCommandCounter = discardedCommandCounter;
     this.advertiseMcp = advertiseMcp;
+    this.meterRegistry = meterRegistry;
+    this.webSocketConnector = webSocketConnector;
+    this.commandTimer = meterRegistry.timer("tcpproxy.command");
+    this.heartbeatTimer = meterRegistry.timer("tcpproxy.heartbeat");
+    this.idleCloseTimer = meterRegistry.timer("tcpproxy.idleClose");
+  }
+
+  @FunctionalInterface
+  interface WebSocketConnector {
+    CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, Listener listener);
+  }
+
+  private static CompletableFuture<WebSocket> createWebSocket(
+      String gatewayWsUrl, String clientIp, Listener listener) {
+    HttpClient client = HttpClient.newHttpClient();
+    var builder = client.newWebSocketBuilder();
+    if (clientIp != null) {
+      builder.header("X-Client-IP", clientIp);
+    }
+    return builder.buildAsync(URI.create(gatewayWsUrl), listener);
   }
 
   void setWebSocket(WebSocket webSocket) {
     this.webSocket = webSocket;
-    flushBuffer();
+    reconnecting = false;
+    startHeartbeat();
+    touchActivity();
+    drainBuffer();
   }
 
   int getBufferedSize() {
     return buffer.size();
   }
 
-  private void flushBuffer() {
-    if (webSocket == null) {
+  private void startHeartbeat() {
+    if (context == null || closing) {
       return;
     }
-    String msg;
-    while ((msg = buffer.poll()) != null) {
-      webSocket.sendText(msg, true);
+    stopHeartbeat();
+    heartbeatFuture =
+        context
+            .executor()
+            .scheduleAtFixedRate(
+                this::sendHeartbeat,
+                HEARTBEAT_INTERVAL.toMillis(),
+                HEARTBEAT_INTERVAL.toMillis(),
+                TimeUnit.MILLISECONDS);
+  }
+
+  private void stopHeartbeat() {
+    if (heartbeatFuture != null) {
+      heartbeatFuture.cancel(false);
+      heartbeatFuture = null;
     }
+  }
+
+  private void touchActivity() {
+    lastActivityNanos = System.nanoTime();
+    scheduleIdleCheck();
+  }
+
+  private void scheduleIdleCheck() {
+    if (context == null || closing) {
+      return;
+    }
+    if (idleFuture != null) {
+      idleFuture.cancel(false);
+    }
+    idleFuture =
+        context
+            .executor()
+            .schedule(this::closeIfIdle, IDLE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+  }
+
+  private void closeIfIdle() {
+    if (closing) {
+      return;
+    }
+    long idleNanos = System.nanoTime() - lastActivityNanos;
+    if (idleNanos < IDLE_TIMEOUT.toNanos()) {
+      scheduleIdleCheck();
+      return;
+    }
+    logger.warn(
+        "Closing Telnet session for {} after {} ms of inactivity",
+        gatewayWsUrl,
+        Duration.ofNanos(idleNanos).toMillis());
+    idleCloseTimer.record(Duration.ofNanos(idleNanos));
+    if (context != null) {
+      context.close();
+    }
+  }
+
+  private void sendHeartbeat() {
+    WebSocket socket = this.webSocket;
+    if (socket == null || closing) {
+      return;
+    }
+    Timer.Sample sample = Timer.start(meterRegistry);
+    CompletableFuture<WebSocket> pingFuture = socket.sendPing(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
+    outstandingSends.add(pingFuture);
+    pingFuture.whenComplete(
+        (ws, error) -> {
+          outstandingSends.remove(pingFuture);
+          sample.stop(heartbeatTimer);
+          if (error != null) {
+            logger.warn("Gateway heartbeat failed; triggering reconnect", error);
+            handleGatewayDisconnect();
+          }
+        });
+  }
+
+  private synchronized void drainBuffer() {
+    if (webSocket == null || inFlightSend != null || closing) {
+      return;
+    }
+    String next = buffer.peek();
+    if (next == null) {
+      return;
+    }
+    CompletableFuture<WebSocket> sendFuture = webSocket.sendText(next, true);
+    inFlightSend = sendFuture;
+    outstandingSends.add(sendFuture);
+    sendFuture.whenComplete(
+        (ws, error) -> {
+          outstandingSends.remove(sendFuture);
+          inFlightSend = null;
+          if (error == null) {
+            buffer.poll();
+            touchActivity();
+          } else {
+            logger.warn("Gateway send failed; scheduling reconnect", error);
+            handleGatewayDisconnect();
+          }
+          drainBuffer();
+        });
   }
 
   @Override
   public void channelActive(ChannelHandlerContext ctx) {
+    context = ctx;
+    touchActivity();
     var remote = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
-    String ip = null;
-    if (remote instanceof java.net.InetSocketAddress address) {
-      var inetAddress = address.getAddress();
-      if (inetAddress != null) {
-        ip = inetAddress.getHostAddress();
-      }
-    }
+    clientIp = extractIp(remote);
     connectionCounter.increment();
     onConnect.run();
-    logger.info("Telnet client connected from {} targeting {}", ip != null ? ip : remote, gatewayWsUrl);
+    logger.info(
+        "Telnet client connected from {} targeting {}", clientIp != null ? clientIp : remote, gatewayWsUrl);
     if (logOnly) {
       logger.info("Log-only mode enabled; skipping WebSocket bridge for {}", gatewayWsUrl);
       return;
     }
-    HttpClient client = HttpClient.newHttpClient();
-    var builder = client.newWebSocketBuilder();
-    if (ip != null) {
-      builder.header("X-Client-IP", ip);
-    }
-    builder.buildAsync(
-        URI.create(gatewayWsUrl),
-        new Listener() {
-          @Override
-          public void onOpen(WebSocket webSocket) {
-            setWebSocket(webSocket);
-            webSocket.request(1);
-            logger.info("WebSocket connected to {}", gatewayWsUrl);
-          }
-
-          @Override
-          public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
-            logger.info("Gateway response: {}", data);
-            ctx.writeAndFlush(data.toString() + "\n");
-            webSocket.request(1);
-            return null;
-          }
-        })
-        .whenComplete(
-            (socket, error) -> {
-              if (error != null) {
-                logger.error("WebSocket connection to {} failed", gatewayWsUrl, error);
-              }
-            });
+    connectToGateway();
   }
 
   @Override
   @Timed(value = "tcpproxy.command")
   protected void channelRead0(ChannelHandlerContext ctx, String msg) {
-    String sanitized = sanitize(ctx, msg);
-    if (sanitized == null) {
-      return;
-    }
+    Timer.Sample sample = Timer.start(meterRegistry);
+    try {
+      String sanitized = sanitize(ctx, msg);
+      if (sanitized == null) {
+        return;
+      }
 
-    logger.info("Received Telnet input: {}", sanitized);
+      logger.info("Received Telnet input: {}", sanitized);
+      touchActivity();
 
-    if (logOnly) {
-      return;
-    }
+      if (logOnly) {
+        return;
+      }
 
-    if (webSocket != null) {
-      webSocket.sendText(sanitized, true);
-    } else {
+      if (!canBufferMore()) {
+        return;
+      }
+
       buffer.add(sanitized);
+      drainBuffer();
+    } finally {
+      sample.stop(commandTimer);
     }
   }
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) {
-    if (webSocket != null) {
-      webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "bye");
-      webSocket = null;
-    }
+    closing = true;
+    stopHeartbeat();
+    cancelIdleCheck();
+    closeGatewayWebSocket();
     onDisconnect.run();
     buffer.clear();
+    cancelOutstandingSends();
+  }
+
+  private boolean canBufferMore() {
+    int depth = buffer.size() + outstandingSends.size();
+    if (depth >= MAX_BUFFER_DEPTH) {
+      if (!closing) {
+        closing = true;
+        logger.warn(
+            "Telnet buffer depth {} exceeded for {}; closing connection to prevent memory pressure",
+            MAX_BUFFER_DEPTH,
+            gatewayWsUrl);
+        discardedCommandCounter.increment();
+        if (context != null) {
+          context.close();
+        }
+      }
+      return false;
+    }
+    return true;
+  }
+
+  private void cancelIdleCheck() {
+    if (idleFuture != null) {
+      idleFuture.cancel(false);
+      idleFuture = null;
+    }
+  }
+
+  private void closeGatewayWebSocket() {
+    WebSocket socket = this.webSocket;
+    webSocket = null;
+    if (socket != null) {
+      try {
+        socket.sendClose(WebSocket.NORMAL_CLOSURE, "bye");
+      } catch (Exception e) {
+        logger.warn("Failed to close gateway WebSocket cleanly", e);
+      }
+    }
+  }
+
+  private void connectToGateway() {
+    if (closing) {
+      return;
+    }
+    reconnecting = true;
+    webSocketConnector
+        .connect(gatewayWsUrl, clientIp, gatewayListener())
+        .whenComplete(
+            (socket, error) -> {
+              if (error != null) {
+                logger.error("WebSocket connection to {} failed", gatewayWsUrl, error);
+                reconnecting = false;
+                scheduleReconnect();
+              }
+            });
+  }
+
+  private void handleGatewayDisconnect() {
+    if (closing || logOnly) {
+      return;
+    }
+    cancelOutstandingSends();
+    closeGatewayWebSocket();
+    stopHeartbeat();
+    reconnecting = false;
+    scheduleReconnect();
+  }
+
+  private void scheduleReconnect() {
+    if (context == null || closing || reconnecting) {
+      return;
+    }
+    reconnecting = true;
+    long delayMillis = backoffDelayMillis();
+    context.executor().schedule(this::connectToGateway, delayMillis, TimeUnit.MILLISECONDS);
+  }
+
+  private void cancelOutstandingSends() {
+    CompletableFuture<WebSocket> flight = inFlightSend;
+    inFlightSend = null;
+    if (flight != null) {
+      flight.cancel(true);
+    }
+    outstandingSends.forEach(future -> future.cancel(true));
+    outstandingSends.clear();
+  }
+
+  private long backoffDelayMillis() {
+    long baseDelay = INITIAL_RECONNECT_DELAY.toMillis();
+    long delay = baseDelay * (1L << Math.min(reconnectAttempts, 10));
+    reconnectAttempts++;
+    return Math.min(delay, MAX_RECONNECT_DELAY.toMillis());
+  }
+
+  private String extractIp(Object remote) {
+    if (remote instanceof java.net.InetSocketAddress address) {
+      var inetAddress = address.getAddress();
+      if (inetAddress != null) {
+        return inetAddress.getHostAddress();
+      }
+    }
+    return null;
+  }
+
+  private Listener gatewayListener() {
+    return new Listener() {
+      @Override
+      public void onOpen(WebSocket webSocket) {
+        setWebSocket(webSocket);
+        webSocket.request(1);
+        reconnectAttempts = 0;
+        logger.info("WebSocket connected to {}", gatewayWsUrl);
+      }
+
+      @Override
+      public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+        touchActivity();
+        logger.info("Gateway response: {}", data);
+        if (context != null) {
+          context.writeAndFlush(data.toString() + "\n");
+        }
+        webSocket.request(1);
+        return null;
+      }
+
+      @Override
+      public CompletionStage<?> onPong(WebSocket webSocket, ByteBuffer message) {
+        touchActivity();
+        webSocket.request(1);
+        return Listener.super.onPong(webSocket, message);
+      }
+
+      @Override
+      public CompletionStage<?> onPing(WebSocket webSocket, ByteBuffer message) {
+        touchActivity();
+        webSocket.sendPong(message);
+        webSocket.request(1);
+        return Listener.super.onPing(webSocket, message);
+      }
+
+      @Override
+      public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+        logger.warn(
+            "Gateway WebSocket closed for {} with status {} and reason {}",
+            gatewayWsUrl,
+            statusCode,
+            reason);
+        handleGatewayDisconnect();
+        return Listener.super.onClose(webSocket, statusCode, reason);
+      }
+
+      @Override
+      public void onError(WebSocket webSocket, Throwable error) {
+        logger.error("WebSocket error for {}", gatewayWsUrl, error);
+        handleGatewayDisconnect();
+      }
+    };
   }
 
   @Override

--- a/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TelnetPipelineIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TelnetPipelineIntegrationTest.java
@@ -22,11 +22,13 @@ class TelnetPipelineIntegrationTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             registry.counter("connections"),
             registry.counter("discarded"),
-            false);
+            false,
+            registry);
 
     WebSocket ws = Mockito.mock(WebSocket.class);
     CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
@@ -57,11 +59,13 @@ class TelnetPipelineIntegrationTest {
     TelnetServerHandler handler =
         new TelnetServerHandler(
             "ws://localhost/ws",
+            false,
             () -> {},
             () -> {},
             registry.counter("connections"),
             registry.counter("discarded"),
-            false);
+            false,
+            registry);
 
     WebSocket ws = Mockito.mock(WebSocket.class);
     CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -17,8 +17,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.string.StringDecoder;
+import io.netty.util.concurrent.DefaultEventExecutor;
 import java.net.InetSocketAddress;
 import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -29,11 +33,29 @@ class TelnetServerHandlerTest {
   private TelnetServerHandler newHandler(SimpleMeterRegistry registry, boolean advertiseMcp) {
     return new TelnetServerHandler(
         "ws://localhost/ws",
+        false,
         () -> {},
         () -> {},
         registry.counter("test"),
         registry.counter("discarded"),
-        advertiseMcp);
+        advertiseMcp,
+        registry);
+  }
+
+  private TelnetServerHandler newHandler(
+      SimpleMeterRegistry registry,
+      boolean advertiseMcp,
+      TelnetServerHandler.WebSocketConnector connector) {
+    return new TelnetServerHandler(
+        "ws://localhost/ws",
+        false,
+        () -> {},
+        () -> {},
+        registry.counter("test"),
+        registry.counter("discarded"),
+        advertiseMcp,
+        registry,
+        connector);
   }
 
   @Test
@@ -74,6 +96,29 @@ class TelnetServerHandlerTest {
 
     handler.channelInactive(ctx);
     assertEquals(0, handler.getBufferedSize());
+  }
+
+  @Test
+  void connectionClosedWhenBufferDepthExceeded() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler handler = newHandler(registry, false);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    DefaultEventExecutor executor = new DefaultEventExecutor();
+    when(ctx.channel()).thenReturn(channel);
+    when(ctx.executor()).thenReturn(executor);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+
+    for (int i = 0; i < 600; i++) {
+      handler.channelRead0(ctx, "cmd" + i);
+    }
+
+    verify(ctx).close();
+    assertEquals(512, handler.getBufferedSize());
+    assertEquals(1.0, registry.counter("discarded").count());
+    executor.shutdownGracefully();
   }
 
   @Test
@@ -239,5 +284,287 @@ class TelnetServerHandlerTest {
     buf.release();
     assertEquals(1.0, registry.counter("discarded").count());
     verify(ws).sendText("cmd", true);
+  }
+
+  @Test
+  void bufferedCommandsReplayAfterGatewayReconnect() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TestConnector connector = new TestConnector();
+    TelnetServerHandler handler = newHandler(registry, false, connector);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    DefaultEventExecutor executor = new DefaultEventExecutor();
+    when(ctx.channel()).thenReturn(channel);
+    when(ctx.executor()).thenReturn(executor);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+
+    StubWebSocket initialSocket = connector.getCurrent();
+    handler.channelRead0(ctx, "look");
+    handler.channelRead0(ctx, "say hi");
+
+    connector.getListener().onClose(initialSocket, 1001, "closing");
+    handler.channelRead0(ctx, "move north");
+    handler.channelRead0(ctx, "get sword");
+
+    assertEquals(2, handler.getBufferedSize());
+
+    StubWebSocket reconnectedSocket = connector.reconnect();
+    handler.setWebSocket(reconnectedSocket);
+
+    executor.shutdownGracefully();
+
+    assertEquals(List.of("move north", "get sword"), reconnectedSocket.getSentTexts());
+  }
+
+  @Test
+  void stuckSendIsCancelledAndReplayedAfterDisconnect() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    ControllableConnector connector = new ControllableConnector(new HangingWebSocket());
+    TelnetServerHandler handler = newHandler(registry, false, connector);
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    DefaultEventExecutor executor = new DefaultEventExecutor();
+    when(ctx.channel()).thenReturn(channel);
+    when(ctx.executor()).thenReturn(executor);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+
+    HangingWebSocket initialSocket = (HangingWebSocket) connector.getCurrent();
+    handler.channelRead0(ctx, "look");
+
+    connector.getListener().onClose(initialSocket, 1001, "closing");
+
+    RecordingWebSocket reconnectedSocket = new RecordingWebSocket();
+    handler.setWebSocket(reconnectedSocket);
+
+    executor.shutdownGracefully();
+
+    assertTrue(initialSocket.getSendFuture().isCancelled());
+    assertEquals(List.of("look"), reconnectedSocket.getSentTexts());
+  }
+
+  private static final class TestConnector implements TelnetServerHandler.WebSocketConnector {
+    private StubWebSocket current;
+    private WebSocket.Listener listener;
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, WebSocket.Listener listener) {
+      this.listener = listener;
+      current = new StubWebSocket();
+      listener.onOpen(current);
+      return CompletableFuture.completedFuture(current);
+    }
+
+    StubWebSocket getCurrent() {
+      return current;
+    }
+
+    WebSocket.Listener getListener() {
+      return listener;
+    }
+
+    StubWebSocket reconnect() {
+      current = new StubWebSocket();
+      listener.onOpen(current);
+      return current;
+    }
+  }
+
+  private static final class ControllableConnector implements TelnetServerHandler.WebSocketConnector {
+    private WebSocket current;
+    private WebSocket.Listener listener;
+
+    ControllableConnector(WebSocket first) {
+      this.current = first;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> connect(String gatewayWsUrl, String clientIp, WebSocket.Listener listener) {
+      this.listener = listener;
+      listener.onOpen(current);
+      return CompletableFuture.completedFuture(current);
+    }
+
+    WebSocket.Listener getListener() {
+      return listener;
+    }
+
+    WebSocket getCurrent() {
+      return current;
+    }
+  }
+
+  private static final class StubWebSocket implements WebSocket {
+    private final List<String> sentTexts = new ArrayList<>();
+    private boolean closed;
+
+    List<String> getSentTexts() {
+      return sentTexts;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      sentTexts.add(data.toString());
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendBinary(ByteBuffer data, boolean last) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPing(ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPong(ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+      closed = true;
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public void request(long n) {}
+
+    @Override
+    public String getSubprotocol() {
+      return "";
+    }
+
+    @Override
+    public boolean isOutputClosed() {
+      return closed;
+    }
+
+    @Override
+    public boolean isInputClosed() {
+      return closed;
+    }
+
+    @Override
+    public void abort() {
+      closed = true;
+    }
+  }
+
+  private static final class HangingWebSocket implements WebSocket {
+    private final CompletableFuture<WebSocket> sendFuture = new CompletableFuture<>();
+
+    CompletableFuture<WebSocket> getSendFuture() {
+      return sendFuture;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      return sendFuture;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendBinary(ByteBuffer data, boolean last) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPing(ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPong(ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+      sendFuture.cancel(true);
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public void request(long n) {}
+
+    @Override
+    public String getSubprotocol() {
+      return "";
+    }
+
+    @Override
+    public boolean isOutputClosed() {
+      return false;
+    }
+
+    @Override
+    public boolean isInputClosed() {
+      return false;
+    }
+
+    @Override
+    public void abort() {
+      sendFuture.cancel(true);
+    }
+  }
+
+  private static final class RecordingWebSocket implements WebSocket {
+    private final List<String> sentTexts = new ArrayList<>();
+
+    List<String> getSentTexts() {
+      return sentTexts;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+      sentTexts.add(data.toString());
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendBinary(ByteBuffer data, boolean last) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPing(ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendPong(ByteBuffer message) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public void request(long n) {}
+
+    @Override
+    public String getSubprotocol() {
+      return "";
+    }
+
+    @Override
+    public boolean isOutputClosed() {
+      return false;
+    }
+
+    @Override
+    public boolean isInputClosed() {
+      return false;
+    }
+
+    @Override
+    public void abort() {}
   }
 }


### PR DESCRIPTION
## Summary
- cancel in-flight websocket sends on disconnects so reconnects can drain buffered commands with bounded depth
- record idle-close duration and guard reconnect scheduling while keeping heartbeat and send tracking intact
- add regression coverage for cancelling stuck sends, enforcing buffer depth closures, and replaying buffered commands after gateway reconnects

## Testing
- ./gradlew :tcp-proxy-service:test --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257c0903188330b0eee8c8de71961f)