### PR TITLE
Fix markdown lint issues in docs

### DIFF
--- a/design/architecture/infrastructure/README.md
+++ b/design/architecture/infrastructure/README.md
@@ -6,19 +6,19 @@ This directory contains core documentation for the shared infrastructure that po
 
 ## 🔀 Core Infrastructure Docs
 
-| Document                          | Description                                                                 |
-|-----------------------------------|-----------------------------------------------------------------------------|
+| Document | Description |
+| --- | --- |
 | [System Architecture Overview](../system-architecture-overview.md) | High-level design with observability and service interactions. |
 | [System Architecture Diagram](../system-architecture-diagram.md) | Visual representation of component relationships and client flows. |
 | [System Context Diagram](../system-context-diagram.md) | Shows clients, DMZ components, internal services, and datastores. |
-| [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups.   |
+| [Deployment Environments](./deployment-environments.md) | Describes how Docker Compose and Kubernetes are used in dev/prod setups. |
 | [Environment & Secrets Management](./environment-and-secrets.md) | How services receive configuration values and handle sensitive data. |
-| [Gateway Architecture](../system-architecture-gateway.md)       | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
-| [Protocol Bridging](../system-architecture-protocol-bridging.md)             | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
+| [Gateway Architecture](../system-architecture-gateway.md) | Details on Spring Cloud Gateway routing, WebSocket support, and service access. |
+| [Protocol Bridging](../system-architecture-protocol-bridging.md) | Explains how FireMUD supports both WebSocket and Telnet clients through a unified backend. |
 | [gRPC API Style & Versioning Guidelines](../system-architecture-grpc.md) | Conventions for service APIs. |
-| [Redis Architecture](../system-architecture-redis.md)   | Describes where Redis is deployed and how session state is stored. |
+| [Redis Architecture](../system-architecture-redis.md) | Describes where Redis is deployed and how session state is stored. |
 | [Security Architecture](../system-architecture-security.md) | TLS termination, mTLS usage, and network policy overview. |
-| [CI/CD Pipeline](../system-architecture-cicd.md)        | Overview of GitHub Actions workflows for building, testing, and deployment. |
+| [CI/CD Pipeline](../system-architecture-cicd.md) | Overview of GitHub Actions workflows for building, testing, and deployment. |
 | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | Snapshot schedules and restore workflow. |
 
 ---

--- a/design/architecture/infrastructure/schedule.md
+++ b/design/architecture/infrastructure/schedule.md
@@ -5,7 +5,7 @@ This document lists automated jobs that run on a schedule. Each entry links to t
 ## GitHub CI
 
 | Scheduled Item | Frequency (UTC) | Documentation | Configuration |
-|----------------|-----------------|---------------|---------------|
+| --- | --- | --- | --- |
 | CI — Build and Security | Daily at 03:00 | [CI/CD Pipeline](../system-architecture-cicd.md) | [.github/workflows/ci.yml](../../../.github/workflows/ci.yml) |
 | CodeQL Analysis | Weekly on Sundays at 00:00 | [CI/CD Pipeline](../system-architecture-cicd.md) | [.github/workflows/codeql.yml](../../../.github/workflows/codeql.yml) |
 | Weekly Security Scan | Weekly on Sundays at 03:00 | [CI/CD Pipeline](../system-architecture-cicd.md) | [.github/workflows/weekly-security-scan.yml](../../../.github/workflows/weekly-security-scan.yml) |
@@ -14,7 +14,7 @@ This document lists automated jobs that run on a schedule. Each entry links to t
 ## Kubernetes Cluster
 
 | Scheduled Item | Frequency (UTC) | Documentation | Configuration |
-|----------------|-----------------|---------------|---------------|
+| --- | --- | --- | --- |
 | PostgreSQL pg_dump | Every 15 minutes | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/postgres/pg-dump-cronjob.yaml](../../../k8s/postgres/pg-dump-cronjob.yaml) |
 | Velero backup verification | Daily at 04:00 | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/velero/verify-backups-cronjob.yaml](../../../k8s/velero/verify-backups-cronjob.yaml) |
 | Velero manifest backups | Every 15 minutes, weekly on Sundays at 02:00, monthly on the 1st at 03:00 | [Backup & Disaster Recovery](../system-architecture-backup-recovery.md) | [k8s/velero/schedule.yaml](../../../k8s/velero/schedule.yaml) |

--- a/design/architecture/microservices/README.md
+++ b/design/architecture/microservices/README.md
@@ -7,19 +7,19 @@ This directory contains detailed design documents for each core microservice in 
 ## 🧩 Core Microservices
 
 | Microservice | Purpose |
-|-------------|---------|
-| [Account Service](./account-service/)                    | Manages user accounts, authentication, profiles, and sessions. |
+| --- | --- |
+| [Account Service](./account-service/) | Manages user accounts, authentication, profiles, and sessions. |
 | [Automation & Scripting Service](./automation-scripting-service/) | Handles AI behaviors, event scripting, and dynamic interactions. |
 | [Entity Management Service](./entity-management-service/) | Controls player characters, NPCs, items, and inventory management. |
