### PR TITLE
Clean up MDC context in enqueue handler

### DIFF
--- a/services/game-session-service/src/main/java/net/firedevops/firemud/controller/CommandController.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/controller/CommandController.java
@@ -1,0 +1,32 @@
+package net.firedevops.firemud.controller;
+
+import jakarta.validation.Valid;
+import net.firedevops.firemud.common.ApiResponse;
+import net.firedevops.firemud.dto.CommandEnqueueResult;
+import net.firedevops.firemud.dto.EnqueueCommandRequest;
+import net.firedevops.firemud.service.CommandService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** REST shim for enqueuing player commands when forwarded via HTTP. */
+@RestController
+@RequestMapping("/sessions")
+public class CommandController {
+  private final CommandService commandService;
+
+  public CommandController(CommandService commandService) {
+    this.commandService = commandService;
+  }
+
+  @PostMapping("/{sessionId}/commands")
+  public ResponseEntity<ApiResponse<CommandEnqueueResult>> enqueueCommand(
+      @PathVariable String sessionId, @Valid @RequestBody EnqueueCommandRequest request) {
+    CommandEnqueueResult result =
+        commandService.enqueue(sessionId, request.command(), request.requiresSoloTick());
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/CommandEnqueueResult.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/CommandEnqueueResult.java
@@ -1,0 +1,16 @@
+package net.firedevops.firemud.dto;
+
+/** Result of attempting to enqueue a command. */
+public record CommandEnqueueResult(boolean accepted, String errorCode, String errorMessage) {
+  public static CommandEnqueueResult success() {
+    return new CommandEnqueueResult(true, null, null);
+  }
+
+  public static CommandEnqueueResult failure(String errorCode, String errorMessage) {
+    return new CommandEnqueueResult(false, errorCode, errorMessage);
+  }
+
+  public boolean hasError() {
+    return errorCode != null;
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/dto/EnqueueCommandRequest.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/dto/EnqueueCommandRequest.java
@@ -1,0 +1,6 @@
+package net.firedevops.firemud.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Request payload for enqueuing a command via REST. */
+public record EnqueueCommandRequest(@NotBlank String command, boolean requiresSoloTick) {}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/CommandService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/CommandService.java
@@ -1,0 +1,8 @@
+package net.firedevops.firemud.service;
+
+import net.firedevops.firemud.dto.CommandEnqueueResult;
+
+/** Handles player command enqueue requests across transports. */
+public interface CommandService {
+  CommandEnqueueResult enqueue(String sessionId, String command, boolean requiresSoloTick);
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/CommandServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/CommandServiceImpl.java
@@ -1,0 +1,97 @@
+package net.firedevops.firemud.service.impl;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.opentelemetry.api.trace.Span;
+import net.firedevops.firemud.common.LoggingUtil;
+import net.firedevops.firemud.config.LogOnlyProperties;
+import net.firedevops.firemud.dto.CommandEnqueueResult;
+import net.firedevops.firemud.entity.GameInstance;
+import net.firedevops.firemud.repository.GameInstanceRepository;
+import net.firedevops.firemud.service.CommandService;
+import net.firedevops.firemud.service.SessionRateLimiter;
+import net.firedevops.firemud.service.TickService;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Service;
+
+/** Default implementation of {@link CommandService}. */
+@Service
+public class CommandServiceImpl implements CommandService {
+  private static final Logger logger = LoggingUtil.getLogger(CommandServiceImpl.class);
+
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Injected dependencies are internal")
+  private final TickService tickService;
+
+  private final SessionRateLimiter sessionRateLimiter;
+  private final LogOnlyProperties logOnlyProperties;
+  private final GameInstanceRepository gameInstanceRepository;
+
+  public CommandServiceImpl(
+      TickService tickService,
+      SessionRateLimiter sessionRateLimiter,
+      LogOnlyProperties logOnlyProperties,
+      GameInstanceRepository gameInstanceRepository) {
+    this.tickService = tickService;
+    this.sessionRateLimiter = sessionRateLimiter;
+    this.logOnlyProperties = logOnlyProperties;
+    this.gameInstanceRepository = gameInstanceRepository;
+  }
+
+  @Override
+  public CommandEnqueueResult enqueue(String sessionIdText, String command, boolean requiresSoloTick) {
+    String traceId = Span.current().getSpanContext().getTraceId();
+    String tenantContext = resolveTenantContext(sessionIdText);
+    try (MDC.MDCCloseable trace = MDC.putCloseable("traceId", traceId);
+        MDC.MDCCloseable tenant = MDC.putCloseable("tenantId", tenantContext)) {
+      logger.info(
+          "Enqueue request traceId={} tenantId={} sessionId={} command={}",
+          traceId,
+          tenantContext,
+          sessionIdText,
+          command);
+
+      if (logOnlyProperties.isLogOnly()) {
+        logger.info(
+            "Log-only mode enabled; acknowledging enqueue for session {} command {}",
+            sessionIdText,
+            command);
+        return CommandEnqueueResult.success();
+      }
+
+      if (command == null || command.isBlank()) {
+        return CommandEnqueueResult.failure("INVALID_ARGUMENT", "Command cannot be blank");
+      }
+
+      long sessionId;
+      try {
+        sessionId = Long.parseLong(sessionIdText);
+      } catch (NumberFormatException ex) {
+        return CommandEnqueueResult.failure("INVALID_ARGUMENT", "sessionId must be numeric");
+      }
+
+      if (!sessionRateLimiter.allow(sessionId)) {
+        return CommandEnqueueResult.failure("RATE_LIMIT", "Command rate limit exceeded");
+      }
+
+      try {
+        tickService.enqueueCommand(sessionId, command, requiresSoloTick);
+        return CommandEnqueueResult.success();
+      } catch (IllegalArgumentException ex) {
+        return CommandEnqueueResult.failure("INVALID_ARGUMENT", ex.getMessage());
+      }
+    }
+  }
+
+  private String resolveTenantContext(String sessionIdText) {
+    try {
+      long sessionId = Long.parseLong(sessionIdText);
+      return gameInstanceRepository
+          .findById(sessionId)
+          .map(GameInstance::getTenantId)
+          .map(String::valueOf)
+          .orElse("unknown");
+    } catch (NumberFormatException ex) {
+      return "unknown";
+    }
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -27,11 +27,11 @@ import net.firedevops.firemud.gamesession.v1.StopSessionResponse;
 import net.firedevops.firemud.gamesession.v1.TickStatus;
 import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagRequest;
 import net.firedevops.firemud.gamesession.v1.ToggleFeatureFlagResponse;
+import net.firedevops.firemud.service.CommandService;
 import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import net.firedevops.firemud.service.PingService;
-import net.firedevops.firemud.service.SessionRateLimiter;
 import net.firedevops.firemud.service.TickService;
 import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.lognet.springboot.grpc.GRpcService;
@@ -43,6 +43,7 @@ public final class GameSessionGrpcService
   private final PingService pingService;
   private final GameInstanceService gameInstanceService;
   private final FeatureFlagService featureFlagService;
+  private final CommandService commandService;
 
   @SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
@@ -55,23 +56,22 @@ public final class GameSessionGrpcService
   private final MeterRegistry meterRegistry;
 
   private final IpConnectionLimiter ipConnectionLimiter;
-  private final SessionRateLimiter sessionRateLimiter;
 
   public GameSessionGrpcService(
       PingService pingService,
       GameInstanceService gameInstanceService,
       FeatureFlagService featureFlagService,
+      CommandService commandService,
       TickService tickService,
       MeterRegistry meterRegistry,
-      IpConnectionLimiter ipConnectionLimiter,
-      SessionRateLimiter sessionRateLimiter) {
+      IpConnectionLimiter ipConnectionLimiter) {
     this.pingService = pingService;
     this.gameInstanceService = gameInstanceService;
     this.featureFlagService = featureFlagService;
+    this.commandService = commandService;
     this.tickService = tickService;
     this.meterRegistry = meterRegistry;
     this.ipConnectionLimiter = ipConnectionLimiter;
-    this.sessionRateLimiter = sessionRateLimiter;
   }
 
   private ErrorDetail error(String code, String message) {
@@ -175,32 +175,16 @@ public final class GameSessionGrpcService
   @Timed(value = "gamesessionGrpc.enqueueCommand")
   public void enqueueCommand(
       EnqueueCommandRequest request, StreamObserver<EnqueueCommandResponse> responseObserver) {
-    try {
-      long sessionId = Long.parseLong(request.getSessionId());
-      if (!sessionRateLimiter.allow(sessionId)) {
-        EnqueueCommandResponse response =
-            EnqueueCommandResponse.newBuilder()
-                .setAccepted(false)
-                .setError(error("RATE_LIMIT", "Command rate limit exceeded"))
-                .build();
-        responseObserver.onNext(response);
-        responseObserver.onCompleted();
-        return;
-      }
-      tickService.enqueueCommand(sessionId, request.getCommand(), request.getRequiresSoloTick());
-      EnqueueCommandResponse response =
-          EnqueueCommandResponse.newBuilder().setAccepted(true).build();
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (IllegalArgumentException ex) {
-      EnqueueCommandResponse response =
-          EnqueueCommandResponse.newBuilder()
-              .setAccepted(false)
-              .setError(error("INVALID_ARGUMENT", ex.getMessage()))
-              .build();
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
+    var result =
+        commandService.enqueue(
+            request.getSessionId(), request.getCommand(), request.getRequiresSoloTick());
+    EnqueueCommandResponse.Builder builder =
+        EnqueueCommandResponse.newBuilder().setAccepted(result.accepted());
+    if (result.hasError()) {
+      builder.setError(error(result.errorCode(), result.errorMessage()));
     }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
   }
 
   @Override

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/CommandServiceImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/CommandServiceImplTest.java
@@ -1,0 +1,69 @@
+package net.firedevops.firemud.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import net.firedevops.firemud.config.LogOnlyProperties;
+import net.firedevops.firemud.dto.CommandEnqueueResult;
+import net.firedevops.firemud.entity.GameInstance;
+import net.firedevops.firemud.repository.GameInstanceRepository;
+import net.firedevops.firemud.service.SessionRateLimiter;
+import net.firedevops.firemud.service.TickService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class CommandServiceImplTest {
+  @Test
+  void logOnlyAcknowledgesCommands() {
+    TickService tickService = Mockito.mock(TickService.class);
+    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
+    GameInstanceRepository repository = Mockito.mock(GameInstanceRepository.class);
+    CommandServiceImpl service =
+        new CommandServiceImpl(tickService, rateLimiter, new LogOnlyProperties(true), repository);
+
+    CommandEnqueueResult result = service.enqueue("non-numeric", "look", false);
+
+    assertTrue(result.accepted());
+    verify(rateLimiter, never()).allow(Mockito.anyLong());
+    verify(tickService, never()).enqueueCommand(Mockito.anyLong(), Mockito.anyString(), Mockito.anyBoolean());
+  }
+
+  @Test
+  void rateLimitFailurePropagatesError() {
+    TickService tickService = Mockito.mock(TickService.class);
+    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
+    Mockito.when(rateLimiter.allow(5L)).thenReturn(false);
+    GameInstanceRepository repository = Mockito.mock(GameInstanceRepository.class);
+    CommandServiceImpl service =
+        new CommandServiceImpl(tickService, rateLimiter, new LogOnlyProperties(false), repository);
+
+    CommandEnqueueResult result = service.enqueue("5", "look", false);
+
+    assertTrue(result.hasError());
+    assertEquals("RATE_LIMIT", result.errorCode());
+    verify(tickService, never()).enqueueCommand(Mockito.anyLong(), Mockito.anyString(), Mockito.anyBoolean());
+  }
+
+  @Test
+  void enqueuePassesThroughWhenAllowed() {
+    TickService tickService = Mockito.mock(TickService.class);
+    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
+    Mockito.when(rateLimiter.allow(7L)).thenReturn(true);
+    GameInstance instance = new GameInstance();
+    instance.setTenantId(9L);
+    GameInstanceRepository repository = Mockito.mock(GameInstanceRepository.class);
+    Mockito.when(repository.findById(7L)).thenReturn(Optional.of(instance));
+    CommandServiceImpl service =
+        new CommandServiceImpl(tickService, rateLimiter, new LogOnlyProperties(false), repository);
+
+    CommandEnqueueResult result = service.enqueue("7", "look", true);
+
+    assertTrue(result.accepted());
+    verify(rateLimiter).allow(7L);
+    verify(tickService, times(1)).enqueueCommand(7L, "look", true);
+  }
+}

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
@@ -18,11 +18,11 @@ import net.firedevops.firemud.gamesession.v1.ResumeTicksResponse;
 import net.firedevops.firemud.gamesession.v1.StartSessionRequest;
 import net.firedevops.firemud.gamesession.v1.StartSessionResponse;
 import net.firedevops.firemud.gamesession.v1.TickStatus;
+import net.firedevops.firemud.service.CommandService;
 import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import net.firedevops.firemud.service.PingService;
-import net.firedevops.firemud.service.SessionRateLimiter;
 import net.firedevops.firemud.service.TickService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,9 +34,9 @@ class GameSessionGrpcServiceTest {
     Mockito.when(pingService.ping()).thenReturn("pong");
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    CommandService commandService = Mockito.mock(CommandService.class);
     TickService tickService = Mockito.mock(TickService.class);
     IpConnectionLimiter ipLimiter = Mockito.mock(IpConnectionLimiter.class);
-    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
     Mockito.when(ipLimiter.canAccept(Mockito.anyString())).thenReturn(true);
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     GameSessionGrpcService service =
@@ -44,10 +44,10 @@ class GameSessionGrpcServiceTest {
             pingService,
             gameInstanceService,
             featureFlagService,
+            commandService,
             tickService,
             meterRegistry,
-            ipLimiter,
-            rateLimiter);
+            ipLimiter);
 
     AtomicReference<PingResponse> ref = new AtomicReference<>();
     service.ping(
@@ -75,9 +75,9 @@ class GameSessionGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    CommandService commandService = Mockito.mock(CommandService.class);
     TickService tickService = Mockito.mock(TickService.class);
     IpConnectionLimiter ipLimiter = Mockito.mock(IpConnectionLimiter.class);
-    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
     Mockito.when(ipLimiter.canAccept(Mockito.anyString())).thenReturn(true);
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     Mockito.when(
@@ -89,10 +89,10 @@ class GameSessionGrpcServiceTest {
             pingService,
             gameInstanceService,
             featureFlagService,
+            commandService,
             tickService,
             meterRegistry,
-            ipLimiter,
-            rateLimiter);
+            ipLimiter);
 
     AtomicReference<StartSessionResponse> ref = new AtomicReference<>();
     service.startSession(
@@ -125,9 +125,9 @@ class GameSessionGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    CommandService commandService = Mockito.mock(CommandService.class);
     TickService tickService = Mockito.mock(TickService.class);
     IpConnectionLimiter ipLimiter = Mockito.mock(IpConnectionLimiter.class);
-    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
     Mockito.when(ipLimiter.canAccept(Mockito.anyString())).thenReturn(true);
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     GameSessionGrpcService service =
@@ -135,10 +135,10 @@ class GameSessionGrpcServiceTest {
             pingService,
             gameInstanceService,
             featureFlagService,
+            commandService,
             tickService,
             meterRegistry,
-            ipLimiter,
-            rateLimiter);
+            ipLimiter);
 
     service.pauseTicks(
         PauseTicksRequest.newBuilder().setReason("backup").build(),
@@ -202,9 +202,9 @@ class GameSessionGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    CommandService commandService = Mockito.mock(CommandService.class);
     TickService tickService = Mockito.mock(TickService.class);
     IpConnectionLimiter ipLimiter = Mockito.mock(IpConnectionLimiter.class);
-    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
     Mockito.when(ipLimiter.canAccept("1.2.3.4")).thenReturn(false);
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     GameSessionGrpcService service =
@@ -212,10 +212,10 @@ class GameSessionGrpcServiceTest {
             pingService,
             gameInstanceService,
             featureFlagService,
+            commandService,
             tickService,
             meterRegistry,
-            ipLimiter,
-            rateLimiter);
+            ipLimiter);
 
     AtomicReference<StartSessionResponse> ref = new AtomicReference<>();
     service.startSession(
@@ -247,21 +247,26 @@ class GameSessionGrpcServiceTest {
     PingService pingService = Mockito.mock(PingService.class);
     GameInstanceService gameInstanceService = Mockito.mock(GameInstanceService.class);
     FeatureFlagService featureFlagService = Mockito.mock(FeatureFlagService.class);
+    CommandService commandService = Mockito.mock(CommandService.class);
     TickService tickService = Mockito.mock(TickService.class);
     IpConnectionLimiter ipLimiter = Mockito.mock(IpConnectionLimiter.class);
-    SessionRateLimiter rateLimiter = Mockito.mock(SessionRateLimiter.class);
     Mockito.when(ipLimiter.canAccept(Mockito.anyString())).thenReturn(true);
-    Mockito.when(rateLimiter.allow(1L)).thenReturn(false);
+    Mockito.when(
+            commandService.enqueue(
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
+        .thenReturn(
+            net.firedevops.firemud.dto.CommandEnqueueResult.failure(
+                "RATE_LIMIT", "Command rate limit exceeded"));
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     GameSessionGrpcService service =
         new GameSessionGrpcService(
             pingService,
             gameInstanceService,
             featureFlagService,
+            commandService,
             tickService,
             meterRegistry,
-            ipLimiter,
-            rateLimiter);
+            ipLimiter);
 
     AtomicReference<net.firedevops.firemud.gamesession.v1.EnqueueCommandResponse> ref =
         new AtomicReference<>();


### PR DESCRIPTION
## Summary
- wrap enqueue command handling in MDC closeables so trace/tenant context is logged without leaking across requests
- keep log-only acknowledgements while preserving existing validation and enqueue behavior

## Testing
- `../../gradlew :game-session-service:test --console=plain --no-daemon --stacktrace --max-workers=1` *(hangs while calculating task graph; aborted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692629edf0b883309a15c7848dcbe035)