### PR TITLE
Refine Redis coordination design and ops docs

### DIFF
--- a/design/architecture/system-architecture-redis-cache.md
+++ b/design/architecture/system-architecture-redis-cache.md
@@ -13,9 +13,9 @@ Redis is already used for transient coordination (ticks, sessions, locks). This 
   - Static or topology data (world geometry, room/zone graphs, published templates, configuration) changes infrequently and is a good fit for aggressive caching with long TTLs or manual invalidation.
 - Dynamic runtime state (inventories, room occupants, transient effects, in-progress combat) changes frequently and must use careful invalidation rules and short-lived caches, if cached at all.
 - Purpose-driven caching only. Objects should be cached because they are expensive to compute or fetch and appear on hot paths, not “just in case.” Profiling and production telemetry will drive what actually lands in Redis.
-- Coordination workload isolation:
-  - In **QA, staging, and production** (any environment used for load tests or player traffic), read-side caches and gateway rate limits are placed on one or more **separate Redis cache/rate-limit deployments**, distinct from the **Coordination Redis** used for ticks, locks, timers, and sessions. Coordination Redis does **not** host caches or rate-limit keys in these environments.
-  - In **local developer** and other low-concurrency lab setups, a single Redis instance may be shared for convenience (see below), but this topology is not considered representative for performance or failure behavior and must not be reused for QA, staging, or production.
+  - Coordination workload isolation:
+  - In environments used for sustained load or player traffic (for example **QA, staging, and production**), read-side caches and gateway rate limits are **strongly recommended** to run on one or more separate Redis cache/rate-limit deployments, distinct from the **Coordination Redis** used for ticks, locks, timers, and sessions. Coordination Redis should not host large, eviction-driven caches in these environments.
+  - In **local developer** and other low-concurrency lab setups, a single Redis instance may be shared for convenience (see below). Smaller self-hosted deployments may also choose to share a single Redis process for both roles if they keep cache TTLs conservative and memory usage bounded; the logical separation in configuration remains the same either way.
 
 ## Candidate Cacheable Object Types
 

--- a/design/architecture/system-architecture-redis-cache.md
+++ b/design/architecture/system-architecture-redis-cache.md
@@ -128,7 +128,7 @@ Operational dashboards track `used_memory`, `maxmemory`, and eviction counters f
 - Alert when eviction counters climb steadily while `keyspace_hits` drop or `blocked_clients` rise, which usually signals a hot key or TTL that is too long.
 - Alert when memory usage grows despite expected TTL decay so cache scans can be inspected before coordination workloads are affected.
 
-These alerts keep you aware of misconfigurations early without hard-coding percentages that don’t make sense at hobby scale.
+These alerts keep you aware of misconfigurations early without hard-coding percentages that don’t make sense at small self-hosted scale.
 
 Rate limiting keys (for example those used by Spring Cloud Gateway’s `RequestRateLimiter`) should be designed to avoid **hot keys** under heavy load:
 

--- a/design/architecture/system-architecture-redis-lua-patterns.md
+++ b/design/architecture/system-architecture-redis-lua-patterns.md
@@ -29,18 +29,18 @@ To keep AOF replay and retries safe, Lua scripts must be **deterministic functio
 
 Scripts that violate these determinism requirements cannot guarantee safe replay and must be rejected during review and CI.
 
-- ### Mandatory Validation Hedge
--
+### Mandatory Validation Hedge
+
 Every mutating script must perform the following validations before executing any writes:
 
 - **Lease token** – re-read `tick-executor-lease:{tenantId}:{regionId}` and compare it to the supplied `leaseToken`. If they differ or the key is missing, the script returns a “stale lease” outcome and performs no writes.
 - **Lock tokens** – for each `tick:{tenantId}:{regionId}:lock:{entityId}` key included in `KEYS`, compare the stored token to the expected value. Any mismatch or absence yields a `"STALE_LOCK"` result without mutation.
 - **`tickId` guard** – when touching `tick:{tenantId}:{regionId}:pending` or other tick-scoped structures, verify the stored `tickId` is ≤ the requested `tickId`. Commit/rollback scripts abort if `tickId` is out of order so only the intended tick makes progress.
--
+
 These checks are enforced via the Lua Script Registry descriptors, generated key-builder helpers, and CI linting so reviewers can automatically catch regressions. Scripts that cannot make these validations (for example, because they run outside a region lease context) are rejected or refactored.
 
-- ### Script Complexity and Runtime Limits
--
+### Script Complexity and Runtime Limits
+
 To prevent Redis from stalling, tick-related scripts are bounded in keys touched and execution time:
 
 - **Key limit** – each script invocation touches at most one lock key, one `pending` key, and a handful of other coordination keys (`timer`, `retry`, `queue`). Scripts that need to touch large key ranges must be split into smaller, bounded operations or moved out of the hot tick path.