-| [Game Design Service](./game-design-service/)            | Provides tools for designing worlds, actions, items, and game events. |
-| [Game Logic Service](./game-logic-service/)              | Implements core gameplay mechanics, command parsing, and actions. |
-| [Game Session Service](./game-session-service/)          | Orchestrates live gameplay sessions and tick execution. |
-| [Logging & Admin Service](./logging-admin-service/)      | Provides centralized logging, analytics, and administration tools. |
-| [Social & Groups Service](./social-groups-service/)      | Manages chat, guilds, and cross-game social networking features. |
-| [Spring Cloud Gateway](./spring-cloud-gateway/)          | Routes WebSocket and HTTP traffic to backend services. |
-| [TCP Proxy Service](./tcp-proxy-service/)                | Bridges Telnet clients into the WebSocket-based backend. |
-| [World Management Service](./world-management-service/)  | Handles world maps, regions, pathfinding data, and procedural generation. |
-| [Service Template](./service-template.md)                | Template for creating new microservice docs. |
+| [Game Design Service](./game-design-service/) | Provides tools for designing worlds, actions, items, and game events. |
+| [Game Logic Service](./game-logic-service/) | Implements core gameplay mechanics, command parsing, and actions. |
+| [Game Session Service](./game-session-service/) | Orchestrates live gameplay sessions and tick execution. |
+| [Logging & Admin Service](./logging-admin-service/) | Provides centralized logging, analytics, and administration tools. |
+| [Social & Groups Service](./social-groups-service/) | Manages chat, guilds, and cross-game social networking features. |
+| [Spring Cloud Gateway](./spring-cloud-gateway/) | Routes WebSocket and HTTP traffic to backend services. |
+| [TCP Proxy Service](./tcp-proxy-service/) | Bridges Telnet clients into the WebSocket-based backend. |
+| [World Management Service](./world-management-service/) | Handles world maps, regions, pathfinding data, and procedural generation. |
+| [Service Template](./service-template.md) | Template for creating new microservice docs. |
 
 All services share the same cluster and databases. Each table stores a `tenantId` and Redis keys use a matching prefix so data stays isolated between games. See [Multi-Tenancy](../system-architecture-multi-tenancy.md) for details.
 

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -92,8 +92,8 @@ resolved during authentication.
 ### REST APIs
 
 | Method | Path | Description |
-| ------ | ---- | ----------- |
-| `GET`  | `/ping` | Simple health check |
+| --- | --- | --- |
+| `GET` | `/ping` | Simple health check |
 | `POST` | `/auth/login` | Authenticate and establish a session; JWT is kept server-side |
 | `POST` | `/auth/request-password-reset` | Request password reset |
 | `POST` | `/auth/complete-password-reset` | Complete password reset |
@@ -101,12 +101,12 @@ resolved during authentication.
 | `POST` | `/auth/verify-email` | Verify email token |
 | `POST` | `/auth/recover-username` | Send username reminder |
 | `POST` | `/accounts` | Create a new user account |
-| `GET`  | `/accounts/{accountId}/export` | Export account data |
+| `GET` | `/accounts/{accountId}/export` | Export account data |
 | `DELETE` | `/accounts/{accountId}` | Delete an account |
 | `POST` | `/accounts/{accountId}/external` | Link external account |
-| `GET`  | `/profiles/{accountId}` | Retrieve profile information |
-| `PUT`  | `/profiles/{accountId}` | Update profile information |
-| `GET`  | `/.well-known/jwks.json` | JWKS for verifying issued JWTs |
+| `GET` | `/profiles/{accountId}` | Retrieve profile information |
+| `PUT` | `/profiles/{accountId}` | Update profile information |
+| `GET` | `/.well-known/jwks.json` | JWKS for verifying issued JWTs |
 
 ## Dependencies
 

--- a/design/architecture/microservices/service-template.md
+++ b/design/architecture/microservices/service-template.md
@@ -30,8 +30,8 @@
 ### REST APIs
 
 | Method | Path | Description |
-| ------ | ---- | ----------- |
-| `GET`  | `/ping` | Health check |
+| --- | --- | --- |
+| `GET` | `/ping` | Health check |
 
 ## Dependencies
 

--- a/design/architecture/service-responsibility-matrix.md
+++ b/design/architecture/service-responsibility-matrix.md
@@ -1,47 +1,47 @@
 # 🧭 Microservices Responsibility Matrix
 
