### PR TITLE
Polish Redis/tick docs and always lint markdown

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -107,7 +107,7 @@ version from GitHub Container Registry.
 
 ## ✅ Markdown Linting via Gradle
 
-This project uses `markdownlint-cli2` to lint Markdown files. To speed up local builds, `./gradlew check` skips Markdown lint along with SpotBugs, Checkstyle, JaCoCo coverage, and other heavy analysis unless the `fullCheck` property is supplied:
+This project uses `markdownlint-cli2` to lint Markdown files. To speed up local builds, the `fullCheck` property controls heavy analysis tasks such as SpotBugs, Checkstyle, Spotless checks, and JaCoCo coverage; these are skipped from `./gradlew check` unless `fullCheck` is supplied. Markdown lint and link checks are relatively fast and always run as part of `check`.
 
 ```bash
 ./gradlew check -PfullCheck
@@ -120,7 +120,7 @@ To always run the full suite of checks locally, add the property to your Gradle 
 org.gradle.project.fullCheck=true
 ```
 
-Restart the daemon once with `./gradlew --stop` so the new setting is picked up. Every subsequent build (`./gradlew build`, `./gradlew check`, etc.) then executes SpotBugs, Checkstyle, Jacoco coverage, and other tasks gated by `fullCheck`.
+Restart the daemon once with `./gradlew --stop` so the new setting is picked up. Every subsequent build (`./gradlew build`, `./gradlew check`, etc.) then executes SpotBugs, Checkstyle, Spotless checks, JaCoCo coverage, and other tasks gated by `fullCheck`.
 
 Verify the property is active with:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -202,22 +202,14 @@ tasks.register<Exec>("linkCheck") {
     environment("CHECK_EXTERNAL_LINKS", if (fullCheck) "1" else "0")
 }
 
-tasks.named("lintMarkdown") {
-    enabled = fullCheck
-}
-
-tasks.named("linkCheck") {
-    enabled = fullCheck
-}
-
 tasks.named("check") {
+    // Always run Markdown lint and link checks; they are relatively fast.
+    dependsOn("lintMarkdown", "linkCheck")
     if (fullCheck) {
         dependsOn(
-            "lintMarkdown",
             "checkstyleMain",
             "spotbugsMain",
-            "jacocoTestReport",
-            "linkCheck"
+            "jacocoTestReport"
         )
     }
 }

--- a/design/architecture/microservices/account-service/README.md
+++ b/design/architecture/microservices/account-service/README.md
@@ -203,7 +203,7 @@ This service sends verification and password reset emails using a configured SMT
 
 ### Session Management
 
