### PR TITLE
Improve TLS misconfiguration handling

### DIFF
--- a/services/tcp-proxy-service/build.gradle.kts
+++ b/services/tcp-proxy-service/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.otlp)
     testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.micrometer.registry.prometheus)
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
 }
 

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/service/TcpProxyEventService.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/service/TcpProxyEventService.java
@@ -1,7 +1,10 @@
 package net.firedevops.firemud.service;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.util.List;
+import java.time.Duration;
 import net.firedevops.firemud.shared.v1.ErrorDetail;
 import net.firedevops.firemud.tcpproxy.v1.NotifyDisconnectResponse;
 import net.firedevops.firemud.tcpproxy.v1.PushBufferedInputResponse;
@@ -18,10 +21,46 @@ public class TcpProxyEventService {
 
   private final TcpProxyEventClient client;
   private final MeterRegistry meterRegistry;
+  private final Timer connectionDurationTimer;
+  private final Counter connectCounter;
+  private final Counter disconnectCounter;
 
   public TcpProxyEventService(TcpProxyEventClient client, MeterRegistry meterRegistry) {
     this.client = client;
     this.meterRegistry = meterRegistry;
+    this.connectionDurationTimer =
+        Timer.builder("tcpproxy.connection.duration")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+    this.connectCounter = meterRegistry.counter("tcpproxy.connection.events", "type", "connect");
+    this.disconnectCounter =
+        meterRegistry.counter("tcpproxy.connection.events", "type", "disconnect");
+  }
+
+  public void recordConnectEvent(String sessionId, String tenantId, String clientIp) {
+    connectCounter.increment();
+    logger
+        .atInfo()
+        .addKeyValue("sessionId", sessionId)
+        .addKeyValue("tenantId", tenantId)
+        .addKeyValue("clientIp", clientIp)
+        .log("Telnet connect event");
+  }
+
+  public void recordDisconnectEvent(
+      String sessionId, String tenantId, String clientIp, Duration connectionDuration) {
+    disconnectCounter.increment();
+    if (connectionDuration != null) {
+      connectionDurationTimer.record(connectionDuration);
+    }
+    logger
+        .atInfo()
+        .addKeyValue("sessionId", sessionId)
+        .addKeyValue("tenantId", tenantId)
+        .addKeyValue("clientIp", clientIp)
+        .addKeyValue(
+            "durationMs", connectionDuration != null ? connectionDuration.toMillis() : null)
+        .log("Telnet disconnect event");
   }
 
   public NotifyDisconnectResponse notifyDisconnect(String sessionId, String tenantId) {

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServer.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import net.firedevops.firemud.service.TcpProxyEventService;
 
 /** Simple Netty-based Telnet server that forwards input to the gateway via WebSocket. */
@@ -39,8 +40,11 @@ public final class TelnetServer {
   private final boolean advertiseMcp;
   private final java.util.concurrent.atomic.AtomicInteger activeConnections =
       new java.util.concurrent.atomic.AtomicInteger();
+  private final java.util.concurrent.atomic.AtomicInteger bufferDepth =
+      new java.util.concurrent.atomic.AtomicInteger();
   private final Counter connectionCounter;
   private final Counter discardedCommandCounter;
+  private final Counter tlsMisconfigCounter;
   private final MeterRegistry meterRegistry;
   private final TcpProxyEventService eventService;
 
@@ -59,8 +63,7 @@ public final class TelnetServer {
       @Value("${TCP_PROXY_TLS_KEY:}") String keyPath,
       @Value("${TCP_PROXY_MCP_ENABLED:false}") boolean advertiseMcp,
       MeterRegistry meterRegistry,
-      TcpProxyEventService eventService)
-      throws SSLException {
+      TcpProxyEventService eventService) {
     this.port = port;
     this.gatewayWsUrl = gatewayWsUrl;
     this.tlsEnabled = tlsEnabled;
@@ -71,14 +74,46 @@ public final class TelnetServer {
     this.meterRegistry = meterRegistry;
     this.connectionCounter = meterRegistry.counter("tcpproxy.connections.total");
     this.discardedCommandCounter = meterRegistry.counter("tcpproxy.telnet.discarded");
+    this.tlsMisconfigCounter = meterRegistry.counter("tcpproxy.tls.misconfig");
     this.eventService = eventService;
     Gauge.builder(
             "tcpproxy.connections.active",
             activeConnections,
             java.util.concurrent.atomic.AtomicInteger::get)
         .register(meterRegistry);
+    Gauge.builder("tcpproxy.buffer.depth", bufferDepth, java.util.concurrent.atomic.AtomicInteger::get)
+        .register(meterRegistry);
+    meterRegistry.counter("tcpproxy.websocket.reconnects").increment(0.0);
     if (tlsEnabled) {
-      sslContext = SslContextBuilder.forServer(new File(certPath), new File(keyPath)).build();
+      validateTlsConfiguration();
+      try {
+        sslContext = SslContextBuilder.forServer(new File(certPath), new File(keyPath)).build();
+      } catch (SSLException e) {
+        tlsMisconfigCounter.increment();
+        String message = "TCP proxy TLS configuration failed to load";
+        logger.error(message, e);
+        throw new IllegalStateException(message, e);
+      }
+    }
+  }
+
+  private void validateTlsConfiguration() {
+    if (!StringUtils.hasText(certPath) || !StringUtils.hasText(keyPath)) {
+      tlsMisconfigCounter.increment();
+      String message = "TCP proxy TLS is enabled but TCP_PROXY_TLS_CERT and TCP_PROXY_TLS_KEY must be set";
+      logger.error(message);
+      throw new IllegalStateException(message);
+    }
+
+    File certFile = new File(certPath);
+    File keyFile = new File(keyPath);
+    if (!certFile.isFile() || !keyFile.isFile() || !certFile.canRead() || !keyFile.canRead()) {
+      tlsMisconfigCounter.increment();
+      String message =
+          "TCP proxy TLS configuration invalid: certificate or key file does not exist or is unreadable";
+      logger.error(
+          "{} (certPath={}, keyPath={})", message, certFile.getAbsolutePath(), keyFile.getAbsolutePath());
+      throw new IllegalStateException(message);
     }
   }
 
@@ -112,7 +147,8 @@ public final class TelnetServer {
                               discardedCommandCounter,
                               advertiseMcp,
                               meterRegistry,
-                              eventService));
+                              eventService,
+                              bufferDepth));
                 }
               });
       serverChannel = b.bind(port).sync().channel();

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/telnet/TelnetServerHandler.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.telnet;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.buffer.ByteBuf;
@@ -23,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.firedevops.firemud.service.TcpProxyEventService;
 import net.firedevops.firemud.tcpproxy.v1.PushBufferedInputResponse;
 import org.slf4j.Logger;