-| Function                                      | Game Design Service | World Management Service | Account Service | Game Session Service | Entity Management Service | Game Logic Service | Automation & Scripting Service | Social & Groups Service | Logging & Admin Service | TCP Proxy Service | Spring Cloud Gateway |
-|-----------------------------------------------|---------------------|--------------------------|-----------------|----------------------|---------------------------|--------------------|--------------------------------|---------------------------|-------------------------|-------------------|----------------------|
-| Game configuration authoring                  | ✔                   |                          |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Custom in-game scripting authoring            | ✔                   |                          |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Game version publishing                       | ✔                   |                          |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Design-time feature flag definitions | ✔                   |                          |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Room and zone editing                         |                     | ✔                        |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| World map region layout                       |                     | ✔                        |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Room state persistence                        |                     | ✔                        |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Pathfinding algorithms and navmesh data       |                     | ✔                        |                 |                      |                           |                    |                                |                           |                         |                   |                      |
-| Account authentication, credential verification, and JWT issuance (JWKS) |                     |                          | ✔               |          |                           |                    |                                |                           |                  |                   |                      |
-| Gameplay login command handling and session binding (Redis) |                     |                          |                 | ✔         |                           |                    |                                |                           |                  |                   |                      |
-| Email and system notifications                |                     |                          | ✔               |                      |                           |                    |                                |                           |                         |                   |                      |
-| Payment, subscriptions, and bans              |                     |                          | ✔               |                      |                           |                    |                                |                           |                         |                   |                      |
-| WebSocket connection/session lifecycle        |                     |                          |                | ✔                    |                           |                    |                               |                           |                         |                   |                       |
-| Reconnection handling (resume gameplay)       |                     |                          |                | ✔                    |                           |                    |                               |                           |                         |                   |                       |
-| Command queuing and dispatch                  |                     |                          |                | ✔                    |                           |                    |                               |                           |                         |                   |                       |
-| Session state storage (volatile, Redis)       |                     |                          |                | ✔                    |                           |                    |                               |                           |                         |                   |                       |
-| Game version activation at runtime            |                     |                          |                | ✔                    |                           |                    |                               |                           |                         |                   |                       |
-| Runtime feature flag overrides                |                     |                          |                | ✔                    |                           |                    |                               |                           |                         |                   |                       |
-| Entity definition and persistence             |                     |                          |                |                      | ✔                         |                    |                               |                           |                         |                   |                       |
-| NPC state, inventory, and stats               |                     |                          |                |                      | ✔                         |                    |                               |                           |                         |                   |                       |
-| Player inventory and stats                    |                     |                          |                |                      | ✔                         |                    |                               |                           |                         |                   |                       |
-| Item definitions and crafting data            |                     |                          |                |                      | ✔                         |                    |                               |                           |                         |                   |                       |
-| Game mechanics and combat resolution          |                     |                          |                |                      |                           | ✔                  |                               |                           |                         |                   |                       |
-| Command parsing and alias resolution          |                     |                          |                |                      |                           | ✔                  |                               |                           |                         |                   |                       |
-| Action execution (movement, attack, etc.)     |                     |                          |                |                      |                           | ✔                  |                               |                           |                         |                   |                       |
-| Progression logic (XP, levels, effects)       |                     |                          |                |                      |                           | ✔                  |                               |                           |                         |                   |                       |
-| Environmental effects (weather, etc.)         |                     |                          |                |                      |                           | ✔                  |                               |                           |                         |                   |                       |
-| Economy logic (trading, shops, pricing)       |                     |                          |                |                      |                           | ✔                  |                               |                           |                         |                   |                       |
-| AI-driven actions and behaviors               |                     |                          |                |                      |                           |                    | ✔                             |                           |                         |                   |                       |
-| Triggered script execution                    |                     |                          |                |                      |                           |                    | ✔                             |                           |                         |                   |                       |
-| Chat and private messaging                    |                     |                          |                |                      |                           |                    |                               | ✔                         |                         |                   |                       |
-| Guilds and group discovery                    |                     |                          |                |                      |                           |                    |                               | ✔                         |                         |                   |                       |
-| Social network graph (friends/blocks/etc.)    |                     |                          |                |                      |                           |                    |                               | ✔                         |                         |                   |                       |
-| Logging and metrics collection                |                     |                          |                |                      |                           |                    |                               |                           | ✔                       |                   |                       |
-| Admin panel and feature flag toggling         |                     |                          |                |                      |                           |                    |                               |                           | ✔                       |                   |                       |
-| Game moderation tools                         |                     |                          |                |                      |                           |                    |                               |                           | ✔                       |                   |                       |
-| Game moderation policy definition             |                     |                          |                |                      |                           |                    |                               |                           | ✔                       |                   |                       |
-| TCP/Telnet socket handling                    |                     |                          |                |                      |                           |                    |                               |                           |                         | ✔                 |                       |
-| Telnet → WebSocket bridging                   |                     |                          |                |                      |                           |                    |                               |                           |                         | ✔                 |                       |
-| WebSocket upgrade, routing, and auth gateway  |                     |                          |                |                      |                           |                    |                               |                           |                         |                   | ✔                     |
+| Function | Game Design Service | World Management Service | Account Service | Game Session Service | Entity Management Service | Game Logic Service | Automation & Scripting Service | Social & Groups Service | Logging & Admin Service | TCP Proxy Service | Spring Cloud Gateway |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Game configuration authoring | ✔ | | | | | | | | | | |
+| Custom in-game scripting authoring | ✔ | | | | | | | | | | |
+| Game version publishing | ✔ | | | | | | | | | | |
+| Design-time feature flag definitions | ✔ | | | | | | | | | | |
+| Room and zone editing | | ✔ | | | | | | | | | |
+| World map region layout | | ✔ | | | | | | | | | |
+| Room state persistence | | ✔ | | | | | | | | | |
+| Pathfinding algorithms and navmesh data | | ✔ | | | | | | | | | |
+| Account authentication, credential verification, and JWT issuance (JWKS) | | | ✔ | | | | | | | | |
+| Gameplay login command handling and session binding (Redis) | | | | ✔ | | | | | | | |
+| Email and system notifications | | | ✔ | | | | | | | | |
+| Payment, subscriptions, and bans | | | ✔ | | | | | | | | |
+| WebSocket connection/session lifecycle | | | | ✔ | | | | | | | |
+| Reconnection handling (resume gameplay) | | | | ✔ | | | | | | | |
+| Command queuing and dispatch | | | | ✔ | | | | | | | |
+| Session state storage (volatile, Redis) | | | | ✔ | | | | | | | |
+| Game version activation at runtime | | | | ✔ | | | | | | | |
+| Runtime feature flag overrides | | | | ✔ | | | | | | | |
+| Entity definition and persistence | | | | | ✔ | | | | | | |
+| NPC state, inventory, and stats | | | | | ✔ | | | | | | |
+| Player inventory and stats | | | | | ✔ | | | | | | |
+| Item definitions and crafting data | | | | | ✔ | | | | | | |
+| Game mechanics and combat resolution | | | | | | ✔ | | | | | |
+| Command parsing and alias resolution | | | | | | ✔ | | | | | |
+| Action execution (movement, attack, etc.) | | | | | | ✔ | | | | | |
+| Progression logic (XP, levels, effects) | | | | | | ✔ | | | | | |
+| Environmental effects (weather, etc.) | | | | | | ✔ | | | | | |
+| Economy logic (trading, shops, pricing) | | | | | | ✔ | | | | | |
+| AI-driven actions and behaviors | | | | | | | ✔ | | | | |
+| Triggered script execution | | | | | | | ✔ | | | | |
+| Chat and private messaging | | | | | | | | ✔ | | | |
+| Guilds and group discovery | | | | | | | | ✔ | | | |
+| Social network graph (friends/blocks/etc.) | | | | | | | | ✔ | | | |
+| Logging and metrics collection | | | | | | | | | ✔ | | |
+| Admin panel and feature flag toggling | | | | | | | | | ✔ | | |
+| Game moderation tools | | | | | | | | | ✔ | | |
+| Game moderation policy definition | | | | | | | | | ✔ | | |
+| TCP/Telnet socket handling | | | | | | | | | | ✔ | |
+| Telnet → WebSocket bridging | | | | | | | | | | ✔ | |
+| WebSocket upgrade, routing, and auth gateway | | | | | | | | | | | ✔ |
 
 ## 📚 Related Documentation
 

--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -7,7 +7,7 @@ session state is managed server-side in Redis and restored via the Game Session
 Service. The service delegates credential verification to the Account Service's `/auth/login` endpoint. Accounts may also authenticate
 using linked external providers such as Google, Discord, or Steam.
 
