### PR TITLE
Docs, CI/CD, and Flyway configuration cleanup

### DIFF
--- a/design/architecture/system-architecture-gateway.md
+++ b/design/architecture/system-architecture-gateway.md
@@ -10,7 +10,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 
 - Built as a Spring Boot microservice
 - Handles **client** request routing, filtering, CORS, rate limiting, retries, and monitoring
-- For admin APIs the Gateway forwards JWTs to backend services without validating them. Gameplay login is processed by the **Game Session Service**; see [Authentication & Authorization](./system-architecture-authentication.md#login-and-session-flow) for the detailed flow.
+- For admin APIs the Gateway forwards JWTs to backend services without validating them. Player login and session binding are processed by the **Game Session Service**; see [Authentication & Authorization](./system-architecture-authentication.md#login-and-session-flow) for the detailed flow.
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required

--- a/design/architecture/system-architecture-gateway.md
+++ b/design/architecture/system-architecture-gateway.md
@@ -14,7 +14,7 @@ This document describes the role and configuration of **Spring Cloud Gateway** i
 - Supports both HTTP and WebSocket protocols
 - Deployed in both development and production environments
 - **Stateless and horizontally scalable** – no sticky sessions required
-- Auto‑scaling policies handle high concurrency.
+- Auto‑scaling policies handle high concurrency
 - Telnet clients keep a **persistent TCP connection** to the TCP Proxy Service; the Gateway
   itself does not hold session state between reconnects
 - Gateway restarts automatically re-establish WebSocket connections to backend services. See [Reconnection Strategy](./system-architecture-reconnection.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,6 @@ org.gradle.caching=true
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=true
 # DO NOT set org.gradle.java.home (remove it if present)
-org.gradle.jvmargs=-Xmx1.5g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx1500m -Dfile.encoding=UTF-8
 org.gradle.workers.max=4
-
 version=0.1.0


### PR DESCRIPTION
# Docs, CI/CD, and Flyway configuration cleanup

High-level changes since the last merge of this branch into `develop`:

- **Docs & formatting**
  - Refined the top-level `README.md` and design docs (architecture, repository structure, user journeys, performance, etc.).
  - Removed emojis from headings so anchors are stable and easier to link to.
  - Added consistent link callout style (`> 🔗 See …`) and clarified list-sorting / line-wrapping rules.

- **CI/CD documentation**
  - Updated the CI/CD architecture doc to match the current GitHub Actions workflows (Buf, Gradle matrix checks, Trivy, docs/link lint, ERD generation, preview environments).
  - Documented concurrency groups, caching of Gradle/Node/Trivy/Buf artifacts, and how link checks run in both `ci.yml` and `docs.yml`.

- **Flyway configuration**
  - Centralized Flyway configuration in the root Gradle build (plugin + `flyway-core` / Postgres dependencies for all services under `services/`).
  - Removed redundant per-service `flyway-core` dependencies and updated the database migrations doc to describe the centralized model.

- **AI formatting guidance**
  - Added an AI formatting rules doc under `design/project-management` so future automated formatting passes (headings, link callouts, sorted lists, line wrapping) are consistent without affecting runtime behavior.

- **Gradle tooling**
  - Enforced a Windows-compatible JVM heap size (`-Xmx1500m`) so the daemon starts reliably and `gradlew lintMarkdown -PfullCheck=true` succeeds on all platforms.