@@ -49,6 +51,9 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private final Timer commandTimer;
   private final Timer heartbeatTimer;
   private final Timer idleCloseTimer;
+  private final Timer reconnectTimer;
+  private final Counter reconnectCounter;
+  private final AtomicInteger bufferDepth;
   private final WebSocketConnector webSocketConnector;
   private final TcpProxyEventService eventService;
   private final TelnetSessionContext sessionContext = new TelnetSessionContext();
@@ -59,6 +64,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   private volatile ScheduledFuture<?> heartbeatFuture;
   private volatile ScheduledFuture<?> idleFuture;
   private volatile long lastActivityNanos;
+  private volatile long connectionStartNanos;
   private volatile boolean mcpNegotiated;
   private WebSocket webSocket;
   private volatile boolean connectedOnce;
@@ -67,6 +73,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       ConcurrentHashMap.newKeySet();
   private volatile CompletableFuture<WebSocket> inFlightSend;
   private String clientIp;
+  private boolean connectEventRecorded;
 
   public TelnetServerHandler(
       String gatewayWsUrl,
@@ -77,7 +84,8 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       io.micrometer.core.instrument.Counter discardedCommandCounter,
       boolean advertiseMcp,
       MeterRegistry meterRegistry,
-      TcpProxyEventService eventService) {
+      TcpProxyEventService eventService,
+      AtomicInteger bufferDepth) {
     this(
         gatewayWsUrl,
         logOnly,
@@ -88,7 +96,8 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
         advertiseMcp,
         meterRegistry,
         TelnetServerHandler::createWebSocket,
-        eventService);
+        eventService,
+        bufferDepth);
   }
 
   TelnetServerHandler(
@@ -101,7 +110,8 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       boolean advertiseMcp,
       MeterRegistry meterRegistry,
       WebSocketConnector webSocketConnector,
-      TcpProxyEventService eventService) {
+      TcpProxyEventService eventService,
+      AtomicInteger bufferDepth) {
     this.gatewayWsUrl = gatewayWsUrl;
     this.logOnly = logOnly;
     this.onConnect = onConnect;
@@ -112,9 +122,14 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     this.meterRegistry = meterRegistry;
     this.webSocketConnector = webSocketConnector;
     this.eventService = eventService;
+    this.bufferDepth = bufferDepth;
     this.commandTimer = meterRegistry.timer("tcpproxy.command");
     this.heartbeatTimer = meterRegistry.timer("tcpproxy.heartbeat");
     this.idleCloseTimer = meterRegistry.timer("tcpproxy.idleClose");
+    this.reconnectTimer = meterRegistry.timer("tcpproxy.websocket.reconnect.delay");
+    this.reconnectCounter = meterRegistry.counter("tcpproxy.websocket.reconnects");
+    this.reconnectCounter.increment(0.0);
+    updateBufferDepthGauge();
   }
 
   @FunctionalInterface