-**Responsibility split**
+## Responsibility Split
 
 - **Account Service** – Verifies credentials (including OTP), issues JWTs, and publishes JWKS for validation.
 - **Game Session Service** – Fronts the `LOGIN` command, stores session context in Redis, and rebinds sockets on reconnect.
@@ -74,10 +74,10 @@ tokens without validating them, and the Game Session Service forwards tokens on 
 
 ### 🧠 Claims
 
-| Field         | Description                                                             |
-|---------------|-------------------------------------------------------------------------|
-| `accountId`   | Identity of the authenticated account                                   |
-| `globalRoles` | Cross-game privileges (e.g., `platformAdmin`, `moderator`)              |
+| Field | Description |
+| --- | --- |
+| `accountId` | Identity of the authenticated account |
+| `globalRoles` | Cross-game privileges (e.g., `platformAdmin`, `moderator`) |
 | `scopedRoles` | Map of `tenantId` → roles (e.g., `"tenant-abc": ["admin", "designer"]`) |
 
 ### 🧾 Example JWT Payload
@@ -97,10 +97,10 @@ tokens without validating them, and the Game Session Service forwards tokens on 
 
 Access to services is governed by roles from the JWT:
 
-| Context        | Description                                                         |
-|----------------|---------------------------------------------------------------------|
-| `globalRoles`  | Platform-wide access (e.g., moderation, admin dashboards)           |
-| `scopedRoles`  | Per-game access (e.g., designer tools, admin features for a game)   |
+| Context | Description |
+| --- | --- |
+| `globalRoles` | Platform-wide access (e.g., moderation, admin dashboards) |
+| `scopedRoles` | Per-game access (e.g., designer tools, admin features for a game) |
 
 ### JWT Usage Scope
 
@@ -149,18 +149,18 @@ occurs automatically during role updates.
 
 ## ✅ Summary
 
-| Topic                 | Description                                                      |
-|-----------------------|------------------------------------------------------------------|
-| Auth Command          | `LOGIN` (or `LOGON`) — supports prompt or argument input |
-| JWT Usage             | Internal-only for backend gRPC auth                             |
-| Claims                | `accountId`, `globalRoles[]`, `scopedRoles{}` |
-| Session State         | Stored in Redis; bound to socket by Game Session Service |
-| Session TTL           | Controlled by `FIREMUD_AUTH_SESSION_EXPIRATION_MS`             |
-| Reauthentication      | Required after disconnect; resumes via Redis if valid |
-| Role Enforcement      | Meta/control services only; gameplay services trust Game Session Service |
-| Role Updates          | Refreshed in-session; no client interaction needed |
+| Topic | Description |
+| --- | --- |
+| Auth Command | `LOGIN` (or `LOGON`) — supports prompt or argument input |
+| JWT Usage | Internal-only for backend gRPC auth |
+| Claims | `accountId`, `globalRoles[]`, `scopedRoles{}` |
+| Session State | Stored in Redis; bound to socket by Game Session Service |
+| Session TTL | Controlled by `FIREMUD_AUTH_SESSION_EXPIRATION_MS` |
+| Reauthentication | Required after disconnect; resumes via Redis if valid |
+| Role Enforcement | Meta/control services only; gameplay services trust Game Session Service |
+| Role Updates | Refreshed in-session; no client interaction needed |
 | Multi-Client Behavior | One session per character; new login replaces old session |
-| Two-Factor Auth       | Optional TOTP for admin and moderator accounts via `/auth/login` |
+| Two-Factor Auth | Optional TOTP for admin and moderator accounts via `/auth/login` |
 
 ---
 

--- a/design/architecture/system-architecture-backup-recovery.md
+++ b/design/architecture/system-architecture-backup-recovery.md
@@ -131,9 +131,9 @@ Because Redis is not a source of truth, this strategy guarantees a clean, determ
 
 ## 🔄 Restore Workflow Summary
 
-| Environment      | Steps |
-|------------------|-------------------------------------------------------------|
-| **Kubernetes**   | Restore PostgreSQL from `pg_dump` → restore other resources with Velero → restart pods → allow Redis to repopulate |
+| Environment | Steps |
+| --- | --- |
+| **Kubernetes** | Restore PostgreSQL from `pg_dump` → restore other resources with Velero → restart pods → allow Redis to repopulate |
 | **Docker Compose** | `dev-tools/restores/restore-db.sh` snapshot → restart containers → Redis repopulates automatically |
 
 Redis always uses AOF for crash recovery during runtime but is **never** restored from backup images. Gameplay resumes after services restart and Redis repopulates from PostgreSQL.

--- a/design/architecture/system-architecture-gateway.md
+++ b/design/architecture/system-architecture-gateway.md
@@ -114,10 +114,10 @@ This approach minimizes latency and matches the protocol table in the
 
 ## Dev vs. Prod Configuration
 
-| Environment | Route Target Format      | Discovery Mechanism        |
-|-------------|---------------------------|-----------------------------|
-| Dev         | `http://service:8080`     | Docker Compose DNS          |
-| Prod        | `http://service.namespace.svc.cluster.local:8080` | Kubernetes DNS |
+| Environment | Route Target Format | Discovery Mechanism |
+| --- | --- | --- |
+| Dev | `http://service:8080` | Docker Compose DNS |
+| Prod | `http://service.namespace.svc.cluster.local:8080` | Kubernetes DNS |
 
 Spring profiles defined in `application.yml` and selected via
 `SPRING_PROFILES_ACTIVE` configure routing targets based on environment.

--- a/design/architecture/system-architecture-overview.md
+++ b/design/architecture/system-architecture-overview.md
@@ -30,11 +30,11 @@ This document provides a high-level view of FireMUD’s system architecture, sho
 
 FireMUD supports seamless gameplay recovery through a layered reconnection model:
 
