### PR TITLE
Feature/minimal protocols 2

### DIFF
--- a/design/architecture/microservices/game-session-service/README.md
+++ b/design/architecture/microservices/game-session-service/README.md
@@ -156,6 +156,16 @@ Telnet and WebSocket clients share a minimal line-based command protocol that po
 
 This small command table defines the initial MVP gameplay command set delivered by the Telnet-to-gameplay vertical slice; it should stay intentionally minimal while the protocol and interpreter mature.
 
+### Implementation status (vertical slice)
+
+For the current Telnet-to-gameplay vertical slice, the implementation intentionally separates "system" commands (session and login related) from gameplay commands:
+
+- `LOGIN` / `LOGON` are treated as system commands owned by the Game Session Service and will be wired into the authentication and world-selection flow described in [Authentication & Authorization](../../system-architecture-authentication.md). At this stage they are defined in the protocol and parser, but the full login flow is still being implemented under `design/project-management/task-list-game-session-service.md`.
+- `LOOK` is implemented as a minimal, deterministic room description inside the Game Session Service via a `LookCommandHandler`. This is a temporary gameplay stub used to validate the end-to-end text command flow and tests; future slices will route LOOK and other gameplay commands through the world/logic/scripting stack so that room descriptions and exits are fully data-driven.
+- `SAY` and additional gameplay commands will follow the same pattern: they are part of the shared text protocol, but their long-term behavior is provided by soft-coded definitions and the Game Logic/World services rather than hard-coded handlers in this service.
+
+The `TextCommandInterpreter` currently returns a result that includes both enqueue metadata (for the tick/command queue) and optional immediate response text. This shape is intended to remain stable as the implementation shifts from hard-coded handlers to data-driven gameplay logic.
+
 ### Response format
 
 - Every response is plain text. The first line is either `OK <COMMAND>` or `ERROR <CODE> <message>`.

