### PR TITLE
Refine TCP proxy log-only quickstart

### DIFF
--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -117,7 +117,7 @@ For a single-command smoke test, enable log-only forwarding with `TCP_PROXY_LOG_
 
 Prefer containers? A minimal Docker Compose profile launches just the gateway and the proxy with the same settings and emits the same log-only Telnet lines. Start it with `docker compose -f docker/docker-compose.tcp-proxy-logonly.yml --profile tcp-proxy-logonly up` and in another terminal run `telnet localhost 2323`. Stop the stack with `docker compose -f docker/docker-compose.tcp-proxy-logonly.yml --profile tcp-proxy-logonly down` when finished.
 
-When pointing at a real gateway, override `GATEWAY_WS_URL` with its WebSocket endpoint. Outside of the `dev` profile the default remains `ws://spring-cloud-gateway:8080/ws` so production pods continue to forward to the cluster gateway when the variable is unset.
+When pointing at a real gateway, override `GATEWAY_WS_URL` with its WebSocket endpoint. Outside of the `dev` profile the default remains `ws://spring-cloud-gateway:8080/ws/game` so production pods continue to forward to the routed gameplay endpoint on the cluster gateway when the variable is unset.
 
 ## Environment Variables
 
@@ -132,7 +132,7 @@ Additional variables control the proxy runtime behaviour:
 | Variable | Purpose | Default |
 | -------- | ------- | ------- |
 | `TCP_PROXY_PORT` | TCP port the proxy listens on | `2323` |
-| `GATEWAY_WS_URL` | WebSocket URL for forwarding to the gateway | `ws://spring-cloud-gateway:8080/ws` |
+| `GATEWAY_WS_URL` | WebSocket URL for forwarding to the gateway | `ws://spring-cloud-gateway:8080/ws/game` |
 | `TCP_PROXY_TLS_ENABLED` | Enable Telnet-over-TLS termination | `false` |
 | `TCP_PROXY_TLS_CERT` | Path to the TLS certificate | *(empty)* |
 | `TCP_PROXY_TLS_KEY` | Path to the TLS private key | *(empty)* |

--- a/design/architecture/microservices/tcp-proxy-service/README.md
+++ b/design/architecture/microservices/tcp-proxy-service/README.md
@@ -109,6 +109,14 @@ Use the bundled `/dev/echo` WebSocket endpoint under the `dev` profile to valida
 5. Connect from a Telnet/MUD client: `telnet localhost 2323`.
 6. Type any text. The proxy logs the input at INFO and echoes the same text back over the Telnet session.
 
+For a single-command smoke test, enable log-only forwarding with `TCP_PROXY_LOG_ONLY=true` so no other services are required and send traffic through the built-in echo handler. The `bootRunLogOnly` Gradle tasks and the Docker Compose profile all use the same `TCP_PROXY_LOG_ONLY` flag so the proxy behaves consistently across local tooling.
+
+- Terminal 1 (gateway): `SPRING_PROFILES_ACTIVE=dev ./gradlew :spring-cloud-gateway:bootRun` (exposes `/dev/echo`).
+- Terminal 2 (proxy): `TCP_PROXY_LOG_ONLY=true GATEWAY_WS_URL=ws://localhost:8080/dev/echo ./gradlew :tcp-proxy-service:bootRun`.
+- Terminal 3 (verification): `telnet localhost 2323` and type a few commands. Watch the proxy logs for entries like `Received Telnet input: look` and `Received Telnet input: move north` without any attempts to connect to the gateway, demonstrating the log-only path.
+
+Prefer containers? A minimal Docker Compose profile launches just the gateway and the proxy with the same settings and emits the same log-only Telnet lines. Start it with `docker compose -f docker/docker-compose.tcp-proxy-logonly.yml --profile tcp-proxy-logonly up` and in another terminal run `telnet localhost 2323`. Stop the stack with `docker compose -f docker/docker-compose.tcp-proxy-logonly.yml --profile tcp-proxy-logonly down` when finished.
+
 When pointing at a real gateway, override `GATEWAY_WS_URL` with its WebSocket endpoint. Outside of the `dev` profile the default remains `ws://spring-cloud-gateway:8080/ws` so production pods continue to forward to the cluster gateway when the variable is unset.
 
 ## Environment Variables