-| Layer               | Responsibility                                               |
-|--------------------|---------------------------------------------------------------|
-| TCP Proxy Service          | Buffers Telnet input; clears on disconnect                    |
-| Spring Cloud Gateway     | Stateless; re-establishes backend connections on reconnect    |
-| Game Session Service | Restores gameplay session using Redis                         |
+| Layer | Responsibility |
+| --- | --- |
+| TCP Proxy Service | Buffers Telnet input; clears on disconnect |
+| Spring Cloud Gateway | Stateless; re-establishes backend connections on reconnect |
+| Game Session Service | Restores gameplay session using Redis |
 
 > 🔗 See [Reconnection Strategy](./system-architecture-reconnection.md) for full details on session resumption, reauthentication, and failure handling.
 
@@ -42,34 +42,34 @@ FireMUD supports seamless gameplay recovery through a layered reconnection model
 
 ## 🔗 Major Components and Their Roles
 
-| Component                          | Purpose                                                                 |
-|-----------------------------------|-------------------------------------------------------------------------|
-| **Web Clients**                   | Modern browser clients using WebSocket or HTTP to access the platform  |
-| **MUD Clients**                   | Traditional Telnet clients connecting via TCP, proxied into the system |
-| **[TCP Proxy Service](./microservices/tcp-proxy-service/README.md)**             | Accepts Telnet connections, buffers input, forwards over WebSocket; proxy-to-gateway mTLS secures the link     |
-| **[Spring Cloud Gateway](./microservices/spring-cloud-gateway/README.md)**          | Handles WebSocket termination, routing, auth, monitoring                |
-| **[Game Session Service](./microservices/game-session-service/README.md)**          | Manages player sessions, tick orchestration, stores runtime flags, input validation |
-| **[Account Service](./microservices/account-service/README.md)**               | Manages player accounts, login, auth, subscription status; ban workflows are available |
-| **[Entity Management Service](./microservices/entity-management-service/README.md)**     | Handles all entity data: players, NPCs, items, stats, inventories      |
-| **[World Management Service](./microservices/world-management-service/README.md)**      | Owns maps, rooms, and tick region structure; provides geometry and world snapshots |
-| **[Game Logic Service](./microservices/game-logic-service/README.md)**            | Executes gameplay mechanics; resolves actions deterministically, including movement/travel cost computation |
-| **[Automation & Scripting Service](./microservices/automation-scripting-service/README.md)**| Triggers AI and scripted behaviors                                     |
-| **[Social & Groups Service](./microservices/social-groups-service/README.md)**     | Manages chat, mail, guilds, and social features                        |
-| **[Logging & Admin Service](./microservices/logging-admin-service/README.md)**       | Provides admin tools, metrics dashboards, audit logs, and toggles runtime flags via the Game Session Service |
-| **[Game Design Service](./microservices/game-design-service/README.md)**           | Authoring tool for designing and publishing game data; defines feature flags; publishing workflow copies data to runtime services |
+| Component | Purpose |
+| --- | --- |
+| **Web Clients** | Modern browser clients using WebSocket or HTTP to access the platform |
+| **MUD Clients** | Traditional Telnet clients connecting via TCP, proxied into the system |
+| **[TCP Proxy Service](./microservices/tcp-proxy-service/README.md)** | Accepts Telnet connections, buffers input, forwards over WebSocket; proxy-to-gateway mTLS secures the link |
+| **[Spring Cloud Gateway](./microservices/spring-cloud-gateway/README.md)** | Handles WebSocket termination, routing, auth, monitoring |
+| **[Game Session Service](./microservices/game-session-service/README.md)** | Manages player sessions, tick orchestration, stores runtime flags, input validation |
+| **[Account Service](./microservices/account-service/README.md)** | Manages player accounts, login, auth, subscription status; ban workflows are available |
+| **[Entity Management Service](./microservices/entity-management-service/README.md)** | Handles all entity data: players, NPCs, items, stats, inventories |
+| **[World Management Service](./microservices/world-management-service/README.md)** | Owns maps, rooms, and tick region structure; provides geometry and world snapshots |
+| **[Game Logic Service](./microservices/game-logic-service/README.md)** | Executes gameplay mechanics; resolves actions deterministically, including movement/travel cost computation |
+| **[Automation & Scripting Service](./microservices/automation-scripting-service/README.md)** | Triggers AI and scripted behaviors |
+| **[Social & Groups Service](./microservices/social-groups-service/README.md)** | Manages chat, mail, guilds, and social features |
+| **[Logging & Admin Service](./microservices/logging-admin-service/README.md)** | Provides admin tools, metrics dashboards, audit logs, and toggles runtime flags via the Game Session Service |
+| **[Game Design Service](./microservices/game-design-service/README.md)** | Authoring tool for designing and publishing game data; defines feature flags; publishing workflow copies data to runtime services |
 
 ---
 For a full list of responsibilities and APIs, refer to the [Microservices Documentation](./microservices/README.md).
 
 ## 🌐 Communication Flows
 
-| Flow                                        | Protocol                       |
-|---------------------------------------------|--------------------------------|
-| Web Clients → Spring Cloud Gateway          | WebSocket (wss) / HTTP (https) |
-| MUD Clients → TCP Proxy Service             | Raw TCP (Telnet)               |
-| TCP Proxy Service → Spring Cloud Gateway    | WebSocket (wss)                |
-| Spring Cloud Gateway → Game Session Service | WebSocket (wss)                |
-| Game Session Service → Other Microservices  | gRPC (internal)                |
+| Flow | Protocol |
+| --- | --- |
+| Web Clients → Spring Cloud Gateway | WebSocket (wss) / HTTP (https) |
+| MUD Clients → TCP Proxy Service | Raw TCP (Telnet) |
+| TCP Proxy Service → Spring Cloud Gateway | WebSocket (wss) |
+| Spring Cloud Gateway → Game Session Service | WebSocket (wss) |
+| Game Session Service → Other Microservices | gRPC (internal) |
 
 ✅ All internal communication from the Game Session Service onward uses **gRPC** with strict schema enforcement.
 
@@ -118,14 +118,14 @@ See [Logging & Monitoring](./system-architecture-logging-monitoring.md) for the 
 
 ## 🗂️ Deployment Layers
 