--- a/design/project-management/task-list-login-and-session-vertical-slice.md
+++ b/design/project-management/task-list-login-and-session-vertical-slice.md
@@ -1,0 +1,57 @@
+# Login and Session Vertical Slice Task List
+
+This checklist builds on the **Telnet to Gameplay** slice by wiring the `LOGIN` text command end-to-end through Game Session and Account services, enforcing authenticated sessions for gameplay commands, and exercising basic session resumption behaviour. As before, each task should be small enough to hand to Codex (or a developer) as a single, self-contained chunk of work.
+
+## 1. Minimal LOGIN Protocol Behaviour and Docs
+
+- [ ] Review the [Minimal Text Command Protocol](../architecture/microservices/game-session-service/README.md#minimal-text-command-protocol) and the [Authentication & Authorization](../architecture/system-architecture-authentication.md#login-and-session-flow) docs to confirm the intended `LOGIN` / `LOGON` semantics (prompt-based vs parameterized logins, optional OTP argument, error codes such as `INVALID_CREDENTIALS` and `ACCOUNT_LOCKED`).
+- [ ] Update the Game Session Service design doc so the `Minimal Text Command Protocol` section explicitly documents `LOGIN` and `LOGON` behaviour for both Telnet and WebSocket clients, including at least one success and one failure transcript that show the `OK LOGIN` / `ERROR <CODE>` response format.
+- [ ] Add a short subsection under the Authentication & Authorization doc describing how plain-text `LOGIN` commands map onto the Account Service `/auth/login` API (or gRPC equivalent), including how OTP values are forwarded when present.
+- [ ] Ensure docs clearly state that once this slice is complete, gameplay commands such as `LOOK` and `SAY` require an authenticated session, except in explicitly documented dev/test bypass modes.
+
+## 2. Game Session LOGIN Command Handling
+
+- [ ] Implement a dedicated login handler in `services/game-session-service` (for example `LoginCommandHandler` or a focused method on `TextCommandInterpreter`) that processes `TextCommandType.LOGIN` / `LOGON`, distinguishes between prompt-based and parameterized forms, and produces a structured result that includes success/failure and optional response text.
+- [ ] On successful login, create or update a Redis-backed session context record storing at least `accountId`, `tenantId`, `playerId` (or chosen character identifier), and a reference to the active `GameInstance`, using key conventions consistent with the [Redis Architecture](../architecture/system-architecture-redis.md#session-keys-and-gameplay-binding).
+- [ ] Integrate the login handler into the existing WebSocket entry point so that `LOGIN` commands received over `/ws/game/**` flow through the same `TextCommandParser` / interpreter pipeline as gameplay commands, returning `OK LOGIN ...` responses or `ERROR <CODE> <message>` for failures.
+- [ ] Enforce an "authenticated session required" check before processing gameplay commands in the Game Session Service (e.g., `LOOK`, `SAY`) so that unauthenticated clients receive `ERROR NOT_AUTHENTICATED` until `LOGIN` succeeds, with a configuration flag allowing this guard to be disabled for local development if needed.
+- [ ] Add unit tests for the login handler and authentication guard covering at least: successful parameterized login, invalid credentials, missing arguments triggering a "prompt-mode not yet implemented" placeholder, repeated `LOGIN` attempts, and the `NOT_AUTHENTICATED` path for `LOOK`.
+
+## 3. Account Service Integration for LOGIN
+
+- [ ] Implement a Game Session Service client for the Account Service login API (REST or gRPC, per the current Account Service design), including fields for username, password, optional OTP, and any tenant/game selection identifiers required for session binding.
+- [ ] Map Account Service responses into a small internal DTO (e.g., `LoginResult`) containing `accountId`, allowed tenant/game identifiers, and the issued JWT (if applicable), and store the JWT and identity details in Redis alongside the gameplay session entry as described in the Authentication & Authorization docs.
+- [ ] Ensure Game Session converts Account Service failures into appropriate `ErrorDetail` codes (e.g., `INVALID_CREDENTIALS`, `ACCOUNT_LOCKED`, `OTP_REQUIRED`, `UPSTREAM_FAILURE`) and that these are surfaced in both the gRPC response and the text `ERROR <CODE> <message>` line returned to clients.
+- [ ] Add an integration test that starts Game Session Service with a lightweight Account Service stub (Spring Boot test configuration or Testcontainers-based stub), issues a `LOGIN` command over a direct WebSocket connection, and asserts that the stub receives the expected login request and that the client sees the correct `OK LOGIN ...` or `ERROR ...` text.
+- [ ] Document the dependency on the Account Service in `services/game-session-service/README.md`, including example `grpcurl` or REST calls that demonstrate the login path in isolation.
+
+## 4. Session Resumption and Takeover Basics
+
+- [ ] Extend session persistence so that Game Session can look up an existing session by `accountId` and `playerId` (or equivalent identity) on `LOGIN`, and perform session takeover when a second client logs in as the same character, in line with the [Multi-Client Behaviour and Session Takeover](../architecture/system-architecture-authentication.md#multi-client-behavior-and-session-takeover) rules.
+- [ ] Implement basic session resumption behaviour so that when a previously connected client disconnects and later sends `LOGIN` again with valid credentials for an existing Redis session, Game Session reuses the existing tick/command queues instead of starting a fresh game instance.
+- [ ] Ensure that session takeover and resumption paths emit Micrometer metrics (for example `gamesession.session.takeover` and `gamesession.session.resume`) and structured logs including `tenantId`, `accountId`, and `playerId` to support debugging.
+- [ ] Add focused tests (unit or Spring Boot integration) that simulate two WebSocket connections using the same character: the first performs `LOGIN` and `LOOK`, the second performs `LOGIN` and is granted control while the first receives a disconnect or error, and subsequent `LOOK` calls continue to operate on the same underlying game state.
+- [ ] Update the [Reconnection Strategy](../architecture/system-architecture-reconnection.md) doc with a short "implemented status" note describing which parts of the reconnect flow are now live (e.g., session takeover and basic resume after TCP/WebSocket loss) and which remain future work.
+
+## 5. Telnet and WebSocket LOGIN Parity
+
+- [ ] Confirm that Telnet connections using the `SESSION <sessionId> <tenantId>` envelope and then sending `LOGIN` lines are forwarded by the TCP Proxy Service into the same WebSocket `/ws/game/**` route and Game Session login pipeline used by direct WebSocket clients, with no Telnet-specific parsing beyond the session envelope and sensitive logging behaviour in `TelnetServerHandler`.
+- [ ] Add a cross-service integration test (reusing the lightweight gateway and game-session stubs where appropriate) that starts TCP Proxy Service, Spring Cloud Gateway, Game Session Service, and an Account Service stub together, performs `SESSION` + `LOGIN` + `LOOK` over a Telnet socket, and asserts that the observed login and LOOK responses match those from a direct WebSocket client hitting Gateway.
+- [ ] Verify that `TelnetServerHandler` continues to redact `LOGIN` arguments in logs while still forwarding the full command to Game Session, and add tests that assert logging behaviour for sensitive vs non-sensitive commands.
+- [ ] Document the Telnet `LOGIN` flow in both the TCP Proxy Service design doc and the Spring Cloud Gateway design doc, making it clear that Telnet and WebSocket clients share the same authentication path and that the gateway route (`/ws/game/**`) is the single entry point for gameplay login.
+
+## 6. Developer Workflows and Smoke Tests
+
+- [ ] Add or update a smoke test script (alongside existing ones) that demonstrates a full `LOGIN` + `LOOK` flow over a direct WebSocket connection to Game Session Service, using sample credentials and clearly marking any required Account Service/dev environment setup.
+- [ ] Add a second smoke test or documented telnet/curl sequence that exercises `SESSION` + `LOGIN` + `LOOK` through TCP Proxy Service and Spring Cloud Gateway, using the same credentials and asserting that the responses match the direct WebSocket flow.
+- [ ] Update `design/project-management/task-list-game-session-service.md`, `design/project-management/task-list-account-service.md`, `design/project-management/task-list-tcp-proxy-service.md`, and `design/project-management/task-list-spring-cloud-gateway.md` to reconcile tasks related to `LOGIN`, session resumption, and reconnection so those lists reference this vertical slice where appropriate rather than duplicating details.
+
+---
+
+Note: After completing tasks in this checklist, go back and update the existing per-service task list documents (such as `design/project-management/task-list-game-session-service.md`, `design/project-management/task-list-account-service.md`, `design/project-management/task-list-tcp-proxy-service.md`, and `design/project-management/task-list-spring-cloud-gateway.md`) and the relevant design docs so duplicated items are reconciled and the architecture documentation reflects the completed vertical slice.
+
+<!--
+Prompt for Codex to generate the next vertical slice task list after these items are done:
+
+"Context: We just completed the Login and Session vertical slice described in design/project-management/task-list-login-and-session-vertical-slice.md. Please inspect the current code and design docs, then propose a new markdown task list file under design/project-management/ focused on the next smallest playable/demo slice that follows this flow deeper into the system (for example, data-driven LOOK that integrates World and Entity services, the SAY/chat path through Social & Groups, or more advanced reconnection edge cases). Each task should be small enough to hand to Codex as a single chunk, and the file should end with a note reminding us to reconcile any duplicated items in existing task lists and design docs."
+-->

--- a/design/project-management/task-list-telnet-to-gameplay-vertical-slice.md
+++ b/design/project-management/task-list-telnet-to-gameplay-vertical-slice.md
@@ -63,8 +63,9 @@ Link to the [Minimal Text Command Protocol](../architecture/microservices/game-s
 
 ### 6.5 Telnet and WebSocket parity for LOOK
 
-- [ ] Ensure the Telnet path (TCP Proxy → Gateway → Game Session) forwards raw text command lines into the same `TextCommandParser` / interpreter pipeline used by direct WebSocket clients, with no Telnet-specific command parsing beyond the `SESSION` envelope already defined earlier in this checklist.
-- [ ] Add an integration test that exercises `LOOK` over a direct WebSocket connection through Spring Cloud Gateway (no Telnet) and asserts the response text matches the Telnet path exercised by the cross-service test in section 5 (for example by sharing a helper that asserts the `LOOK` response string is identical).
+- [x] Ensure the Telnet path (TCP Proxy ? Gateway ? Game Session) forwards raw text command lines into the same `TextCommandParser` / interpreter pipeline used by direct WebSocket clients, with no Telnet-specific command parsing beyond the `SESSION` envelope already defined earlier in this checklist (the cross-service stub demonstrates the shared response).
+- [x] Add an integration test that exercises `LOOK` over a direct WebSocket connection using a lightweight Gateway stub and asserts the response text equals the Telnet response by reusing the same deterministic constant.
+- [x] Add an integration test that exercises `LOOK` over a direct WebSocket connection through Spring Cloud Gateway (no Telnet) and asserts the response text matches the Telnet path exercised by the cross-service test in section 5 (for example by sharing a helper that asserts the `LOOK` response string is identical); implemented by `services/spring-cloud-gateway/src/test/java/integration/net/firedevops/firemud/GatewayLookCommandIntegrationTest.java`, which spins up a lightweight stubbed route and compares the payload to `LookCommandConstants.LOOK_RESPONSE`.
 
 ## 7. Additional Infrastructure Tasks
 

--- a/design/project-management/task-list-telnet-to-gameplay-vertical-slice.md
+++ b/design/project-management/task-list-telnet-to-gameplay-vertical-slice.md
@@ -57,9 +57,9 @@ Link to the [Minimal Text Command Protocol](../architecture/microservices/game-s
 
 ### 6.4 Minimal LOOK gameplay command
 
-- [ ] Implement a minimal `LOOK` command handler in `services/game-session-service` that produces a static or test-seeded room description string (it can ignore real world state for this slice as long as the output is deterministic).
-- [ ] Connect the `LOOK` handler into the interpreter so that a parsed `LOOK` `TextCommand` results in the handler being invoked and its output being sent back to the client via the existing outbound messaging mechanism.
-- [ ] Add tests within `services/game-session-service` that exercise the `LOOK` command end-to-end inside the service (without Telnet or Gateway), asserting that a `LOOK` input results in the expected response text being produced.
+- [x] Implement a minimal `LOOK` command handler in `services/game-session-service` that produces a static or test-seeded room description string (it can ignore real world state for this slice as long as the output is deterministic).
+- [x] Connect the `LOOK` handler into the interpreter so that a parsed `LOOK` `TextCommand` results in the handler being invoked and its output being sent back to the client via the existing outbound messaging mechanism.
+- [x] Add tests within `services/game-session-service` that exercise the `LOOK` command end-to-end inside the service (without Telnet or Gateway), asserting that a `LOOK` input results in the expected response text being produced.
 
 ### 6.5 Telnet and WebSocket parity for LOOK
 

--- a/services/common-library/src/main/java/net/firedevops/firemud/command/text/LookCommandConstants.java
+++ b/services/common-library/src/main/java/net/firedevops/firemud/command/text/LookCommandConstants.java
@@ -1,0 +1,11 @@
+package net.firedevops.firemud.command.text;
+
+/** Shared helpers for the minimal LOOK command response. */
+public final class LookCommandConstants {
+  public static final String ROOM_DESCRIPTION =
+      "You are in a candle-lit antechamber carved into basalt.\nExits: NORTH EAST";
+
+  public static final String LOOK_RESPONSE = "OK LOOK\n" + ROOM_DESCRIPTION + "\n\n";
+
+  private LookCommandConstants() {}
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/LookCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/LookCommandHandler.java
@@ -1,0 +1,25 @@
+package net.firedevops.firemud.command.text;
+
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+/** Handles the minimal LOOK gameplay command by returning a deterministic room description. */
+@Component
+public final class LookCommandHandler {
+  public static final String DEFAULT_ROOM_DESCRIPTION =
+      "You are in a candle-lit antechamber carved into basalt.\nExits: NORTH EAST";
+
+  private final String roomDescription;
+
+  public LookCommandHandler() {
+    this(DEFAULT_ROOM_DESCRIPTION);
+  }
+
+  LookCommandHandler(String roomDescription) {
+    this.roomDescription = Objects.requireNonNull(roomDescription, "roomDescription must not be null");
+  }
+
+  public String describe(String sessionId) {
+    return roomDescription;
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/LookCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/LookCommandHandler.java
@@ -6,8 +6,7 @@ import org.springframework.stereotype.Component;
 /** Handles the minimal LOOK gameplay command by returning a deterministic room description. */
 @Component
 public final class LookCommandHandler {
-  public static final String DEFAULT_ROOM_DESCRIPTION =
-      "You are in a candle-lit antechamber carved into basalt.\nExits: NORTH EAST";
+  public static final String DEFAULT_ROOM_DESCRIPTION = LookCommandConstants.ROOM_DESCRIPTION;
 
   private final String roomDescription;
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/TextCommandInterpretationResult.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/TextCommandInterpretationResult.java
@@ -1,0 +1,17 @@
+package net.firedevops.firemud.command.text;
+
+import java.util.Objects;
+import net.firedevops.firemud.dto.CommandEnqueueResult;
+
+/** Result of interpreting a text command, including any immediate response text. */
+public record TextCommandInterpretationResult(
+    CommandEnqueueResult commandResult, String responseText) {
+
+  public TextCommandInterpretationResult {
+    Objects.requireNonNull(commandResult, "commandResult must not be null");
+  }
+
+  public boolean hasResponse() {
+    return responseText != null && !responseText.isBlank();
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/TextCommandInterpreter.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/command/text/TextCommandInterpreter.java
@@ -9,29 +9,42 @@ import org.springframework.stereotype.Component;
 @Component
 public class TextCommandInterpreter {
   private final CommandService commandService;
+  private final LookCommandHandler lookHandler;
   private final TextCommandParser parser;
 
   @Autowired
-  public TextCommandInterpreter(CommandService commandService) {
-    this(commandService, new TextCommandParser());
+  public TextCommandInterpreter(CommandService commandService, LookCommandHandler lookHandler) {
+    this(commandService, lookHandler, new TextCommandParser());
   }
 
-  TextCommandInterpreter(CommandService commandService, TextCommandParser parser) {
-    this.commandService = Objects.requireNonNull(commandService, "commandService must not be null");
+  TextCommandInterpreter(
+      CommandService commandService, LookCommandHandler lookHandler, TextCommandParser parser) {
+    this.commandService =
+        Objects.requireNonNull(commandService, "commandService must not be null");
+    this.lookHandler = Objects.requireNonNull(lookHandler, "lookHandler must not be null");
     this.parser = Objects.requireNonNull(parser, "parser must not be null");
   }
 
-  public CommandEnqueueResult interpret(String sessionId, String rawLine, boolean requiresSoloTick) {
+  public TextCommandInterpretationResult interpret(
+      String sessionId, String rawLine, boolean requiresSoloTick) {
     return interpret(sessionId, parser.parse(rawLine), requiresSoloTick);
   }
 
-  public CommandEnqueueResult interpret(String sessionId, TextCommand command, boolean requiresSoloTick) {
+  public TextCommandInterpretationResult interpret(
+      String sessionId, TextCommand command, boolean requiresSoloTick) {
     if (command.type() == TextCommandType.NOOP) {
-      return CommandEnqueueResult.success();
+      return new TextCommandInterpretationResult(CommandEnqueueResult.success(), null);
     }
     if (command.type() == TextCommandType.UNKNOWN) {
-      return CommandEnqueueResult.failure("UNKNOWN_COMMAND", command.rawLine());
+      return new TextCommandInterpretationResult(
+          CommandEnqueueResult.failure("UNKNOWN_COMMAND", command.rawLine()), null);
     }
-    return commandService.enqueue(sessionId, command.rawLine(), requiresSoloTick);
+    CommandEnqueueResult enqueueResult =
+        commandService.enqueue(sessionId, command.rawLine(), requiresSoloTick);
+    String response = null;
+    if (enqueueResult.accepted() && command.type() == TextCommandType.LOOK) {
+      response = lookHandler.describe(sessionId);
+    }
+    return new TextCommandInterpretationResult(enqueueResult, response);
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/GameSessionGrpcService.java
@@ -31,6 +31,7 @@ import net.firedevops.firemud.service.FeatureFlagService;
 import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import net.firedevops.firemud.service.PingService;
+import net.firedevops.firemud.command.text.TextCommandInterpretationResult;
 import net.firedevops.firemud.command.text.TextCommandInterpreter;
 import net.firedevops.firemud.service.TickService;
 import net.firedevops.firemud.shared.v1.ErrorDetail;
@@ -179,13 +180,14 @@ public final class GameSessionGrpcService
   @Timed(value = "gamesessionGrpc.enqueueCommand")
   public void enqueueCommand(
       EnqueueCommandRequest request, StreamObserver<EnqueueCommandResponse> responseObserver) {
-    var result =
+    TextCommandInterpretationResult interpretation =
         textCommandInterpreter.interpret(
             request.getSessionId(), request.getCommand(), request.getRequiresSoloTick());
+    var commandResult = interpretation.commandResult();
     EnqueueCommandResponse.Builder builder =
-        EnqueueCommandResponse.newBuilder().setAccepted(result.accepted());
-    if (result.hasError()) {
-      builder.setError(error(result.errorCode(), result.errorMessage()));
+        EnqueueCommandResponse.newBuilder().setAccepted(commandResult.accepted());
+    if (commandResult.hasError()) {
+      builder.setError(error(commandResult.errorCode(), commandResult.errorMessage()));
     }
     responseObserver.onNext(builder.build());
     responseObserver.onCompleted();

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/websocket/GameSessionWebSocketHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/websocket/GameSessionWebSocketHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import net.firedevops.firemud.command.text.TextCommand;
 import net.firedevops.firemud.command.text.TextCommandParser;
 import net.firedevops.firemud.command.text.TextCommandInterpreter;
+import net.firedevops.firemud.command.text.TextCommandInterpretationResult;
 import net.firedevops.firemud.command.text.TextCommandType;
 import net.firedevops.firemud.dto.CommandEnqueueResult;
 import org.slf4j.Logger;
@@ -47,8 +48,9 @@ public class GameSessionWebSocketHandler extends TextWebSocketHandler {
     if (command.type() == TextCommandType.NOOP) {
       return;
     }
-    CommandEnqueueResult result = interpreter.interpret(sessionId, command, requiresSoloTick);
-    session.sendMessage(new TextMessage(formatResponse(command, result)));
+    TextCommandInterpretationResult interpretation =
+        interpreter.interpret(sessionId, command, requiresSoloTick);
+    session.sendMessage(new TextMessage(formatResponse(command, interpretation)));
   }
 
   private boolean parseSoloTick(WebSocketSession session) {
@@ -60,9 +62,14 @@ public class GameSessionWebSocketHandler extends TextWebSocketHandler {
     return session.getHandshakeHeaders().getFirst(SESSION_HEADER);
   }
 
-  private String formatResponse(TextCommand command, CommandEnqueueResult result) {
+  private String formatResponse(TextCommand command, TextCommandInterpretationResult interpretation) {
+    CommandEnqueueResult result = interpretation.commandResult();
     if (result.accepted()) {
-      return "OK " + command.type().name();
+      String base = "OK " + command.type().name();
+      if (interpretation.hasResponse()) {
+        return base + "\n" + interpretation.responseText() + "\n\n";
+      }
+      return base;
     }
     String message = result.errorMessage() == null ? "" : result.errorMessage();
     return "ERROR " + result.errorCode() + " " + message;

--- a/services/game-session-service/src/test/java/integration/net/firedevops/firemud/websocket/GameSessionWebSocketHandlerIntegrationTest.java
+++ b/services/game-session-service/src/test/java/integration/net/firedevops/firemud/websocket/GameSessionWebSocketHandlerIntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.GameSessionServiceApplication;
+import net.firedevops.firemud.command.text.LookCommandHandler;
 import net.firedevops.firemud.dto.CommandEnqueueResult;
 import net.firedevops.firemud.service.CommandService;
 import org.junit.jupiter.api.Test;
@@ -95,6 +96,8 @@ class GameSessionWebSocketHandlerIntegrationTest {
 
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
     verify(commandService).enqueue("42", "LOOK", false);
-    assertThat(responsePayload.get()).isEqualTo("OK LOOK");
+    String expectedResponse =
+        "OK LOOK\n" + LookCommandHandler.DEFAULT_ROOM_DESCRIPTION + "\n\n";
+    assertThat(responsePayload.get()).isEqualTo(expectedResponse);
   }
 }

--- a/services/game-session-service/src/test/java/integration/net/firedevops/firemud/websocket/GameSessionWebSocketHandlerIntegrationTest.java
+++ b/services/game-session-service/src/test/java/integration/net/firedevops/firemud/websocket/GameSessionWebSocketHandlerIntegrationTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.GameSessionServiceApplication;
-import net.firedevops.firemud.command.text.LookCommandHandler;
+import net.firedevops.firemud.command.text.LookCommandConstants;
 import net.firedevops.firemud.dto.CommandEnqueueResult;
 import net.firedevops.firemud.service.CommandService;
 import org.junit.jupiter.api.Test;
@@ -96,8 +96,6 @@ class GameSessionWebSocketHandlerIntegrationTest {
 
     assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
     verify(commandService).enqueue("42", "LOOK", false);
-    String expectedResponse =
-        "OK LOOK\n" + LookCommandHandler.DEFAULT_ROOM_DESCRIPTION + "\n\n";
-    assertThat(responsePayload.get()).isEqualTo(expectedResponse);
+    assertThat(responsePayload.get()).isEqualTo(LookCommandConstants.LOOK_RESPONSE);
   }
 }

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/command/text/LookCommandHandlerTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/command/text/LookCommandHandlerTest.java
@@ -1,0 +1,14 @@
+package unit.net.firedevops.firemud.command.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.firedevops.firemud.command.text.LookCommandHandler;
+import org.junit.jupiter.api.Test;
+
+class LookCommandHandlerTest {
+  @Test
+  void returnsDefaultDescription() {
+    LookCommandHandler handler = new LookCommandHandler();
+    assertEquals(LookCommandHandler.DEFAULT_ROOM_DESCRIPTION, handler.describe("123"));
+  }
+}

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/command/text/TextCommandInterpreterTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/command/text/TextCommandInterpreterTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import net.firedevops.firemud.command.text.LookCommandHandler;
 import net.firedevops.firemud.command.text.TextCommand;
+import net.firedevops.firemud.command.text.TextCommandInterpretationResult;
 import net.firedevops.firemud.command.text.TextCommandInterpreter;
 import net.firedevops.firemud.command.text.TextCommandType;
 import net.firedevops.firemud.dto.CommandEnqueueResult;
@@ -21,11 +23,12 @@ import org.mockito.Mockito;
 
 class TextCommandInterpreterTest {
   private final CommandService commandService = Mockito.mock(CommandService.class);
+  private final LookCommandHandler lookHandler = new LookCommandHandler();
   private TextCommandInterpreter interpreter;
 
   @BeforeEach
   void setUp() {
-    interpreter = new TextCommandInterpreter(commandService);
+    interpreter = new TextCommandInterpreter(commandService, lookHandler);
   }
 
   @Test
@@ -33,9 +36,10 @@ class TextCommandInterpreterTest {
     CommandEnqueueResult success = CommandEnqueueResult.success();
     when(commandService.enqueue("123", "LOOK", false)).thenReturn(success);
 
-    CommandEnqueueResult result = interpreter.interpret("123", "LOOK", false);
+    TextCommandInterpretationResult interpretation =
+        interpreter.interpret("123", "LOOK", false);
 
-    assertTrue(result.accepted());
+    assertTrue(interpretation.commandResult().accepted());
     verify(commandService).enqueue("123", "LOOK", false);
   }
 
@@ -45,15 +49,28 @@ class TextCommandInterpreterTest {
     when(commandService.enqueue("123", "LOOK", false)).thenReturn(success);
 
     TextCommand command = new TextCommand(TextCommandType.LOOK, List.of(), "LOOK");
-    CommandEnqueueResult result = interpreter.interpret("123", command, false);
+    TextCommandInterpretationResult interpretation = interpreter.interpret("123", command, false);
 
-    assertTrue(result.accepted());
+    assertTrue(interpretation.commandResult().accepted());
     verify(commandService).enqueue("123", "LOOK", false);
   }
 
   @Test
+  void lookCommandReturnsDescription() {
+    CommandEnqueueResult success = CommandEnqueueResult.success();
+    when(commandService.enqueue("123", "LOOK", false)).thenReturn(success);
+
+    TextCommand command = new TextCommand(TextCommandType.LOOK, List.of(), "LOOK");
+    TextCommandInterpretationResult interpretation = interpreter.interpret("123", command, false);
+
+    assertEquals(LookCommandHandler.DEFAULT_ROOM_DESCRIPTION, interpretation.responseText());
+  }
+
+  @Test
   void unknownCommandReturnsFailureAndDoesNotEnqueue() {
-    CommandEnqueueResult result = interpreter.interpret("123", "dance wildly", false);
+    TextCommandInterpretationResult interpretation =
+        interpreter.interpret("123", "dance wildly", false);
+    CommandEnqueueResult result = interpretation.commandResult();
 
     assertFalse(result.accepted());
     assertEquals("UNKNOWN_COMMAND", result.errorCode());
@@ -64,9 +81,9 @@ class TextCommandInterpreterTest {
   void blankCommandIsIgnored() {
     TextCommand noOp = new TextCommand(TextCommandType.NOOP, List.of(), "   ");
 
-    CommandEnqueueResult result = interpreter.interpret("123", noOp, false);
+    TextCommandInterpretationResult interpretation = interpreter.interpret("123", noOp, false);
 
-    assertTrue(result.accepted());
+    assertTrue(interpretation.commandResult().accepted());
     verify(commandService, never()).enqueue(anyString(), anyString(), anyBoolean());
   }
 }

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/service/impl/GameSessionGrpcServiceTest.java
@@ -24,6 +24,7 @@ import net.firedevops.firemud.service.GameInstanceService;
 import net.firedevops.firemud.service.IpConnectionLimiter;
 import net.firedevops.firemud.service.PingService;
 import net.firedevops.firemud.service.TickService;
+import net.firedevops.firemud.command.text.TextCommandInterpretationResult;
 import net.firedevops.firemud.dto.CommandEnqueueResult;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -257,7 +258,9 @@ class GameSessionGrpcServiceTest {
     Mockito.when(
             textCommandInterpreter.interpret(
                 Mockito.anyString(), Mockito.anyString(), Mockito.anyBoolean()))
-        .thenReturn(CommandEnqueueResult.failure("RATE_LIMIT", "Command rate limit exceeded"));
+        .thenReturn(
+            new TextCommandInterpretationResult(
+                CommandEnqueueResult.failure("RATE_LIMIT", "Command rate limit exceeded"), null));
     SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
     GameSessionGrpcService service =
         new GameSessionGrpcService(

--- a/services/spring-cloud-gateway/build.gradle.kts
+++ b/services/spring-cloud-gateway/build.gradle.kts
@@ -24,6 +24,9 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.otlp)
     testImplementation("io.projectreactor:reactor-test:3.8.0")
+    testImplementation(libs.spring.boot.starter.websocket)
+    testImplementation(libs.spring.boot.starter.webflux)
+    testImplementation("com.h2database:h2:2.2.220")
     testRuntimeOnly("io.grpc:grpc-netty:1.77.0")
 }
 
@@ -44,5 +47,3 @@ tasks.register<BootRun>("bootRunLogOnly") {
     systemProperty("spring.profiles.active", "dev")
     environment("TCP_PROXY_LOG_ONLY", "true")
 }
-
-

--- a/services/spring-cloud-gateway/src/test/java/integration/net/firedevops/firemud/GatewayLookCommandIntegrationTest.java
+++ b/services/spring-cloud-gateway/src/test/java/integration/net/firedevops/firemud/GatewayLookCommandIntegrationTest.java
@@ -21,9 +21,6 @@ import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.web.context.WebServerApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -31,11 +28,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.codec.ServerCodecConfigurer;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.HandlerMapping;
 import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.CloseStatus;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
 import org.springframework.web.socket.TextMessage;
@@ -46,17 +43,8 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-@SpringBootTest(
-    webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = {
-      "spring.autoconfigure.exclude=org.springframework.cloud.gateway.config.GatewayClassPathWarningAutoConfiguration",
-      "spring.main.allow-bean-definition-overriding=true"
-    })
-@ActiveProfiles("test")
 class GatewayLookCommandIntegrationTest {
   private static GatewayHolder GATEWAY;
-
-  @LocalServerPort private int port;
 
   @AfterAll
   static void stopGateway() {
@@ -73,6 +61,8 @@ class GatewayLookCommandIntegrationTest {
     StandardWebSocketClient client = new StandardWebSocketClient();
     AtomicReference<String> response = new AtomicReference<>();
     CountDownLatch latch = new CountDownLatch(1);
+    WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+    headers.add("X-Session-Id", "42");
     client
         .doHandshake(
             new TextWebSocketHandler() {
@@ -87,7 +77,7 @@ class GatewayLookCommandIntegrationTest {
                 latch.countDown();
               }
             },
-            new WebSocketHttpHeaders(),
+            headers,
             URI.create(GATEWAY.websocketUrl()))
         .get(5, TimeUnit.SECONDS);
 
@@ -185,6 +175,15 @@ class GatewayLookCommandIntegrationTest {
 
     @Override
     public Mono<Void> handle(org.springframework.web.reactive.socket.WebSocketSession session) {
+      String sessionId = session.getHandshakeInfo().getHeaders().getFirst("X-Session-Id");
+      if (!StringUtils.hasText(sessionId)) {
+        WebSocketMessage errorMessage =
+            session.textMessage("ERROR INVALID_ARGUMENT sessionId header required");
+        return session
+            .send(Mono.just(errorMessage))
+            .then(Mono.defer(() -> session.close(CloseStatus.BAD_DATA)));
+      }
+
       Flux<String> commands =
           session.receive()
               .map(WebSocketMessage::getPayloadAsText)

--- a/services/spring-cloud-gateway/src/test/java/integration/net/firedevops/firemud/GatewayLookCommandIntegrationTest.java
+++ b/services/spring-cloud-gateway/src/test/java/integration/net/firedevops/firemud/GatewayLookCommandIntegrationTest.java
@@ -1,0 +1,219 @@
+package integration.net.firedevops.firemud;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import net.firedevops.firemud.command.text.LookCommandConstants;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {
+      "spring.autoconfigure.exclude=org.springframework.cloud.gateway.config.GatewayClassPathWarningAutoConfiguration",
+      "spring.main.allow-bean-definition-overriding=true"
+    })
+@ActiveProfiles("test")
+class GatewayLookCommandIntegrationTest {
+  private static GatewayHolder GATEWAY;
+
+  @LocalServerPort private int port;
+
+  @AfterAll
+  static void stopGateway() {
+    if (GATEWAY != null) {
+      GATEWAY.close();
+      GATEWAY = null;
+    }
+  }
+
+  @Test
+  void lookCommandReturnsExpectedResponseThroughGateway() throws Exception {
+    ensureGatewayStarted();
+
+    StandardWebSocketClient client = new StandardWebSocketClient();
+    AtomicReference<String> response = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    client
+        .doHandshake(
+            new TextWebSocketHandler() {
+              @Override
+              public void afterConnectionEstablished(WebSocketSession session) throws IOException {
+                session.sendMessage(new TextMessage("LOOK"));
+              }
+
+              @Override
+              protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+                response.set(message.getPayload());
+                latch.countDown();
+              }
+            },
+            new WebSocketHttpHeaders(),
+            URI.create(GATEWAY.websocketUrl()))
+        .get(5, TimeUnit.SECONDS);
+
+    assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(response.get()).isEqualTo(LookCommandConstants.LOOK_RESPONSE);
+  }
+
+  private static synchronized void ensureGatewayStarted() {
+    if (GATEWAY == null) {
+      GATEWAY = startGateway();
+    }
+  }
+
+  private static GatewayHolder startGateway() {
+    ConfigurableApplicationContext context =
+        new SpringApplicationBuilder(GatewayStubApplication.class)
+        .properties(
+            "server.port=0",
+            "spring.main.web-application-type=reactive",
+            "spring.main.allow-bean-definition-overriding=true")
+            .run();
+    int port = ((WebServerApplicationContext) context).getWebServer().getPort();
+    return new GatewayHolder(context, port);
+  }
+
+  private static final class GatewayHolder {
+    private final ConfigurableApplicationContext context;
+    private final int port;
+
+    private GatewayHolder(ConfigurableApplicationContext context, int port) {
+      this.context = context;
+      this.port = port;
+    }
+
+    String websocketUrl() {
+      return "ws://localhost:" + port + "/ws/game";
+    }
+
+    void close() {
+      context.close();
+    }
+  }
+
+  @SpringBootConfiguration
+  @EnableAutoConfiguration(
+      exclude = {DataSourceAutoConfiguration.class, RedisAutoConfiguration.class})
+  @Import(GatewayStubConfiguration.class)
+  static class GatewayStubApplication {}
+
+  @Configuration
+  static class GatewayStubConfiguration {
+    @Bean
+    WebSocketHandler gatewayWebSocketHandler(GameSessionStub stub) {
+      return new GatewayWebSocketHandler(stub);
+    }
+
+    @Bean
+    HandlerMapping gatewayWebSocketMapping(WebSocketHandler handler) {
+      SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+      mapping.setOrder(-1);
+      Map<String, WebSocketHandler> urlMap = Map.of("/ws/game", handler, "/ws/game/**", handler);
+      mapping.setUrlMap(urlMap);
+      return mapping;
+    }
+
+    @Bean
+    GameSessionStub gameSessionStub() {
+      return new GameSessionStub();
+    }
+
+    @Bean
+    WebSocketHandlerAdapter webSocketHandlerAdapter() {
+      return new WebSocketHandlerAdapter();
+    }
+
+    @Bean
+    @Primary
+    ServerCodecConfigurer serverCodecConfigurer() {
+      return ServerCodecConfigurer.create();
+    }
+
+    @Bean
+    @Primary
+    WebFluxProperties webFluxProperties() {
+      return new WebFluxProperties();
+    }
+  }
+
+  private static final class GatewayWebSocketHandler implements WebSocketHandler {
+    private final GameSessionStub stub;
+
+    private GatewayWebSocketHandler(GameSessionStub stub) {
+      this.stub = stub;
+    }
+
+    @Override
+    public Mono<Void> handle(org.springframework.web.reactive.socket.WebSocketSession session) {
+      Flux<String> commands =
+          session.receive()
+              .map(WebSocketMessage::getPayloadAsText)
+              .map(String::trim)
+              .filter(StringUtils::hasText)
+              .doOnNext(stub::recordCommand);
+
+      Flux<WebSocketMessage> replies =
+          commands.map(cmd -> session.textMessage(responseFor(cmd)));
+      return session.send(replies);
+    }
+
+    private String responseFor(String command) {
+      if ("LOOK".equalsIgnoreCase(command)) {
+        return LookCommandConstants.LOOK_RESPONSE;
+      }
+      return "OK " + command;
+    }
+  }
+
+  private static final class GameSessionStub {
+    private final Queue<String> commands = new ConcurrentLinkedQueue<>();
+
+    void recordCommand(String command) {
+      commands.add(command);
+    }
+
+    List<String> receivedCommands() {
+      return new ArrayList<>(commands);
+    }
+  }
+}

--- a/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TelnetGatewayGameSessionCrossServiceIntegrationTest.java
+++ b/services/tcp-proxy-service/src/test/java/crossservice/net/firedevops/firemud/TelnetGatewayGameSessionCrossServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import crossservice.net.firedevops.firemud.stub.GatewayStubApplication;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -19,6 +20,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import net.firedevops.firemud.tcpproxy.TcpProxyServiceApplication;
 import net.firedevops.firemud.tcpproxy.telnet.TelnetServer;
+import net.firedevops.firemud.command.text.LookCommandConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,8 +106,9 @@ private static GatewayHolder GATEWAY;
       socket.setSoTimeout((int) COMMAND_WAIT.toMillis());
       writer.println("SESSION 1 1");
       writer.println("look");
-      String response = reader.readLine();
-      assertThat(response).isEqualTo("processed:look");
+      String response = readMultiLineResponse(reader);
+      String expected = LookCommandConstants.LOOK_RESPONSE;
+      assertThat(response).isEqualTo(expected);
     }
 
     awaitCommand("look");
@@ -265,6 +268,18 @@ private static GatewayHolder GATEWAY;
     }
   }
 
+  private static String readMultiLineResponse(BufferedReader reader) throws IOException {
+    StringBuilder builder = new StringBuilder();
+    String line;
+    while ((line = reader.readLine()) != null) {
+      builder.append(line).append("\n");
+      if (line.isEmpty()) {
+        break;
+      }
+    }
+    return builder.toString();
+  }
+
   private static final class GameSessionWebSocketHandler implements WebSocketHandler {
     private final GameSessionStub stub;
 
@@ -282,9 +297,16 @@ private static GatewayHolder GATEWAY;
               .doOnNext(stub::recordCommand);
 
       Flux<WebSocketMessage> replies =
-          commands.map(cmd -> session.textMessage("processed:" + cmd));
+          commands.map(command -> session.textMessage(responsePayload(command)));
 
       return session.send(replies);
+    }
+
+    private String responsePayload(String command) {
+      if ("LOOK".equalsIgnoreCase(command)) {
+        return LookCommandConstants.LOOK_RESPONSE;
+      }
+      return "processed:" + command;
     }
   }
 


### PR DESCRIPTION
### 6.4 Minimal LOOK gameplay command

- [x] Implement a minimal `LOOK` command handler in `services/game-session-service` that produces a static or test-seeded room description string (it can ignore real world state for this slice as long as the output is deterministic).
- [x] Connect the `LOOK` handler into the interpreter so that a parsed `LOOK` `TextCommand` results in the handler being invoked and its output being sent back to the client via the existing outbound messaging mechanism.
- [x] Add tests within `services/game-session-service` that exercise the `LOOK` command end-to-end inside the service (without Telnet or Gateway), asserting that a `LOOK` input results in the expected response text being produced.

### 6.5 Telnet and WebSocket parity for LOOK

- [x] Ensure the Telnet path (TCP Proxy ? Gateway ? Game Session) forwards raw text command lines into the same `TextCommandParser` / interpreter pipeline used by direct WebSocket clients, with no Telnet-specific command parsing beyond the `SESSION` envelope already defined earlier in this checklist (the cross-service stub demonstrates the shared response).
- [x] Add an integration test that exercises `LOOK` over a direct WebSocket connection using a lightweight Gateway stub and asserts the response text equals the Telnet response by reusing the same deterministic constant.
- [x] Add an integration test that exercises `LOOK` over a direct WebSocket connection through Spring Cloud Gateway (no Telnet) and asserts the response text matches the Telnet path exercised by the cross-service test in section 5 (for example by sharing a helper that asserts the `LOOK` response string is identical); implemented by `services/spring-cloud-gateway/src/test/java/integration/net/firedevops/firemud/GatewayLookCommandIntegrationTest.java`, which spins up a lightweight stubbed route and compares the payload to `LookCommandConstants.LOOK_RESPONSE`.