--- a/docker/docker-compose.tcp-proxy-logonly.yml
+++ b/docker/docker-compose.tcp-proxy-logonly.yml
@@ -1,0 +1,23 @@
+services:
+  spring-cloud-gateway:
+    build: ../services/spring-cloud-gateway
+    profiles:
+      - tcp-proxy-logonly
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+    ports:
+      - "8080:8080"
+
+  tcp-proxy-service:
+    build: ../services/tcp-proxy-service
+    profiles:
+      - tcp-proxy-logonly
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      TCP_PROXY_LOG_ONLY: "true"
+      GATEWAY_WS_URL: ws://localhost:8080/dev/echo
+    ports:
+      - "2323:2323"
+    depends_on:
+      spring-cloud-gateway:
+        condition: service_started

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.register<BootRun>("bootRunLogOnly") {
     mainClass.set("net.firedevops.firemud.SpringCloudGatewayApplication")
     classpath = sourceSets.main.get().runtimeClasspath
     systemProperty("spring.profiles.active", "dev")
-    environment("GATEWAY_WS_LOG_ONLY", "true")
+    environment("TCP_PROXY_LOG_ONLY", "true")
 }
 
 

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -52,7 +52,7 @@ public final class TelnetServer {
 
   public TelnetServer(
       @Value("${TCP_PROXY_PORT:2323}") int port,
-      @Value("${GATEWAY_WS_URL:ws://spring-cloud-gateway:8080/ws}") String gatewayWsUrl,
+      @Value("${GATEWAY_WS_URL:ws://spring-cloud-gateway:8080/ws/game}") String gatewayWsUrl,
       @Value("${TCP_PROXY_TLS_ENABLED:false}") boolean tlsEnabled,
       @Value("${TCP_PROXY_LOG_ONLY:false}") boolean logOnly,
       @Value("${TCP_PROXY_TLS_CERT:}") String certPath,

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -52,7 +52,7 @@ public final class TelnetServer {
 
   public TelnetServer(
       @Value("${TCP_PROXY_PORT:2323}") int port,
-      @Value("${GATEWAY_WS_URL:ws://localhost:8080/dev/echo}") String gatewayWsUrl,
+      @Value("${GATEWAY_WS_URL:ws://spring-cloud-gateway:8080/ws}") String gatewayWsUrl,
       @Value("${TCP_PROXY_TLS_ENABLED:false}") boolean tlsEnabled,
       @Value("${TCP_PROXY_LOG_ONLY:false}") boolean logOnly,
       @Value("${TCP_PROXY_TLS_CERT:}") String certPath,

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -71,6 +71,41 @@ class TelnetServerHandlerTest {
   }
 
   @Test
+  void logOnlyModeSkipsGatewayConnection() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TelnetServerHandler.WebSocketConnector connector =
+        Mockito.mock(TelnetServerHandler.WebSocketConnector.class);
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            true,
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry.counter("discarded"),
+            false,
+            registry,
+            connector,
+            Mockito.mock(TcpProxyEventService.class));
+
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    DefaultEventExecutor executor = new DefaultEventExecutor();
+    when(ctx.channel()).thenReturn(channel);
+    when(ctx.executor()).thenReturn(executor);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 0));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "SESSION sess-1 tenant-1");
+    handler.channelRead0(ctx, "look");
+
+    verify(connector, never()).connect(anyString(), anyString(), anyString(), anyString(), any());
+    assertEquals(0, handler.getBufferedSize());
+
+    executor.shutdownGracefully();
+  }
+
+  @Test
   void bufferedInputFlushedOnWebSocketConnect() {
     SimpleMeterRegistry registry = new SimpleMeterRegistry();
     TelnetServerHandler handler =


### PR DESCRIPTION
## Summary
- align the proxy's default gateway WebSocket URL with the production gateway service while the dev profile keeps the /dev/echo override
- clarify the log-only smoke test steps and expected Telnet log lines while documenting the shared TCP_PROXY_LOG_ONLY flag across Gradle and Docker Compose flows

## Testing
- ./gradlew :tcp-proxy-service:test --tests "*TelnetServerHandlerTest" --console=plain --no-daemon

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926399cd1c48330890a323f19c072cd)