-| Layer                  | Technology                                                   |
-|------------------------|--------------------------------------------------------------|
-| Client Layer           | Browser, Telnet MUD Clients                                  |
-| Proxy Layer            | TCP Proxy Service (LoadBalancer Service)                     |
-| API Gateway Layer      | Spring Cloud Gateway (LoadBalancer Service)                  |
-| Gameplay Session Layer | Game Session Service                                         |
-| Service Layer          | Microservices (Account, Entity, World, Logic, etc.)          |
-| Infrastructure Layer   | Kubernetes with IPVS, Docker Compose (for local development) |
+| Layer | Technology |
+| --- | --- |
+| Client Layer | Browser, Telnet MUD Clients |
+| Proxy Layer | TCP Proxy Service (LoadBalancer Service) |
+| API Gateway Layer | Spring Cloud Gateway (LoadBalancer Service) |
+| Gameplay Session Layer | Game Session Service |
+| Service Layer | Microservices (Account, Entity, World, Logic, etc.) |
+| Infrastructure Layer | Kubernetes with IPVS, Docker Compose (for local development) |
 
 Deployment health checks (readiness and liveness probes) for these layers are
 described in detail in

--- a/design/architecture/system-architecture-procedural-generation.md
+++ b/design/architecture/system-architecture-procedural-generation.md
@@ -54,17 +54,17 @@ Generates biome-aware terrain maps with elevation, water features, forest densit
 
 #### Generation Pipeline:
 
-| Step                     | Purpose                                     | Common Techniques                          |
-|--------------------------|---------------------------------------------|--------------------------------------------|
-| **Elevation Map**        | Define height (mountains, valleys)          | `Perlin Noise`, `Diamond-Square`           |
-| **Moisture Map**         | Define biome type (desert, swamp, forest)   | Gradient sampling, additional noise layer  |
-| **Biome Assignment**     | Use height + moisture to classify terrain   | Threshold tables or biome rulesets         |
-| **Region Partitioning**  | Divide into zones/factions                  | `Voronoi`, seeded points + expansion       |
-| **River/Lake Simulation**| Carve out natural water features            | Flow fields, downhill tracing              |
-| **Forest/Cave Generation** | Place dense blobs of trees or underground | Cellular automata                          |
-| **Feature Placement**    | Place towns, dungeons, landmarks            | `Poisson Disk Sampling`, seeded rules      |
-| **Connectivity Graph**   | Generate roads, rivers, and path exits      | A*, flow maps, elevation-aware routing     |
-| **Room Graph Export**    | Convert terrain grid into room data         | Either sparse (POIs and path nodes only) or full (1:1 room per map cell) |
+| Step | Purpose | Common Techniques |
+| --- | --- | --- |
+| **Elevation Map** | Define height (mountains, valleys) | `Perlin Noise`, `Diamond-Square` |
+| **Moisture Map** | Define biome type (desert, swamp, forest) | Gradient sampling, additional noise layer |
+| **Biome Assignment** | Use height + moisture to classify terrain | Threshold tables or biome rulesets |
+| **Region Partitioning** | Divide into zones/factions | `Voronoi`, seeded points + expansion |
+| **River/Lake Simulation** | Carve out natural water features | Flow fields, downhill tracing |
+| **Forest/Cave Generation** | Place dense blobs of trees or underground | Cellular automata |
+| **Feature Placement** | Place towns, dungeons, landmarks | `Poisson Disk Sampling`, seeded rules |
+| **Connectivity Graph** | Generate roads, rivers, and path exits | A*, flow maps, elevation-aware routing |
+| **Room Graph Export** | Convert terrain grid into room data | Either sparse (POIs and path nodes only) or full (1:1 room per map cell) |
 
 > The room generation mode (sparse vs full) is selectable per generation request, depending on the game’s desired level of detail and exploration density.
 
@@ -74,15 +74,15 @@ Generates biome-aware terrain maps with elevation, water features, forest densit
 
 All generators emit a normalized structure:
 
-| Field         | Description                                         |
-|---------------|-----------------------------------------------------|
-| `roomId`      | Unique identifier                                   |
+| Field | Description |
+| --- | --- |
+| `roomId` | Unique identifier |
 | `coordinates` | Grid location (used for spatial logic and editing) |
-| `exitMap`     | Map of direction → `roomId`                         |
-| `tags`        | Optional labels like `"start"`, `"town"`, etc.     |
-| `biome`       | Biome or terrain type (if applicable)              |
-| `elevation`   | Numeric terrain height (used for visuals or logic) |
-| `regionId`    | Optional grouping for partitioned maps             |
+| `exitMap` | Map of direction → `roomId` |
+| `tags` | Optional labels like `"start"`, `"town"`, etc. |
+| `biome` | Biome or terrain type (if applicable) |
+| `elevation` | Numeric terrain height (used for visuals or logic) |
+| `regionId` | Optional grouping for partitioned maps |
 
 `spacingMultiplier` is stored on the containing region (World Management) and can globally scale movement speed across the map. In sparse layouts Game Logic uses room coordinates and this `spacingMultiplier` to derive movement/travel cost, so nearby rooms are quick to traverse while large gaps produce longer travel times.
 