@@ -264,6 +279,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
             logger.warn("Gateway send failed; scheduling reconnect", error);
             handleGatewayDisconnect();
           }
+          updateBufferDepthGauge();
           drainBuffer();
         });
   }
@@ -274,7 +290,9 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     touchActivity();
     var remote = ctx.channel() != null ? ctx.channel().remoteAddress() : null;
     clientIp = extractIp(remote);
+    connectionStartNanos = System.nanoTime();
     connectionCounter.increment();
+    updateBufferDepthGauge();
     onConnect.run();
     logger.info(
         "Telnet client connected from {} targeting {}", clientIp != null ? clientIp : remote, gatewayWsUrl);
@@ -305,6 +323,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
           logger.warn("Ignoring Telnet input before session envelope: {}", sanitized);
           return;
         }
+        notifyConnectIfReady();
         ensureGatewayConnected();
         return;
       }
@@ -316,6 +335,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       }
 
       buffer.add(sanitized);
+      updateBufferDepthGauge();
       drainBuffer();
     } finally {
       sample.stop(commandTimer);
@@ -329,13 +349,21 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     cancelIdleCheck();
     closeGatewayWebSocket();
     onDisconnect.run();
+    Duration connectionDuration = null;
+    if (connectionStartNanos > 0) {
+      connectionDuration = Duration.ofNanos(System.nanoTime() - connectionStartNanos);
+    }
+    eventService.recordDisconnectEvent(
+        sessionContext.sessionId(), sessionContext.tenantId(), clientIp, connectionDuration);
     notifyDisconnectAsync();
     buffer.clear();
     cancelOutstandingSends();
+    updateBufferDepthGauge();
   }
 
   private boolean canBufferMore() {
     int depth = buffer.size() + outstandingSends.size();
+    bufferDepth.set(depth);
     if (depth >= MAX_BUFFER_DEPTH) {
       if (!closing) {
         closing = true;
@@ -354,7 +382,11 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
   }
 
   private boolean captureSessionContext(String sanitized) {
-    return sessionContext.captureFromEnvelope(sanitized);
+    boolean captured = sessionContext.captureFromEnvelope(sanitized);
+    if (captured) {
+      notifyConnectIfReady();
+    }
+    return captured;
   }
 
   private void cancelIdleCheck() {
@@ -421,8 +453,10 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       return;
     }
     reconnecting = true;
+    reconnectCounter.increment();
     long delayMillis = backoffDelayMillis();
     context.executor().schedule(this::connectToGateway, delayMillis, TimeUnit.MILLISECONDS);
+    reconnectTimer.record(Duration.ofMillis(delayMillis));
   }
 
   private void cancelOutstandingSends() {
@@ -433,6 +467,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     }
     outstandingSends.forEach(future -> future.cancel(true));
     outstandingSends.clear();
+    updateBufferDepthGauge();
   }
 
   private long backoffDelayMillis() {
@@ -448,6 +483,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
     while ((next = buffer.poll()) != null) {
       drained.add(next);
     }
+    updateBufferDepthGauge();
     return drained;
   }
 
