### PR TITLE
Align game session log-only task defaults

### DIFF
--- a/services/game-session-service/README.md
+++ b/services/game-session-service/README.md
@@ -4,3 +4,11 @@ Design details are kept in the architecture docs:
 [📄 Game Session Service Design](../../design/architecture/microservices/game-session-service/README.md)
 
 This README is only a stub. **Do not place design information here.**
+
+## Local development
+
+- `./gradlew :game-session-service:bootRunLogOnly` starts the service with `spring.profiles.active=dev`, sets `GAME_SESSION_LOG_ONLY=true`, and runs in log-only mode for local testing without external dependencies.
+
+## Environment variables
+
+- `GAME_SESSION_LOG_ONLY`: When set to `true`, the service acknowledges requests and logs actions without persisting state or contacting external systems. The `bootRunLogOnly` Gradle task enables this by default.

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -26,15 +26,11 @@ dependencies {
 }
 
 tasks.named<BootRun>("bootRun") {
-    systemProperty("spring.profiles.active", System.getProperty("spring.profiles.active") ?: "dev")
-}
+    val activeProfile = System.getProperty("spring.profiles.active")
+        ?: System.getenv("SPRING_PROFILES_ACTIVE")
+        ?: "dev"
 
-tasks.named<BootRun>("bootRun") {
-    val activeProfile = System.getProperty("spring.profiles.active") ?: System.getenv("SPRING_PROFILES_ACTIVE")
-
-    if (activeProfile == null) {
-        systemProperty("spring.profiles.active", "dev")
-    }
+    systemProperty("spring.profiles.active", activeProfile)
 }
 
 tasks.register<BootRun>("bootRunLogOnly") {

--- a/services/game-session-service/build.gradle.kts
+++ b/services/game-session-service/build.gradle.kts
@@ -1,4 +1,6 @@
 
+import org.springframework.boot.gradle.tasks.run.BootRun
+
 apply(from = "${rootDir}/gradle/proto-convention.gradle")
 
 dependencies {
@@ -21,6 +23,27 @@ dependencies {
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
     compileOnly("com.github.spotbugs:spotbugs-annotations:4.9.8")
+}
+
+tasks.named<BootRun>("bootRun") {
+    systemProperty("spring.profiles.active", System.getProperty("spring.profiles.active") ?: "dev")
+}
+
+tasks.named<BootRun>("bootRun") {
+    val activeProfile = System.getProperty("spring.profiles.active") ?: System.getenv("SPRING_PROFILES_ACTIVE")
+
+    if (activeProfile == null) {
+        systemProperty("spring.profiles.active", "dev")
+    }
+}
+
+tasks.register<BootRun>("bootRunLogOnly") {
+    group = "application"
+    description = "Start the game session service in dev with log-only handling"
+    mainClass.set("net.firedevops.firemud.GameSessionServiceApplication")
+    classpath = sourceSets.main.get().runtimeClasspath
+    systemProperty("spring.profiles.active", "dev")
+    environment("GAME_SESSION_LOG_ONLY", "true")
 }
 
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/config/LogOnlyProperties.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/config/LogOnlyProperties.java
@@ -1,0 +1,17 @@
+package net.firedevops.firemud.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LogOnlyProperties {
+  private final boolean logOnly;
+
+  public LogOnlyProperties(@Value("${GAME_SESSION_LOG_ONLY:false}") boolean logOnly) {
+    this.logOnly = logOnly;
+  }
+
+  public boolean isLogOnly() {
+    return logOnly;
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/FeatureFlagServiceImpl.java
@@ -4,6 +4,7 @@ import io.micrometer.core.annotation.Timed;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.dto.FeatureFlagDto;
 import net.firedevops.firemud.dto.ToggleFeatureFlagRequest;
 import net.firedevops.firemud.entity.FeatureFlag;
@@ -21,12 +22,18 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
 
   private final FeatureFlagRepository repository;
   private final FeatureFlagMapper mapper;
+  private final LogOnlyProperties logOnlyProperties;
 
   @Override
   @Timed(value = "gamesession.feature.toggle")
   @Transactional
   public FeatureFlagDto toggleFlag(ToggleFeatureFlagRequest request) {
     logger.info("Toggling feature flag {} for tenant {}", request.name(), request.tenantId());
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info("Log-only mode enabled; acknowledging toggle without persistence");
+      return new FeatureFlagDto(null, request.tenantId(), request.name(), request.enabled());
+    }
+
     Optional<FeatureFlag> existing =
         repository.findByTenantIdAndName(request.tenantId(), request.name());
     FeatureFlag flag = existing.orElseGet(FeatureFlag::new);

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameInstanceServiceImpl.java
@@ -10,6 +10,7 @@ import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.saga.SagaBuilder;
 import net.firedevops.firemud.common.saga.SagaException;
 import net.firedevops.firemud.common.saga.SagaRunner;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.dto.GameInstanceDto;
 import net.firedevops.firemud.dto.StartSessionRequest;
 import net.firedevops.firemud.entity.GameInstance;
@@ -37,6 +38,7 @@ public final class GameInstanceServiceImpl implements GameInstanceService {
   private final EntityManagementClient entityManagementClient;
   private final SagaRunner sagaRunner;
   private final MeterRegistry meterRegistry;
+  private final LogOnlyProperties logOnlyProperties;
 
   public GameInstanceServiceImpl(
       GameInstanceRepository repository,
@@ -46,7 +48,8 @@ public final class GameInstanceServiceImpl implements GameInstanceService {
       WorldManagementClient worldManagementClient,
       EntityManagementClient entityManagementClient,
       SagaRunner sagaRunner,
-      MeterRegistry meterRegistry) {
+      MeterRegistry meterRegistry,
+      LogOnlyProperties logOnlyProperties) {
     this.repository = repository;
     this.mapper = mapper;
     this.sessionStateService = sessionStateService;
@@ -55,6 +58,7 @@ public final class GameInstanceServiceImpl implements GameInstanceService {
     this.entityManagementClient = entityManagementClient;
     this.sagaRunner = sagaRunner;
     this.meterRegistry = meterRegistry;
+    this.logOnlyProperties = logOnlyProperties;
   }
 
   // Constructor used in unit tests
@@ -70,13 +74,29 @@ public final class GameInstanceServiceImpl implements GameInstanceService {
         null,
         null,
         null,
-        new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
+        new io.micrometer.core.instrument.simple.SimpleMeterRegistry(),
+        new LogOnlyProperties(false));
   }
 
   @Override
   @Timed(value = "gamesession.start")
   @Transactional
   public GameInstanceDto startSession(StartSessionRequest request) {
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info(
+          "Log-only mode enabled; acknowledging start for tenant {} version {} patch {}", 
+          request.tenantId(),
+          request.runtimeVersion(),
+          request.scriptPatchVersion());
+      return new GameInstanceDto(
+          -1L,
+          request.tenantId(),
+          request.runtimeVersion(),
+          request.scriptPatchVersion(),
+          request.ownerAccountId(),
+          "RUNNING");
+    }
+
     logger.info(
         "Starting game session for tenant {} version {} patch {}",
         request.tenantId(),
@@ -135,6 +155,11 @@ public final class GameInstanceServiceImpl implements GameInstanceService {
   @Timed(value = "gamesession.stop")
   @Transactional
   public GameInstanceDto stopSession(long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info("Log-only mode enabled; acknowledging stop for session {}", sessionId);
+      return new GameInstanceDto(sessionId, 0L, "log-only", null, 0L, "STOPPED");
+    }
+
     GameInstance instance =
         repository
             .findById(sessionId)
@@ -168,6 +193,11 @@ public final class GameInstanceServiceImpl implements GameInstanceService {
   @Timed(value = "gamesession.restart")
   @Transactional
   public GameInstanceDto restartSession(long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info("Log-only mode enabled; acknowledging restart for session {}", sessionId);
+      return new GameInstanceDto(sessionId, 0L, "log-only", null, 0L, "RUNNING");
+    }
+
     GameInstance instance =
         repository
             .findById(sessionId)

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/IpConnectionLimiterImpl.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -18,18 +19,25 @@ public class IpConnectionLimiterImpl implements IpConnectionLimiter {
   private final int maxConnectionsPerIp;
 
   private final Duration entryTtl;
+  private final LogOnlyProperties logOnlyProperties;
 
   public IpConnectionLimiterImpl(
       StringRedisTemplate redisTemplate,
       @Value("${GAME_SESSION_MAX_CONNECTIONS_PER_IP:5}") int maxConnectionsPerIp,
-      @Value("${GAME_SESSION_CONN_TTL_SEC:3600}") long entryTtlSeconds) {
+      @Value("${GAME_SESSION_CONN_TTL_SEC:3600}") long entryTtlSeconds,
+      LogOnlyProperties logOnlyProperties) {
     this.redisTemplate = redisTemplate;
     this.maxConnectionsPerIp = maxConnectionsPerIp;
     this.entryTtl = Duration.ofSeconds(entryTtlSeconds);
+    this.logOnlyProperties = logOnlyProperties;
   }
 
   @Override
   public boolean canAccept(String ip) {
+    if (logOnlyProperties.isLogOnly()) {
+      return true;
+    }
+
     String key = ipKey(ip);
     String value = redisTemplate.opsForValue().get(key);
     long count = value == null ? 0L : Long.parseLong(value);
@@ -38,6 +46,10 @@ public class IpConnectionLimiterImpl implements IpConnectionLimiter {
 
   @Override
   public void register(String ip, long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      return;
+    }
+
     String ipKey = ipKey(ip);
     Long count = redisTemplate.opsForValue().increment(ipKey);
     if (Long.valueOf(1L).equals(count)) {
@@ -48,6 +60,10 @@ public class IpConnectionLimiterImpl implements IpConnectionLimiter {
 
   @Override
   public void release(long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      return;
+    }
+
     String sessionKey = sessionKey(sessionId);
     String ip = redisTemplate.opsForValue().get(sessionKey);
     if (ip != null) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/SessionRateLimiterImpl.java
@@ -2,6 +2,7 @@ package net.firedevops.firemud.service.impl;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.service.SessionRateLimiter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,16 +17,23 @@ public class SessionRateLimiterImpl implements SessionRateLimiter {
   private final StringRedisTemplate redisTemplate;
 
   private final int maxMessagesPerSecond;
+  private final LogOnlyProperties logOnlyProperties;
 
   public SessionRateLimiterImpl(
       StringRedisTemplate redisTemplate,
-      @Value("${GAME_SESSION_MAX_MSGS_PER_SEC:20}") int maxMessagesPerSecond) {
+      @Value("${GAME_SESSION_MAX_MSGS_PER_SEC:20}") int maxMessagesPerSecond,
+      LogOnlyProperties logOnlyProperties) {
     this.redisTemplate = redisTemplate;
     this.maxMessagesPerSecond = maxMessagesPerSecond;
+    this.logOnlyProperties = logOnlyProperties;
   }
 
   @Override
   public boolean allow(long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      return true;
+    }
+
     String key = key(sessionId);
     Long count = redisTemplate.opsForValue().increment(key);
     if (Long.valueOf(1L).equals(count)) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import net.firedevops.firemud.common.conflict.ConflictTracker;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.repository.GameInstanceRepository;
 import net.firedevops.firemud.service.TickService;
 import org.slf4j.Logger;
@@ -39,6 +40,7 @@ public class TickServiceImpl implements TickService {
   private final MeterRegistry meterRegistry;
   private final ConflictTracker conflictTracker;
   private final GameInstanceRepository gameInstanceRepository;
+  private final LogOnlyProperties logOnlyProperties;
 
   @Value("${game.tick-duration-ms:1000}")
   private long tickDurationMs;
@@ -131,6 +133,12 @@ public class TickServiceImpl implements TickService {
   @Override
   @Timed(value = "gamesession.command.enqueue")
   public void enqueueCommand(Long sessionId, String command, boolean requiresSoloTick) {
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info(
+          "Log-only mode enabled; recording enqueue request for session {} command {}", sessionId, command);
+      return;
+    }
+
     Long tenantId = findTenantId(sessionId);
     String value = (requiresSoloTick ? "S|" : "N|") + command;
     redisTemplate.opsForList().rightPush(queueKey(tenantId, sessionId), value);
@@ -142,6 +150,11 @@ public class TickServiceImpl implements TickService {
   @Timed(value = "gamesession.tick.process")
   @Async("tickExecutor")
   public void processTick(Long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info("Log-only mode enabled; skipping tick processing for session {}", sessionId);
+      return;
+    }
+
     if (pauseRequested.get()) {
       logger.debug("Tick processing skipped while paused");
       return;
@@ -222,6 +235,11 @@ public class TickServiceImpl implements TickService {
   @Override
   @Timed(value = "gamesession.state.query")
   public String queryState(Long sessionId) {
+    if (logOnlyProperties.isLogOnly()) {
+      logger.info("Log-only mode enabled; returning empty state for session {}", sessionId);
+      return "{}";
+    }
+
     Long tenantId = findTenantId(sessionId);
     Object state = redisTemplate.opsForValue().get(stateKey(tenantId, sessionId));
     return state != null ? state.toString() : "{}";

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameInstanceServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.dto.GameInstanceDto;
 import net.firedevops.firemud.dto.StartSessionRequest;
 import net.firedevops.firemud.entity.GameInstance;
@@ -31,7 +32,15 @@ class GameInstanceServiceImplTest {
     meterRegistry = new SimpleMeterRegistry();
     service =
         new GameInstanceServiceImpl(
-            repository, mapper, stateService, null, null, null, null, meterRegistry);
+            repository,
+            mapper,
+            stateService,
+            null,
+            null,
+            null,
+            null,
+            meterRegistry,
+            new LogOnlyProperties(false));
   }
 
   @Test

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/IpConnectionLimiterImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/IpConnectionLimiterImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import net.firedevops.firemud.config.LogOnlyProperties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,8 @@ class IpConnectionLimiterImplTest {
         .when(redis)
         .delete(anyString());
 
-    IpConnectionLimiterImpl limiter = new IpConnectionLimiterImpl(redis, 1, 60);
+    IpConnectionLimiterImpl limiter =
+        new IpConnectionLimiterImpl(redis, 1, 60, new LogOnlyProperties(false));
     assertTrue(limiter.canAccept("1.2.3.4"));
     limiter.register("1.2.3.4", 1L);
     assertFalse(limiter.canAccept("1.2.3.4"));

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/SessionRateLimiterImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/SessionRateLimiterImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import net.firedevops.firemud.config.LogOnlyProperties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,8 @@ class SessionRateLimiterImplTest {
         .when(ops)
         .set(anyString(), anyString());
     doAnswer(inv -> true).when(redis).expire(anyString(), org.mockito.ArgumentMatchers.any());
-    SessionRateLimiterImpl limiter = new SessionRateLimiterImpl(redis, 2);
+    SessionRateLimiterImpl limiter =
+        new SessionRateLimiterImpl(redis, 2, new LogOnlyProperties(false));
     assertTrue(limiter.allow(1L));
     assertTrue(limiter.allow(1L));
     assertFalse(limiter.allow(1L));

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/TickServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
+import net.firedevops.firemud.config.LogOnlyProperties;
 import net.firedevops.firemud.service.TickService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,9 @@ class TickServiceImplTest {
     meterRegistry = new SimpleMeterRegistry();
     conflictTracker = mock(net.firedevops.firemud.common.conflict.ConflictTracker.class);
     repository = mock(net.firedevops.firemud.repository.GameInstanceRepository.class);
-    service = new TickServiceImpl(redisTemplate, meterRegistry, conflictTracker, repository);
+    service =
+        new TickServiceImpl(
+            redisTemplate, meterRegistry, conflictTracker, repository, new LogOnlyProperties(false));
     ((TickServiceImpl) service).init();
     var instance = new net.firedevops.firemud.entity.GameInstance();
     instance.setTenantId(1L);


### PR DESCRIPTION
## Summary
- align the game session bootRun default profile handling with the TCP proxy pattern and keep the log-only run task using dev profile
- inject the new LogOnlyProperties dependency in unit tests for rate limiting, ticks, and game instance services

## Testing
- `./gradlew :game-session-service:check --console=plain --no-daemon`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259da0c3088330bda93cb6309ad531)