@@ -137,11 +137,11 @@ Generation parameters can be tuned at runtime through the [Procedural Generation
 
 ## ✅ Feature Overview
 
-| Area                     | Status                                      |
-|--------------------------|---------------------------------------------|
-| Biome-based gameplay     | Movement cost and visibility adjustments     |
-| Terrain traversal rules  | Rules defined per biome and elevation delta  |
-| Region-specific scripting| Integrated with spawn rules and lore         |
+| Area | Status |
+| --- | --- |
+| Biome-based gameplay | Movement cost and visibility adjustments |
+| Terrain traversal rules | Rules defined per biome and elevation delta |
+| Region-specific scripting | Integrated with spawn rules and lore |
 
 Additional capabilities:
 

--- a/design/architecture/system-architecture-protocol-bridging.md
+++ b/design/architecture/system-architecture-protocol-bridging.md
@@ -8,10 +8,10 @@ This document describes how FireMUD supports **both modern and traditional MUD c
 
 FireMUD enables real-time interaction through two types of client connections:
 
-| Client Type             | Protocol       | Entry Point                     |
-|-------------------------|----------------|----------------------------------|
-| Web-based clients       | WebSocket      | Spring Cloud Gateway (`/ws/game/**`) |
-| Traditional MUD clients | TCP (Telnet)   | TCP Proxy Service (custom)      |
+| Client Type | Protocol | Entry Point |
+| --- | --- | --- |
+| Web-based clients | WebSocket | Spring Cloud Gateway (`/ws/game/**`) |
+| Traditional MUD clients | TCP (Telnet) | TCP Proxy Service (custom) |
 
 Despite their differences, both protocols are normalized into the same internal architecture using a **WebSocket-based session layer**.
 

--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -6,11 +6,11 @@ FireMUD enables seamless gameplay recovery across network interruptions, client 
 
 ## 🧩 Reconnection Layers
 
-| Layer              | Responsibility                                                               |
-|-------------------|-------------------------------------------------------------------------------|
-| **TCP Proxy Service**      | Parses Telnet input and clears buffered commands; exposes gRPC hooks for session recovery |
+| Layer | Responsibility |
+| --- | --- |
+| **TCP Proxy Service** | Parses Telnet input and clears buffered commands; exposes gRPC hooks for session recovery |
 | **Spring Cloud Gateway** | Stateless WebSocket passthrough; reconnects backend automatically |
-| **Game Session Service**   | Restores session from Redis; rebinds socket, region, and timers |
+| **Game Session Service** | Restores session from Redis; rebinds socket, region, and timers |
 
 Each layer handles fault tolerance independently.
 **Only client connection loss requires reauthentication.**
@@ -78,15 +78,15 @@ Gameplay resumes cleanly when a session is resumed — whether due to reconnect 
 
 ## 🔄 Resume vs Reload Scenarios
 
-| Event                                           | Result                                         |
-|------------------------------------------------|------------------------------------------------|
-| Client disconnect (TCP/WebSocket)              | Requires new `LOGIN`; may resume via Redis     |
-| TCP Proxy Service restart                              | Telnet clients disconnected; new `LOGIN` required       |
-| Spring Cloud Gateway restart                           | Web clients disconnected; Telnet clients stay connected |
-| Game Session Service restart                          | Transparent if client remains connected         |
-| Manual re-`LOGIN` from same character          | Treated as reconnect; resumes if Redis intact |
-| Redis session expired/missing                  | Treated as fresh login; gameplay starts anew   |
-| New client logs in as same character           | Old session terminated; new one resumes control |
+| Event | Result |
+| --- | --- |
+| Client disconnect (TCP/WebSocket) | Requires new `LOGIN`; may resume via Redis |
+| TCP Proxy Service restart | Telnet clients disconnected; new `LOGIN` required |
+| Spring Cloud Gateway restart | Web clients disconnected; Telnet clients stay connected |
+| Game Session Service restart | Transparent if client remains connected |
+| Manual re-`LOGIN` from same character | Treated as reconnect; resumes if Redis intact |
+| Redis session expired/missing | Treated as fresh login; gameplay starts anew |
+| New client logs in as same character | Old session terminated; new one resumes control |
 
 > 🔑 Only **client disconnection** requires `LOGIN`. Game Session Service restarts are invisible if the socket stays open. TCP Proxy restarts drop Telnet clients, while Gateway restarts disconnect Web clients; Telnet clients proxied through the Gateway remain connected.
 

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -83,13 +83,13 @@ Redis keys follow strict naming conventions to ensure:
 
 ### Key Format Examples
 
-| Redis Key                      | Description                              |
-|-------------------------------|------------------------------------------|
-| `tick:lock:{tenantId}:{entityId}` | Lock for entity during tick execution    |
-| `tick:pending:{tenantId}:{regionId}` | Staged results for a tick region         |
-| `room:{tenantId}:{roomId}`               | Hot room cache as JSON (occupants and metadata)                  |
-| `retry:{tenantId}:{regionId}`            | Retry queue for failed actions           |
-| `timer:{tenantId}:{entityId}:{effectId}` | Cooldown/effect timer metadata (in ms)   |
+| Redis Key | Description |
+| --- | --- |
+| `tick:lock:{tenantId}:{entityId}` | Lock for entity during tick execution |
+| `tick:pending:{tenantId}:{regionId}` | Staged results for a tick region |
+| `room:{tenantId}:{roomId}` | Hot room cache as JSON (occupants and metadata) |
+| `retry:{tenantId}:{regionId}` | Retry queue for failed actions |
+| `timer:{tenantId}:{entityId}:{effectId}` | Cooldown/effect timer metadata (in ms) |
 | `remote:{tenantId}:{entityId}` | Queue for cross-region command follow-ups |
 
 > 🔗 `remote:{tenantId}:{entityId}` keys route cross-region commands. See [Cross-Region Command Execution and Result Relay](./system-architecture-ticks.md#📡-cross-region-command-execution-and-result-relay)

--- a/design/architecture/system-architecture-security.md
+++ b/design/architecture/system-architecture-security.md
@@ -96,19 +96,19 @@ JWT signing keys rotate manually or through cert-manager automation.
 
 ## ✅ Summary
 
-| Topic                     | Strategy                                                                 |
-|---------------------------|--------------------------------------------------------------------------|
-| JWT Secret Storage        | Kubernetes Secrets with hot reload via `JwtSecretWatcher`; rotation can be manual or automated via cert-manager |
-| Key & Cert Rotation       | Hot reload via `TlsCertificateWatcher`; automatic JWKS rotation with credential caching |
-| TLS Termination           | Load balancer                                                 |
-| Internal Encryption       | mTLS via Kubernetes Secrets; server certificate hot reload enabled |
-| Trust Enforcement         | JWT + mTLS + Kubernetes NetworkPolicies                                  |
-| Brute-Force Defense       | Game Session Service enforces per-IP connection and command rate limits; Gateway applies Redis rate limiting |
-| Abuse Detection           | Login tracking and command-level heuristics enforce usage patterns |
-| Telnet Controls           | Telnet protocol command whitelist + sanitization implemented |
-| Admin Role Access         | JWT-only; no special network-level restrictions |
-| Zero Trust                | Enforced via mTLS and JWT-based validation |
-| 2FA                       | Available for admin and moderator accounts via TOTP codes               |
+| Topic | Strategy |
+| --- | --- |
+| JWT Secret Storage | Kubernetes Secrets with hot reload via `JwtSecretWatcher`; rotation can be manual or automated via cert-manager |
+| Key & Cert Rotation | Hot reload via `TlsCertificateWatcher`; automatic JWKS rotation with credential caching |
+| TLS Termination | Load balancer |
+| Internal Encryption | mTLS via Kubernetes Secrets; server certificate hot reload enabled |
+| Trust Enforcement | JWT + mTLS + Kubernetes NetworkPolicies |
+| Brute-Force Defense | Game Session Service enforces per-IP connection and command rate limits; Gateway applies Redis rate limiting |
+| Abuse Detection | Login tracking and command-level heuristics enforce usage patterns |
+| Telnet Controls | Telnet protocol command whitelist + sanitization implemented |
+| Admin Role Access | JWT-only; no special network-level restrictions |
+| Zero Trust | Enforced via mTLS and JWT-based validation |
+| 2FA | Available for admin and moderator accounts via TOTP codes |
 
 ---
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -255,13 +255,13 @@ may be notified that the chain was halted.
 
 ## 🧠 Service Responsibilities
 
-| Service                   | Role                                                                 |
-|---------------------------|----------------------------------------------------------------------|
-| **Game Session Service**          | Orchestrates tick regions, lock acquisition, retries, commit flow    |
-| **Game Logic Service**            | Resolves each queued action deterministically, including movement/travel cost computation from World geometry and region metadata |
-| **Automation & Scripting**| Injects AI or scripted commands into queues                          |
-| **World Management**      | Defines tick region layout and room segmentation                     |
-| **Redis**                 | Stores locks, timers, staged changes, retry metadata; executes Lua   |
+| Service | Role |
+| --- | --- |
+| **Game Session Service** | Orchestrates tick regions, lock acquisition, retries, and commit flow |
+| **Game Logic Service** | Resolves each queued action deterministically, including movement/travel cost computation from World geometry and region metadata |
+| **Automation & Scripting** | Injects AI or scripted commands into queues |
+| **World Management** | Defines tick region layout and room segmentation |
+| **Redis** | Stores locks, timers, staged changes, retry metadata; executes Lua |
 
 > Game Session Service manages all tick lifecycle logic and delegates atomic operations to Redis via Lua.
 

--- a/design/architecture/system-architecture-transactions.md
+++ b/design/architecture/system-architecture-transactions.md
@@ -6,12 +6,12 @@ This document explains how FireMUD coordinates data consistency across its indep
 
 ## 🧠 Terminology Clarification
 
-| Term         | Meaning |
-|--------------|---------|
-| **Command**  | A gameplay action issued by a player or AI (e.g., attack, move, use item). Executed inside a tick as a **self-contained transaction**, backed by Redis. |
+| Term | Meaning |
+| --- | --- |
+| **Command** | A gameplay action issued by a player or AI (e.g., attack, move, use item). Executed inside a tick as a **self-contained transaction**, backed by Redis. |
 | **Transaction** | A unit of work that must either fully succeed or be rolled back. Each in-game command is treated as an atomic transaction. |
-| **Tick**     | A scheduled gameplay loop slice. Each tick processes one command per entity and uses Redis for coordination, rollback, and fairness. Ticks are not atomic across all commands — each command is executed as an independent transaction. |
-| **Saga**     | A long-running, cross-service workflow composed of multiple local transactions. Used only for **non-gameplay**, out-of-band operations (e.g., account creation, game publishing). Sagas rely on compensating actions for rollback and eventual consistency. |
+| **Tick** | A scheduled gameplay loop slice. Each tick processes one command per entity and uses Redis for coordination, rollback, and fairness. Ticks are not atomic across all commands — each command is executed as an independent transaction. |
+| **Saga** | A long-running, cross-service workflow composed of multiple local transactions. Used only for **non-gameplay**, out-of-band operations (e.g., account creation, game publishing). Sagas rely on compensating actions for rollback and eventual consistency. |
 
 ---
 
@@ -40,11 +40,11 @@ This model provides:
 
 Sagas are only used for **non-tick, multi-service workflows** involving persistent state changes that cannot be coordinated via Redis. These include:
 
-| Use Case              | Description |
-|-----------------------|-------------|
-| **Account Creation**  | Create account → provision default character → initialize world state |
-| **Game Publishing**   | Validate and persist design → push to World Service → toggle publish flags |
-| **Admin Operations**  | Issue bans, content revocation, or entity cleanup with audit logging |
+| Use Case | Description |
+| --- | --- |
+| **Account Creation** | Create account → provision default character → initialize world state |
+| **Game Publishing** | Validate and persist design → push to World Service → toggle publish flags |
+| **Admin Operations** | Issue bans, content revocation, or entity cleanup with audit logging |
 | **In-Game Purchase (rare)** | Only if involving external billing or cross-service coordination beyond Redis tick safety |
 
 These workflows:

--- a/design/project-management/core-requirements.md
+++ b/design/project-management/core-requirements.md
@@ -175,7 +175,7 @@ See [Tick System](../architecture/system-architecture-ticks.md) and [Reconnectio
 ## 4. Non-Functional Requirements
 
 | **Category** | **Requirement** |
-|-------------|----------------|
+| --- | --- |
 | **Performance** | Must support **hundreds to thousands of concurrent players** per game instance. |
 | **Scalability** | Must support **horizontal scaling of services independently**. |
 | **Reliability** | **Automated failover and redundancy** for high availability. |


### PR DESCRIPTION
## Summary
- Reformat markdown tables across infrastructure and architecture docs to use consistent compact styling that satisfies markdownlint
- Update authentication documentation heading and summary tables while keeping content unchanged
- Align procedural generation and other design references with the standardized table layout

## Testing
- ./gradlew lintMarkdown linkCheck -PfullCheck --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263dc943948330ab90919ef816f5fb)