@@ -469,6 +505,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
                     sessionContext.sessionId(),
                     code);
                 buffer.addAll(buffered);
+                updateBufferDepthGauge();
                 drainBuffer();
               }
             })
@@ -479,6 +516,7 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
                   sessionContext.sessionId(),
                   error);
               buffer.addAll(buffered);
+              updateBufferDepthGauge();
               drainBuffer();
               return null;
             });
@@ -492,6 +530,18 @@ public class TelnetServerHandler extends SimpleChannelInboundHandler<String> {
       return true;
     }
     return OK.equals(response.getError().getCode());
+  }
+
+  private void updateBufferDepthGauge() {
+    bufferDepth.set(buffer.size() + outstandingSends.size());
+  }
+
+  private void notifyConnectIfReady() {
+    if (connectEventRecorded || !sessionContext.isReady()) {
+      return;
+    }
+    eventService.recordConnectEvent(sessionContext.sessionId(), sessionContext.tenantId(), clientIp);
+    connectEventRecorded = true;
   }
 
   private void notifyDisconnectAsync() {

--- a/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/PrometheusMetricsIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/PrometheusMetricsIntegrationTest.java
@@ -1,0 +1,66 @@
+package net.firedevops.firemud;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusScrapeEndpoint;
+import java.util.Properties;
+import net.firedevops.firemud.service.TcpProxyEventClient;
+
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    classes = TcpProxyServiceApplication.class,
+    properties = {
+      "TCP_PROXY_PORT=0",
+      "TCP_PROXY_TLS_ENABLED=false",
+      "GATEWAY_WS_URL=ws://localhost/ws",
+      "spring.flyway.enabled=false",
+      "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration",
+      "management.endpoints.web.exposure.include=health,prometheus",
+      "management.endpoint.prometheus.enabled=true"
+    })
+@Import(PrometheusMetricsIntegrationTest.MetricsTestConfig.class)
+class PrometheusMetricsIntegrationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @MockBean private TcpProxyEventClient tcpProxyEventClient;
+
+  @Test
+  void prometheusEndpointExposesTcpProxyMetrics() {
+    String body =
+        restTemplate.getForObject("http://localhost:" + port + "/actuator/prometheus", String.class);
+
+    assertThat(body)
+        .contains("tcpproxy_buffer_depth")
+        .contains("tcpproxy_websocket_reconnects_total")
+        .contains("tcpproxy_connection_duration_seconds")
+        .contains("tcpproxy_tls_misconfig_total");
+  }
+
+  @TestConfiguration(proxyBeanMethods = false)
+  static class MetricsTestConfig {
+    @Bean
+    PrometheusMeterRegistry prometheusMeterRegistry() {
+      return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    }
+
+    @Bean
+    PrometheusScrapeEndpoint prometheusScrapeEndpoint(PrometheusMeterRegistry registry) {
+      return new PrometheusScrapeEndpoint(registry.getPrometheusRegistry(), new Properties());
+    }
+  }
+}

--- a/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TelnetPipelineIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TelnetPipelineIntegrationTest.java
@@ -12,6 +12,7 @@ import io.netty.handler.codec.string.StringDecoder;
 import java.net.http.WebSocket;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import net.firedevops.firemud.service.TcpProxyEventService;
@@ -31,7 +32,8 @@ class TelnetPipelineIntegrationTest {
             registry.counter("discarded"),
             false,
             registry,
-            Mockito.mock(TcpProxyEventService.class));
+            Mockito.mock(TcpProxyEventService.class),
+            new AtomicInteger());
 
     WebSocket ws = Mockito.mock(WebSocket.class);
     CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);