-Authentication generates a JWT that is stored **server-side** in Redis for internal calls. Keys follow `session:{tenantId}:{token}` and expire according to `session-expiration-ms` in `AuthProperties`. The TTL is configured via the `FIREMUD_AUTH_SESSION_EXPIRATION_MS` environment variable described in [Environment & Secrets](../../infrastructure/environment-and-secrets.md#authentication).
+Authentication generates a JWT that is stored **server-side** in Redis for internal calls. Keys follow `session:{tenantId}:{tokenHash}`, where `tokenHash` is a fixed-length digest (for example, a hex-encoded SHA-256 of the JWT), and expire according to `session-expiration-ms` in `AuthProperties`. The TTL is configured via the `FIREMUD_AUTH_SESSION_EXPIRATION_MS` environment variable described in [Environment & Secrets](../../infrastructure/environment-and-secrets.md#authentication).
 
 ### Two-Factor Authentication
 

--- a/design/architecture/microservices/automation-scripting-service/sandbox-runtime-design.md
+++ b/design/architecture/microservices/automation-scripting-service/sandbox-runtime-design.md
@@ -152,7 +152,7 @@ Memory safety relies on three complementary mechanisms:
    - Containers and JVM options enforce hard ceilings on memory usage.
    - Catastrophic violations (for example, `OutOfMemoryError`) cause the container to be restarted and are treated as infrastructure issues, not script-level sandbox errors.
 
-### Enforcement Mechanism
+### Memory Enforcement Mechanism
 
 Within a script run, the engine implements **soft memory guards**:
 

--- a/design/architecture/microservices/entity-management-service/README.md
+++ b/design/architecture/microservices/entity-management-service/README.md
@@ -168,13 +168,14 @@ grpcurl -plaintext localhost:6565 entity_management.v1.EntityManagementService/P
 
 ### Tick Locking
 
-This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:{tenantId}:{regionId}:lock:{entityId}` key described in the [Redis Architecture](../../system-architecture-redis.md) document so that lock keys share a hash tag with tick queues and pending state. Lock TTLs follow the canonical formula from the Redis design:
+This service participates in tick processing by acquiring Redis locks before mutating entity state. The `TickLockService` uses the `tick:{tenantId}:{regionId}:lock:{entityId}` key described in the [Redis Architecture](../../system-architecture-redis.md) document so that lock keys share a hash tag with tick queues and pending state. Lock TTLs follow the simplified formula from the Redis design:
 
-- `lock_ttl_ms = clamp(tick_budget_ms * 3, MIN_LOCK_TTL_MS, MAX_LOCK_TTL_MS)`
-- `tick_budget_ms` maps to the `game.tick-budget-ms` property.
-- `MIN_LOCK_TTL_MS` and `MAX_LOCK_TTL_MS` map to the `game.tick-min-lock-ttl-ms` and `game.tick-max-lock-ttl-ms` properties (defaults 500 ms and 5_000 ms respectively).
+- The Game Session Service exposes `game.tick-interval-ms` as the primary pacing knob.
+- Internally it derives a soft budget and TTLs, for example:
+  - `tick_budget_ms = tick_interval_ms * 0.8`
+  - `lock_ttl_ms = clamp(tick_budget_ms * 8, 500, 5_000)`
 
-These settings keep locks alive long enough for normal ticks to complete while still bounding the recovery window for stalled ticks.
+Entity Management treats `lock_ttl_ms` as an opaque value supplied by shared helpers; it does not define its own lock TTL configuration. This keeps locks alive long enough for normal ticks to complete while still bounding the recovery window for stalled ticks.
 
 Entity Management assumes the **per-command execution phases** described in the [Tick System design](../../system-architecture-ticks.md#per-command-execution-phases): commands that touch multiple entities in the same region resolve their target set first (for example, the two parties in a trade or all entities in a room for AoE effects), then acquire the necessary `tick:{tenantId}:{regionId}:lock:{entityId}` keys in a deterministic order. If any required lock is unavailable, the command fails, staged changes are rolled back via Redis, and the Game Session Service reschedules the work using the retry mechanisms described in the Tick System and Redis designs.
 

--- a/design/architecture/performance-optimization.md
+++ b/design/architecture/performance-optimization.md
@@ -82,9 +82,10 @@ These notes summarize typical optimizations applied across FireMUD services.
   downloads between CI runs.
 - Separate build jobs for backend, frontend, and docs keep feedback fast and
   allow caching to be scoped to the tools they use.
-- Heavy analysis tasks (SpotBugs, Checkstyle, JaCoCo, markdownlint, link
-  checking) are gated behind the `fullCheck` flag so routine local builds stay
-  quick while CI can still run the full suite when needed.
+- Heavy analysis tasks (SpotBugs, Checkstyle, JaCoCo, Spotless checks) are
+  gated behind the `fullCheck` flag so routine local builds stay quick while
+  CI can still run the full suite when needed. Markdown lint and link checks
+  are relatively fast and always run as part of `check`.
 
 ## Related Documentation
 

--- a/design/architecture/system-architecture-authentication.md
+++ b/design/architecture/system-architecture-authentication.md
@@ -12,7 +12,7 @@ Authentication is performed via plaintext `LOGIN` commands. Clients are stateles
 
 Admin and moderator accounts can optionally enable **two-factor authentication**. When a `two_factor_secret` is present, the Account Service expects a one-time TOTP code during login. The `/auth/login` REST endpoint and the `Authenticate` gRPC call both accept an `otp` field for this purpose. The Game Session Service forwards this OTP when a player logs in.
 
-Issued JWTs are stored in Redis using keys `session:{tenantId}:{token}` with an expiration controlled by `session-expiration-ms` (default `3600000` ms). JWT and session lifetimes are configured via the `FIREMUD_AUTH_JWT_EXPIRATION_MS` and `FIREMUD_AUTH_SESSION_EXPIRATION_MS` environment variables documented in [Environment & Secrets](./infrastructure/environment-and-secrets.md#authentication).
+Issued JWTs are stored in Redis using keys `session:{tenantId}:{tokenHash}` where `tokenHash` is a fixed-length digest (for example, a hex-encoded SHA-256 of the JWT). This keeps key lengths bounded and avoids leaking raw token contents into key names. The entries use an expiration controlled by `session-expiration-ms` (default `3600000` ms). JWT and session lifetimes are configured via the `FIREMUD_AUTH_JWT_EXPIRATION_MS` and `FIREMUD_AUTH_SESSION_EXPIRATION_MS` environment variables documented in [Environment & Secrets](./infrastructure/environment-and-secrets.md#authentication).
 
 ---
 

--- a/design/architecture/system-architecture-redis-cache.md
+++ b/design/architecture/system-architecture-redis-cache.md
@@ -13,7 +13,9 @@ Redis is already used for transient coordination (ticks, sessions, locks). This 
   - Static or topology data (world geometry, room/zone graphs, published templates, configuration) changes infrequently and is a good fit for aggressive caching with long TTLs or manual invalidation.
 - Dynamic runtime state (inventories, room occupants, transient effects, in-progress combat) changes frequently and must use careful invalidation rules and short-lived caches, if cached at all.
 - Purpose-driven caching only. Objects should be cached because they are expensive to compute or fetch and appear on hot paths, not “just in case.” Profiling and production telemetry will drive what actually lands in Redis.
-- Coordination workload isolation. By default, read-side caches and gateway rate limits are placed on a **separate Redis cache/rate-limit cluster** rather than sharing the **Coordination Redis** used for ticks, locks, timers, and sessions. Only small, tightly bounded aggregates may be considered for the coordination cluster, and even then only with explicit justification and review.
+- Coordination workload isolation:
+  - In **QA, staging, and production** (any environment used for load tests or player traffic), read-side caches and gateway rate limits are placed on one or more **separate Redis cache/rate-limit deployments**, distinct from the **Coordination Redis** used for ticks, locks, timers, and sessions. Coordination Redis does **not** host caches or rate-limit keys in these environments.
+  - In **local developer** and other low-concurrency lab setups, a single Redis instance may be shared for convenience (see below), but this topology is not considered representative for performance or failure behavior and must not be reused for QA, staging, or production.
 
 ## Candidate Cacheable Object Types
 
@@ -107,9 +109,9 @@ For **small or development deployments** that share all workloads on a single Re
 - This configuration is intended for **low-concurrency lab and developer environments only**, not for QA, staging, production, or any player-facing game instances.
 - The configuration should still avoid mixing large, eviction-driven caches with critical coordination keys under `allkeys-*` policies, because it can silently evict locks, timers, or staging keys.
 - Even with `maxmemory-policy noeviction`, conservative cache TTLs, and tight cache size limits, shared coordination+cache Redis remains **operationally fragile**: any mis-sized cache or unexpected hot key can push the node into `OOM` conditions where coordination writes begin to fail.
-- If a single-node instance must serve both coordination and cache traffic, it is strongly recommended to:
+- If a single-node instance must serve both coordination and cache traffic in a local/dev setup, it is strongly recommended to:
   - Use `maxmemory-policy noeviction`, with very small, well-bounded caches used purely for development convenience; and
-  - Move to separate logical Redis instances (for example, two containers or pods) whenever a scenario moves beyond low-volume, single-user testing so coordination and cache eviction policies can diverge even on the same host.
+  - Move to separate logical Redis instances (for example, two containers or pods) as soon as a scenario moves beyond low-volume, single-user testing so coordination and cache eviction policies can diverge even on the same host.
 
 Operational dashboards track `used_memory`, `maxmemory`, and eviction counters for each deployment. Alert thresholds are tuned so approaching memory pressure or unexpected eviction activity is visible well before it threatens coordination workloads.
 

--- a/design/architecture/system-architecture-redis-lua-patterns.md
+++ b/design/architecture/system-architecture-redis-lua-patterns.md
@@ -11,6 +11,24 @@ re-invocation behavior for tick-related scripts.
 
 Tick-related scripts must be idempotent: **re-running the same script with the same `KEYS` and `ARGV` must not apply new logical effects**. To make this concrete, scripts follow a small set of patterns:
 
+### Determinism Requirements
+
+To keep AOF replay and retries safe, Lua scripts must be **deterministic functions of their inputs and current Redis state**:
+
+- Scripts may only use:
+  - The `KEYS` and `ARGV` provided by the caller.
+  - The current contents of Redis keys they read.
+- Scripts must **not**:
+  - Call `math.random` or any other RNG to influence behavior or generate IDs.
+  - Use `TIME` or any other clock-based primitive to affect keys, members, scores, or control flow.
+  - Synthesize new identifiers (for example, random suffixes or timestamps embedded in keys, ZSET members, or values) inside the Lua code.
+  - Depend on external state or side effects outside Redis (for example, global variables mutated across runs).
+- When randomness or time is required for a workflow:
+  - Those values are generated in the caller (for example, Java code), passed in via `ARGV`, and treated as ordinary arguments.
+  - AOF replay re-runs the script with the **same** `ARGV`, preserving idempotent behavior.
+
+Scripts that violate these determinism requirements cannot guarantee safe replay and must be rejected during review and CI.
+
 - **Pattern 1 – Lease/lock token validation (guard-then-no-op)**
   - Every mutating script begins by validating the current lease and, where applicable, lock tokens:
     - Read `tick-executor-lease:{tenantId}:{regionId}` and compare its stored token to the `leaseToken` passed in `ARGV`.

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -199,6 +199,18 @@ Operationally, AOF files are treated as **all-or-nothing** coordination history 
 
 Manual “surgery” on AOF contents is **not supported** in FireMUD runbooks. Either the AOF is trusted and used as-is, or it is discarded and the node restarts with an empty (or cleanly resynchronized) coordination keyspace.
 
+For **breaking coordination script changes** (for example, changes that reinterpret existing `pending`/timer/session payloads or adjust validation logic for stored values), FireMUD intentionally avoids relying on AOF replay across versions:
+
+- Script changes are classified into:
+  - **Safe changes** – bugfixes or internal refactors that do not change how existing stored payloads are interpreted. These may be deployed without special AOF handling.
+  - **Breaking changes** – any change that could cause a new script version to interpret existing coordination keys differently (for example, schema changes without a migration, new required fields, or changed validation rules).
+- For breaking changes, the runbook is:
+  - Schedule a maintenance window.
+  - Stop accepting new gameplay commands and pause ticks for affected tenants/regions (or globally for small/self-hosted deployments).
+  - Explicitly **flush coordination state** for the affected slots (for example, by clearing tick/lock/timer/retry/session prefixes in the Coordination Redis deployment or recreating the coordination Redis instance).
+  - Deploy the new scripts and services and restart tick processing; Redis rebuilds coordination state from PostgreSQL and fresh gameplay.
+- AOF replay is therefore relied on only within a given script semantics window. When script behavior changes in a way that is not trivially backward-compatible for stored payloads, operators treat existing coordination state as disposable and restart from a clean keyspace instead of attempting cross-version replay.
+
 #### Replica Promotion and Missed Writes
 
 Because replication is asynchronous:
@@ -213,7 +225,18 @@ From the tick system’s perspective, this is indistinguishable from a larger AO
   - Are skipped, with impact bounded to the same best-effort window described above.
 - Stale coordination keys that survived failover cannot cause double-apply or split-brain behavior because all mutating scripts validate lease tokens, lock tokens, `tickId`, and `generation` fields before making changes.
 
-Replication-lag and health metrics (documented under Observability) are used to detect environments where promotion would routinely imply unacceptably large coordination gaps so operators can tune Redis or adjust tick budgets accordingly.
+Replication-lag and health metrics (documented under Observability) are used to detect environments where promotion would routinely imply unacceptably large coordination gaps so operators can tune Redis or adjust tick budgets accordingly. For coordination workloads, FireMUD ties acceptable replication lag to the tick interval:
+
+- As a starting envelope:
+  - **Target:** `p99` replication lag for coordination shards < **0.25 × `tick-duration-ms`**.
+  - **Warning:** lag regularly between **0.25 ×** and **1.0 ×** `tick-duration-ms`.
+  - **Red line:** lag ≥ **1 full tick window** for any shard, especially when sustained.
+- From a gameplay perspective:
+  - Promotion with lag comfortably below one tick implies that, in the worst case, affected regions may lose at most one tick’s worth of volatile coordination state, which the replay model is designed to tolerate.
+  - If replication lag frequently approaches or exceeds a tick window, some regions may systematically lose more ticks than others during failover (for example, repeatedly skipping several ticks of timers or retries), which can bias gameplay.
+- For small/self-hosted deployments where it is difficult to keep lag within this envelope:
+  - It is acceptable to run Coordination Redis with a single primary (and an optional replica used only for observability or manual promotion) and to treat promotion of a significantly behind replica as equivalent to dropping coordination state for affected tenants/regions.
+  - Replica promotion in such environments should be a rare, deliberate operation with explicit runbooks indicating that recent tick/session state may be lost; gameplay resumes from PostgreSQL and new coordination activity instead of relying on the replica’s stale view.
 
 #### Lua Scripts and AOF Replay
 
@@ -402,6 +425,16 @@ Changing how identifiers are normalized or how hash tags are formed (for example
       - Allow old keys to expire naturally if they are strictly transient and do not need to be carried forward.
     - Remove compatibility code and old normalization paths once the keyspace has converged.
 - At no point should two different normalization versions be used concurrently for new keys without an explicit compatibility layer; doing so risks splitting a logical `{tenantId, regionId}` across shards and breaking the assumption that all tick keys for a region are co-located.
+- **Operational constraint – do not combine with resharding**
+  - Normalization changes and Redis Cluster resharding (slot rebalancing, adding/removing masters) are **not performed in the same maintenance window**. For small/self-hosted deployments the protocol is:
+    - When changing normalization:
+      - Treat the cluster slot map as fixed for the duration of the migration.
+      - Pause or drain ticks and new commands for affected tenants/regions.
+      - Migrate keys according to the steps above, validate that each `{tenantId, regionId}` now lives under its new hash tag, then resume ticks.
+    - When resharding the cluster:
+      - Treat it as a pure infrastructure operation: no changes to normalization helpers or hash-tag format.
+      - Application code continues to use the current normalization version while slots move underneath.
+  - If both changes are required in a small deployment, they are sequenced explicitly: normalization migration first (with stable cluster topology), then resharding as a separate, later step.
 
 Session and timer keys do not participate in tick multi-key scripts and may use simpler patterns as long as they preserve `tenantId` prefixes and avoid cross-shard assumptions. In particular:
 
@@ -433,18 +466,18 @@ These key-shape and hash-tag rules are **enforced**, not just conventions:
   - Construct keys using the same helpers used in production.
   - Assert that all keys passed to a given Lua script share the same hash tag substring (the content inside `{}`).
   - In dev/test profiles, verify hash-slot alignment via `CLUSTER KEYSLOT` checks so regressions are caught early.
-- A structured **Lua Script Registry** and descriptor format keeps Java key builders and Lua `KEYS[...]` ordering in sync:
-  - Each script is described by a small machine-readable descriptor (for example a JSON/YAML file or Java annotation) that declares:
+- A structured **Lua Script Registry** and descriptor format kept in the `firemud-common` library keeps Java key builders and Lua `KEYS[...]` ordering in sync:
+  - Each script is described by a small machine-readable descriptor (for example a JSON/YAML file or Java annotation) that lives alongside the Lua source in `firemud-common` and declares:
     - The logical script name.
     - The required number and order of `KEYS` (with symbolic names such as `lockKey`, `pendingKey`, `leaseKey`, `timerKey`).
     - The allowed key prefixes for each position (for example `tick:`/`retry:`/`timer:` for tick scripts, `session:` only for session scripts).
     - Whether the script is expected to be **multi-key shard-local** or **single-key**.
     - How many entity lock keys (`tick:{tenantId}:{regionId}:lock:{entityId}`) it is allowed to touch (for example `max_entity_locks = 1` for the default case).
     - Whether the script participates in an **ordered multi-lock** pattern (rare) where more than one entity lock is acquired under a deterministic ordering, as described in the tick design.
-  - Java key-builder APIs for each script are generated from (or validated against) this descriptor so that:
+  - Java key-builder APIs and registry helpers for each script are defined in `firemud-common` and generated from (or validated against) these descriptors so that:
     - Builders construct `KEYS[...]` in exactly the declared order.
-    - Callers cannot assemble `KEYS` arrays manually; they must call the generated builders.
-  - A CI step parses descriptors, loads the Lua source, and verifies:
+    - Callers in individual services cannot assemble `KEYS` arrays manually; they must call the shared builders.
+  - A CI step in the `firemud-common` module parses descriptors, loads the Lua source, and verifies:
     - The script’s `KEYS` count matches the descriptor.
     - All sample `KEYS` produced by the Java builders share the same hash tag for multi-key scripts.
     - Single-key scripts receive exactly one key.
@@ -458,11 +491,11 @@ These key-shape and hash-tag rules are **enforced**, not just conventions:
 
 Pull requests that introduce new tick-related keys or Lua scripts must:
 
-- Add or update the corresponding script descriptor and key-builder APIs.
-- Extend the shared Redis test suite to prove:
+- Add or update the corresponding script descriptor, Lua source, and key-builder/registry APIs in the `firemud-common` library.
+- Extend the shared Redis test suite in `firemud-common` to prove:
   - Correct `KEYS` ordering and hash-tag alignment.
   - Enforcement of the declared prefix constraints (for example, tests that intentionally supply a mismatched prefix and assert a fast failure or no-op).
-- Avoid ad-hoc `EVAL`/`EVALSHA` calls; all script invocations go through registry-backed helpers that resolve the SHA and build `KEYS` from descriptors.
+- Avoid ad-hoc `EVAL`/`EVALSHA` calls; all script invocations in services go through registry-backed helpers exported from `firemud-common` that resolve the SHA and build `KEYS` from descriptors.
 
 Scripts that hard-code non-hash-tagged tick keys, mix forbidden prefixes, or produce `CROSSSLOT` errors under tests are rejected.
 
@@ -478,15 +511,15 @@ Redis’s single-threaded model is extended using **Lua scripts** for atomic ope
 - Session rebinding and deduplication (`session:*` keys; strictly single-key scripts that operate on one session key per call)
 - Retry queue updates
 
-All Lua scripts are:
+All Lua scripts that participate in tick coordination, sessions, and automation are:
 
-- Stored under `services/game-session-service/src/main/resources/redis/`
+- Owned and packaged by the shared `firemud-common` library under a common `redis/` resources path.
 - **Idempotent**
 - **Shard-local**
 - **Retry-safe**
 - Designed to avoid cross-tick contamination
 
-Tick-related multi-key operations **must not** be implemented as ad-hoc sequences of plain Redis commands outside these scripts. All staging, commit, rollback, and lock manipulation that touches multiple tick keys (locks, `pending`, queues, timers, or retry metadata) is performed exclusively via the Lua scripts in `services/game-session-service/src/main/resources/redis/` so transactional behavior remains consistent and replay-safe.
+Tick-related multi-key operations **must not** be implemented as ad-hoc sequences of plain Redis commands outside these scripts. All staging, commit, rollback, and lock manipulation that touches multiple tick keys (locks, `pending`, queues, timers, or retry metadata) is performed exclusively via the registered Lua scripts shipped in `firemud-common` so transactional behavior remains consistent and replay-safe across services.
 
 Additional guardrails for script authors:
 
@@ -502,11 +535,11 @@ Additional guardrails for script authors:
 Every new or modified Lua script that participates in tick coordination, sessions, or automation must satisfy the following checklist before it is accepted:
 
 - **Registered contract**
-  - The script is registered in the central **Lua Script Registry** with:
+  - The script lives in the `firemud-common` shared library and is registered in the central **Lua Script Registry** with:
     - A logical script name.
     - A descriptor that declares the exact `KEYS` count, ordering, and allowed prefixes.
     - A flag indicating whether it is multi-key shard-local or strictly single-key.
-  - Java callers invoke the script only via registry-backed helpers and generated key builders; there are no ad-hoc `EVAL`/`EVALSHA` calls.
+  - Java callers in services invoke the script only via registry-backed helpers and generated key builders from `firemud-common`; there are no ad-hoc `EVAL`/`EVALSHA` calls in individual services.
 
 - **Key shape and shard-locality**
   - For multi-key scripts:
@@ -540,6 +573,39 @@ Every new or modified Lua script that participates in tick coordination, session
     - Include tests that exercise behavior against representative values for each supported `schemaVersion` so incompatibilities between script logic and stored payloads are caught in CI rather than at runtime.
 
 Scripts that do not meet this checklist—mismatched descriptors, prefix violations, non-idempotent behavior, or missing tests—must be rejected during review and CI until they are brought into compliance.
+
+### Access Control, Redis Users, and Operational Guardrails
+
+The Lua Script Registry and key-shape rules assume that **all multi-key coordination writes** go through registered scripts and shared helpers. To keep this enforceable in practice:
+
+- **Application user vs. ops user**
+  - Coordination clients (Game Session, Automation & Scripting, any future tick participants) connect to Redis using a dedicated **application user** (for example, `coord_app`) that:
+    - Has permission to execute `EVALSHA`/`SCRIPT LOAD` and write commands (`SET`, `DEL`, `PEXPIRE`, etc.) on the coordination database/index.
+    - Is used exclusively by application code and maintenance jobs that go through the script registry and key-builder helpers; humans do not use this account from interactive tools in production.
+  - Human operators and tools (Redis CLI, RedisInsight, ad-hoc scripts) connect using a separate **read-only ops user** (for example, `ops_ro`) that:
+    - Is restricted to `@read` commands and explicitly **denied** `EVAL`, `EVALSHA`, `SCRIPT LOAD`, and write commands (`SET`, `DEL`, `EXPIRE`, `PEXPIRE`, etc.) for the coordination deployment.
+    - May still read coordination keys (`GET`, `HGETALL`, `ZRANGE`, `SCAN`, etc.) for inspection and debugging.
+
+- **Operational expectations**
+  - All coordination prefixes (`tick:*`, `retry:*`, `timer:*`, `remote:*`, `session:*`, and automation/tick scheduler keys that share their hash tags) are treated as **write-only via application code**. Ad-hoc write commands against these prefixes from CLI or external scripts are not supported and are considered unsafe.
+  - If coordination state must be repaired or migrated, operators:
+    - Prefer to stop or drain the Game Session Service for affected tenants/regions.
+    - Use dedicated, versioned tools or maintenance code paths that go through the same script registry and key-builder helpers as normal ticks, rather than issuing raw Redis commands.
+    - Avoid hand-editing individual keys for tick/lock/session prefixes; manual changes risk violating token, `tickId`, or shard-locality invariants in ways that are hard to detect.
+
+- **Scope for ad-hoc operations**
+  - Ad-hoc `SET`/`DEL` or `EVAL`/`EVALSHA` may be used for **non-coordination workloads** (for example, cache or rate-limit deployments) where invariants are looser and keys are explicitly segregated by prefix and Redis instance.
+  - Even in those environments, it is recommended to follow a similar “app user vs. ops user” split so that accidental destructive commands in a CLI session cannot impact coordination keys.
+
+- **Break-glass behavior**
+  - In rare emergency scenarios where direct modification of coordination keys is deemed unavoidable (for example, to unblock a stuck test cluster), such actions:
+    - Are performed only with an explicitly documented “break-glass” superuser account, not with `coord_app` or `ops_ro`.
+    - Are treated as violating some of the replay/idempotency assumptions in this document for affected tenants/regions and require a follow-up review and, where appropriate, flushing or rebuilding coordination state from PostgreSQL.
+  - Production incident runbooks should favor:
+    - Halting ticks, draining regions, or flushing coordination state for specific tenants/regions, over hand-editing individual keys.
+    - Redeploying services or rerunning maintenance tools that use the normal script registry, instead of issuing raw Redis commands against coordination prefixes.
+
+These guardrails keep the script registry’s guarantees meaningful: application code and registered scripts are solely responsible for mutating coordination keys, while human operators and tooling default to **read-only** access for those prefixes.
 
 ### Script Loading, `EVALSHA`, and Failover Behavior
 
@@ -704,6 +770,10 @@ To make sure locks do not routinely expire while legitimate work is still in fli
   - A region enters a **degraded** state if, over a rolling window (for example 5 minutes), either:
     - More than a configurable percentage of its ticks are over-TTL (for example >5%), or
     - It produces a configurable number of consecutive over-TTL ticks (for example 3 in a row).
+  - Over-TTL ticks are tracked separately from **lock acquisition contention**:
+    - Immediate lock conflicts (for example, `SET NX` returning false before any work starts) increment contention-style counters such as `tick_lock_contention_total` or `game_session_lock_contention_total`.
+    - Over-TTL ticks increment a distinct “slow work” signal (for example, `tick.over_ttl_total` or a derived metric where `tick.execution_time_ms >= lock_ttl_ms`).
+    - High contention with **normal** Redis latency and tick durations points to game/command design hotspots; high over-TTL rates correlated with elevated Redis or downstream latency point to **capacity or infrastructure** problems.
   - When a region is marked degraded, the TickScheduler:
     - Reduces that region’s effective tick fan-out (for example, lowers the maximum commands processed per tick) and may modestly increase the tick interval to create headroom.
     - Continues to complete in-flight ticks but avoids starting new ticks more aggressively than the configured pacing, rather than silently allowing long-running work to compete with healthy regions.
@@ -750,7 +820,7 @@ Redis is **required** for tick coordination, sessions, and automation. When Redi
     - New gameplay sessions and commands that depend on ticks or sessions are rejected until Redis connectivity recovers.
   - Non-gameplay services that do not depend on Redis (for example, Account, Game Design, Logging & Admin) may remain available; this is the primary form of “graceful degradation” at the product level.
 
-This policy applies consistently across the conditions described elsewhere in this document: replication failures or sustained lag, `OOM`/evictions of coordination keys, repeated over-TTL ticks, and client-level connection timeouts all drive regions through the same **healthy → degraded → halted** progression, rather than each caller inventing its own ad-hoc behavior.
+This policy applies consistently across the conditions described elsewhere in this document: replication failures or sustained lag, `OOM`/evictions of coordination keys, repeated over-TTL ticks, and client-level connection timeouts all drive regions through the same **healthy → degraded → halted** progression, rather than each caller inventing its own ad-hoc behavior. Cases where Redis remains healthy but downstream services are unavailable (for example, database or gRPC outages) are handled as **stalled regions** at the tick scheduler layer, as described in the Tick System design; leases continue to enforce single-writer coordination, while stalled/healthy status reflects whether that writer is actually making progress.
 
 To avoid flapping when metrics hover around thresholds, transitions between these states apply simple hysteresis and cooldown rules:
 
@@ -778,8 +848,21 @@ To keep behavior consistent across environments, FireMUD defines **recommended S
     - >5% of its ticks are **over-TTL**, or
     - it produces **3 consecutive** over-TTL ticks.
   - Warning alert: region enters degraded state.
+  - Diagnostic guidance:
+    - If **contention metrics** (for example, `tick_lock_contention_total`, `game_session_lock_contention_total`) are high for a small set of entities or regions, while Redis latency and tick durations remain within SLOs and over‑TTL rates are low, treat this primarily as a **gameplay/hotspot** or command design issue and rely on the normal backoff/fairness rules.
+    - If **over‑TTL rates** are high across many entities or regions and correlate with elevated Redis latency or downstream error rates, treat this as a **capacity or infrastructure** problem; prefer reducing tick rates (for example by increasing `tick-duration-ms`) or addressing Redis/DB performance, rather than assuming simple contention and relying solely on backoff.
   - Practical guidance for self-hosted setups: if you routinely see “tick budget exceeded” or over‑TTL warnings across many regions and do not want to deeply tune GC or workloads, simply **increase `game.tick-duration-ms`** (and matching automation tick duration) and restart. All derived budgets and TTLs grow proportionally, reducing the chance of expiries at the cost of slightly slower ticks.
   - Critical alert: region remains degraded for more than a configurable window (for example **10–15 minutes**); at this point the Game Session Service may halt new ticks and reject new commands for that region until operators intervene.
+
+- **Coordination key inspection and admin commands**
+  - For coordination prefixes (`tick:*`, `retry:*`, `timer:*`, `remote:*`, `session:*` and related automation/tick-scheduler keys that share their hash tags):
+    - Operators use **single-key** commands (`GET`, `HGETALL`, `ZRANGE`, `DEL key`) or app-level maintenance tools; they must not issue multi-key commands such as `MGET` or `DEL key1 key2` that span arbitrary keys.
+    - If a multi-key command against these prefixes produces a `CROSSSLOT` error, that is treated as a signal that the operation is mixing shards or regions incorrectly; the correct fix is to narrow the operation (for example, to a single `{tenantId}:{regionId}` hash tag) or use application-level tools, not to work around `CROSSSLOT` via client-side retries.
+  - Bulk inspection or cleanup for coordination keys (for example, deleting all tick keys for a region) should be implemented as:
+    - Application-level maintenance flows or scripts that:
+      - Use shared key builders and Lua helpers.
+      - Restrict operations to keys that share a hash tag.
+    - Or, in small/self-hosted setups, controlled one-off scripts that operate on one region/tenant at a time using the same rules. Ad-hoc multi-key commands in Redis CLI against coordination prefixes are discouraged.
 
 - **Coordination Redis memory and eviction**
   - On the Coordination Redis deployment (which uses `maxmemory-policy noeviction`):
@@ -802,6 +885,38 @@ To keep behavior consistent across environments, FireMUD defines **recommended S
     - Critical alert: eviction rate that grows without bound or consistently exceeds a fraction of the keyspace per hour (for example, evicting more than **5%** of average key count per hour), indicating mis-sized caches or runaway writers.
 
 These thresholds are intended to be **explicit starting points**, not immutable rules. Operators may tighten or relax them per environment, but architecture and implementation should treat the classes of behavior above—high script runtimes, elevated coordination latency, over-TTL ticks, coordination `OOM`/evictions, and runaway cache eviction—as the canonical “red lines” that justify automated degradation and paging.
+
+**Default remediation actions**
+
+To keep responses consistent across incidents, the following “first response” actions are recommended when thresholds trip:
+
+- **High Lua/command latency or blocked clients (Coordination Redis)**
+  - Immediately reduce tick throughput:
+    - Lower per-tick fan-out (for example, reduce `game.tick-max-commands`) and, if needed, modestly increase `game.tick-duration-ms` to create headroom.
+  - If latency remains high, shed optional work before core gameplay:
+    - Pause or slow down automation/script ticks and non-essential background tasks that use Coordination Redis.
+  - Treat changes to Redis config (for example, `lua-time-limit`) as a secondary lever; prefer scaling capacity or reducing load first.
+
+- **Replication lag near or above the tick-relative envelope**
+  - Avoid automatic promotion of lagging replicas for Coordination Redis; treat promotion as a deliberate operation with runbooks that call out the risk of recent tick/session loss.
+  - Medium term, either:
+    - Reduce write pressure (for example, increase `game.tick-duration-ms`), or
+    - Improve Redis/cluster/network capacity so lag falls back within the target envelope.
+  - If chronic high lag cannot be resolved in a small/self-hosted environment, consider running Coordination Redis effectively as a single-primary (with replicas used only for observability/manual promotion) and treating promotion of a behind replica as equivalent to dropping volatile coordination state.
+
+- **Coordination Redis OOM or evictions**
+  - Immediately mark affected regions degraded or halted and reject new commands for those regions; do not attempt to continue normal tick processing while evictions/OOMs occur.
+  - Remediate by:
+    - Increasing memory or moving non-essential workloads (caches/rate limits) off the Coordination Redis deployment.
+    - Tightening per-tenant caps on active regions, sessions, timers, or outstanding commands so coordination footprints fit comfortably within `maxmemory`.
+  - If memory pressure cannot be relieved cleanly, it may be preferable to flush coordination keys for specific tenants/regions and rebuild state from PostgreSQL rather than operating under repeated OOM conditions.
+
+- **Misuse of multi-key commands on coordination prefixes**
+  - Treat `CROSSSLOT` errors from administrative tools against `tick:*`, `session:*`, `timer:*`, `retry:*`, or related prefixes as configuration or tooling bugs, not transient outages.
+  - Stop using offending commands immediately and switch to:
+    - App-level maintenance endpoints/scripts that operate per-region (per-hash tag), or
+    - Single-key Redis operations for inspection or targeted deletes.
+  - Update ops scripts and playbooks so multi-key commands against coordination prefixes are explicitly disallowed going forward.
 
 ### Example Lock Workflow
 
@@ -1071,7 +1186,7 @@ Redis stores transient gameplay session state for each connected player, includi
 - Conflict and retry metadata
 
 Session keys use the prefix `session:{tenantId}:{sessionId}` as described in the
-[Game Session Service README](./microservices/game-session-service/README.md#redis-keys).
+[Game Session Service README](./microservices/game-session-service/README.md#redis-keys). The `sessionId` is an opaque server-side identifier (for example, a UUID or a fixed-length hash derived from the underlying JWT or account/session tuple) chosen to keep key length bounded and independent of the raw token size.
 
 Session entries expire after `FIREMUD_AUTH_SESSION_EXPIRATION_MS` milliseconds as
 configured in [Environment & Secrets](./infrastructure/environment-and-secrets.md#authentication). The Game Session
@@ -1158,7 +1273,7 @@ When `UNSUPPORTED_SCHEMA_VERSION` appears in metrics or logs, runbooks treat it 
 - A sign that session schema or deployment versions are out of sync (for example, services writing a newer `schemaVersion` than the CAS script supports, or an incomplete rollback).
 - A trigger to:
   - Align deployments so all Game Session Service instances run scripts that understand the highest `schemaVersion` currently in use, and
-  - Optionally run a **session schema cleanup** tool for specific tenants that scans `session:{tenantId}:*` keys for unknown versions and deletes or aggressively expires those entries. Because Redis sessions are non-authoritative and bounded by `FIREMUD_AUTH_SESSION_EXPIRATION_MS`, removing unknown-version sessions is acceptable; affected players simply need to perform a fresh `LOGIN`.
+  - Optionally run a **session schema cleanup** tool for specific tenants that scans `session:{tenantId}:*` keys for unknown versions and deletes or aggressively expires those entries. Cleanup is run as a one-off, single-worker maintenance task (per Coordination Redis deployment) to avoid competing with ticks; because Redis sessions are non-authoritative and bounded by `FIREMUD_AUTH_SESSION_EXPIRATION_MS`, removing unknown-version sessions is acceptable and affected players simply need to perform a fresh `LOGIN`.
 
 ### Session Schema Cleanup and Large Keyspaces
 
@@ -1177,9 +1292,10 @@ When runbooks call for explicit cleanup (for example, after a major schema chang
   - Operate on a **per-tenant prefix** such as `session:{tenantId}:*`; avoid scanning the entire Redis keyspace when only some tenants are affected.
   - Prefer targeted selectors (for example, `session:{tenantId}:*` with filters inside the tool) over global `SCAN` patterns.
 - Bounded SCAN usage:
+  - Run **at most one cleanup worker at a time** per Coordination Redis deployment; do not schedule overlapping cleanup jobs for multiple tenants or run them from multiple services concurrently.
   - Use Redis `SCAN` with modest `COUNT` values (for example, 100–1000) to avoid long blocking periods.
   - Enforce a maximum runtime per invocation (for example, 10–30 seconds) and exit cleanly when the time budget is exhausted; subsequent runs resume from the last cursor or continuation token.
-  - Insert small delays between batches when running in continuous jobs so scans do not monopolize CPU or I/O on the Redis node.
+  - Insert small delays between batches so scans do not monopolize CPU or I/O on the Redis node; cleanup jobs are treated as **maintenance tasks**, not continuous background load.
 - Observability:
   - Emit metrics such as `session.cleanup_scanned_total`, `session.cleanup_deleted_total`, and `session.cleanup_duration_seconds` to capture how much work the cleaner performs and its impact.
   - Log tenant identifiers and approximate key counts so operators can correlate cleanup activity with changes in memory usage and `UNSUPPORTED_SCHEMA_VERSION` metrics.

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -324,65 +324,26 @@ Combined with the **lock token semantics** described in the Tick System design, 
 
 **TTL envelopes and worst-case pauses**
 
-Lease TTLs and lock TTLs are chosen and monitored as part of a single envelope:
+For self-hosted and hobby deployments, FireMUD keeps lease and lock TTLs intentionally simple:
 
-- `lock_ttl_ms` is derived from the soft tick budget using a configurable multiplier and bounds as described in the Tick System design (`lock_ttl_ms = clamp(tick_budget_ms * LOCK_TTL_MULTIPLIER, MIN_LOCK_TTL_MS, MAX_LOCK_TTL_MS)`).
-- `lease_ttl_ms` is configured **strictly greater than** both the soft tick budget and `lock_ttl_ms` (for example, on the order of multiple ticks) so that:
-  - Under healthy conditions, an executor refreshes the lease several times during normal operation and **lease expiry is not expected**.
-  - Lock expiry during an in-flight tick is an **exceptional condition**, not part of the normal execution path.
-  - A lock acquired under a given lease epoch is never refreshed across epochs; once its TTL starts, it can block work for that entity for at most `lock_ttl_ms` from acquisition, even if leadership changes.
+- The **only** timing setting you normally configure is a region’s tick interval (`game.tick-interval-ms`).
+- The Game Session Service derives internal values from that single knob using fixed multipliers:
+  - `tick_budget_ms = tick_interval_ms * 0.8` (soft execution budget, not exposed as config).
+  - `lock_ttl_ms = clamp(tick_budget_ms * 8, 500, 5_000)` – entity lock TTL.
+  - `lease_ttl_ms = clamp(tick_budget_ms * 16, 2_000, 15_000)` – region lease TTL for `tick-executor-lease:{tenantId}:{regionId}`.
 
-`MAX_LOCK_TTL_MS` is therefore treated as a **hard upper bound** on per-entity failover stall caused purely by stale locks from a previous leader. Region-level progress is defined as “some entities advance”: a region may temporarily skip work for entities behind stale locks, but it should not be considered globally stuck unless the number or duration of such stalled entities crosses the degradation thresholds described under Observability.
+This keeps the relationship simple and predictable:
 
-Capacity planning and SLOs therefore assume:
+- Locks live significantly longer than a normal tick’s work, so transient pauses rarely cause expiries.
+- Leases outlive locks by a fixed factor, so region leadership remains stable unless the executor truly disappears or stalls for an extended period.
+- All three values scale together when you change `tick-interval-ms`; there is no need to tune separate TTL properties per environment.
 
-- `p99` end-to-end tick execution time (lock acquisition → commit/rollback + lock release) remains within a conservative fraction of `lock_ttl_ms` (for example ≤50% in steady state, with alerts when sustained runtime exceeds 70%).
-- Over-TTL ticks (where `tick.execution_time_ms >= lock_ttl_ms`) are rare outliers; dashboards and alerts treat a sustained over-TTL rate above a small threshold as a **degradation signal** that requires investigation (GC tuning, tick-budget adjustment, or load shedding).
+Under rare, worst-case pauses:
 
-When rare, worst-case pauses still occur:
+- If a pause exceeds `lock_ttl_ms` but the executor retains the lease, locks may expire and be reacquired, but token and `tickId` checks in Lua ensure late work fails safely and is retried instead of double-applying.
+- If a pause exceeds `lease_ttl_ms`, another executor may acquire the lease and resume ticks from Redis; when the original worker resumes, lease-token checks prevent it from committing state from the old epoch, and any stale locks are allowed to expire naturally under their original `lock_ttl_ms`.
 
-- If a pause exceeds `lock_ttl_ms` but the executor retains the lease:
-  - Locks may expire and be reacquired by the same or another worker.
-  - Lock tokens and `pending`/`tickId` checks in Lua ensure that any late work from the original worker fails safely (token or epoch mismatch) and is retried instead of double-applying effects.
-  - The original executor must treat the loss of a lock as a **hard failure** for the in-flight work on that entity:
-    - It does not attempt to “complete” the current attempt without first reacquiring the lock via the shared helper.
-    - If it chooses to retry, it does so by reacquiring the lock and re-running the workflow from a clean state, not by partially reusing stale local state.
-- If a pause exceeds `lease_ttl_ms`:
-  - Another executor may acquire the region lease and resume ticks from the surviving Redis state.
-  - When the original worker resumes, lease-token checks prevent it from committing or rolling back tick state; its in-flight work is treated as failed and rescheduled via the normal retry mechanisms.
-  - The new leader may encounter `tick:{tenantId}:{regionId}:lock:{entityId}` keys whose tokens do not match its current lease epoch. These are treated as **stale locks** from the previous epoch:
-    - The new leader does **not** refresh or forcibly clear those locks.
-    - It skips work for the affected entities while continuing to process entities that are not behind stale locks.
-    - The stale locks naturally expire within their original `lock_ttl_ms`, after which the new leader can reacquire locks and resume work for those entities.
-
-In both cases, the design optimizes for **safety and fairness under load**:
-
-- Tick effects are not applied twice.
-- Regions with repeated over-TTL behavior are automatically marked degraded and, if necessary, halted until operators correct the underlying cause.
-
-**Configuration knobs and startup validation**
-
-Lease and lock TTLs are controlled via explicit configuration properties:
-
-- `game.tick-budget-ms` – soft tick execution budget per region.
-- `game.tick-min-lock-ttl-ms` / `game.tick-max-lock-ttl-ms` – bounds for computing `lock_ttl_ms`.
-- `game.tick-lease-ttl-ms` – region lease TTL used for `tick-executor-lease:{tenantId}:{regionId}` keys.
-
-Internally, the Game Session Service also defines a `MAX_LEASE_TTL_MS` constant that bounds how long a region can remain “logically owned” by a single lease epoch even if the executor disappears. Region leases are intentionally **short-lived coordination hints** (seconds, not minutes), not long-duration ownership records; if an executor vanishes and its lease remains valid for longer than a small multiple of the tick budget, that is treated as a misconfiguration rather than a supported steady state.
-
-At startup, the Game Session Service derives `lock_ttl_ms` from `game.tick-budget-ms` and validates:
-
-- `game.tick-min-lock-ttl-ms <= game.tick-max-lock-ttl-ms`.
-- `lock_ttl_ms` (computed) satisfies `lock_ttl_ms >= game.tick-budget-ms` and remains within `[MIN_LOCK_TTL_MS, MAX_LOCK_TTL_MS]` as documented in the Tick System design.
-- `game.tick-lease-ttl-ms` is **strictly greater than** both `game.tick-budget-ms` and the computed `lock_ttl_ms` (for example, at least 2–3× `lock_ttl_ms`), but also bounded above:
-  - `game.tick-lease-ttl-ms <= MAX_LEASE_TTL_MS`, where `MAX_LEASE_TTL_MS` is on the order of a small multiple of the tick budget (for example, a few seconds to tens of seconds, not minutes).
-  - Optionally, `game.tick-lease-ttl-ms <= LEASE_TO_LOCK_TTL_MULTIPLIER * lock_ttl_ms` for a small fixed multiplier (for example 3–5×), so leases never outlive lock TTLs by more than a modest factor.
-
-Because a lock from a previous lease epoch can stall only the entity it guards and only until its TTL expires, `MAX_LOCK_TTL_MS` also defines the **maximum tolerated per-entity failover stall window**. Configurations that attempt to increase `lock_ttl_ms` beyond this envelope are rejected; stall budgets longer than `MAX_LOCK_TTL_MS` must be justified by an explicit design change rather than ad-hoc configuration.
-
-If any of these invariants are violated in any profile (dev, test, staging, or production), **startup fails fast** with a clear configuration error. There is no automatic fallback to “safe defaults”; running with an unsafe TTL envelope is treated as a configuration bug that must be corrected before the service can accept gameplay traffic.
-
-These checks make misconfigured TTL envelopes visible early and keep all environments within the intended safety margins.
+Region-level progress is defined as “some entities advance”; regions with frequent over‑TTL ticks are treated as degraded by the scheduler and may have their tick rate reduced, but these behaviors are driven by simple ratios of `tick.execution_time_ms` to `lock_ttl_ms`, not by additional configuration properties.
 
 Implementations may also use local monotonic clocks or Redis’s `TIME` command **for diagnostics only**, for example to:
 
@@ -708,15 +669,14 @@ Tick-related scripts must be idempotent: **re-running the same script with the s
 
 **Lock TTL formula and guardrails**
 
-Tick locks use a TTL derived from the region’s soft tick budget to balance safety and recovery:
+Tick locks use a TTL derived from the **tick interval** to balance safety and recovery:
 
-- The Game Session Service computes a default lock TTL as:
-  - `lock_ttl_ms = clamp(tick_budget_ms * 3, MIN_LOCK_TTL_MS, MAX_LOCK_TTL_MS)`
-  - `MIN_LOCK_TTL_MS` defaults to 500 ms.
-  - `MAX_LOCK_TTL_MS` defaults to 5_000 ms.
-- Configuration rules:
-  - Operators may adjust `tick_budget_ms`, `MIN_LOCK_TTL_MS`, and `MAX_LOCK_TTL_MS` via configuration, but the Game Session Service **always applies the clamp** to avoid accidentally tiny or excessively long lock durations.
-  - A lock TTL must never exceed the maximum region-level recovery window defined in the Tick System design; if configuration attempts to raise it further, the Game Session Service caps it at `MAX_LOCK_TTL_MS` and logs a warning.
+- The Game Session Service exposes `game.tick-interval-ms` as the primary knob that controls pacing.
+- Internally it computes:
+  - `tick_budget_ms = tick_interval_ms * 0.8`
+  - `lock_ttl_ms = clamp(tick_budget_ms * 8, 500, 5_000)`
+  - `lease_ttl_ms = clamp(tick_budget_ms * 16, 2_000, 15_000)`
+- These values are not meant to be tuned independently in typical deployments; changing `tick-interval-ms` is usually sufficient.
 
 **Runtime validation and observability**
 
@@ -818,6 +778,7 @@ To keep behavior consistent across environments, FireMUD defines **recommended S
     - >5% of its ticks are **over-TTL**, or
     - it produces **3 consecutive** over-TTL ticks.
   - Warning alert: region enters degraded state.
+  - Practical guidance for self-hosted setups: if you routinely see “tick budget exceeded” or over‑TTL warnings across many regions and do not want to deeply tune GC or workloads, simply **increase `game.tick-duration-ms`** (and matching automation tick duration) and restart. All derived budgets and TTLs grow proportionally, reducing the chance of expiries at the cost of slightly slower ticks.
   - Critical alert: region remains degraded for more than a configurable window (for example **10–15 minutes**); at this point the Game Session Service may halt new ticks and reject new commands for that region until operators intervene.
 
 - **Coordination Redis memory and eviction**

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -22,6 +22,8 @@ Redis is always treated as **non-authoritative for game data**: all canonical ga
 
 - In **development and ephemeral test environments**, Redis behaves as a **disposable coordination cache**. Helm may wipe its AOF between runs, and no guarantees are made about preserving in-flight ticks, sessions, or timers across deployments.
 - In **staging and production-equivalent environments**, Redis behaves as a **long-lived coordination log**. AOF is preserved across normal rollouts and node restarts; crash recovery and replay semantics described in this document apply and must not be bypassed by automatic AOF resets.
+-
+The acceptable loss window is intentionally capped: affected `{tenantId, regionId}` pairs should lose at most a single tick’s worth of coordination state (locks, timers, sessions) during a routine failover, and the tick effect ledger must show that each staged effect either replayed or was marked `ABANDONED` before subsequent ticks are scheduled. Anything materially beyond this (for example repeated gaps greater than the tick interval or a growing backlog of pending effects) is treated as an incident requiring investigation, not as “normal” volatility.
 
 All subsequent sections assume the **staging/production coordination mode** unless explicitly labeled as “dev/ephemeral only.” Deployment and runbook docs call out where behavior differs by environment.
 
@@ -65,6 +67,12 @@ should be configured as distinct logical Redis deployments even if they share th
 same underlying host. Sharing a single deployment for both workloads is strongly
 discouraged because misconfiguration (for example, eviction policies or memory
 limits) can silently impact coordination keys and gameplay availability.
+
+Call out this separation in playbooks so that local developers do not treat the
+shared-instance convenience as representative of production behavior: eviction
+policies, `maxmemory`, and TTL behavior in a dev instance are intentionally
+unreliable, they can spill over into the coordination workload, and metrics/alerts
+should only be trusted when the workloads are split as described above.
 
 Redis acts as a **coordinated real-time buffer**, not a source of truth, but is still treated as **critical** for game availability and consistency.
 
@@ -328,7 +336,7 @@ Lease management is split into two distinct operations:
 
 This lease acts as the **macro-level lock** for a region: it prevents multiple executors from driving ticks concurrently for the same `{tenantId, regionId}` while still allowing fast failover and rebalancing. Fine-grained entity locks (`tick:{tenantId}:{regionId}:lock:{entityId}`) are used *within* a leader to coordinate per-command work and crash recovery; they do not replace the leadership lease.
 
-**Lease token / epoch semantics**
+### Lease Token and Epoch Semantics
 
 To avoid “split-brain” scenarios during GC pauses or network stalls (for example, executor A holds the lease, pauses until its TTL expires, executor B acquires the lease, and then A resumes), the lease value stores a **random, opaque token** (for example, a UUID) in addition to the executor identity. The Game Session Service:
 
@@ -345,7 +353,7 @@ Combined with the **lock token semantics** described in the Tick System design, 
 - A worker that resumes after losing the lease cannot commit or roll back tick state, even if it still holds local lock tokens.
 - Only the current lease holder (epoch) can progress `tick:{tenantId}:{regionId}:pending`, timers, and retry metadata for that region; any stale workers see a lease-token mismatch and abort, returning a retry outcome instead of applying stateful changes.
 
-**TTL envelopes and worst-case pauses**
+### TTL Envelopes and Worst-Case Pauses
 
 For self-hosted and hobby deployments, FireMUD keeps lease and lock TTLs intentionally simple:
 
@@ -400,8 +408,9 @@ To keep hash tags unambiguous and compatible with Redis Cluster’s parsing rule
   - Treat changes to normalization behavior (for example, different case folding or slug rules) as **schema changes** that require a migration plan, not as local implementation details.
 
 Under a given normalization version, the `tenantId` and `regionId` segments that appear inside hash tags are **normalized identifiers**, not arbitrary external IDs. They must:
-  - Omit `{`, `}`, and `:` characters (since `{}` delimit hash tags and `:` is used as a separator in key names).
-  - Use a restricted character set such as lowercase letters, digits, and `-` / `_` (for example `[a-z0-9_-]+`).
+
+- Omit `{`, `}`, and `:` characters (since `{}` delimit hash tags and `:` is used as a separator in key names).
+- Use a restricted character set such as lowercase letters, digits, and `-` / `_` (for example `[a-z0-9_-]+`).
 - If an external tenant or region identifier does not meet these constraints (for example, it contains Unicode, braces, or colons), it is first mapped to a stable normalized form (for example, a slug, hex-encoded UUID, or other opaque token) before being used in Redis keys.
 - The same normalized `tenantId` / `regionId` values are reused consistently across all tick-related keys so that a given `{tenantId, regionId}` hash tag always represents the same shard-local region.
 
@@ -733,7 +742,7 @@ Tick-related scripts must be idempotent: **re-running the same script with the s
 
 ### Lock TTL and Example Lock Workflow
 
-**Lock TTL formula and guardrails**
+#### Lock TTL Formula and Guardrails
 
 Tick locks use a TTL derived from the **tick interval** to balance safety and recovery:
 
@@ -744,7 +753,7 @@ Tick locks use a TTL derived from the **tick interval** to balance safety and re
   - `lease_ttl_ms = clamp(tick_budget_ms * 16, 2_000, 15_000)`
 - These values are not meant to be tuned independently in typical deployments; changing `tick-interval-ms` is usually sufficient.
 
-**Runtime validation and observability**
+#### Runtime Validation and Observability
 
 The safety of this TTL formula depends on how long **end-to-end tick work** takes under load, including:
 
@@ -886,7 +895,7 @@ To keep behavior consistent across environments, FireMUD defines **recommended S
 
 These thresholds are intended to be **explicit starting points**, not immutable rules. Operators may tighten or relax them per environment, but architecture and implementation should treat the classes of behavior above—high script runtimes, elevated coordination latency, over-TTL ticks, coordination `OOM`/evictions, and runaway cache eviction—as the canonical “red lines” that justify automated degradation and paging.
 
-**Default remediation actions**
+#### Default Remediation Actions
 
 To keep responses consistent across incidents, the following “first response” actions are recommended when thresholds trip:
 
@@ -988,6 +997,9 @@ Each `tick:{tenantId}:{regionId}:pending` entry stores a **single in-flight tick
 
 - A `tickId` that is monotonically increasing per `{tenantId, regionId}` tick stream
 - The staged effects for that tick (for example, serialized entity mutations or event descriptors)
+- A reference to the durable **tick effect ledger** recorded in PostgreSQL (see the [Tick System and Runtime Design](./system-architecture-ticks.md#tick-effect-ledger-and-replay-guarantees) section) so every staged effect shares an explicit `(tenantId, regionId, tickId, effectKey)` identity and a `status` (`SCHEDULED`, `APPLIED`, `ABANDONED`).
+
+This tight Redis/PostgreSQL coupling guarantees that replay is never silent: redis-managed pending state cannot exist without a ledger entry, and the ledger’s terminal states prove whether replay re-applied or consciously abandoned each effect.
 
 Lua scripts treat the presence of `tick:{tenantId}:{regionId}:pending` as meaning **“this tick may need to be (re)applied”**, regardless of whether a previous attempt completed. Domain updates are designed to be idempotent with respect to `tickId` and effect identity, so reapplying the same `tickId` after a crash or failover does not corrupt state. The `pending` key is created **without a TTL** so it survives primary crashes and failover; it is only removed when the tick has been successfully applied or explicitly abandoned.
 
@@ -1051,8 +1063,8 @@ When an action crosses regional boundaries (for example a player moving between
 rooms on different shards) the Game Session Service decomposes the transition
 into **two sequential ticks**:
 
-1. **Tick&nbsp;A** on _Shard&nbsp;X_ performs exit logic and clears local state.
-2. **Tick&nbsp;B** on _Shard&nbsp;Y_ applies entry logic and rebinds the
+1. **Tick&nbsp;A** on *Shard&nbsp;X* performs exit logic and clears local state.
+2. **Tick&nbsp;B** on *Shard&nbsp;Y* applies entry logic and rebinds the
    session in the new region.
 
 No lock, Lua script, or tick context may span shards. The Game Session Service
@@ -1135,7 +1147,7 @@ FireMUD actively monitors Redis performance and tick health:
 
 Redis outages or sustained high latency on the **coordination cluster** are treated as explicit failure modes with well-defined behavior for ticks, locks, leases, and sessions.
 
-**Health states for Coordination Redis**
+#### Health States for Coordination Redis
 
 - **Healthy:** Redis latency and error rates are within normal bounds.
   - Game Session and other services process commands and ticks normally.
@@ -1165,7 +1177,7 @@ Redis outages or sustained high latency on the **coordination cluster** are trea
     - The system does not attempt to run ad-hoc in-memory fallbacks for ticks, locks, or sessions; correctness takes precedence over partial gameplay.
     - Operators are alerted via high-severity alerts so they can restore Redis; gameplay for affected regions resumes only once Coordination Redis is healthy again.
 
-**Lock, lease, and session behavior on reconnect**
+#### Lock, Lease, and Session Behavior on Reconnect
 
 When Coordination Redis recovers after an outage or severe degradation, tick executors and session flows:
 

--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -2,6 +2,58 @@
 
 This document outlines how FireMUD executes custom in-game behavior through a sandboxed scripting framework. It complements the [Automation & Scripting Service](./microservices/automation-scripting-service/README.md) and expands on the extensibility goals in the [core requirements](../project-management/core-requirements.md).
 
+## Implementation Status
+
+This document describes the **target-state architecture** for scripting and automation. The implementation is evolving toward this design; this section captures a snapshot as of 2025-12-04. For the most accurate, fine-grained status, refer to the [Automation & Scripting Service Task List](../project-management/task-list-automation-scripting-service.md).
+
+- **Implemented and in active use**
+  - Sandboxed script runtime and core Automation & Scripting Service, including quota enforcement via `ScriptQuotaService` and Redis-backed `ScriptTickService` staging.
+  - Hot reloading of scripts published by the Game Design Service and version-aware script execution, aligned with the versioning model in [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md#script-only-patch-versions).
+  - Visual DSL editor for script creation and testing in the Game Design Service, mapping component graphs to Automation & Scripting Service definitions.
+  - Advanced NPC behavior modules (morale, PvE encounters, formations) and state-driven / event-driven NPC behaviors integrated with the tick system.
+
+- **Planned or partially implemented**
+  - Copying published version data into the Automation & Scripting Service schema via Saga, and broader script-driven world generation flows (runtime generation requests via isolated ticks, generation seed persistence, and script-driven population triggers).
+  - Expansion of the PvE encounter library, biome-specific events, and world generation features called out in the Automation & Scripting Service and world generation task lists.
+  - Scheduler leadership leases and per-region tick-stream consumption for `script-leader:{tenantId}` are implemented; sharded leases, `automation:timer:{tenantId}:{regionId}` indexing, and long-term audit-retention jobs continue to evolve. See [Scheduler Leadership & Coordination](#scheduler-leadership--coordination) for scripting-specific lease and timer keys, the Automation & Scripting Service README (`design/architecture/microservices/automation-scripting-service/README.md#architecture--design-notes`) for current runtime behavior, and the [Automation & Scripting Service Task List](../project-management/task-list-automation-scripting-service.md) for remaining work.
+
+Operators looking for **runtime knobs and environment variables** should see the [Environment Variables](#environment-variables) section of this document and the Automation & Scripting Service README (`design/architecture/microservices/automation-scripting-service/README.md#environment-variables`), which is the authoritative source for current settings and defaults.
+
+Maintainers should update this section whenever major scripting features land or significant architecture pieces change so it remains a reliable guide to what is live versus aspirational.
+
+### Area Status Snapshot
+
+The table below summarizes the high-level implementation status of major areas described in this document. For deeper or evolving details, always consult the Automation & Scripting Service task list and README.
+
+| Area | Status (as of 2025-12-04) | Notes |
+| --- | --- | --- |
+| Script runtime & DSL | Implemented | Sandbox execution, core Automation & Scripting Service, and visual DSL editor are in active use, including basic quotas. |
+| Automation queues & script ticks | Implemented | `automation_queue:{tenantId}:{entityId}` and `automation:tick:{tenantId}:{scriptId}:...` staging are implemented; script work items flow into tick commands as described under [TL;DR Flow](#tldr-flow). |
+| Integration with tick commands | Implemented | Script-generated tick commands are enqueued into the same per-entity tick queues used by Game Session, and participate in the normal lock/idempotency model. |
+| Scheduler leadership & timers | Designed / partial | Per-tenant `script-leader:{tenantId}` leases and heartbeat-driven interval scheduling are implemented; sharded leases, `automation:timer:{tenantId}:{regionId}`–backed timer indexing, and long-term audit-retention jobs are tracked in the Automation & Scripting Service README and task list. |
+| Quotas & fairness | Implemented / evolving | Per-script quotas (`ScriptQuotaService`) and basic fairness rules are implemented; multi-level budgets and advanced throttling controls continue to evolve. |
+| Audit & metrics | Implemented / evolving | `script_event_audit` and core automation metrics exist; retention policies and additional dashboards are being refined. |
+
+## Table of Contents
+
+- [Implementation Status](#implementation-status)
+- [Goals](#goals)
+- [TL;DR Flow](#tldr-flow)
+- [Supported Script Events](#supported-script-events)
+- [Determinism & Allowed Non-Determinism](#determinism--allowed-non-determinism)
+- [Integration with Game Logic & Tick System](#integration-with-game-logic--tick-system)
+- [Sandboxing & Security](#sandboxing--security)
+- [Redis Key Summary for Scripting](#redis-key-summary-for-scripting)
+- [Script Timers vs Tick Timers](#script-timers-vs-tick-timers)
+- [Scheduler Leadership & Coordination](#scheduler-leadership--coordination)
+- [Fairness & Abuse Prevention](#fairness--abuse-prevention)
+- [Resource Isolation and Multi-Level Budgets](#resource-isolation-and-multi-level-budgets)
+- [Auditability & Metrics](#auditability--metrics)
+- [Hot Reload & Resume Behavior](#hot-reload--resume-behavior)
+- [Deployment & Versioning](#deployment--versioning)
+
+---
+
 ### Who Should Read What
 
 - **Game designers and content authors**
@@ -16,22 +68,6 @@ This document outlines how FireMUD executes custom in-game behavior through a sa
   - Focus on: [Failure Modes and Error Handling](#failure-modes-and-error-handling), [Fairness & Abuse Prevention](#fairness--abuse-prevention), [Resource Isolation and Multi-Level Budgets](#resource-isolation-and-multi-level-budgets), [Auditability & Metrics](#auditability--metrics), and the high-level references to Redis and tick behavior.
   - Pair this document with [System Architecture: Logging & Monitoring](./system-architecture-logging-monitoring.md), [System Architecture: Redis](./system-architecture-redis.md), and the Automation & Scripting Service README for concrete metric, alerting, and runbook details.
 
-### Quick Reference
-
-- [Implementation Status](#implementation-status)
-- [Goals](#goals)
-- [TL;DR Flow](#tldr-flow)
-- [Supported Script Events](#supported-script-events)
-- [Determinism & Allowed Non-Determinism](#determinism--allowed-non-determinism)
-- [Integration with Game Logic & Tick System](#integration-with-game-logic--tick-system)
-- [Sandboxing & Security](#sandboxing--security)
-- [Scheduler Leadership & Coordination](#scheduler-leadership--coordination)
-- [Fairness & Abuse Prevention](#fairness--abuse-prevention)
-- [Resource Isolation and Multi-Level Budgets](#resource-isolation-and-multi-level-budgets)
-- [Auditability & Metrics](#auditability--metrics)
-- [Hot Reload & Resume Behavior](#hot-reload--resume-behavior)
-- [Deployment & Versioning](#deployment--versioning)
-
 ## Terminology Glossary
 
 - **Game tick** – a region-scoped tick in the Game Session Service. Each `{tenantId, regionId}` advances through a monotonic `tickId` stream; game ticks are authoritative for gameplay state changes and use `tick:{tenantId}:{regionId}:...` keys and locks as described in [Tick System and Runtime Design](./system-architecture-ticks.md).
@@ -39,7 +75,7 @@ This document outlines how FireMUD executes custom in-game behavior through a sa
 - **Automation queue** – a per-tenant, per-entity Redis queue (`automation_queue:{tenantId}:{entityId}`) that holds **post-handler script work items** (domain commands plus script metadata such as `scriptEventId`, `scriptId`, and version information) after sandboxed DSL execution and before automation ticks convert them into tick commands and move them into tick-compatible queues.
 - **Tick heartbeat** – a **gRPC streaming feed** produced by the Game Session Service that reports `tickId` progression per `{tenantId, regionId}`. The script scheduler consumes this heartbeat over a long-lived gRPC stream to count “every N ticks” intervals and align `onInterval` triggers with the canonical game tick timeline without owning tick execution itself. See [Tick Events & Heartbeat Stream](./system-architecture-ticks.md#tick-events--heartbeat-stream) for transport details.
 
-### Versioning terms
+### Versioning Terms
 
 These definitions summarize how common versioning concepts are used in this document; the full model lives in [System Architecture: Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md).
 
@@ -74,40 +110,7 @@ Later sections use these terms consistently: triggers lead to DSL runs, which pr
 - **Handling retries and duplicates**
   - The Automation & Scripting Service treats script execution as **at-most-once per `scriptEventId`**. If it receives a duplicate delivery for the same `{tenantId, regionId, scriptId, eventType, scriptEventId}`—for example, because the caller retried a `TriggerScriptEvent` gRPC call—it does **not** re-run the DSL graph for that trigger. Instead it consults existing `script_event_audit` state and treats the duplicate as a replay of an already completed or skipped trigger, optionally recording a no-op audit entry or metric.
   - Downstream services and replay tools rely on `(tenantId, regionId, tickId, scriptEventId)` (or a derived `effectId`) as their idempotency token when applying script-originated effects, so duplicate deliveries for the same tuple are safe replays that do not produce new side effects.
-
-## Implementation Status
-
-This document describes the **target-state architecture** for scripting and automation. The implementation is evolving toward this design; this section captures a snapshot as of 2025-12-04. For the most accurate, fine-grained status, refer to the [Automation & Scripting Service Task List](../project-management/task-list-automation-scripting-service.md).
-
-- **Implemented and in active use**
-  - Sandboxed script runtime and core Automation & Scripting Service, including quota enforcement via `ScriptQuotaService` and Redis-backed `ScriptTickService` staging.
-  - Hot reloading of scripts published by the Game Design Service and version-aware script execution, aligned with the versioning model in [Versioning & Runtime Configuration](./system-architecture-versioning-runtime.md#script-only-patch-versions).
-  - Visual DSL editor for script creation and testing in the Game Design Service, mapping component graphs to Automation & Scripting Service definitions.
-  - Advanced NPC behavior modules (morale, PvE encounters, formations) and state-driven / event-driven NPC behaviors integrated with the tick system.
-
-- **Planned or partially implemented**
-  - Copying published version data into the Automation & Scripting Service schema via Saga, and broader script-driven world generation flows (runtime generation requests via isolated ticks, generation seed persistence, and script-driven population triggers).
-  - Expansion of the PvE encounter library, biome-specific events, and world generation features called out in the Automation & Scripting Service and world generation task lists.
-  - Scheduler leadership leases and per-region tick-stream consumption for `script-leader:{tenantId}` are implemented; sharded leases, `automation:timer:{tenantId}:{regionId}` indexing, and long-term audit-retention jobs continue to evolve. See [Scheduler Leadership & Coordination](#scheduler-leadership--coordination) for scripting-specific lease and timer keys, the Automation & Scripting Service README (`design/architecture/microservices/automation-scripting-service/README.md#architecture--design-notes`) for current runtime behavior, and the [Automation & Scripting Service Task List](../project-management/task-list-automation-scripting-service.md) for remaining work.
-
-Operators looking for **runtime knobs and environment variables** should see the [Environment Variables](#environment-variables) section of this document and the Automation & Scripting Service README (`design/architecture/microservices/automation-scripting-service/README.md#environment-variables`), which is the authoritative source for current settings and defaults.
-
-Maintainers should update this section whenever major scripting features land or significant architecture pieces change so it remains a reliable guide to what is live versus aspirational.
-
-### Area Status Snapshot
-
-The table below summarizes the high-level implementation status of major areas described in this document. For deeper or evolving details, always consult the Automation & Scripting Service task list and README.
-
-| Area | Status (as of 2025-12-04) | Notes |
-| --- | --- | --- |
-| Script runtime & DSL | Implemented | Sandbox execution, core Automation & Scripting Service, and visual DSL editor are in active use, including basic quotas. |
-| Automation queues & script ticks | Implemented | `automation_queue:{tenantId}:{entityId}` and `automation:tick:{tenantId}:{scriptId}:...` staging are implemented; script work items flow into tick commands as described under [TL;DR Flow](#tldr-flow). |
-| Integration with tick commands | Implemented | Script-generated tick commands are enqueued into the same per-entity tick queues used by Game Session, and participate in the normal lock/idempotency model. |
-| Scheduler leadership & timers | Designed / partial | Per-tenant `script-leader:{tenantId}` leases and heartbeat-driven interval scheduling are implemented; sharded leases, `automation:timer:{tenantId}:{regionId}`–backed timer indexing, and long-term audit-retention jobs are tracked in the Automation & Scripting Service README and task list. |
-| Quotas & fairness | Implemented / evolving | Per-script quotas (`ScriptQuotaService`) and basic fairness rules are implemented; multi-level budgets and advanced throttling controls continue to evolve. |
-| Audit & metrics | Implemented / evolving | `script_event_audit` and core automation metrics exist; retention policies and additional dashboards are being refined. |
-
----
+  - In the gRPC layer, these identifiers travel on a **TriggerScriptEvent-style** request and on script metadata fields attached to tick commands. The target-state API will carry them in fields such as `tenant_id`, `region_id`, `entity_id`, `script_event_id`, `script_id`, `script_patch_version`, and `tick_id` within the Automation & Scripting gRPC package; see the automation scripting section of the generated gRPC reference (`design/grpc-docs/grpc-api.md#automation-scripting_v1_automation_scripting_service-proto`) for the concrete schema as it evolves.
 
 ## Goals
 
@@ -178,7 +181,7 @@ This section walks through a typical happy-path flow where an NPC script reacts 
 
 2. **Script lookup and quota checks**
    - The Automation & Scripting Service looks up all scripts bound to `onEnterRegion` for the target entity and tenant, using the version metadata provided by the Game Session Service to resolve the correct script definitions.
-   - For each candidate script, `ScriptQuotaService` applies per-script and per-tenant limits (for example, `SCRIPT_QUOTA_LIMIT` / `SCRIPT_QUOTA_WINDOWSECONDS`) before any work is enqueued. If a script has exceeded its quota, the trigger for that script is skipped, `script_quota_denied_total` is incremented, and an audit entry is recorded with an appropriate outcome; other scripts bound to the same event may still proceed if their quotas allow it.
+   - For each candidate script, `ScriptQuotaService` applies per-script and per-tenant limits before any work is enqueued, following the quota and budgeting rules described in [Fairness & Abuse Prevention](#fairness--abuse-prevention) and [Per-Script Scheduling Policies](#per-script-scheduling-policies). Triggers that violate quotas or budgets are skipped and recorded in `script_event_audit` and metrics; other scripts bound to the same event may still proceed if their own quotas allow it.
 
 3. **DSL graph evaluation in the sandbox**
    - Scripts that pass quota checks are compiled DSL graphs. The Automation & Scripting Service executes the `onEnterRegion` handler inside a sandboxed runtime, walking the graph of condition, timer, and action nodes for the current event payload.
@@ -196,6 +199,7 @@ This section walks through a typical happy-path flow where an NPC script reacts 
 6. **Audit trail and metrics**
    - For each trigger, the Automation & Scripting Service emits an audit record into the `script_event_audit` store; in the target architecture this is a **PostgreSQL table** managed by the Automation & Scripting Service. The canonical schema is defined in the [Auditability & Metrics](#auditability--metrics) section, but in practice each row at minimum captures identifiers such as `scriptEventId`, `scriptId`, `tenantId`, `tickId`, the effective script version, and an `outcome` / `reason` pair. Retention is controlled by `SCRIPT_EVENT_AUDIT_RETENTION_DAYS` and `SCRIPT_EVENT_AUDIT_MAX_ROWS` as described in the Automation & Scripting Service README.
    - Metrics such as `automation_script_triggers_total`, `automation_script_skips_total`, `automation_script_triggers_dropped_total`, `script_quota_allowed_total`, `script_quota_denied_total`, and `automation_tick_events_enqueued_total` are updated throughout this flow so operators can monitor how often `onEnterRegion` scripts fire, how many are skipped by policy, and how much automation work is being handed to the tick system. These metrics integrate with the broader logging and monitoring strategy described in [System Architecture: Logging & Monitoring](./system-architecture-logging-monitoring.md).
+   - If the `scriptPatchVersion` pinned by the Game Session Service for a given game is later marked failed or unknown for that tenant, subsequent triggers that reference it follow the behavior described under [Reload Failure Handling](#reload-failure-handling) rather than this happy-path flow.
 
 ## Example: Periodic Patrol via `onInterval`
 
@@ -210,7 +214,7 @@ This example shows how a script that runs on a fixed cadence (for example, an NP
    - Leaders track these interval entries alongside other automation timers, using bounded scans and the automation tick budget (`AUTOMATION_TICK_DURATION_MS`, `AUTOMATION_TICK_MAX_EVENTS`, `AUTOMATION_TICK_BUDGET_MS`) to decide which `onInterval` triggers should fire in each automation tick.
 
 3. **Firing `onInterval` and enforcing budgets**
-   - When an interval becomes due, the scheduler creates a `scriptEventId` for the `onInterval` trigger and performs the same per-script and per-tenant quota checks described earlier. If the script is outside its budgets or disabled, the trigger is skipped and recorded in both metrics and the audit feed.
+   - When an interval becomes due, the scheduler creates a `scriptEventId` for the `onInterval` trigger and evaluates it using the same quota, cadence, and budgeting layers described in [Fairness & Abuse Prevention](#fairness--abuse-prevention) and [Per-Script Scheduling Policies](#per-script-scheduling-policies). If the script is outside its budgets or disabled, the trigger is skipped and recorded in both metrics and the audit feed.
    - If allowed, the scheduler enqueues the `onInterval` trigger for sandbox execution and updates the interval entry with a new `nextTick` or `nextRunAt`, ensuring the cadence remains stable even if some intervals are occasionally delayed by load.
 
 4. **Sandbox execution and command enqueue**
@@ -220,6 +224,7 @@ This example shows how a script that runs on a fixed cadence (for example, an NP
 5. **Execution, audit, and observability**
    - On subsequent ticks, the Game Session Service executes at most one command per entity per tick, so patrol movements and emotes follow the same fairness and conflict-resolution rules as player actions.
    - Each fired interval contributes to `automation_script_triggers_total` (tagged with `eventType=onInterval`) and, if it produces work, increases `automation_tick_events_enqueued_total`. An audit record is written to `script_event_audit` (see [Auditability & Metrics](#auditability--metrics)) so missed or delayed intervals can be debugged using the recorded `outcome` and `reason` fields alongside identifiers like `scriptEventId`, `scriptId`, and `tickId`.
+   - If the `scriptPatchVersion` pinned by the Game Session Service for a given game is later marked failed or unknown for that tenant, triggers that reference it follow the behavior described under [Reload Failure Handling](#reload-failure-handling) instead of the happy-path flow outlined here.
 
 ## Scripting DSL
 
@@ -250,9 +255,25 @@ Before a script is accepted, the Automation & Scripting Service runs a **loop sa
 - A loop is considered **safe** only if the SCC contains at least one **bounded guard node**, such as a `Counter` node with a finite `maxIterations`. Loops without such a guard are rejected at validation time with a descriptive error that points to the participating nodes and is surfaced in the Game Design Service UI so designers see exactly which connections must change before the script can be published.
 - In addition to static checks, the runtime enforces a **per-run iteration budget**. If a bug or future change allows an unsafe loop to slip through static analysis, the engine aborts the run with a `sandbox_error` (for example, `reason=iteration_budget_exceeded`) before it can spin indefinitely. See `design/architecture/microservices/automation-scripting-service/sandbox-runtime-design.md` for details on runtime safeguards.
 
+### Designer Debugging & Validation
+
+From a game designer’s perspective, debugging a script centers on **what the editor shows** and **how the platform reports problems**, rather than on implementation details:
+
+- **Graph validation and unsafe loops**
+  - The Game Design Service highlights invalid wiring (for example, missing connections, incompatible types, or unbounded cycles) directly in the visual editor. Errors point to the specific nodes and edges that must change before publish, including loops rejected by the loop safety analysis described above.
+  - Scripts with unsafe or deprecated components (for example, components marked `UNSAFE`) appear in a dedicated “requires migration” view. They must be migrated and republished before they are eligible to run again; see the forced deprecation flow in this section for details.
+
+- **Runtime outcomes and auto-disable**
+  - When a script misbehaves at runtime—exceeding quotas, hitting sandbox errors, or being disabled by the failure-rate circuit breaker—the Automation & Scripting Service records a canonical `outcome` and `reason` in `script_event_audit`. Common examples include `quota_denied`, `sandbox_error`, `disabled_due_to_errors`, and `skipped_disabled`; see [Failure Modes and Error Handling](#failure-modes-and-error-handling).
+  - Administrative disables and throttling (for example, `runtimeStatus=DISABLED` or `DISABLE_AFTER_DRAIN`) are reflected in script metadata and surfaced through the Game Design and Logging & Admin tools. Designers can see which scripts are paused, why they were disabled (for example, `admin_hard_disable`), and when they can be safely re-enabled; see [Fairness & Abuse Prevention](#fairness--abuse-prevention).
+
+- **Where to look when debugging**
+  - For **editor-time issues**, fix the graph based on the validation errors in the Game Design Service UI and re-run validation before publishing.
+  - For **runtime issues**, start from the script’s recent entries in `script_event_audit` and the associated metrics in [Auditability & Metrics](#auditability--metrics), then adjust quotas or disable/throttle the script using the flows described under [Fairness & Abuse Prevention](#fairness--abuse-prevention).
+
 ### Determinism & Allowed Non-Determinism
 
-Scripts are designed to be **deterministic under replay** for a given game configuration and event. The Automation & Scripting Service enforces this by constraining how randomness and time are exposed to DSL components:
+Scripts are designed to behave **deterministically for a given game configuration and event**, so that both the original execution and any offline replay in tools or tests produce the same observable behavior. The Automation & Scripting Service enforces this by constraining how randomness and time are exposed to DSL components:
 
 - All **pseudo-random behavior** (for example, “pick a random waypoint”, “roll for loot”, or encounter selection) flows through curated components that read from a **seeded RNG** supplied by the runtime. The seed is derived from stable identifiers such as `{tenantId, regionId, scriptId, scriptEventId, tickId, scriptPatchVersion}` so that re-evaluating the same trigger with the same inputs produces the **same sequence of random values**. Components must not call process-wide RNG APIs directly; they receive a scoped RNG instance from the sandbox.
   Seeds are derived from this tuple primarily so offline replay tools and test harnesses can reproduce behavior for a given event stream; production tick replays never re-enter the DSL for the same `scriptEventId`.
@@ -580,11 +601,11 @@ The table below summarizes the major quota and budget types that apply to script
 
 | Type | Scope | Governing settings / sources | Primary metrics |
 | --- | --- | --- | --- |
-| **Per-script quota** | Per script (`tenantId`, `scriptId`) | `SCRIPT_QUOTA_LIMIT`, `SCRIPT_QUOTA_WINDOWSECONDS`, evaluated by `ScriptQuotaService` before a run starts. | `script_quota_allowed_total`, `script_quota_denied_total`, `automation_script_triggers_dropped_total{reason="quota"}`, `automation_script_triggers_total{outcome="quota_denied"}`. |
-| **Per-script cadence & concurrency** | Per script | `intervalTicks`, `concurrencyPolicy` (`drop_new` / `queue_until_free`), `maxConcurrent`. Stored in script metadata and used by the scheduler when deciding which triggers to admit. | `automation_script_queue_delay_seconds`, `automation_script_triggers_dropped_total` (for drops due to queue/concurrency), audit `outcome` / `reason` values such as `dropped_quota`. |
-| **Per-script priority** | Per script | `priorityTag` (`high`, `normal`, `background`) and per-tier enqueue budgets (for example, high=8/min, normal=4/min, background=2/min). | `automation_script_triggers_total` (tagged by tier), `automation_script_skips_total` (e.g., `reason="priority_throttled"` when tiers are constrained), `automation_script_triggers_dropped_total` for hard drops. |
-| **Per-tenant tier budgets** | Per tenant and priority tier | Tenant-scoped automation budgets per tier, tracked as aggregates such as `automation_script_tenant_budget_seconds{tenantId, tier}`. | `automation_script_tenant_budget_seconds{tenantId, tier}`, `automation_script_skips_total{reason="tenant_budget_exceeded"}`, audit `outcome="tenant_budget_exceeded"` with appropriate `reason`. |
-| **Cluster-wide safety limits** | Entire Automation & Scripting cluster | Global ceilings on automation work, including `AUTOMATION_TICK_MAX_EVENTS` and cluster-level CPU/time budgets. | `automation_tick_events_enqueued_total`, `automation_script_triggers_dropped_total` (for drops when global ceilings are hit), high-level resource metrics from the logging/monitoring stack. |
+| **Per-script quota** | Per script (`tenantId`, `scriptId`) | `SCRIPT_QUOTA_LIMIT`, `SCRIPT_QUOTA_WINDOWSECONDS`, evaluated by `ScriptQuotaService` before a run starts. | Quota-allow/deny and drop metrics for individual scripts; see the Automation & Scripting Service README for exact meter names and labels. |
+| **Per-script cadence & concurrency** | Per script | `intervalTicks`, `concurrencyPolicy` (`drop_new` / `queue_until_free`), `maxConcurrent`. Stored in script metadata and used by the scheduler when deciding which triggers to admit. | Queue delay and drop metrics plus audit `outcome` / `reason` values such as `dropped_quota`; see the service README for the full metric catalog. |
+| **Per-script priority** | Per script | `priorityTag` (`high`, `normal`, `background`) and per-tier enqueue budgets (for example, high=8/min, normal=4/min, background=2/min). | Tiered trigger/skip metrics that show how often high/normal/background work is admitted or throttled; exact meters are documented in the Automation & Scripting Service README. |
+| **Per-tenant tier budgets** | Per tenant and priority tier | Tenant-scoped automation budgets per tier, tracked as aggregates such as `automation_script_tenant_budget_seconds{tenantId, tier}`. | Budget consumption and skip metrics per tenant/tier, plus matching audit outcomes such as `tenant_budget_exceeded`; see the README for concrete metric definitions. |
+| **Cluster-wide safety limits** | Entire Automation & Scripting cluster | Global ceilings on automation work, including `AUTOMATION_TICK_MAX_EVENTS` and cluster-level CPU/time budgets. | Cluster-level throughput and drop metrics that indicate when global ceilings are hit; refer to the service README for the detailed metric list. |
 
 These layers compose in order: a trigger must pass per-script quotas, cadence and concurrency checks, per-tenant budgets, and cluster-wide ceilings before it runs. When a trigger is rejected at any layer, the decision is reflected consistently via `script_event_audit.outcome` / `reason` and the metrics listed above.
 
@@ -697,12 +718,12 @@ Not all columns are populated for every row, but this shape ensures that sandbox
 
 Metrics include:
 
-- **Scheduler metrics** – `automation_script_triggers_total`, `automation_script_skips_total` (broken out by policy), `automation_script_queue_delay_seconds` for queued triggers waiting on concurrency limits, `automation_script_leadership_changes_total` to monitor failovers, and `automation_script_triggers_dropped_total` to capture quota/queue drops so operators can tune `ScriptQuotaService` windows.
-- **Quota metrics** – `script_quota_allowed_total` and `script_quota_denied_total` (shared with the Automation & Scripting Service README) track per-script quota decisions in a consistent way across documentation and implementations.
+- **Scheduler metrics** tracking how often triggers are accepted, skipped, queued, replayed, or dropped, as well as leadership changes and queue delay under load.
+- **Quota and budget metrics** tracking per-script quota decisions and per-tenant/cluster budget usage, so operators can tell whether pressure is coming from a specific script, tenant, or the entire cluster.
 
 Logs annotate each audit row with the scheduler lease holder and tick details, making it easier to trace why a timer fired or was dropped.
 
-The list above highlights the most important cross-cutting metrics for the scripting architecture. The **Automation & Scripting Service README** remains the **single source of truth** for the complete set of service-specific metrics, their labels, and any future additions or removals.
+The list above highlights the most important cross-cutting metric categories for the scripting architecture. The **Automation & Scripting Service README** remains the **single source of truth** for the complete set of service-specific metrics, their exact meter names and labels, and any future additions or removals.
 
 Audit records remain available for troubleshooting for the first 30 days or until the table reaches 1,000,000 rows, whichever comes first; a nightly maintenance job truncates old entries to keep storage bounded while preserving recent history.
 Operators tune retention via `SCRIPT_EVENT_AUDIT_RETENTION_DAYS` (default `30`) and `SCRIPT_EVENT_AUDIT_MAX_ROWS` (default `1000000`), ensuring the cleanup job can safely trim both by row count and elapsed duration.

--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -416,7 +416,7 @@ The table below summarizes **which outcomes are retried** and which are treated 
 | `infrastructure_error` (e.g., gRPC `UNAVAILABLE`, `DEADLINE_EXCEEDED`, transient Redis timeout) | Network hiccups, temporary downstream unavailability | **May be retried** according to platform retry policy (bounded attempts, backoff, and idempotent downstream handlers) |
 | `INVALID_ARGUMENT` / `PERMISSION_DENIED` / other client or policy errors | Callers sent bad data or lack permission | No retry; callers must correct inputs or permissions |
 
-**Outcome-to-metric mapping**
+### Outcome-to-Metric Mapping
 
 This section is **illustrative**, not normative. The **authoritative definitions** for metric names, labels, and alerting behavior live in:
 
@@ -555,11 +555,11 @@ Automation-specific keys such as `script-leader:{tenantId}` and `script-schedule
   - If a leader loses access to the tick heartbeat stream (for example, due to network partition or Game Session unavailability) but can still reach Redis, it treats the tick timeline as **unreliable**:
     - `onInterval` and other cadence-based triggers pause for the affected `{tenantId, regionId}` entries rather than extrapolating tick counts locally.
     - The authoritative timer state in `automation:timer:{tenantId}:{regionId}` is effectively **frozen** during the outage: entries remain in Redis with their current `nextTick` / `nextRunAt` values, but leaders do not advance or fire them while the heartbeat is unhealthy.
-	    - When the heartbeat recovers and a healthy tick stream resumes, leaders:
-	      - Reconcile the stored `script-scheduler:{tenantId}:{regionId}:lastTickId` with the latest observed `tickId`.
-	      - Walk forward through the gap and determine which timers became due while the heartbeat was unavailable.
-	      - Enqueue a bounded set of **catch-up triggers** for each timer (typically one trigger per missed `onInterval` boundary or `onTimerExpire` event), subject to per-script quotas, per-tenant budgets, and cluster ceilings so that long outages do not produce unbounded bursts. There is no fixed global “catch-up horizon”; the effective replay window is defined by these budgets and ceilings, so very old due timers may never be replayed and are treated as intentionally dropped once the system has advanced to the current tick/time.
-	      - Update `lastTickId` and each timer’s `nextTick` / `nextRunAt` so cadence resumes from the latest tick/time, treating any skipped triggers as intentionally dropped once the system has caught up to “now.”
+    - When the heartbeat recovers and a healthy tick stream resumes, leaders:
+      - Reconcile the stored `script-scheduler:{tenantId}:{regionId}:lastTickId` with the latest observed `tickId`.
+      - Walk forward through the gap and determine which timers became due while the heartbeat was unavailable.
+      - Enqueue a bounded set of **catch-up triggers** for each timer (typically one trigger per missed `onInterval` boundary or `onTimerExpire` event), subject to per-script quotas, per-tenant budgets, and cluster ceilings so that long outages do not produce unbounded bursts. There is no fixed global “catch-up horizon”; the effective replay window is defined by these budgets and ceilings, so very old due timers may never be replayed and are treated as intentionally dropped once the system has advanced to the current tick/time.
+      - Update `lastTickId` and each timer’s `nextTick` / `nextRunAt` so cadence resumes from the latest tick/time, treating any skipped triggers as intentionally dropped once the system has caught up to “now.”
     - One-off event-driven triggers that do not depend on tick cadence may continue to run if safe and configured to do so, but the recommended default is to bias toward pausing automation rather than drifting away from the canonical tick stream.
   - Leaders log structured warnings and emit metrics (for example `automation_script_leadership_changes_total` and a heartbeat health gauge) so operators can detect and remediate heartbeat issues.
 
@@ -791,7 +791,7 @@ For a consolidated view of the primary quota and budget knobs (per-script, per-t
   Scripting Service.
 - These quota and throttling controls work **in combination with** the failure-rate circuit breaker described under [Failure Modes and Error Handling](#failure-modes-and-error-handling), which can automatically place misbehaving scripts into a `disabled_due_to_errors` state when error rates exceed configured thresholds.
 
-#### Operational Disable / Throttle Flows
+### Operational Disable / Throttle Flows
 
 - **Disable now (hard stop)** – When an administrator marks a script as disabled in the Game Design or Logging & Admin tools, the Automation & Scripting Service flips a `runtimeStatus=DISABLED` flag in script metadata. The scheduler stops accepting **new triggers** for that script immediately (recording `outcome=skipped_disabled` and a suitable `reason`, such as `admin_hard_disable`, in `script_event_audit`), but does not preempt in-flight runs; they are allowed to complete under existing quotas.
 - **Soft-disable after current run** – For scripts that should drain gracefully, administrators can set `runtimeStatus=DISABLE_AFTER_DRAIN`. The scheduler continues to run any currently queued triggers up to a small grace window, then transitions the script to `DISABLED` once its active and queued counts reach zero. Subsequent triggers are skipped and logged to `script_event_audit` with `outcome=skipped_disabled` and a reason that reflects the drain behavior.

--- a/design/architecture/system-architecture-shared-libraries.md
+++ b/design/architecture/system-architecture-shared-libraries.md
@@ -47,7 +47,10 @@ DTO records for common tasks (paging, IDs, basic metadata) live here so services
 Tick coordination and other Redis-backed workflows rely on a small set of shared helpers provided by the common library:
 
 - **Key Naming helpers** – A `RedisKeyNaming` (or similarly named) utility centralizes construction of tick-related keys such as `tick:{tenantId}:{regionId}:lock:{entityId}`, `tick:{tenantId}:{regionId}:pending`, `retry:{tenantId}:{regionId}`, and `timer:{tenantId}:{regionId}`. Application code must build these keys exclusively through the helper; direct string concatenation of `tick:`, `retry:`, or `timer:` prefixes in services is discouraged so hash-tag and naming rules remain consistent. The helper enforces the `{tenantId}:{regionId}` hash tag and is the single source of truth for tick key shapes.
-- **Lua script invocation helpers** – A small Redis/Lua helper class wraps `EVALSHA` calls for tick scripts. It ensures that:
+- **Lua scripts, descriptors, and invocation helpers** – The common library owns:
+  - All coordination-related Lua scripts (tick staging/commit/rollback, locks, timers, retries, session CAS, automation scheduling) under a shared `redis/` resources path.
+  - Machine-readable script descriptors that declare `KEYS` order, allowed prefixes, and shard-locality for each script.
+  - A small Redis/Lua helper class that wraps `EVALSHA` calls for tick/session/automation scripts. It ensures that:
   - Scripts are invoked with the correct first key (a tick key with the `{tenantId}:{regionId}` hash tag).
   - `NOSCRIPT` errors are handled by reloading the script on the appropriate master and retrying once.
   - Callers pass keys built via `RedisKeyNaming` so multi-key operations stay shard-local.
@@ -56,7 +59,7 @@ Tick coordination and other Redis-backed workflows rely on a small set of shared
   - Lua scripts respect the configured `MAX_TICK_SCRIPT_KEYS` bound and do not introduce “just one more key” without extending tests.
   - Automation and session scripts are declared as **single-key** in their descriptors; tests assert that their `KEYS` length is exactly one and fail fast if additional keys are introduced without an explicit design change.
   - Prefix discipline is enforced consistently: tick scripts are allowed only tick/coordination prefixes (`tick:`, `retry:`, `timer:`, `remote:`), session scripts only `session:`, and automation scripts only `automation_queue:` / `automation:tick:`. CI lints Lua sources against these rules so mixed `tick:*` + `automation:*` or `tick:*` + `session:*` scripts cannot be added inadvertently.
-  - Any new tick-related script or key path added by a service includes corresponding updates to the helpers and tests.
+  - Any new tick-related script or key path added by a service includes corresponding updates to the shared scripts, descriptors, helpers, and tests in `firemud-common`; individual services do not define their own independent copies.
 
 For Redis-backed caches and rate limiting, the common library may also provide:
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -79,6 +79,29 @@ The **region boundary** is therefore the unit of atomicity and authority:
 - All tick locks, staging, timers, retry metadata, and session participation for a `{tenantId, regionId}` are owned by that region’s active executor.
 - No lock, Lua script, or tick context spans multiple regions. Cross-region flows are modeled as **messages between region executors**, not shared locks.
 
+### Region Progress vs Lease Ownership
+
+Region leases are intentionally **short‑lived coordination hints**, not full health indicators. It is possible for an executor to:
+
+- Continue renewing the `tick-executor-lease:{tenantId}:{regionId}` key (Redis and lease logic are healthy), while
+- Making little or no **forward progress** because downstream dependencies (PostgreSQL, domain gRPC services) are slow or unreachable.
+
+To distinguish this “lease held but stalled” case from a true lease loss:
+
+- The Game Session Service tracks **per-region progress signals**, such as:
+  - The timestamp or tick counter of the **last successful commit** for `{tenantId, regionId}`.
+  - A small counter of **consecutive failed ticks** for that region caused by downstream errors or timeouts (not by lock contention alone).
+- When a region exceeds simple hardcoded thresholds (for example, several consecutive failures or no successful ticks for many multiples of `tick-duration-ms`), the scheduler treats the region as **stalled** even though it still holds the lease.
+
+Behavior for stalled regions:
+
+- New ticks are **not scheduled** for that `{tenantId, regionId}` until progress recovers.
+- New gameplay commands targeting that region are **rejected** with a clear “region unavailable” style error instead of being accepted and stuck behind a non‑advancing executor.
+- The executor continues to renew the lease during a short grace period so no other instance takes over and attempts the same failing work against unhealthy dependencies.
+- If a large number of regions on the same instance become stalled, the instance’s readiness/liveness can be marked unhealthy so orchestration restarts it once dependencies recover.
+
+Lease expiry and failover remain strictly about **coordination safety** (avoiding split‑brain on Redis state). Stalled region handling is layered on top as a **progress watchdog**: leases tell you who owns a region’s coordination keys, while stalled/healthy tell you whether that owner is actually advancing game state.
+
 ---
 
 ## Distributed Locking

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -89,20 +89,15 @@ To prevent concurrent entity updates, ticks acquire **distributed locks** in Red
 - `SET NX PX` with expiry for exclusive ownership, via a shared lock helper
 - Lua-based atomic checks to avoid race conditions
 
-Lock TTLs are derived from the **soft tick execution budget** using the formula described in the Redis architecture. Conceptually:
+In practice, the system keeps this simple by exposing a **single primary knob**—the region tick interval—and deriving lock/lease TTLs from that:
 
-- The platform computes `lock_ttl_ms` as `clamp(tick_budget_ms * LOCK_TTL_MULTIPLIER, MIN_LOCK_TTL_MS, MAX_LOCK_TTL_MS)`, where:
-  - `LOCK_TTL_MULTIPLIER` is a configuration property (for example `5` in production profiles) rather than a hard-coded constant of `3`.
-  - `MIN_LOCK_TTL_MS` / `MAX_LOCK_TTL_MS` bound the envelope for all regions.
-- This gives headroom for pauses (GC, CPU spikes, brief scheduler jitter) without letting the lock expire while work is still in progress, while still bounding how long a stale lock can block progress.
+- `tick_interval_ms` is the configured target interval between ticks for a region.
+- Internally, the Game Session Service computes a soft execution budget (for example `tick_budget_ms = tick_interval_ms * 0.8`) and then derives TTLs using fixed multipliers:
+  - `lock_ttl_ms = clamp(tick_budget_ms * 8, 500, 5_000)`
+  - `lease_ttl_ms = clamp(tick_budget_ms * 16, 2_000, 15_000)`
+- These multipliers are **hard-coded defaults** for hobby/self‑hosted deployments; they are chosen to give generous headroom for GC pauses and hiccups without requiring per‑environment tuning.
 
-Capacity planning and configuration tuning rely on **measured data**, not just the multiplier:
-
-- Load/perf tests and production telemetry must show that `p99` tick execution time (lock acquisition → commit/rollback + lock release) remains under a configurable fraction of `lock_ttl_ms` (for example **≤50%** in steady state, with alerts when sustained runtime exceeds **70%**).
-- The recommended process is:
-  - Start from a conservative `LOCK_TTL_MULTIPLIER` (for example, 5× the soft tick budget).
-  - Measure `tick.execution_time_ms`, `tick.lock_ttl_ms`, and headroom ratios under realistic workloads.
-  - Adjust `tick_budget_ms` and/or `LOCK_TTL_MULTIPLIER` per environment so that GC pauses and normal load variations still fall well within the configured envelope.
+This keeps configuration light—typically you only adjust `tick_interval_ms`—while still ensuring locks live long enough for normal work to finish and stale locks are cleared after a bounded window.
 
 Rare, extreme pauses (for example long GC) may still exceed `lock_ttl_ms`. In those cases:
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -79,6 +79,21 @@ The **region boundary** is therefore the unit of atomicity and authority:
 - All tick locks, staging, timers, retry metadata, and session participation for a `{tenantId, regionId}` are owned by that region’s active executor.
 - No lock, Lua script, or tick context spans multiple regions. Cross-region flows are modeled as **messages between region executors**, not shared locks.
 
+### Tick Effect Ledger and Replay Guarantees
+
+Tick coordination relies on Redis for the fast staging surface, but PostgreSQL remains the source of truth for whether a tick effect was ever applied. To make this explicit:
+
+- Every tick effect that can be staged in `tick:{tenantId}:{regionId}:pending` or the retry/timer queues must also write a durable row in a “tick effect ledger” table (`tick_effects` or similar) owned by the Game Session Service. Each row records `tenant_id`, `region_id`, `tick_id`, `effect_key`, `command_id`, `status` (`SCHEDULED`, `APPLIED`, `ABANDONED`), a `reason` or `outcome` code, `created_at`, and `updated_at`.
+- The ledger enforces the invariant that for any `(tenant_id, region_id, tick_id, effect_key)` exactly one terminal state exists: either `status = APPLIED` (effect successfully committed to domain state) or `status = ABANDONED` (effect intentionally skipped or unrecoverable), and rows may not remain stuck in `SCHEDULED` beyond a configurable grace window.
+- On replay (for example after failover or replaying `pending` entries), the executor loads ledger rows with `status = SCHEDULED` for that tick and:
+  - Re-queues/re-runs effects whose domain targets do not yet reflect `APPLIED`, then update the row to `APPLIED`.
+  - If replay determines the effect is no longer valid (expired session, entity gone, tick de-scheduled, etc.), it updates the row to `ABANDONED` with a precise `reason`.
+  - If the effect was already applied (e.g., because of idempotent writes or cached state), it marks the ledger row as `APPLIED` and skips running the Lua script again.
+- This ledger makes replay visible:  services expose metrics such as `tick.effects_pending_total`, `tick.effects_applied_total`, `tick.effects_abandoned_total{reason}`, and `tick.effects_replayed_total`. Alerts fire if pending counts remain above thresholds for longer than a tick window or if the abandoned ratio grows unexpectedly.
+- Every Lua script that stages effects is required to include the `effect_key` used in the ledger so that matches between Redis and PostgreSQL can be validated. Scripts that cannot be tied back to a ledger row are rejected.
+
+With this contract, operators and automation can detect whether replay occurred, how long effects sat in `SCHEDULED`, and whether any stale `pending` entries were consciously abandoned instead of silently forgotten.
+
 ### Region Progress vs Lease Ownership
 
 Region leases are intentionally **short‑lived coordination hints**, not full health indicators. It is possible for an executor to:
@@ -286,7 +301,7 @@ Within a region’s tick, each **command** is treated as a small, idempotent wor
      - It stages and commits changes via the tick Lua scripts and gRPC calls to domain services, using `tickId` and effect-guard tables for idempotency.
    - For cross-region commands:
      - The origin region applies any purely local effects first (for example, local animations, partial buffs, or immediate messaging).
-     - It then enqueues follow-up commands into the target regions’ queues (for example under `remote:{tenantId}:{entityId}`) so remote executors can apply their parts in their own ticks. See [Cross-Region Command Execution and Result Relay](#📡-cross-region-command-execution-and-result-relay).
+     - It then enqueues follow-up commands into the target regions’ queues (for example under `remote:{tenantId}:{entityId}`) so remote executors can apply their parts in their own ticks. See [Cross-Region Command Execution and Result Relay](#cross-region-command-execution-and-result-relay).
 
 4. **Completion / Finalization (optional)**
    - Many commands do not require awareness of “all regions finished”; origin and target regions can operate independently with eventual consistency.
@@ -468,6 +483,8 @@ Timer scheduling, rescheduling, and cancellation are coordinated by the same Lua
 Durations can be modified on the fly:
 
 - `scaled = base * multiplier`
+- Used for spell effects, world modifiers (e.g., slow motion), or status changes
+- Time scaling affects **durations**, not tick rate
 
 ### Tick Event Stream
 
@@ -479,8 +496,6 @@ The Game Session Service publishes a **tick event stream** so other services (sc
 - `activeVersionId` pinned for that tick
 
 Leaders lease Redis keys (`tick-events-lease:{tenantId}:{regionId}`) before consuming the stream to avoid duplicate processing. The stream can be delivered via Redis Streams or pub/sub; the implementation ensures catch-up by storing the last processed offset in Redis so a recovering scheduler can resume from the right `tickId`. This event stream powers the Automation & Scripting scheduler’s “every N ticks” logic, the reconnection doc’s timer replay hints, and any other out-of-band reporting you need.
-- Used for spell effects, world modifiers (e.g., slow motion), or status changes
-- Time scaling affects **durations**, not tick rate
 
 > Runtime feature flags controlling global pace or status effects are applied by the Game Session Service before tick execution.
 > For design-time definitions see [Game Design Service Feature Flags](./microservices/game-design-service/feature-flags.md);

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/service/impl/ScriptTickServiceImpl.java
@@ -37,14 +37,8 @@ public class ScriptTickServiceImpl implements ScriptTickService {
   private final net.firedevops.firemud.service.quota.ScriptQuotaService quotaService;
   private final ConflictTracker conflictTracker;
 
-  @Value("${automation.tick-budget-ms:100}")
-  private long tickBudgetMs;
-
-  @Value("${automation.tick-min-lock-ttl-ms:500}")
-  private long minLockTtlMs;
-
-  @Value("${automation.tick-max-lock-ttl-ms:5000}")
-  private long maxLockTtlMs;
+  @Value("${automation.tick-duration-ms:1000}")
+  private long tickDurationMs;
 
   @Value("${automation.tick-max-events:50}")
   private int tickMaxEvents;
@@ -190,23 +184,24 @@ public class ScriptTickServiceImpl implements ScriptTickService {
       awaitReplication();
     } finally {
       long elapsed = (System.nanoTime() - start) / 1_000_000;
-      if (elapsed > tickBudgetMs) {
+      long budgetMs = (long) (tickDurationMs * 0.8);
+      if (elapsed > budgetMs) {
         budgetExceededCounter.increment();
-        logger.debug("Tick budget exceeded: {} ms", elapsed);
+        logger.debug("Tick budget exceeded: {} ms (budget {} ms)", elapsed, budgetMs);
       }
       redisTemplate.delete(lockKey);
     }
   }
 
   private long computeLockTtlMs() {
-    long unclamped = tickBudgetMs * 3;
-    if (unclamped < minLockTtlMs) {
-      return minLockTtlMs;
+    long tickBudgetMs = (long) (tickDurationMs * 0.8);
+    long lockTtl = tickBudgetMs * 8;
+    if (lockTtl < 500L) {
+      lockTtl = 500L;
+    } else if (lockTtl > 5_000L) {
+      lockTtl = 5_000L;
     }
-    if (unclamped > maxLockTtlMs) {
-      return maxLockTtlMs;
-    }
-    return unclamped;
+    return lockTtl;
   }
 
   private String queueKey(Long tenantId, Long scriptId) {

--- a/services/automation-scripting-service/src/main/resources/application-prod.yml
+++ b/services/automation-scripting-service/src/main/resources/application-prod.yml
@@ -25,7 +25,6 @@ script:
 automation:
   tick-duration-ms: ${AUTOMATION_TICK_DURATION_MS:1000}
   tick-max-events: ${AUTOMATION_TICK_MAX_EVENTS:50}
-  tick-budget-ms: ${AUTOMATION_TICK_BUDGET_MS:100}
 
 server:
   compression:

--- a/services/automation-scripting-service/src/main/resources/application.yml
+++ b/services/automation-scripting-service/src/main/resources/application.yml
@@ -26,7 +26,6 @@ script:
 automation:
   tick-duration-ms: 1000
   tick-max-events: 50
-  tick-budget-ms: 100
 
 server:
   compression:

--- a/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
+++ b/services/entity-management-service/src/main/java/net/firedevops/firemud/service/impl/TickLockServiceImpl.java
@@ -31,14 +31,8 @@ public class TickLockServiceImpl implements TickLockService {
 
   private Counter lockContentionCounter;
 
-  @Value("${game.tick-budget-ms:100}")
-  private long tickBudgetMs;
-
-  @Value("${game.tick-min-lock-ttl-ms:500}")
-  private long minLockTtlMs;
-
-  @Value("${game.tick-max-lock-ttl-ms:5000}")
-  private long maxLockTtlMs;
+  @Value("${game.tick-duration-ms:1000}")
+  private long tickDurationMs;
 
   @PostConstruct
   void initMetrics() {
@@ -61,21 +55,21 @@ public class TickLockServiceImpl implements TickLockService {
     return acquired;
   }
 
+  private long computeLockTtlMs() {
+    long tickBudgetMs = (long) (tickDurationMs * 0.8);
+    long lockTtl = tickBudgetMs * 8;
+    if (lockTtl < 500L) {
+      lockTtl = 500L;
+    } else if (lockTtl > 5_000L) {
+      lockTtl = 5_000L;
+    }
+    return lockTtl;
+  }
+
   @Override
   @Timed(value = "tick.lock.release")
   public void releaseLock(Long tenantId, Long entityId) {
     redisTemplate.delete(lockKey(tenantId, entityId));
-  }
-
-  private long computeLockTtlMs() {
-    long unclamped = tickBudgetMs * 3;
-    if (unclamped < minLockTtlMs) {
-      return minLockTtlMs;
-    }
-    if (unclamped > maxLockTtlMs) {
-      return maxLockTtlMs;
-    }
-    return unclamped;
   }
 
   private String lockKey(Long tenantId, Long entityId) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/service/impl/TickServiceImpl.java
@@ -47,12 +47,6 @@ public class TickServiceImpl implements TickService {
   @Value("${game.tick-duration-ms:1000}")
   private long tickDurationMs;
 
-  @Value("${game.tick-budget-ms:100}")
-  private long tickBudgetMs;
-
-  @Value("${game.solo-tick-budget-ms:500}")
-  private long soloTickBudgetMs;
-
   @Value("${game.tick-max-commands:50}")
   private int tickMaxCommands;
 

--- a/services/game-session-service/src/main/resources/application-prod.yml
+++ b/services/game-session-service/src/main/resources/application-prod.yml
@@ -20,7 +20,6 @@ management:
 
 game:
   tick-duration-ms: ${GAME_TICK_DURATION_MS:1000}
-  tick-budget-ms: ${GAME_TICK_BUDGET_MS:100}
   tick-max-commands: ${GAME_TICK_MAX_COMMANDS:50}
 
 firemud:

--- a/services/game-session-service/src/main/resources/application.yml
+++ b/services/game-session-service/src/main/resources/application.yml
@@ -22,7 +22,6 @@ management:
         enabled: true
 game:
   tick-duration-ms: 1000
-  tick-budget-ms: 100
   tick-max-commands: 50
   logic:
     default-room-id: "1021"


### PR DESCRIPTION
This PR builds on the previous Redis/tick coordination work with a small follow-up of documentation and tooling improvements.

Changes since develop (top-level commits):
- fd7a3f18 Always run markdown/link lint and fix doc issues
- 45f18008 Merge remote-tracking branch 'Github/develop' into feature/chat-say-pr2
- 7a6489cc Merge pull request #1914 from benhook1013/feature/chat-say-pr2
- 04dbb108 Tighten Redis coordination, session, and cache design
- b76867e0 Refine scripting architecture documentation
- ac04f3ed Simplify tick timing to single interval and derived TTLs
- bd93e478 Refine Redis and tick docs for coordination, idempotency, and degradation
- ab218856 Update scripting and Redis Lua docs
- eeef63b2 Add table of contents to Redis architecture doc

For full history, see: git log develop..feature/chat-say-pr2