### PR TITLE
build: fix gatling plugin version

### DIFF
--- a/dev-tools/load-testing/build.gradle.kts
+++ b/dev-tools/load-testing/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    id("io.gatling.gradle") version "3.15.0.8"
+    id("io.gatling.gradle") version "3.14.9.8"
 }
 
 dependencies {
-    implementation("io.gatling:gatling-core:3.15.0")
-    implementation("io.gatling:gatling-http:3.15.0")
+    implementation("io.gatling:gatling-core:3.14.9")
+    implementation("io.gatling:gatling-http:3.14.9")
 }
 
 // keep simulations under src/gatling


### PR DESCRIPTION
This follow-up PR carries the post-merge fix for the dynamic Gradle dependency-submission failure on `develop`.

It corrects the Gatling plugin and library versions in `dev-tools/load-testing` so root `./gradlew help` can configure successfully again.

Validation:
- `./gradlew help`
- `./gradlew :load-testing:tasks --all`