@@ -71,7 +73,8 @@ class TelnetPipelineIntegrationTest {
             registry.counter("discarded"),
             false,
             registry,
-            Mockito.mock(TcpProxyEventService.class));
+            Mockito.mock(TcpProxyEventService.class),
+            new AtomicInteger());
 
     WebSocket ws = Mockito.mock(WebSocket.class);
     CompletableFuture<WebSocket> future = CompletableFuture.completedFuture(ws);

--- a/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TlsMisconfigurationIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/integration/net/firedevops/firemud/telnet/TlsMisconfigurationIntegrationTest.java
@@ -1,0 +1,74 @@
+package net.firedevops.firemud.telnet;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import net.firedevops.firemud.service.TcpProxyEventService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import net.firedevops.firemud.telnet.TelnetServer;
+
+class TlsMisconfigurationIntegrationTest {
+
+  @Test
+  void tlsMisconfigurationFailsFastWithClearMessage() {
+    assertThatThrownBy(
+            () ->
+                new SpringApplicationBuilder(TestConfig.class)
+                    .web(WebApplicationType.NONE)
+                    .properties(
+                        "TCP_PROXY_PORT=0",
+                        "TCP_PROXY_TLS_ENABLED=true",
+                        "TCP_PROXY_TLS_CERT=/nonexistent/cert.pem",
+                        "TCP_PROXY_TLS_KEY=/nonexistent/key.pem",
+                        "spring.flyway.enabled=false",
+                        "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration,org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration")
+                    .run())
+        .hasRootCauseInstanceOf(IllegalStateException.class)
+        .hasRootCauseMessage(
+            "TCP proxy TLS configuration invalid: certificate or key file does not exist or is unreadable");
+  }
+
+  @Configuration
+  static class TestConfig {
+
+    @Bean
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    @Bean
+    TcpProxyEventService tcpProxyEventService() {
+      return Mockito.mock(TcpProxyEventService.class);
+    }
+
+    @Bean
+    TelnetServer telnetServer(
+        @Value("${TCP_PROXY_PORT:2323}") int port,
+        @Value("${GATEWAY_WS_URL:ws://localhost/ws}") String gatewayWsUrl,
+        @Value("${TCP_PROXY_TLS_ENABLED:false}") boolean tlsEnabled,
+        @Value("${TCP_PROXY_LOG_ONLY:false}") boolean logOnly,
+        @Value("${TCP_PROXY_TLS_CERT:}") String certPath,
+        @Value("${TCP_PROXY_TLS_KEY:}") String keyPath,
+        @Value("${TCP_PROXY_MCP_ENABLED:false}") boolean advertiseMcp,
+        MeterRegistry meterRegistry,
+        TcpProxyEventService tcpProxyEventService) {
+      return new TelnetServer(
+          port,
+          gatewayWsUrl,
+          tlsEnabled,
+          logOnly,
+          certPath,
+          keyPath,
+          advertiseMcp,
+          meterRegistry,
+          tcpProxyEventService);
+    }
+  }
+}

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerHandlerTest.java
@@ -21,9 +21,11 @@ import io.netty.util.concurrent.DefaultEventExecutor;
 import java.net.InetSocketAddress;
 import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -43,7 +45,8 @@ class TelnetServerHandlerTest {
         registry.counter("discarded"),
         advertiseMcp,
         registry,
-        Mockito.mock(TcpProxyEventService.class));
+        Mockito.mock(TcpProxyEventService.class),
+        new AtomicInteger());
   }
 
   private TelnetServerHandler newHandler(
@@ -60,7 +63,8 @@ class TelnetServerHandlerTest {
         advertiseMcp,
         registry,
         connector,
-        Mockito.mock(TcpProxyEventService.class));
+        Mockito.mock(TcpProxyEventService.class),
+        new AtomicInteger());
   }
 
   private WebSocket stubWebSocket() {
@@ -397,7 +401,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            Mockito.mock(TcpProxyEventService.class));
+            Mockito.mock(TcpProxyEventService.class),
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -428,7 +433,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            Mockito.mock(TcpProxyEventService.class));
+            Mockito.mock(TcpProxyEventService.class),
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -459,7 +465,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            Mockito.mock(TcpProxyEventService.class));
+            Mockito.mock(TcpProxyEventService.class),
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -493,7 +500,8 @@ class TelnetServerHandlerTest {
               listener.onOpen(new RecordingWebSocket());
               return CompletableFuture.completedFuture(new RecordingWebSocket());
             },