--- a/design/architecture/system-architecture-redis-operations.md
+++ b/design/architecture/system-architecture-redis-operations.md
@@ -1,0 +1,193 @@
+# FireMUD Redis Operations & Migrations
+
+This document captures **operational runbooks and migration procedures** for Coordination Redis. It complements the conceptual guarantees in `system-architecture-redis.md` and the Lua authoring patterns in `system-architecture-redis-lua-patterns.md`.
+
+The invariants and contracts in `system-architecture-redis.md` remain authoritative. This file focuses on **“when X happens, do 1–2–3”** guidance.
+
+## Table of Contents
+
+- [FireMUD Redis Operations & Migrations](#firemud-redis-operations--migrations)
+  - [AOF Size and Restart Budget](#aof-size-and-restart-budget)
+  - [Lua Compatibility Registry & Script Upgrades](#lua-compatibility-registry--script-upgrades)
+  - [Replica Promotion and Missed Writes](#replica-promotion-and-missed-writes)
+  - [Key Shape Mistakes and Coordination Resets](#key-shape-mistakes-and-coordination-resets)
+  - [Normalization and Hash-Tag Migration](#normalization-and-hash-tag-migration)
+
+---
+
+## AOF Size and Restart Budget
+
+**Goal:** Keep Coordination Redis restart behavior predictable and avoid unbounded AOF growth.
+
+**Targets**
+
+- Soft AOF size limit per node: **1–2 GiB**.
+- Typical restart time (AOF or RDB+AOF replay): **30–60 seconds**.
+
+**Runbook: AOF too large or restarts too slow**
+
+1. Confirm via metrics or `INFO`:
+   - AOF size substantially exceeds the soft limit, or
+   - Restart time is routinely above 60 seconds.
+2. Schedule a maintenance window.
+3. Stop game services for affected tenants/regions (or globally for a single-node deployment).
+4. Reset Coordination Redis:
+   - Stop Redis.
+   - Delete or recreate the volume that holds the AOF.
+   - Start Redis with an empty keyspace and the desired AOF configuration (`appendonly yes`, `appendfsync everysec`, `aof-use-rdb-preamble yes`, etc.).
+5. Resume ticks and player traffic once services are healthy.
+   - Expect players to re-login or restart games.
+   - Coordination state is rebuilt from PostgreSQL and fresh gameplay activity.
+
+Manual AOF “surgery” is **not supported**. Either the AOF is trusted and replayed as-is, or it is discarded and Redis restarts from a clean keyspace.
+
+---
+
+## Lua Compatibility Registry & Script Upgrades
+
+**Goal:** Roll out Lua script changes safely, knowing when coordination state must be reset.
+
+**Inputs**
+
+- The **Lua Compatibility Registry** (in `firemud-common`) declares, per script:
+  - `schemaVersionsSupported`.
+  - `KEYS`/`ARGV` contract.
+  - A compatibility tag: `compatible` or `breaking_requires_reset`.
+
+**Runbook: Upgrading scripts**
+
+1. Classify changes:
+   - Tag each modified script as `compatible` or `breaking_requires_reset` based on the registry rules (no change to KEYS/ARGV shape, semantics, or supported schemas for `compatible`).
+2. Run the **coordination upgrade planner** (dev-tools):
+   - Compares the current deployment’s registry to the target version.
+   - Reports whether a **coordination reset** is required.
+3. If all changes are `compatible`:
+   - Deploy new scripts and services as part of the normal rollout.
+   - Rely on existing `NOSCRIPT` handling and Lua preload behavior.
+4. If any script is `breaking_requires_reset`:
+   - Use the upgrade planner’s reset plan:
+     1. Pause ticks and stop accepting new gameplay commands globally (or for the affected tenants/regions).
+     2. Stop the Coordination Redis instance (or logical deployment) used for ticks and sessions.
+     3. Delete or recreate the volume that holds its AOF.
+     4. Restart Redis with an empty keyspace.
+     5. Run a lightweight health check (scripts load successfully; test ticks can be scheduled).
+     6. Unpause ticks and player traffic.
+   - Optionally, advanced operators may:
+     - Stand up a **new** Coordination Redis instance with an empty AOF.
+     - Point application services at it.
+     - Decommission the old instance after inspection.
+5. Confirm reset safety before resuming:
+   - Verify the tick effect ledger reports no `SCHEDULED` rows for the affected `(tenantId, regionId)` pairs.
+   - Ensure any in-flight commands are either retried or marked `ABANDONED` at the domain layer.
+
+The registry remains the **single source of truth** for whether coordination state can be safely replayed across script versions (`compatible`) or must be reset (`breaking_requires_reset`).
+
+---
+
+## Replica Promotion and Missed Writes
+
+**Goal:** Handle Redis replica promotion without violating tick/replay guarantees.
+
+**Facts**
+
+- Coordination Redis uses **asynchronous replication**.
+- A promoted replica may be missing recent coordination writes.
+- The **new primary’s keyspace is authoritative** after promotion.
+
+**Behavior**
+
+- Promotion from a replica with modest lag is equivalent to a small AOF tail-loss window:
+  - Missing keys are treated as if they never existed.
+  - Ticks/retries/timers are re-enqueued from surviving state/PostgreSQL or skipped within the accepted tail-loss envelope.
+- Replay safety is preserved because:
+  - Mutating scripts validate lease tokens, lock tokens, `tickId`, and `generation` before writing.
+  - The tick effect ledger and idempotency guards in PostgreSQL remain the source of truth for “has this effect applied?”
+
+**Lag envelopes (tie lag to tick interval)**
+
+- **Target:** p99 replication lag < ~0.25 × `tick_interval_ms`.
+- **Warning:** sustained lag between ~0.25 × and 1.0 × `tick_interval_ms`.
+- **Red line:** lag ≥ 1× `tick_interval_ms` for a shard.
+
+**Runbook: Promotion decisions**
+
+1. Monitor replication lag via metrics (see Observability section in the main Redis doc).
+2. If lag is within the **target** envelope:
+   - Automatic or manual promotion is acceptable from a replay perspective; expect at most ~one tick of lost coordination state.
+3. If lag is in the **warning** band:
+   - Investigate underlying causes (capacity, network, slow scripts) and consider delaying promotions until lag recovers.
+4. If lag crosses the **red line** for a shard:
+   - Avoid automatic promotion from that replica.
+   - Either:
+     - Wait for lag to return to the target envelope, or
+     - Treat promotion as a **deliberate “drop recent coordination state” event**:
+       - Pause ticks for affected tenants/regions.
+       - Promote the replica.
+       - Use coordination reset tooling to rebuild state from PostgreSQL and new activity.
+
+Smaller self-hosted deployments may prefer a single primary (with an optional replica only for observability/manual promotion) and treat any promotion with significant lag as equivalent to resetting coordination state for affected regions.
+
+---
+
+## Key Shape Mistakes and Coordination Resets
+
+**Goal:** Remediate mis-keyed or mis-sharded coordination keys without complex in-place surgery.
+
+**Coordination keys** (`tick:*`, `timer:*`, `retry:*`, `remote:*`, leases, and tick-related locks) are treated as volatile and backed by PostgreSQL + replay.
+
+**Runbook: Mis-sharded coordination keys**
+
+1. Detect the issue:
+   - Hash-tag or key-shape mistakes discovered via CI, logs, or metrics (for example, CROSSSLOT errors or inconsistent region placement).
+2. Pause affected workloads:
+   - Pause tick scheduling globally or for affected tenants/regions.
+3. Reset Coordination Redis for the affected scope:
+   - For node-wide issues: reset the Coordination Redis keyspace (per-node) using the AOF reset procedure.
+   - For tenant/region-local issues: use tooling that targets only those prefixes or logical databases, if available.
+4. Resume ticks and sessions:
+   - Allow coordination keys to rebuild naturally from PostgreSQL and fresh gameplay activity.
+
+Fine-grained, live migration of mis-sharded coordination keys is **not** the default; it is considered an advanced, optional extension when dropping coordination state is unacceptable for particular tenants.
+
+---
+
+## Normalization and Hash-Tag Migration
+
+**Goal:** Change how `tenantId` / `regionId` normalization and hash tags are formed without breaking shard-local assumptions.
+
+See the “Hash Tag Normalization” section in `system-architecture-redis.md` for the conceptual contract. This section focuses on the operational steps.
+
+**Runbook: Normalization migration via reset (simplest path)**
+
+1. Plan the change:
+   - Implement the new normalization version (for example `NORMALIZATION_V2`) in shared helpers.
+   - Ensure the new normalization keeps `{tenantId, regionId}` stable and valid.
+2. Schedule a maintenance window.
+3. Pause ticks and stop accepting new commands for affected tenants/regions (or globally).
+4. Deploy services using the new normalization helpers.
+5. Start a fresh Coordination Redis deployment (or logical database) with an empty keyspace:
+   - Point Game Session and other coordination clients at the new deployment.
+   - Do not attempt to migrate existing coordination keys.
+6. Resume ticks and player traffic:
+   - Existing game instances may require restart or reconnection.
+   - Coordination state is rebuilt from PostgreSQL and new activity.
+
+**Runbook: In-place normalization migration (advanced option)**
+
+When dropping all coordination state is not acceptable, operators may implement a dedicated migration tool using the shared key builders:
+
+1. Freeze topology:
+   - Avoid Redis Cluster resharding during the normalization migration.
+2. Pause or drain ticks and new commands for affected tenants/regions.
+3. Migrate keys:
+   - For each affected prefix, rewrite keys from old hash tags to new ones using a maintenance tool that:
+     - Operates on explicit prefixes (no full-keyspace scans).
+     - Preserves values and semantics across the move.
+4. Validate:
+   - Confirm that keys for a given `{tenantId, regionId}` share the expected hash tag.
+   - Run smoke tests to verify tick and session behavior.
+5. Resume ticks and commands.
+6. Separately, perform any required Redis Cluster resharding as a **later, independent maintenance** once normalization is stable.
+
+For most self-hosted deployments, the **reset-based migration** is preferred. In-place migrations are reserved for cases where coordination state for specific tenants cannot simply be dropped.
+

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -24,7 +24,7 @@ Redis is always treated as **non-authoritative for game data**: all canonical ga
 
 - In **development and ephemeral test environments**, Redis behaves as a **disposable coordination cache**. Helm may wipe its AOF between runs, and no guarantees are made about preserving in-flight ticks, sessions, or timers across deployments.
 - In **staging and production-equivalent environments**, Redis behaves as a **long-lived coordination log**. AOF is preserved across normal rollouts and node restarts; crash recovery and replay semantics described in this document apply and must not be bypassed by automatic AOF resets.
--
+
 The acceptable loss window is intentionally capped to a **small, bounded tail of recent coordination state per `{tenantId, regionId}`**. In staging and production-like deployments the target is on the order of **one to two seconds of activity** per region. For typical tick intervals (for example `tick-interval-ms >= 250`), this corresponds to losing at most a handful of ticks for an affected region during a routine failover. Anything materially beyond this (for example, repeated effective loss windows greater than **2 seconds** or more than **2×** the configured tick interval, or a growing backlog of pending effects) is treated as an incident requiring investigation, not as “normal” volatility.
 
 All subsequent sections assume the **staging/production coordination mode** unless explicitly labeled as “dev/ephemeral only.” Deployment and runbook docs call out where behavior differs by environment.
@@ -338,9 +338,10 @@ On restart, Redis replays AOF entries in order, including `EVAL`/`EVALSHA` calls
   - Use set-style semantics for staged effects and queues so duplicate inserts become no-ops.
 
 Coordination payloads (pending ticks, timers, retry queues, remote queues) also expose a `schemaVersion` so Lua scripts can safely evolve. New script revisions:
-  - Read the stored `schemaVersion` and either handle the expected version or return `UNSUPPORTED_SCHEMA_VERSION` without making writes.
-  - Implement multi-version handling when releasing a breaking change, allowing the new version to coexist with the old one while Redis entries with the legacy version are drained or explicitly flushed.
-  - Use lightweight migration tools (e.g., tenant-scoped cleaners that drop or rewrite old-version payloads) rather than assuming a full keyspace flush is acceptable.
+
+- Read the stored `schemaVersion` and either handle the expected version or return `UNSUPPORTED_SCHEMA_VERSION` without making writes.
+- Implement multi-version handling when releasing a breaking change, allowing the new version to coexist with the old one while Redis entries with the legacy version are drained or explicitly flushed.
+- Use lightweight migration tools (e.g., tenant-scoped cleaners that drop or rewrite old-version payloads) rather than assuming a full keyspace flush is acceptable.
 
 As a result:
 
@@ -492,7 +493,7 @@ An optional lock refresh helper exists for extremely long commands, but it itsel
 - Its usage is **observable**: callers increment metrics such as `redis.tick.lock_refresh_requests_total` and `redis.tick.lock_refresh_denied_total`, and dashboards/alerts highlight regions where refresh is used frequently so those commands can be decomposed into shorter work units.
 
 This discipline keeps locks bounded and makes it easy to reason about the “one executor per region” invariant even when leases and lock TTLs interact badly: whenever a lease is lost, scripts receiving a `STALE_LEASE` response abort immediately, and the remaining stale locks simply expire under `lock_ttl_ms`, preventing any stateful writes from proceeding in a conflicting epoch.
- 
+
 Implementations may also use local monotonic clocks or Redis’s `TIME` command **for diagnostics only**, for example to:
 
 - Log warnings when an executor believes it has held a lease significantly longer than `game.tick-lease-ttl-ms` would suggest under normal renewal cadence, or
@@ -599,10 +600,10 @@ Automation and scripting keys follow a similar pattern:
 
 If future automation features legitimately require **region-local, atomic coordination** with tick keys, the migration path is clear:
 
- - Introduce new keys `automation_queue:{tenantId}:{regionId}:{entityId}` that adopt the same `{tenantId}:{regionId}` hash tag as tick keys so they map to the same shard.
- - Update the shared key-building helpers, Lua Script Registry descriptors, and code generation so every automation script that touches regional queues must validate the hash tag and align with the tick region.
- - Migrate producers/consumers gradually, writing to both the old and new key shapes during the transition and iterating until the automation workload is fully region-local.
- - Treat this as an architectural shift: document the migration, review sharding implications, and implement it via the shared helpers rather than ad-hoc string concat.
+- Introduce new keys `automation_queue:{tenantId}:{regionId}:{entityId}` that adopt the same `{tenantId}:{regionId}` hash tag as tick keys so they map to the same shard.
+- Update the shared key-building helpers, Lua Script Registry descriptors, and code generation so every automation script that touches regional queues must validate the hash tag and align with the tick region.
+- Migrate producers/consumers gradually, writing to both the old and new key shapes during the transition and iterating until the automation workload is fully region-local.
+- Treat this as an architectural shift: document the migration, review sharding implications, and implement it via the shared helpers rather than ad-hoc string concat.
 
 These key-shape and hash-tag rules are **enforced**, not just conventions:
 
@@ -1344,7 +1345,6 @@ These metrics form the contract for Coordination Redis observability; alerts or 
 Treat these thresholds as normative requirements for the coordination cluster; future tooling should reference this table rather than scattering metric checks throughout the doc.
 
 ### Graceful Degradation Modes and Alert Thresholds
-### Graceful Degradation Modes and Alert Thresholds
 
 Redis outages or sustained high latency on the **coordination cluster** are treated as explicit failure modes with well-defined behavior for ticks, locks, leases, and sessions.
 
@@ -1369,14 +1369,14 @@ Redis outages or sustained high latency on the **coordination cluster** are trea
   - Example triggers:
     - `redis.up` gauge reports down for the coordination cluster or for the shard that owns a given `{tenantId, regionId}` hash tag.
     - High error rates for basic commands (for example `GET`/`SET` on tick/session keys) over a short window.
-  - Behavior for affected regions:
-    - Game Session **hard-fails new gameplay commands** that require ticks, returning a clear “service unavailable” style error for those regions.
-    - It **freezes tick scheduling** for affected `{tenantId, regionId}` pairs rather than attempting to buffer commands in memory or continue without coordination guarantees.
-    - Existing locks and leases are treated as **lost** for scheduling purposes; the scheduler does not assume they survived the outage and simply waits for Redis to return before attempting further work in those regions.
+- Behavior for affected regions:
+  - Game Session **hard-fails new gameplay commands** that require ticks, returning a clear “service unavailable” style error for those regions.
+  - It **freezes tick scheduling** for affected `{tenantId, regionId}` pairs rather than attempting to buffer commands in memory or continue without coordination guarantees.
+  - Existing locks and leases are treated as **lost** for scheduling purposes; the scheduler does not assume they survived the outage and simply waits for Redis to return before attempting further work in those regions.
 - Behavior for unaffected regions:
-    - Regions whose hash tags map to healthy shards may continue processing ticks, as long as global SLOs (latency, error rates) remain acceptable.
-  - In all cases:
-    - The system does not attempt to run ad-hoc in-memory fallbacks for ticks, locks, or sessions; correctness takes precedence over partial gameplay.
+  - Regions whose hash tags map to healthy shards may continue processing ticks, as long as global SLOs (latency, error rates) remain acceptable.
+- In all cases:
+  - The system does not attempt to run ad-hoc in-memory fallbacks for ticks, locks, or sessions; correctness takes precedence over partial gameplay.
   - Operators are alerted via high-severity alerts so they can restore Redis; gameplay for affected regions resumes only once Coordination Redis is healthy again.
 
 ### Client Backpressure Policy
@@ -1427,10 +1427,10 @@ sessions. Deployments should keep this value aligned with or slightly longer tha
 that JWT and server-side session lifetimes remain coherent. Configuration validation enforces this relationship in
 non-dev profiles:
 
- - `FIREMUD_AUTH_SESSION_EXPIRATION_MS` must be **greater than or equal to** `FIREMUD_AUTH_JWT_EXPIRATION_MS` (optionally plus a small safety margin). This ensures that, under normal conditions, a JWT never outlives its corresponding Redis session entry.
- - If configuration attempts to set a shorter Redis session TTL than the JWT lifetime in production or staging, the authentication and Game Session services treat it as a misconfiguration: startup fails fast (or falls back to a safe, derived TTL when running in special “emergency” contexts) and logs a clear error rather than silently allowing “JWT still valid but session state already expired” behavior.
- - Services running in staging/production refuse to boot if this invariant is violated; promoting a dev profile with weaker validation to a player-facing environment requires an explicit config review and manual override that is documented in the runbooks.
- - Operators who intentionally want a shorter reconnection window than the JWT lifetime should make that choice explicit via environment profiles and documentation; in that case, reconnect flows will reject resumptions once the Redis TTL has elapsed even if the JWT remains technically valid.
+- `FIREMUD_AUTH_SESSION_EXPIRATION_MS` must be **greater than or equal to** `FIREMUD_AUTH_JWT_EXPIRATION_MS` (optionally plus a small safety margin). This ensures that, under normal conditions, a JWT never outlives its corresponding Redis session entry.
+- If configuration attempts to set a shorter Redis session TTL than the JWT lifetime in production or staging, the authentication and Game Session services treat it as a misconfiguration: startup fails fast (or falls back to a safe, derived TTL when running in special “emergency” contexts) and logs a clear error rather than silently allowing “JWT still valid but session state already expired” behavior.
+- Services running in staging/production refuse to boot if this invariant is violated; promoting a dev profile with weaker validation to a player-facing environment requires an explicit config review and manual override that is documented in the runbooks.
+- Operators who intentionally want a shorter reconnection window than the JWT lifetime should make that choice explicit via environment profiles and documentation; in that case, reconnect flows will reject resumptions once the Redis TTL has elapsed even if the JWT remains technically valid.
 
 From a capacity perspective, gameplay sessions are treated as **part of the normal coordination footprint**, not as a separate, tightly budgeted workload. At the expected hobby/self-hosted scale and reconnection windows, `session:*` keys are assumed to consume a relatively small, bounded share of Coordination Redis memory compared to tick locks, timers, and pending state. The design therefore does **not** introduce explicit per-tenant session quotas or dedicated session Redis topologies by default; general coordination memory thresholds, eviction/OOM alerts, and the ability to lower session TTLs or limit concurrent sessions per tenant are considered sufficient safeguards. If real-world usage ever shows `session:*` keys dominating memory or triggering coordination `OOM` conditions, the preferred remediation is to adjust TTLs or admission-control limits first, and only consider new Redis deployments for sessions if those simple measures prove inadequate.
 

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -8,6 +8,7 @@ This document outlines FireMUD’s usage of Redis as a **transient, high-perform
 
 - [FireMUD System Architecture: Redis](#firemud-system-architecture-redis)
   - [Table of Contents](#table-of-contents)
+  - [How to Read This Document](#how-to-read-this-document)
   - [Redis as a Volatile State Layer](#redis-as-a-volatile-state-layer)
   - [Redis Availability, Consistency, and Safety Guarantees](#redis-availability-consistency-and-safety-guarantees)
   - [Key Naming and Shard Discipline](#key-naming-and-shard-discipline)
@@ -17,6 +18,22 @@ This document outlines FireMUD’s usage of Redis as a **transient, high-perform
   - [Session Keys and Gameplay Binding](#session-keys-and-gameplay-binding)
   - [Future Cache Design and Versioned Aggregates](#future-cache-design-and-versioned-aggregates)
   - [Related Documentation](#related-documentation)
+
+---
+
+## How to Read This Document
+
+- If you are changing **tick execution, locks, or Lua scripts**, focus on:
+  - [Redis Availability, Consistency, and Safety Guarantees](#redis-availability-consistency-and-safety-guarantees)
+  - [Atomicity and Concurrency Control](#atomicity-and-concurrency-control)
+  - [FireMUD Redis Lua Patterns](./system-architecture-redis-lua-patterns.md)
+- If you are operating or tuning **Redis itself** (AOF, failover, resets, migrations), focus on:
+  - [Redis Availability, Consistency, and Safety Guarantees](#redis-availability-consistency-and-safety-guarantees)
+  - [Redis Operations & Migrations](#redis-operations--migrations)
+  - [Observability and Reliability](#observability-and-reliability)
+- If you only need **key formats and prefixes**, see:
+  - [Key Naming and Shard Discipline](#key-naming-and-shard-discipline)
+  - The key format cheat sheet in [Key Format Examples](#key-format-examples)
 
 ---
 
@@ -157,69 +174,33 @@ Architecture and implementation must therefore treat Redis as:
 
 > For operational context on Docker Compose vs Kubernetes, see [Deployment Environments](./infrastructure/deployment-environments.md).
 
-### Replication, Durability, and Loss Characteristics
+### Tail-Loss Model and Availability Guarantees
 
-- Writes are **asynchronously replicated**.
-- **AOF (Append-Only File)** is enabled for durability and crash recovery on coordination Redis deployments in staging and production.
-- Development uses [config/redis/redis.conf](../../config/redis/redis.conf) for the single-node instance and can
-  persist the AOF via the `redis-data` volume. See
-  [Developer Setup](../../DEVELOPER_SETUP.md#optional-redis-persistence) for details and the
-  RedisInsight debugging UI.
-- In **development and ephemeral test environments**, Helm may reset the AOF on install/upgrade via
-  [`redis-aof-reset-job.yaml`](../../k8s/helm/firemud/templates/redis-aof-reset-job.yaml) to guarantee a clean
-  slate between runs (see [Backup & Recovery](./system-architecture-backup-recovery.md#redis-aof-reset-on-deployment)).
-- In **staging and production**, Redis AOF files and volumes are **preserved across application deployments**. Resetting Redis
-  (and thereby terminating active sessions and discarding all volatile tick state) is treated as an explicit
-  operational action, not part of normal CI/CD rollout or default Helm behavior.
+Coordination Redis is **AOF-persistent but non-authoritative**. The system assumes that:
 
-The `redis-aof-reset-job` is **strictly scoped** and must be treated as **dev/ephemeral-only tooling**:
+- Writes are asynchronously replicated, and AOF configuration (fsync policy, rewrite settings, disk performance) determines how many recent writes may be lost on crash or failover.
+- Redis may legitimately lose a **small tail window** of coordination state per `{tenantId, regionId}` (locks, timers, `pending` entries, queues, sessions).
 
-- It is only enabled in **ephemeral** dev/test namespaces where all games are disposable and losing volatile coordination state (sessions, pending ticks, timers, queues) on each deploy is acceptable.
-- Staging, pre-production, and production environments:
-  - Must not include the reset Job in their Helm values.
-  - Treat any AOF reset or Redis flush as a manual, audited operation with clear runbooks and explicit player-impact notes.
-- Helm values and CI/CD pipelines must not reuse dev/test Redis values for production namespaces; production values files are separate so misconfiguration cannot silently enable AOF resets outside ephemeral environments.
+FireMUD explicitly targets a **small tail-loss window** for coordination state in player-facing environments:
 
-Redis provides **best-effort durability** for volatile coordination state, not absolute guarantees:
+- Under normal conditions, deployments aim to lose **no more than ~1–2 seconds** of recent coordination writes per node during a crash or failover (typically a handful of ticks per region).
+- Environments where effective loss windows regularly exceed **2 seconds** or more than **2×** the configured tick interval for a region are considered **degraded** and should trigger investigation or configuration changes (for example, slower tick intervals or stronger durability).
 
-- AOF rewrite policy (for example Redis’s `auto-aof-rewrite-percentage` and `auto-aof-rewrite-min-size` settings), `appendfsync` behavior, disk performance, replication lag, and failover timing all influence how much recent state can be lost if a node crashes between an in-memory update and the next durable write.
-- FireMUD explicitly targets a **small tail-loss window** for coordination state in player-facing environments:
-  - Under normal conditions, deployments should aim to lose **no more than ~1–2 seconds** of recent coordination writes per node during a crash or failover, which typically corresponds to at most a handful of ticks per `{tenantId, regionId}`.
-  - Environments where effective loss windows regularly exceed **2 seconds** or more than **2×** the configured tick interval for a region are considered **degraded** and should trigger investigation or configuration changes (for example, slower tick intervals or stronger durability).
-- Correctness in the presence of such loss is preserved by:
-  - Treating Redis as non-authoritative and replaying ticks based on PostgreSQL and any surviving `tick:{tenantId}:{regionId}:pending` keys.
-  - Relying on the idempotent tick and domain logic described in [Crash Recovery and Replay](./system-architecture-ticks.md#crash-recovery-and-replay) so replays never apply new logical effects twice.
+Correctness in the presence of such loss is preserved by:
 
-Coordination Redis deployments in staging and production are expected to:
+- Treating Redis as non-authoritative and replaying ticks based on PostgreSQL and any surviving `tick:{tenantId}:{regionId}:pending` keys.
+- Relying on the idempotent tick and domain logic described in [Crash Recovery and Replay](./system-architecture-ticks.md#crash-recovery-and-replay) so replays never apply new logical effects twice.
+- Enforcing that mutating Lua scripts validate lease/lock tokens and monotonic guards (`tickId`, `generation`) before writing so stale coordination keys cannot double-apply effects.
 
-- Run with AOF enabled (`appendonly yes`) and an fsync policy at least as strong as Redis’s `appendfsync everysec` so that the tail-loss window is bounded to a small number of ticks (on the order of 1–2 seconds) under normal conditions.
-- Use an AOF configuration that keeps restart and rewrite costs manageable for a self-hosted, hobby-style deployment, for example:
-  - `aof-use-rdb-preamble yes` so most history is stored as an RDB snapshot plus a short AOF tail.
-  - `auto-aof-rewrite-percentage 100` and `auto-aof-rewrite-min-size 256mb` (or similar) so rewrite work runs only when the AOF has meaningfully grown.
-- Avoid disabling fsync entirely for coordination workloads (`appendfsync no` is not acceptable), even in performance experiments; test profiles that relax durability must be clearly labeled as such and not reused for player-facing environments.
+FireMUD **actively measures** effective tail-loss instead of relying solely on Redis configuration:
 
-#### Tail-Loss Measurement and Region Health
+- The Game Session Service maintains a per-region tick watermark in PostgreSQL and compares it with observable Redis state to derive `tail_loss_ticks` / `tail_loss_ms` metrics.
+- Simple built-in thresholds drive region health:
+  - Loss ≤ ~2 seconds or ≤ 2× `tick_interval_ms` → region remains **healthy**.
+  - Loss above that envelope but below a higher cap → region is **degraded**; tick fan-out slows and operators see clear warnings.
+  - Loss that exceeds the higher cap or indicates inconsistent coordination state (for example, missing `pending` entries for committed `tickId` values) → the region is marked **coordination-untrustworthy** and tick scheduling halts until reset or repair.
 
-FireMUD **actively measures** effective tail-loss instead of relying on Redis configuration alone:
-
-- The Game Session Service maintains a **per-region tick watermark** in PostgreSQL (for example `(tenantId, regionId, lastTickId, lastCommittedAt)`).
-- During normal tick commits and after Redis restarts or failovers, Game Session compares:
-  - The highest `tickId` and coordination state it can observe for a `{tenantId, regionId}` in Redis, with
-  - The tick watermark persisted in PostgreSQL for that region.
-- From this comparison it derives a **per-region tail-loss estimate** (in ticks and milliseconds) and publishes it via Prometheus metrics (for example `gamesession.redis.tail_loss_ticks` and `gamesession.redis.tail_loss_ms`).
-- Simple, **built-in thresholds** drive region health without additional configuration:
-  - Loss ≤ ~2 seconds or ≤ 2× `tick_interval_ms` → region remains **healthy**; metrics record the event for observability.
-  - Loss above that envelope but below a higher cap (for example 5 seconds) → region is marked **degraded**; tick fan-out slows and operators see clear warnings.
-  - Loss that exceeds the higher cap or indicates obviously inconsistent coordination state (for example missing `pending` entries for committed `tickId` values) → the region is marked **coordination-untrustworthy** and tick scheduling halts until automated tooling or an operator performs recovery.
-
-The **1–2 second** window described above is therefore treated as both a configuration target and an enforced SLO: deployments that routinely exceed it surface degradation through metrics and, where necessary, automatic pausing of affected regions.
-
-FireMUD does **not** use the Redis `WAIT` command in application code. Replication remains asynchronous; the system assumes that:
-
-- The primary may acknowledge a write before any given replica has applied it.
-- Failover can, in rare cases, promote a replica that has not yet seen the latest coordination updates.
-
-Correctness across those scenarios is achieved by treating Redis as a volatile coordination layer and relying on PostgreSQL and idempotent replay for authoritative state, rather than on synchronous replication acks for tick safety.
+Implementation details for AOF configuration, reset jobs, and environment-specific behavior (dev vs staging vs production) are documented in the Redis operations doc and deployment/backup documentation.
 
 Cluster operators **may** additionally configure Redis replication safety knobs such as `min-replicas-to-write` and `min-replicas-max-lag` on Coordination Redis deployments to avoid accepting writes when no reasonably up-to-date replicas are available. These are **infrastructure-level safeguards only**:
 
@@ -258,97 +239,41 @@ Manual “surgery” on AOF contents is **not supported** in FireMUD runbooks. E
 
 #### AOF Size and Restart Budget
 
-For small/self-hosted FireMUD deployments, coordination Redis should remain **simple to operate**:
+### Redis Operations & Migrations
 
-- As a rule of thumb, keep each node’s coordination AOF size below roughly **1–2 GiB**. Bigger files are allowed but should be treated as a sign that retention or rewrite settings may need adjustment.
-- Redis restart time for a healthy node (including AOF or RDB+AOF replay) should ordinarily complete within **30–60 seconds**. Nodes that routinely take longer to restart are considered **operationally unhealthy** for coordination workloads.
+Operational runbooks (AOF sizing/reset, Lua upgrades, replica promotion, key-shape remediation, and normalization/hash-tag migration) are documented in detail in `system-architecture-redis-operations.md`. This section summarizes the core expectations:
 
-If restarts become slow or AOF files grow beyond these soft budgets, it is acceptable for operators to:
+- Coordination Redis is **simple to reset**: when correctness can be re-established from PostgreSQL and idempotent replay, operators prefer to drop volatile coordination state and rebuild it rather than surgery on AOF contents.
+- Lua script changes are classified via the **Lua Compatibility Registry**; changes tagged `breaking_requires_reset` require a coordination reset, orchestrated by the upgrade planner and reset tooling.
+- Replica promotion is treated as an extension of the AOF tail-loss model; acceptable replication lag is tied to `tick_interval_ms`, and promoting from a significantly behind replica is treated as a deliberate “drop recent coordination state” event.
+- Mis-keyed or mis-sharded coordination keys are remediated via **coordination resets** using shared key builders and reset tools, rather than ad-hoc key rewrites.
+- Normalization and hash-tag changes are handled via either:
+  - A reset-based migration (simplest path, rebuild from PostgreSQL), or
+  - An advanced in-place migration tool that rewrites keys using shared helpers while preserving shard-local invariants.
 
-- Schedule a maintenance window.
-- Stop game services for affected tenants/regions (or globally for a hobby deployment).
-- Reset the coordination Redis instance by:
-  - Stopping Redis,
-  - Deleting or recreating the volume that holds the AOF, and
-  - Starting Redis with an empty keyspace.
-- Allow ticks and sessions to rebuild coordination state from PostgreSQL and new gameplay activity.
-
-For hobby/self-hosted servers this “reset and rebuild” option is a valid trade-off: players may need to re-login or restart games after such a reset, but the node returns to a clean, fast-restarting state without complex AOF tuning.
-
-FireMUD also maintains a **Lua Compatibility Registry** for coordination scripts:
-
-- Each script declaration records:
-  - A `schemaVersionsSupported` list describing which `schemaVersion` values it is expected to handle in Redis payloads (for example `[1]` or `[1,2]`).
-  - The `KEYS`/`ARGV` contract.
-  - A compatibility tag, typically one of:
-    - `compatible` – the change preserves replay behavior for all existing stored payloads handled by the previous version.
-    - `breaking_requires_reset` – the change alters how existing stored payloads are interpreted or validated and therefore cannot rely on cross-version AOF replay.
-- Changes tagged `compatible` must meet **all** of the following criteria:
-  - `KEYS`/`ARGV` count and ordering are unchanged.
-  - The script continues to correctly handle **every** `schemaVersion` value that may exist in Redis for that script.
-  - For representative payload fixtures of each supported `schemaVersion`, re-running the same logical AOF sequences under the new script either:
-    - Produces the same final coordination state as before, or
-    - Produces only strictly benign differences (for example, extra metrics or logging) that do not affect tick/session semantics.
-  - Tests in `firemud-common` exercise “old-schema” and “new-schema” payloads and prove idempotent replay behavior under the new script body.
-- Any change that does not convincingly meet these criteria must be tagged `breaking_requires_reset` by default, including:
-  - Dropping support for an older `schemaVersion` value while keys with that version may still exist.
-  - Changing how existing fields are interpreted or validated so previously accepted payloads would now be rejected or handled differently.
-  - Adding new required fields that older payloads do not contain.
-- Without a clear compatibility tag and associated proof, changes are rejected; the registry is the authoritative source for whether replay state is preserved (`compatible`) or coordination state must be reset (`breaking_requires_reset`).
-
-For **breaking coordination script changes** (entries tagged `breaking_requires_reset` in the compatibility registry), FireMUD intentionally avoids relying on AOF replay across versions:
-
-- Script changes are classified into:
-  - **Safe changes** – bugfixes or internal refactors that do not change how existing stored payloads are interpreted and pass the compatibility tests above. These may be deployed without special AOF handling.
-  - **Breaking changes** – any change marked `breaking_requires_reset` because it could cause a new script version to interpret or validate existing coordination keys differently.
-- For breaking changes, the runbook is:
-  - A small **coordination upgrade planner** tool (part of the FireMUD dev-tools) compares the current deployment’s Lua Compatibility Registry to the target version and decides whether a coordination reset is required:
-    - If all script changes are tagged `compatible`, the planner reports that no special Redis handling is required beyond the usual deployment process.
-    - If any script is tagged `breaking_requires_reset`, the planner reports that a coordination reset is required for this upgrade.
-  - In hobby and small/self-hosted deployments, the preferred pattern is for the planner to **orchestrate the reset automatically** when breaking changes are present:
-    - Pause ticks and stop accepting new gameplay commands globally (or for the affected tenants/regions), for example by toggling a Game Session “tick enabled” flag or calling an admin endpoint.
-    - Stop the coordination Redis instance (or logical deployment) used for ticks and sessions.
-    - Delete or recreate the volume that holds its AOF, and restart Redis with an empty keyspace (“whole-node reset”).
-    - Optionally run a lightweight health check (scripts load successfully, test ticks can be scheduled) and then unpause ticks and player traffic.
-  - Where finer granularity is truly required, the planner may instead:
-    - Stand up a **new** coordination Redis instance with an empty AOF.
-    - Point application services at it (for example by updating configuration and restarting Game Session).
-    - Decommission the old instance after any necessary inspection.
-    - This advanced path is intentionally out of scope for the default hobby/self-hosted profile and should only be used when coordination state cannot simply be dropped.
-  - Regardless of mechanism, PostgreSQL/domain services must be aware of the reset: operators confirm that the tick effect ledger reports no `SCHEDULED` rows for the affected `(tenantId, regionId)` pairs and that any in-flight commands are either retried or rejected before allowing replay to resume.
-  - After reset, the new scripts and services run against an empty coordination keyspace and Redis rebuilds tick and session state from PostgreSQL and fresh gameplay activity.
-- Operators must **never** rely on deleting keys from a live primary while retaining its old AOF and expecting future restarts to replay only the post-flush state. For coordination Redis, either the AOF is trusted as the complete history for that node, or it is discarded and the node restarts from a clean keyspace.
-- AOF replay is therefore relied on only within a given script semantics window where compatibility has been proven. When script behavior changes in a way that is not trivially backward-compatible for stored payloads (that is, changes tagged `breaking_requires_reset`), FireMUD treats existing coordination state as disposable and restarts from a clean keyspace instead of attempting cross-version replay.
+Full procedures, including step-by-step actions and maintenance window guidance, are in `system-architecture-redis-operations.md`.
 
 #### Replica Promotion and Missed Writes
 
-Because replication is asynchronous:
+Replication for Coordination Redis is **asynchronous**, so a promoted replica may be missing some recent coordination writes from the former primary. After promotion, the **new primary’s keyspace is authoritative** for coordination state even if some tail keys (locks, timers, `pending` entries, queues, sessions) never replicated.
 
-- A promoted replica may legitimately be missing some of the latest coordination writes from the former primary.
-- After promotion, the **new primary’s keyspace becomes authoritative** for coordination state, even if tail keys (recent locks, timers, `pending` entries, queues, or sessions) were never replicated.
+From the tick system’s perspective this is equivalent to a larger AOF tail-loss window:
 
-From the tick system’s perspective, this is indistinguishable from a larger AOF tail-loss window:
+- Missing keys are treated as if they never existed; ticks, retries, and timers are either re-enqueued from surviving state/PostgreSQL or skipped within the same tail-loss envelope described earlier.
+- Stale keys cannot cause double-apply or split-brain behavior because all mutating scripts validate lease tokens, lock tokens, `tickId`, and `generation` fields before writing, and the tick effect ledger / idempotency guards in PostgreSQL remain the source of truth for “has this effect applied?”.
 
-- Missing coordination keys are treated as if they never existed; ticks, retries, and timers that depended on them either:
-  - Are re-enqueued based on surviving state and PostgreSQL, or
-  - Are skipped, with impact bounded to the same best-effort window described above.
-- Stale coordination keys that survived failover cannot cause double-apply or split-brain behavior because all mutating scripts validate lease tokens, lock tokens, `tickId`, and `generation` fields before making changes.
-  - The system also enforces a durable tick effect ledger (see [Tick System and Runtime Design](./system-architecture-ticks.md#tick-effect-ledger-and-replay-guarantees)) and per-command idempotency guards in PostgreSQL so that whenever a command reports `APPLIED` in the authoritative store, the ledger/guard rows prove that state was committed and Redis replayers either skip or reapply effects accordingly. Redis alone never decides whether a command is complete; the ledger ensures replay never double-applies even when `pending` entries vanish after failover.
+Replication-lag metrics (see Observability) tie acceptable lag to the tick interval:
 
-Replication-lag and health metrics (documented under Observability) are used to detect environments where promotion would routinely imply unacceptably large coordination gaps so operators can tune Redis or adjust tick budgets accordingly. For coordination workloads, FireMUD ties acceptable replication lag to the tick interval:
+- **Target:** p99 replication lag < ~0.25 × `tick_interval_ms`.
+- **Warning:** sustained lag between ~0.25 × and 1.0 × `tick_interval_ms`.
+- **Red line:** lag ≥ 1× `tick_interval_ms` for a shard; promotion from such a replica is treated as a “drop recent coordination state” event.
 
-- As a starting envelope:
-  - **Target:** `p99` replication lag for coordination shards < **0.25 × `tick-duration-ms`**.
-  - **Warning:** lag regularly between **0.25 ×** and **1.0 ×** `tick-duration-ms`.
-  - **Red line:** lag ≥ **1 full tick window** for any shard, especially when sustained.
-- From a gameplay perspective:
-  - Promotion with lag comfortably below one tick implies that, in the worst case, affected regions may lose at most one tick’s worth of volatile coordination state, which the replay model is designed to tolerate.
-  - If replication lag frequently approaches or exceeds a tick window, some regions may systematically lose more ticks than others during failover (for example, repeatedly skipping several ticks of timers or retries), which can bias gameplay.
-- For small/self-hosted deployments where it is difficult to keep lag within this envelope:
-  - It is acceptable to run Coordination Redis with a single primary (and an optional replica used only for observability or manual promotion) and to treat promotion of a significantly behind replica as equivalent to dropping coordination state for affected tenants/regions.
-  - Replica promotion in such environments should be a rare, deliberate operation with explicit runbooks indicating that recent tick/session state may be lost; gameplay resumes from PostgreSQL and new coordination activity instead of relying on the replica’s stale view.
+At the **red line**, automated failover tools should avoid promoting the lagging replica. Operators either:
 
-“Significantly behind” is quantified operationally: any shard whose p99 replication lag surpasses **1× tick-duration** for more than a few consecutive measurement windows enters a **degraded promotion** state. Automated failover/promotion tooling is gated on this metric—controllers refuse to promote a lagging replica automatically, and alerts route to on-call so the team can either (a) wait for the replica to catch up before failing over or (b) execute a deliberate “drop coordination state” runbook with explicit passenger impact documentation. The same alert fires even if you manually promote the node; the runbook documents the expectation that only a single recent tick’s worth of coordination state may be affected, and operators must either replay using the tick effect ledger or mark the effects `ABANDONED` before resuming gameplay.
+- Wait for lag to return to the target envelope before allowing promotion, or
+- Execute a deliberate coordination-reset runbook for affected tenants/regions (using the reset tooling described above), accepting loss of recent coordination state and resuming from PostgreSQL and new activity.
+
+Smaller self-hosted deployments may choose to run with a single primary (and an optional replica used only for observability or manual promotion) and treat any promotion of a significantly behind replica as equivalent to resetting coordination state for the affected regions.
 
 #### Lua Scripts and AOF Replay
 
@@ -398,7 +323,9 @@ These conventions provide **logical tenant isolation** at the keyspace level. Ev
 
 We also track lightweight per-tenant counters for key counts, queue length, and timer density, but those budgets only become enforceable when the shard already shows contention signals from the observability contract (lock-acquire failures, eviction spikes, high blocked-client duration). Once a tenant-region pair contributes to a degraded shard, the scheduler temporarily sheds its new commands, retries them later in the tick cycle, and logs `redis.tick.tenant_queue_length_exceeded` so dashboards highlight which tenant triggered the mitigation. When the shard is quiet, tenants may use the full headroom—this keeps the fairness rules dormant until contention exists while still giving you a lever to protect other tenants when a noisy workload starts to dominate.
 
-### Key Format Examples
+### Key Format Examples (Cheat Sheet)
+
+This table lists the most important coordination keys and their responsibilities.
 
 | Redis Key | Description |
 | --- | --- |
@@ -422,11 +349,11 @@ Despite the hash-tag discipline above, mistakes in key shape or hash-tag constru
 
 - **Coordination keys (`tick:*`, `timer:*`, `retry:*`, `remote:*`, leases, and tick-related locks)**:
   - These keys are treated as **volatile coordination state** and are always backed by authoritative PostgreSQL state and idempotent replay.
-  - For hobby/self-hosted deployments, the default remediation for incorrect hash tags or mis-sharded coordination keys is to use the **coordination reset** tooling described in [Cluster-Wide Anomalies and Coordinated Reset](#cluster-wide-anomalies-and-coordinated-reset):
+  - The default remediation for incorrect hash tags or mis-sharded coordination keys is to use the **coordination reset** tooling described in [Cluster-Wide Anomalies and Coordinated Reset](#cluster-wide-anomalies-and-coordinated-reset):
     - Pause tick scheduling (globally or for affected tenants/regions).
     - Reset the Coordination Redis keyspace (per-node or per-tenant/region).
     - Allow ticks and sessions to rebuild coordination state from PostgreSQL and fresh gameplay activity.
-  - FireMUD does **not** attempt fine-grained, live migration of mis-sharded coordination keys by default; for a solo operator, discarding and rebuilding volatile coordination state is the simpler and safer option.
+  - FireMUD does **not** attempt fine-grained, live migration of mis-sharded coordination keys by default; discarding and rebuilding volatile coordination state is the baseline, with more targeted repair tools treated as optional extensions where needed.
 
 - **Non-coordination keys (for example future cache keys, selected automation prefixes, or other long-lived aggregates)**:
   - When incorrect key shapes cannot be safely discarded, migrations are handled via **small, one-off migration tools** under the `dev-tools` profile rather than general-purpose key movers:
@@ -496,7 +423,7 @@ From the coordination layer’s perspective, **lease and lock tokens are meaning
 
 ### TTL Envelopes and Worst-Case Pauses
 
-For self-hosted and hobby deployments, FireMUD keeps lease and lock TTLs intentionally simple:
+For self-hosted deployments, FireMUD keeps lease and lock TTLs intentionally simple:
 
 - The **only** timing setting you normally configure is a region’s tick interval (`game.tick-interval-ms`).
 - The Game Session Service derives internal values from that single knob using fixed multipliers:
@@ -934,36 +861,19 @@ so that a given logical script identifier never silently points at a stale SHA w
 
 ### Lua Script Complexity and Runtime Guidelines
 
-Redis executes Lua scripts on the same single-threaded event loop that serves normal commands. To protect shard latency without over-specifying hard numeric limits, FireMUD applies the following guidelines to all tick-related scripts:
+Redis executes Lua scripts on the same single-threaded event loop that serves normal commands. To protect shard latency without over-specifying numeric limits, FireMUD applies a few core guidelines to all tick-related scripts:
 
-- **Bounded work per script**
-  - Scripts must not iterate over unbounded lists, sets, or streams.
-  - Operations should be `O(1)` or `O(log n)` relative to key cardinality wherever possible.
-  - Any looping logic must be bounded by explicit, small limits (for example, “process at most N commands/timers per invocation”), with the remainder handled in future ticks.
-  - Scripts must not build large in-memory aggregates (for example, assembling full copies of large hashes, lists, or sets into Lua tables); any aggregation beyond a small, bounded slice belongs in service code outside Redis rather than inside Lua.
+- Scripts perform **bounded work** per invocation (no unbounded scans or large in-memory aggregates) and touch only a **small, fixed set of keys** (for example, one lock key, one pending key, and a handful of queues/timers for a single region).
+- Implementations define and enforce a small constant upper bound on the number of keys any tick-related script may touch (for example, a `MAX_TICK_SCRIPT_KEYS` configuration). Unit tests and CI enforce this so “just one more key” changes are deliberate and reviewed.
+- The Game Session Service and other coordination clients record **per-script latency metrics** (for example, histograms keyed by logical script name) so operators can see which Lua scripts dominate time on each shard and tune the system based on observed behavior.
+- Scripts check simple preconditions first (for example, presence of lock keys, correct tokens, expected `pending` state) and abort quickly if they are not met instead of reconstructing complex state.
+- Scripts that mutate domain-facing tick state (for example, committing staged effects or releasing locks) **must re-validate** both the relevant lock token(s) and the current lease token for `{tenantId, regionId}` within the **same script invocation** that performs the mutation. Callers **MUST NOT** perform domain mutations, database writes, or external side effects based on lock/lease state observed in one Lua call and then assume it remains valid in a subsequent Lua call (“check‑then‑act” across multiple invocations is forbidden).
 
-- **Limited keys and arguments**
-  - Scripts should operate on a small, fixed set of keys per invocation (for example, one lock key, one pending key, and a handful of queues/timers for a single region).
-  - Bulk fan-out or large multi-key operations should be decomposed into multiple smaller calls instead of a single monolithic script.
-  - Implementations define and enforce a small constant upper bound on the number of keys any tick-related script may touch (for example, a `MAX_TICK_SCRIPT_KEYS` configuration on the order of a handful of keys per region). This bound is captured in configuration and validated via unit tests so “just one more key” changes are deliberate and reviewed; scripts that exceed the configured bound are rejected during testing.
-
-- **Per-script runtime observability**
-  - The Game Session Service and other coordination clients record **per-script latency metrics** (for example, histograms keyed by logical script name) so operators can see which Lua scripts dominate time on each shard and tune the system based on observed behavior.
-
-- **Abort-early behavior**
-  - Every script should check simple preconditions first (for example, presence of lock keys, correct tokens, expected `pending` state) and abort quickly if they are not met.
-  - Scripts must not fall back to scanning large keyspaces or reconstructing complex state when preconditions are missing; instead, they return a result that signals the caller to retry or perform higher-level recovery.
-  - Scripts that mutate domain-facing tick state (for example, committing staged effects or releasing locks) **must re-validate** both the relevant lock token(s) and the current lease token for `{tenantId, regionId}` within the **same script invocation** that performs the mutation. Callers **MUST NOT** perform domain mutations, database writes, or external side effects based on lock/lease state observed in one Lua call and then assume it remains valid in a subsequent Lua call (“check‑then‑act” across multiple invocations is forbidden).
-
-Operational runbooks treat **long-running or stuck Lua scripts** as production issues:
-
-- Monitoring tracks Redis `slowlog`, blocked-client counts, command/runtime latency distributions, and the per-script metrics above. Sustained outliers trigger alerts so operators can investigate which script or workload is responsible and adjust scripts or configuration as needed.
-- In emergencies where a script is known to mutate only Redis state and is demonstrably stuck, operators may use `SCRIPT KILL` on the affected node to unblock the event loop. This is reserved for last-resort scenarios and must be followed by verification that callers correctly handle partial progress (for example, by re-running idempotent staging or commit scripts).
-- Runbooks emphasize **fixing the underlying script or workload** (for example, tightening bounds, reducing per-call work, or refactoring hot paths) rather than relying on `SCRIPT KILL` as a routine control mechanism.
+Operational runbooks treat **long-running or stuck Lua scripts** as production issues: monitoring tracks Redis `slowlog`, blocked-client counts, command/runtime latency distributions, and the per-script metrics above. Sustained outliers trigger alerts so operators can investigate which script or workload is responsible and adjust scripts or configuration as needed; emergency use of `SCRIPT KILL` is reserved for rare cases and must be followed by verification that callers correctly handle partial progress.
 
 ### Idempotent Script Patterns and Examples
 
-Tick-related scripts must be idempotent: **re-running the same script with the same `KEYS` and `ARGV` must not apply new logical effects**. Detailed patterns (lease/lock validation, tickId guards, effect-key sets, queue uniqueness, and idempotency test templates), along with a worked lock-acquire example, are documented in [Redis Lua Patterns](./system-architecture-redis-lua-patterns.md). Scripts referenced in this document are expected to follow those patterns or motivated variants.
+Tick-related scripts must be idempotent: **re-running the same script with the same `KEYS` and `ARGV` must not apply new logical effects**. Detailed determinism rules (for example, avoiding `TIME` and RNG), lease/lock validation patterns, `tickId` guards, effect-key sets, queue uniqueness, and idempotency test templates are documented in [Redis Lua Patterns](./system-architecture-redis-lua-patterns.md). This Redis architecture document describes the guarantees those patterns provide; the Lua patterns document is the canonical reference for how to implement and test scripts.
 
 ### Lock TTL and Example Lock Workflow
 
@@ -1394,6 +1304,17 @@ These metrics form the contract for Coordination Redis observability. They are s
 | `redis.tick.command_shed_total` | >0 ongoing | N/A | Extended | Exposed by backpressure logic (see below); use to tune client shedding behavior. |
 
 Treat the **Core** rows as the minimum alerting surface for any deployment that hosts real players. Extended metrics and alerts (for example per-script latency breakdowns, tenant-level fairness counters, automation-queue depth, blocked-client histograms, and cache eviction trends) build on top of these core signals and are valuable for diagnosis and tuning but not required to enforce the basic safety guarantees of the tick system.
+
+#### Minimum Operations Checklist
+
+Before hosting real players, operators should confirm that:
+
+- AOF is enabled for Coordination Redis with an fsync policy at least as strong as `appendfsync everysec`, and restarts with AOF replay complete within the expected time budget.
+- The **tail-loss SLO** is enforced via the watermark and `tail_loss_ms` / `tail_loss_ticks` metrics, with alerts when effective loss exceeds the 1–2 second envelope.
+- The **core metrics** in the table above are scraped and wired to alerts (script availability, Lua p99 latency, over-TTL ticks, coordination OOM, stuck `pending` entries).
+- The tick region health state machine (`HEALTHY`, `DEGRADED`, `COORDINATION_UNTRUSTWORTHY` / `HALTED`) is enabled and its thresholds are configured appropriately for the deployment.
+- A tested **coordination reset** or migration path exists (for example, via the dev-tools reset and upgrade planner) and runbooks describe when to invoke it.
+- Basic Redis reachability and health (for example, `redis.up`, replication lag where applicable) are visible in dashboards so operators can correlate incidents with underlying infrastructure.
 
 ### Graceful Degradation Modes and Alert Thresholds
 

--- a/design/architecture/system-architecture-redis.md
+++ b/design/architecture/system-architecture-redis.md
@@ -45,35 +45,28 @@ Redis is used **exclusively for non-authoritative, transient data**, including:
 - TTL-based service caches such as hot room lookups and recent chat history (see [Performance Optimization Guidelines](./performance-optimization.md))
 - Automation queue keys for script events (`automation_queue:{tenantId}:{entityId}`) that are treated as **single-key operations** from Redis’s perspective (see [Hash Tags and Redis Cluster Slotting](#hash-tags-and-redis-cluster-slotting) for guidance if future automation scripts need to combine these keys with tick-region keys atomically)
 
-FireMUD distinguishes between **Coordination Redis** and **Cache/Rate‑Limit
-Redis**:
+FireMUD distinguishes between two **logical roles** for Redis:
 
-- Coordination Redis handles ticks, locks, timers, sessions, and other
-  gameplay‑critical coordination state. Services that participate in tick
+- **Coordination Redis** – ticks, locks, timers, sessions, automation queues, and other gameplay‑critical coordination state. Services that participate in tick
   execution or session management (for example, Game Session Service, Automation
-  & Scripting Service, Social & Groups Service) connect to the **Coordination
-  Redis** deployment using `FIREMUD_REDIS_COORD_HOST` and
-  `FIREMUD_REDIS_COORD_PORT`.
-- Cache/Rate‑Limit Redis handles gateway rate limiting and best‑effort caches.
-  Services that only perform rate limiting or read‑side caching (for example,
-  Spring Cloud Gateway) connect using `FIREMUD_REDIS_CACHE_HOST` and
+  & Scripting Service, Social & Groups Service) connect using
+  `FIREMUD_REDIS_COORD_HOST` / `FIREMUD_REDIS_COORD_PORT`.
+- **Cache/Rate‑Limit Redis** – gateway rate limiting and best‑effort caches. Services that only perform rate limiting or read‑side caching (for example,
+  Spring Cloud Gateway) connect using `FIREMUD_REDIS_CACHE_HOST` /
   `FIREMUD_REDIS_CACHE_PORT`.
 
-For local development and other single‑node setups, all of these variables may
-point at the same instance. In that case, developers typically set
-`FIREMUD_REDIS_HOST`, `FIREMUD_REDIS_COORD_HOST`, and `FIREMUD_REDIS_CACHE_HOST`
-to the same `host:port` pair so services can be configured consistently while
-still exercising both code paths. When the `*_COORD_*` or `*_CACHE_*` variables
-are unset, services fall back to `FIREMUD_REDIS_HOST` and `FIREMUD_REDIS_PORT` as
-documented in
-[Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#redis-connection).
-In **player‑facing or shared environments** (staging, QA, production),
-Coordination Redis and Cache/Rate‑Limit Redis must be configured as **distinct
-logical Redis deployments** even if they share the same underlying host
-hardware. Sharing a single deployment for both workloads is treated as a
-non‑compliant configuration because misconfiguration (for example, eviction
-policies or memory limits) can silently impact coordination keys and gameplay
-availability.
+These are **logical roles, not hard requirements about instance count**:
+
+- In small or single‑admin deployments, both roles may point at the **same Redis instance** (single container or VM) with conservative configuration.
+- In higher‑throughput or multi‑tenant deployments, operators can point them at **separate instances or clusters** to isolate eviction policies, memory, and failure domains.
+
+Environment variables make this split **config‑driven**:
+
+- When `FIREMUD_REDIS_COORD_*` or `FIREMUD_REDIS_CACHE_*` are unset, services fall back to `FIREMUD_REDIS_HOST` / `FIREMUD_REDIS_PORT` as documented in
+  [Environment Variables & Secrets Management](./infrastructure/environment-and-secrets.md#redis-connection).
+- When both sets are configured, services respect the separation and treat the corresponding deployments as independent roles.
+
+Production‑quality deployments are strongly encouraged to **avoid mixing heavy caches with coordination workloads** on the same Redis process, because misconfiguration (for example, eviction policies or memory limits) can silently impact coordination keys and gameplay availability. However, the architecture and code paths remain the same whether roles share an instance or not; only capacity and failure characteristics change.
 
 Coordination Redis also enforces its role via ACL and simple self‑checks:
 
@@ -205,7 +198,21 @@ Coordination Redis deployments in staging and production are expected to:
   - `auto-aof-rewrite-percentage 100` and `auto-aof-rewrite-min-size 256mb` (or similar) so rewrite work runs only when the AOF has meaningfully grown.
 - Avoid disabling fsync entirely for coordination workloads (`appendfsync no` is not acceptable), even in performance experiments; test profiles that relax durability must be clearly labeled as such and not reused for player-facing environments.
 
-Future operational work may introduce concrete observability around tail-loss behavior (for example, measuring effective loss windows in staging/production and tightening Redis configuration accordingly), but the **1–2 second** envelope above is the default design assumption for self-hosted deployments unless explicitly overridden.
+#### Tail-Loss Measurement and Region Health
+
+FireMUD **actively measures** effective tail-loss instead of relying on Redis configuration alone:
+
+- The Game Session Service maintains a **per-region tick watermark** in PostgreSQL (for example `(tenantId, regionId, lastTickId, lastCommittedAt)`).
+- During normal tick commits and after Redis restarts or failovers, Game Session compares:
+  - The highest `tickId` and coordination state it can observe for a `{tenantId, regionId}` in Redis, with
+  - The tick watermark persisted in PostgreSQL for that region.
+- From this comparison it derives a **per-region tail-loss estimate** (in ticks and milliseconds) and publishes it via Prometheus metrics (for example `gamesession.redis.tail_loss_ticks` and `gamesession.redis.tail_loss_ms`).
+- Simple, **built-in thresholds** drive region health without additional configuration:
+  - Loss ≤ ~2 seconds or ≤ 2× `tick_interval_ms` → region remains **healthy**; metrics record the event for observability.
+  - Loss above that envelope but below a higher cap (for example 5 seconds) → region is marked **degraded**; tick fan-out slows and operators see clear warnings.
+  - Loss that exceeds the higher cap or indicates obviously inconsistent coordination state (for example missing `pending` entries for committed `tickId` values) → the region is marked **coordination-untrustworthy** and tick scheduling halts until automated tooling or an operator performs recovery.
+
+The **1–2 second** window described above is therefore treated as both a configuration target and an enforced SLO: deployments that routinely exceed it surface degradation through metrics and, where necessary, automatic pausing of affected regions.
 
 FireMUD does **not** use the Redis `WAIT` command in application code. Replication remains asynchronous; the system assumes that:
 
@@ -218,6 +225,22 @@ Cluster operators **may** additionally configure Redis replication safety knobs 
 
 - Gameplay logic does not depend on them for correctness.
 - Enabling them trades write availability for additional replication guarantees and must be evaluated per environment.
+
+#### Cluster-Wide Anomalies and Coordinated Reset
+
+Mass failovers or misconfigured Redis clusters can produce **widespread, inconsistent coordination state** (for example multiple regions simultaneously marked `coordination-untrustworthy` by the health rules above). FireMUD treats these situations as **explicit reset events**, not as normal volatility:
+
+- The Game Session Service classifies each `{tenantId, regionId}` into coarse states such as `HEALTHY`, `DEGRADED`, or `COORDINATION_UNTRUSTWORTHY` based on:
+  - Tail-loss estimates and SLO violations.
+  - Stuck or missing `tick:{tenantId}:{regionId}:pending` entries relative to PostgreSQL tick watermarks.
+  - Repeated Lua/script failures for core coordination scripts in that region.
+- When a **small number of regions** are degraded but remain within the documented tail-loss window, operators may allow them to self-heal while monitoring metrics.
+- When **multiple regions** across a deployment enter the `COORDINATION_UNTRUSTWORTHY` state in a short window, the system treats this as a **cluster-wide anomaly**. In these cases a small, automated “coordination reset” tool (part of FireMUD’s dev-tools) can:
+  - Pause tick scheduling globally (or for affected tenants/regions only).
+  - Reset the Coordination Redis keyspace (either whole-node or per-tenant/region, depending on configuration).
+  - Run a lightweight health check (Lua scripts load, sample ticks schedule and commit).
+  - Unpause ticks so coordination state is rebuilt from PostgreSQL and fresh gameplay activity.
+- This reset path is intentionally **simple and opinionated**: rather than attempting fine-grained, manual repair of inconsistent coordination keys, operators either accept the measured tail-loss as within SLO or use the coordinated reset tool to discard volatile state and rely on replay. Larger or more strictly available deployments may layer more advanced, prefix-specific repair tools on top of this baseline if dropping coordination state is not acceptable for certain tenants, but the core design and invariants remain unchanged.
 
 #### AOF Truncation and Corruption
 
@@ -392,6 +415,25 @@ We also track lightweight per-tenant counters for key counts, queue length, and 
 > for details.
 > 📌 For session-related keys and structure, see [Session Keys and Gameplay Binding](#session-keys-and-gameplay-binding)
 > ⚠️ Tick regions and player sessions are **always scoped to a single Redis shard** to preserve atomicity. Cross-shard operations are avoided.
+
+### Key Shape Mistakes and Migration Strategy
+
+Despite the hash-tag discipline above, mistakes in key shape or hash-tag construction may occur over time. FireMUD treats these in two broad categories:
+
+- **Coordination keys (`tick:*`, `timer:*`, `retry:*`, `remote:*`, leases, and tick-related locks)**:
+  - These keys are treated as **volatile coordination state** and are always backed by authoritative PostgreSQL state and idempotent replay.
+  - For hobby/self-hosted deployments, the default remediation for incorrect hash tags or mis-sharded coordination keys is to use the **coordination reset** tooling described in [Cluster-Wide Anomalies and Coordinated Reset](#cluster-wide-anomalies-and-coordinated-reset):
+    - Pause tick scheduling (globally or for affected tenants/regions).
+    - Reset the Coordination Redis keyspace (per-node or per-tenant/region).
+    - Allow ticks and sessions to rebuild coordination state from PostgreSQL and fresh gameplay activity.
+  - FireMUD does **not** attempt fine-grained, live migration of mis-sharded coordination keys by default; for a solo operator, discarding and rebuilding volatile coordination state is the simpler and safer option.
+
+- **Non-coordination keys (for example future cache keys, selected automation prefixes, or other long-lived aggregates)**:
+  - When incorrect key shapes cannot be safely discarded, migrations are handled via **small, one-off migration tools** under the `dev-tools` profile rather than general-purpose key movers:
+    - Migration tools operate on clearly scoped prefixes (for example `automation_queue:{tenantId}:*` or `view:roomLook:{tenantId}:*`) rather than scanning the entire keyspace.
+    - They run against paused traffic or dedicated maintenance windows, rewriting keys from the old shape to the new shape on a clean Redis instance or while the affected prefixes are temporarily quiesced.
+    - After the migration, services are updated to use the new key builders and prefixes exclusively; the old shape is considered deprecated and removed from descriptors and helpers.
+  - These tools are treated as **per-mistake utilities**, not long-lived infrastructure: when a key-shape issue is discovered, a targeted migrator is written, executed once, and then retired alongside the old key format.
 
 ### Region Leadership and Tick Executor Lease
 
@@ -569,7 +611,7 @@ Changing how identifiers are normalized or how hash tags are formed (for example
 
 ##### Normalization Migration Protocol for Small/Self-Hosted Deployments
 
-For hobby and small/self-hosted servers, the simplest and safest way to change normalization behavior (for example, moving from `NORMALIZATION_V1` to `NORMALIZATION_V2`) is to **treat coordination state as disposable** and rebuild it from PostgreSQL and new gameplay activity:
+For smaller self-hosted servers, the simplest and safest way to change normalization behavior (for example, moving from `NORMALIZATION_V1` to `NORMALIZATION_V2`) is often to **treat coordination state as disposable** and rebuild it from PostgreSQL and new gameplay activity:
 
 - Preferred protocol:
   - Schedule a maintenance window.
@@ -580,7 +622,7 @@ For hobby and small/self-hosted servers, the simplest and safest way to change n
     - Do not attempt to migrate existing coordination keys; allow locks, queues, and timers to rebuild naturally as ticks resume.
   - Resume ticks and player traffic once services are healthy. Existing game instances may require restart or reconnection; in-flight coordination state is lost but authoritative state in PostgreSQL remains intact.
 
-This protocol keeps migration operationally simple and avoids subtle cross-version key placement issues. For larger or more strictly available deployments that cannot afford to drop all coordination state, a more advanced migration (moving keys from old tags to new tags in place) can be implemented as a dedicated maintenance tool using the shared key builders and following the general phases above, but such flows are intentionally out of scope for the default hobby/self-hosted profile.
+This protocol keeps migration operationally simple and avoids subtle cross-version key placement issues. Deployments that cannot afford to drop all coordination state for a normalization change may instead implement a more advanced migration (moving keys from old tags to new tags in place) as a dedicated maintenance tool using the shared key builders and following the general phases above; this is an **optional extension** on top of the baseline “reset and rebuild” design, not a separate architecture.
 
 Session and timer keys do not participate in tick multi-key scripts and may use simpler patterns as long as they preserve `tenantId` prefixes and avoid cross-shard assumptions. In particular:
 
@@ -711,6 +753,7 @@ Every new or modified Lua script that participates in tick coordination, session
     - Session scripts: `session:` only.
     - Cache/rate-limit scripts: their own non-coordination prefixes and **never** `tick:`/`session:`.
   - CI fails if the script text references forbidden prefixes.
+  - Coordination-related lock and lease keys (`tick:{tenantId}:{regionId}:lock:{entityId}`, `tick-executor-lease:{tenantId}:{regionId}`, and related coordination keys) are **only** created, updated, or deleted from within registry-backed Lua scripts. Direct `SET`, `SET NX`, `DEL`, or similar commands against these prefixes in application code are forbidden; ad-hoc locking for unrelated maintenance flows must use distinct, non-`tick:` prefixes (for example `maintenance-lock:{tenantId}:...`) so they cannot interfere with tick invariants.
 
 - **Idempotency and safety**
   - The script is idempotent with respect to its inputs (`KEYS`/`ARGV`):
@@ -910,7 +953,7 @@ Redis executes Lua scripts on the same single-threaded event loop that serves no
 - **Abort-early behavior**
   - Every script should check simple preconditions first (for example, presence of lock keys, correct tokens, expected `pending` state) and abort quickly if they are not met.
   - Scripts must not fall back to scanning large keyspaces or reconstructing complex state when preconditions are missing; instead, they return a result that signals the caller to retry or perform higher-level recovery.
-  - Scripts that mutate domain-facing tick state (for example, committing staged effects or releasing locks) **must re-validate** both the relevant lock token(s) and the current lease token for `{tenantId, regionId}` within the **same script invocation** that performs the mutation; callers must not “check then act” across multiple, separate Lua calls.
+  - Scripts that mutate domain-facing tick state (for example, committing staged effects or releasing locks) **must re-validate** both the relevant lock token(s) and the current lease token for `{tenantId, regionId}` within the **same script invocation** that performs the mutation. Callers **MUST NOT** perform domain mutations, database writes, or external side effects based on lock/lease state observed in one Lua call and then assume it remains valid in a subsequent Lua call (“check‑then‑act” across multiple invocations is forbidden).
 
 Operational runbooks treat **long-running or stuck Lua scripts** as production issues:
 
@@ -933,7 +976,11 @@ Tick locks use a TTL derived from the **tick interval** to balance safety and re
   - `tick_budget_ms = tick_interval_ms * 0.8`
   - `lock_ttl_ms = clamp(tick_budget_ms * 8, 500, 5_000)`
   - `lease_ttl_ms = clamp(tick_budget_ms * 16, 2_000, 15_000)`
-- These values are not meant to be tuned independently in typical deployments; changing `tick-interval-ms` is usually sufficient.
+- These values are not meant to be tuned independently in typical deployments; changing `tick-interval-ms` is usually sufficient. Deployments may additionally enable a **simple auto-tuning loop** in the Game Session Service to account for JVM pauses and workload differences:
+  - The service tracks the ratio of `tick.execution_time_ms` to `lock_ttl_ms` per region (for example via `gamesession.tick.lock_ttl_ratio` metrics).
+  - When a region repeatedly approaches the TTL (for example many ticks with `lock_ttl_ratio >= 0.8`) but does not routinely exceed it, the service may increase a single global “TTL safety multiplier” within a capped range (for example from 8× up to at most 12×) and recompute `lock_ttl_ms`/`lease_ttl_ms` accordingly.
+  - When ticks are consistently far below the TTL (for example `lock_ttl_ratio <= 0.25` over a long window), the service may decrease that multiplier (down to a documented minimum) to surface liveness issues sooner without introducing extra configuration.
+  - This auto-tuning behavior is intentionally conservative and controlled via configuration; it changes only a **single internal multiplier** based on observed metrics so smaller self-hosted deployments can avoid manual lock/lease tuning, while larger deployments can leave it disabled and rely on explicit configuration if preferred.
 
 #### Runtime Validation and Observability
 
@@ -1220,11 +1267,12 @@ To keep this contract enforceable across services and teams, FireMUD treats it a
   - The canonical idempotency table schemas and indexes (for example `tick_effect_guard` with `(tenantId, regionId, tickId, effectKey)`).
   - Helper APIs such as `recordEffectIfNew(...)` / `hasEffectBeenApplied(...)` that encapsulate the “insert-or-detect-replay” logic.
   - Standard metrics (`tick.effects_applied_total`, `tick.effects_duplicate_suppressed_total`) and log fields that domain services emit when applying or suppressing effects.
+  - A reusable **idempotency contract test harness** that exercises handlers with repeated and out-of-order `(tickId, effectKey)` combinations against an in-memory database, so services can adopt a standard test without bespoke fixtures.
 - Domain services that participate in tick-driven mutations:
   - Must depend on this shared library rather than implementing their own ad-hoc guards.
-  - Must implement contract tests that:
-    - Apply the same tick/effect combination twice and assert that database state changes only once.
-    - Apply ticks out of order (for example, `tickId+1` then `tickId`) and assert that guards prevent corruption.
+  - Must register their tick-driven handlers with the shared contract test harness so that:
+    - Applying the same tick/effect combination twice is verified to change database state only once.
+    - Applying ticks out of order (for example, `tickId+1` then `tickId`) is verified not to corrupt state.
 - Static checks and code review guidance reinforce this requirement:
   - New tick handlers are not considered complete unless they use the shared idempotency APIs for every domain mutation they perform.
   - PR templates and review checklists explicitly call out:
@@ -1329,20 +1377,23 @@ FireMUD actively monitors Redis performance and tick health:
 
 ### Redis Metrics & Thresholds Contract
 
-These metrics form the contract for Coordination Redis observability; alerts or degradation states must trip if they cross the highlighted thresholds for longer than the listed durations:
+These metrics form the contract for Coordination Redis observability. They are split into:
 
-| Metric | Threshold | Duration | Operator Action |
-| --- | --- | --- | --- |
-| `redis.lua.script_load_failures` | ≥1 per shard | 5m | Mark affected shards degraded, pause ticks until scripts reload. |
-| `redis.lua.script_missing_for_region` | ≥1 per region | Immediate | Stop scheduling ticks for that `{tenantId, regionId}` until every master hosts the script. |
-| `redis.lua.script_runtime_p99` | >2× `tick_interval_ms` | 3m | Degrade region, slow tick fan-out, reject new commands until latency recovers. |
-| `redis.tick.lock_acquire_failed` | >5 per region | 10 ticks | Increment region-level degradation counter; pause commands after 2 such windows. |
-| `redis.tick.lock_ttl_exceeded_total` | >5 occurrences | 5m | Treat as headroom breach; pause region and review workloads. |
-| `redis.coordination_oom_errors` | ≥1 | 1m | Critical — halt ticks, escalate to on-call, investigate `maxmemory`/payloads. |
-| `redis.tick.pending_stuck_total` | >0 | 2 tick intervals | Halt ticks for the region, inspect `tick effect ledger` before resuming. |
-| `redis.tick.command_shed_total` | >0 ongoing | N/A | Exposed by backpressure logic (see below); use to tune client shedding behavior. |
+- **Core signals** – required before hosting real players; they drive the region health state machine and halt/degrade decisions.
+- **Extended signals** – recommended for deeper analysis and larger deployments, but not strictly required for a small self-hosted server.
 
-Treat these thresholds as normative requirements for the coordination cluster; future tooling should reference this table rather than scattering metric checks throughout the doc.
+| Metric | Threshold | Duration | Tier | Operator Action |
+| --- | --- | --- | --- | --- |
+| `redis.lua.script_load_failures` | ≥1 per shard | 5m | Core | Mark affected shards degraded, pause ticks until scripts reload. |
+| `redis.lua.script_missing_for_region` | ≥1 per region | Immediate | Core | Stop scheduling ticks for that `{tenantId, regionId}` until every master hosts the script. |
+| `redis.lua.script_runtime_p99` | >2× `tick_interval_ms` | 3m | Core | Degrade region, slow tick fan-out, reject new commands until latency recovers. |
+| `redis.tick.lock_acquire_failed` | >5 per region | 10 ticks | Extended | Increment region-level degradation counter; pause commands after 2 such windows. |
+| `redis.tick.lock_ttl_exceeded_total` | >5 occurrences | 5m | Core | Treat as headroom breach; pause region and review workloads. |
+| `redis.coordination_oom_errors` | ≥1 | 1m | Core | Critical — halt ticks, escalate to on-call, investigate `maxmemory`/payloads. |
+| `redis.tick.pending_stuck_total` | >0 | 2 tick intervals | Core | Halt ticks for the region, inspect the tick effect ledger, repair or reset coordination state, then resume. |
+| `redis.tick.command_shed_total` | >0 ongoing | N/A | Extended | Exposed by backpressure logic (see below); use to tune client shedding behavior. |
+
+Treat the **Core** rows as the minimum alerting surface for any deployment that hosts real players. Extended metrics and alerts (for example per-script latency breakdowns, tenant-level fairness counters, automation-queue depth, blocked-client histograms, and cache eviction trends) build on top of these core signals and are valuable for diagnosis and tuning but not required to enforce the basic safety guarantees of the tick system.
 
 ### Graceful Degradation Modes and Alert Thresholds
 
@@ -1432,7 +1483,7 @@ non-dev profiles:
 - Services running in staging/production refuse to boot if this invariant is violated; promoting a dev profile with weaker validation to a player-facing environment requires an explicit config review and manual override that is documented in the runbooks.
 - Operators who intentionally want a shorter reconnection window than the JWT lifetime should make that choice explicit via environment profiles and documentation; in that case, reconnect flows will reject resumptions once the Redis TTL has elapsed even if the JWT remains technically valid.
 
-From a capacity perspective, gameplay sessions are treated as **part of the normal coordination footprint**, not as a separate, tightly budgeted workload. At the expected hobby/self-hosted scale and reconnection windows, `session:*` keys are assumed to consume a relatively small, bounded share of Coordination Redis memory compared to tick locks, timers, and pending state. The design therefore does **not** introduce explicit per-tenant session quotas or dedicated session Redis topologies by default; general coordination memory thresholds, eviction/OOM alerts, and the ability to lower session TTLs or limit concurrent sessions per tenant are considered sufficient safeguards. If real-world usage ever shows `session:*` keys dominating memory or triggering coordination `OOM` conditions, the preferred remediation is to adjust TTLs or admission-control limits first, and only consider new Redis deployments for sessions if those simple measures prove inadequate.
+From a capacity perspective, gameplay sessions are treated as **part of the normal coordination footprint**, not as a separate, tightly budgeted workload. At the expected self-hosted scale and reconnection windows, `session:*` keys are assumed to consume a relatively small, bounded share of Coordination Redis memory compared to tick locks, timers, and pending state. The design therefore does **not** introduce explicit per-tenant session quotas or dedicated session Redis topologies by default; general coordination memory thresholds, eviction/OOM alerts, and the ability to lower session TTLs or limit concurrent sessions per tenant are considered sufficient safeguards. If real-world usage ever shows `session:*` keys dominating memory or triggering coordination `OOM` conditions, the preferred remediation is to adjust TTLs or admission-control limits first, and only consider new Redis deployments for sessions if those simple measures prove inadequate.
 
 Long-running, headless coordination contexts (for example automation bots, replays, or background AI runners) may need richer lifetimes than interactive clients. Those workloads use dedicated prefixes such as `session:headless:{tenantId}:{sessionId}` and leverage a separate TTL (for example `FIREMUD_AUTH_HEADLESS_EXPIRATION_MS`) that is allowed to exceed the interactive reconnection window. Their Lua scripts explicitly document how often they renew their TTLs and operate without relying on JWT-limited reconnections, so they do not compete with player-facing sessions for the same expiration governance. This separation ensures the “maximum reconnection window” statement remains true for human players while still supporting long-lived actors that stay bound to a running game instance.
 
@@ -1466,6 +1517,18 @@ All session bind, rebind, and takeover flows are performed via a **Lua compare-a
   - Verifies that the binding is still compatible with the requested operation (for example, same session attempting a rebind, or an authorized takeover flow) and that the `generation`/`schemaVersion` values are understood.
   - Applies the new binding atomically (updating binding fields, incrementing the `generation` counter, and preserving or migrating any schema-versioned fields as needed).
   - Optionally emits structured metadata for audit and debugging (for example, `previousSocketId`, `newSocketId`, `reason`, `oldSchemaVersion`, `newSchemaVersion`).
+
+### Cross-Space Consistency: Sessions vs Tick Regions
+
+Session keys and tick-region keys are intentionally decoupled for sharding and resilience, but they must still remain **logically aligned**:
+
+- For each active `session:{tenantId}:{sessionId}`, the Game Session Service tracks the **current region binding** in PostgreSQL (for example the `game_instances` row and any per-session routing metadata) rather than relying solely on Redis.
+- A lightweight health loop periodically samples a small number of active sessions per tenant and:
+  - Verifies that their recorded region binding matches the tick region that is currently processing commands for the associated character or game instance.
+  - Emits metrics such as `session.region_mismatch_total` and `session.region_mismatch_current` when it finds discrepancies (for example, a session bound to Region A while ticks are executing in Region B).
+- These metrics make misalignment between `session:*` state and tick-region execution visible without attempting to “repair” bindings automatically:
+  - Occasional mismatches may indicate normal race conditions or recent moves.
+  - Sustained or clustered mismatches across many sessions or tenants signal configuration bugs, cross-region movement issues, or replay anomalies that require investigation.
 
 Value schema versioning and backward compatibility are treated as explicit contracts:
 

--- a/design/architecture/system-architecture-scripting.md
+++ b/design/architecture/system-architecture-scripting.md
@@ -687,6 +687,10 @@ Per-tenant and per-script metrics include:
 - `automation_script_triggers_total`, `automation_script_skips_total`, and `automation_script_triggers_dropped_total`, tagged with reasons such as `quota`, `tenant_budget_exceeded`, or `cluster_limit_reached`.
 - `script_quota_allowed_total` / `script_quota_denied_total` for per-script quota checks.
 - Queue-level metrics such as `automation_queue_enqueued_total` and `automation_queue_drained_total` are defined and documented in the Automation & Scripting Service README and should be used alongside the metrics above to monitor how quickly automation queues are filling and draining per tenant and script.
+- A lightweight **orphan detection** signal helps catch drift between automation queues and tick execution:
+  - `automation_queue_orphaned_entries_total` counts work items that have remained in `automation_queue:{tenantId}:{entityId}` beyond a bounded age window (for example, N ticks or seconds) without corresponding staging in `automation:tick:{tenantId}:{scriptId}:...` or entries in the tick effect ledger.
+  - `automation_queue_oldest_entry_age_seconds` records the age of the oldest sampled queue item per tenant/script so operators can see when automation backlogs are failing to drain into ticks.
+  - A small, bounded inspector loop in `ScriptTickService` samples a subset of queues per interval to update these metrics; it does **not** attempt to repair or delete items itself, but surfaces misalignment between automation and tick processing for investigation.
 
 - **Outcome and policy context**
   - `outcome` – canonical outcome enum value (see [Failure Modes and Error Handling](#failure-modes-and-error-handling)), for example `success`, `quota_denied`, `skipped_disabled`, `tenant_budget_exceeded`, `disabled_unsafe_component`.

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -132,9 +132,11 @@ In practice, the system keeps this simple by exposing a **single primary knob**�
 - Internally, the Game Session Service computes a soft execution budget (for example `tick_budget_ms = tick_interval_ms * 0.8`) and then derives TTLs using fixed multipliers:
   - `lock_ttl_ms = clamp(tick_budget_ms * 8, 500, 5_000)`
   - `lease_ttl_ms = clamp(tick_budget_ms * 16, 2_000, 15_000)`
-- These multipliers are **hard-coded defaults** for hobby/self‑hosted deployments; they are chosen to give generous headroom for GC pauses and hiccups without requiring per‑environment tuning.
+- These multipliers are **hard-coded defaults** chosen to give generous headroom for GC pauses and hiccups without requiring per‑environment tuning. Deployment profiles that need different behavior can adjust `tick-interval-ms` and, optionally, the TTL safety multiplier described in the Redis architecture.
 
 This keeps configuration light—typically you only adjust `tick_interval_ms`—while still ensuring locks live long enough for normal work to finish and stale locks are cleared after a bounded window.
+
+Region health transitions (`HEALTHY` → `DEGRADED` → `HALTED`) and the thresholds that drive them are defined in [Redis Availability, Consistency, and Safety Guarantees](./system-architecture-redis.md#redis-availability-consistency-and-safety-guarantees) and the Redis observability contract. This section focuses on how TTLs interact with that shared health model.
 
 Rare, extreme pauses (for example long GC) may still exceed `lock_ttl_ms`. In those cases:
 

--- a/design/architecture/system-architecture-ticks.md
+++ b/design/architecture/system-architecture-ticks.md
@@ -124,8 +124,7 @@ Lease expiry and failover remain strictly about **coordination safety** (avoidin
 To prevent concurrent entity updates, ticks acquire **distributed locks** in Redis using:
 
 - `tick:{tenantId}:{regionId}:lock:{entityId}` (see [Redis Key Reference](./system-architecture-redis.md#key-naming-and-shard-discipline))
-- `SET NX PX` with expiry for exclusive ownership, via a shared lock helper
-- Lua-based atomic checks to avoid race conditions
+- **Lua-based lock/lease scripts** registered in the shared Lua Script Registry for acquisition, verification, and release. Tick and lease keys are **never** created or modified via ad-hoc `SET NX PX` calls; all coordination flows use the registry-backed Lua helpers so lock tokens and lease epochs are consistently enforced.
 
 In practice, the system keeps this simple by exposing a **single primary knob**—the region tick interval—and deriving lock/lease TTLs from that:
 
@@ -184,13 +183,13 @@ Many gameplay commands conceptually touch **multiple entities** (for example tra
   - Coordination between legs (for example ensuring that both sides of a trade succeed or fail together) occurs via PostgreSQL and/or small coordinator records, not by holding multiple Redis entity locks simultaneously.
   - There is an explicit **fan-in cap** per command (for example `MAX_LOCKED_ENTITIES_PER_COMMAND`); features that need to touch more entities must do so over multiple ticks or via chunked follow-up commands.
 
-- **Exceptions require a global lock ordering and all-or-nothing behavior:**
+  - **Exceptions require a global lock ordering and all-or-nothing behavior:**
   - If a future command truly cannot be decomposed and must take more than one entity lock inside a single script, it **must** acquire locks in a global, deterministic order (for example, sort all `entityId` values and acquire locks in ascending order) and operate within a single `{tenantId, regionId}` shard; cross-region multi-lock commands are not allowed.
   - If any lock in that ordered set cannot be acquired, the script immediately releases all previously acquired locks, returns a contention result, and the Game Session Service reschedules the command using the standard backoff rules; no partial logical effects are applied for that command.
   - Such scripts are treated as special cases, reviewed carefully, and documented with their lock ordering assumptions and maximum entity counts. The Redis architecture and Lua Script Registry reinforce this by:
-    - Declaring, per script, a `max_entity_locks` value in the script descriptor (default `1` for normal tick scripts).
-    - Requiring explicit opt-in to an **ordered multi-lock** mode (and associated tests) for any script that needs `max_entity_locks > 1`.
-    - Failing CI when a Lua script attempts to use more entity lock keys than declared or bypasses the ordered multi-lock contract.
+    - Declaring, per script, a `max_entity_locks` value in the script descriptor (default `1` for normal tick scripts) and a **hard fan-in cap** (for example `MAX_ENTITY_LOCKS_PER_MULTI_LOCK_SCRIPT = 2`) for any multi-lock script. Scripts that need more than this cap are not permitted; their features must be redesigned to use one-lock-per-entity patterns.
+    - Maintaining an explicit, small **whitelist** of scripts allowed to set `max_entity_locks > 1` in the registry. Adding a new multi-lock script is treated as an architectural change and requires updating this whitelist and associated documentation; by default, no tick scripts are multi-lock.
+    - Failing CI when a Lua script attempts to use more entity lock keys than declared, bypasses the ordered multi-lock contract, or sets `max_entity_locks > 1` without being on the registry whitelist.
 
 By treating “one entity lock per script” as the default contract, enforcing a small, explicit fan-in cap, and reserving ordered multi-lock patterns for rare, all-or-nothing cases, the tick system:
 

--- a/design/project-management/ai-rules-local.md
+++ b/design/project-management/ai-rules-local.md
@@ -50,6 +50,7 @@ Testing:
 - Load: Gatling
 - New features must include unit tests and, where applicable, integration tests.
 - Verify coverage with JaCoCo by running `./gradlew check` before committing.
+- When invoking Gradle from AI tooling or scripts, prefer the default daemon (no `--no-daemon` flag) so repeated tasks stay fast; only use `--no-daemon` when explicitly debugging daemon issues.
 
 When advising on architecture or operations, keep the “well-engineered hobby/self-hosted deployment” mindset front and center: prefer clean, high-quality patterns but avoid introducing new knobs, clusters, or heavy operational plans unless evidence shows a future need beyond the anticipated single-admin usage. Favor **simple automation and one-shot tools** (for example, a small CLI that drives a reset, migration, or health check) over complex, manual runbooks whenever they reduce day-to-day operator effort without adding long-term complexity.
 


### PR DESCRIPTION
Changes since branching from develop:
- Documented Coordination vs Cache Redis deployments along with gateway and shared-library wiring, and expanded the architecture/project management guides covering multi-tenancy, LLM tooling, automation, and procedural generation so the design narrative matches the new gameplay flows.
- Completed the Look/SAY execution path, including the aggregation services, command handlers, caches, telnet/WebSocket/TCP routing, gateway and client config, and the rich cross-service fixtures/tests that prove the chat/look regression flows end-to-end.
- Hardened game-session, scripting, and Redis observability/runbooks to highlight latency guardrails, tail-loss expectations, and operational guidance for the infrastructure that backs the new features.

Testing:
- Not run (not requested)