-            eventService);
+            eventService,
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -530,7 +538,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            eventService);
+            eventService,
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -582,7 +591,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            eventService);
+            eventService,
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -631,7 +641,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            eventService);
+            eventService,
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -681,7 +692,8 @@ class TelnetServerHandlerTest {
             false,
             registry,
             connector,
-            eventService);
+            eventService,
+            new AtomicInteger());
     ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
     Channel channel = mock(Channel.class);
     DefaultEventExecutor executor = new DefaultEventExecutor();
@@ -705,6 +717,42 @@ class TelnetServerHandlerTest {
 
     assertEquals(List.of("cast fireball"), connector.getCurrent().getSentTexts());
     assertEquals(0, handler.getBufferedSize());
+  }
+
+  @Test
+  void structuredEventsIncludeConnectionDuration() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    TcpProxyEventService eventService = Mockito.mock(TcpProxyEventService.class);
+    TelnetServerHandler handler =
+        new TelnetServerHandler(
+            "ws://localhost/ws",
+            false,
+            () -> {},
+            () -> {},
+            registry.counter("test"),
+            registry.counter("discarded"),
+            false,
+            registry,
+            eventService,
+            new AtomicInteger());
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    Channel channel = mock(Channel.class);
+    DefaultEventExecutor executor = new DefaultEventExecutor();
+    when(ctx.channel()).thenReturn(channel);
+    when(ctx.executor()).thenReturn(executor);
+    when(channel.remoteAddress()).thenReturn(new InetSocketAddress("10.0.0.5", 9000));
+
+    handler.channelActive(ctx);
+    handler.channelRead0(ctx, "SESSION sess-99 tenant-42");
+    handler.channelInactive(ctx);
+
+    ArgumentCaptor<Duration> durationCaptor = ArgumentCaptor.forClass(Duration.class);
+    verify(eventService).recordConnectEvent("sess-99", "tenant-42", "10.0.0.5");
+    verify(eventService)
+        .recordDisconnectEvent(
+            eq("sess-99"), eq("tenant-42"), eq("10.0.0.5"), durationCaptor.capture());
+    assertTrue(durationCaptor.getValue().toMillis() >= 0);
+    executor.shutdownGracefully();
   }
 
   private static final class RecordingConnector implements TelnetServerHandler.WebSocketConnector {

--- a/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
+++ b/services/tcp-proxy-service/src/test/java/unit/net/firedevops/firemud/telnet/TelnetServerTest.java
@@ -1,9 +1,13 @@
 package net.firedevops.firemud.telnet;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import net.firedevops.firemud.service.TcpProxyEventService;
 
@@ -33,5 +37,30 @@ class TelnetServerTest {
     server.start();
     server.stop();
     assertTrue(true); // no exception means success
+  }
+
+  @Test
+  void tlsMisconfigurationFailsFastAndIncrementsMetric(@TempDir Path tempDir) {
+    var registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    String cert = tempDir.resolve("missing-cert.pem").toString();
+    String key = tempDir.resolve("missing-key.pem").toString();
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new TelnetServer(
+                    0,
+                    "ws://localhost/ws",
+                    true,
+                    false,
+                    cert,
+                    key,
+                    false,
+                    registry,
+                    Mockito.mock(TcpProxyEventService.class)));
+
+    assertTrue(ex.getMessage().contains("TLS"));
+    assertEquals(1.0, registry.counter("tcpproxy.tls.misconfig").count());
   }
 }


### PR DESCRIPTION
## Summary
- wrap TLS context load failures in a consistent IllegalStateException to fail fast with clear logging/metrics
- emit structured connect/disconnect event logs with key values for session, tenant, and client IP
- add a Spring integration test that asserts TLS misconfiguration produces the expected startup error message

## Testing
- ./gradlew :tcp-proxy-service:test --console=plain --no-daemon --tests "*TlsMisconfigurationIntegrationTest"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263f1db76c8330884e28bab8a061ab)