### PR TITLE
ci: normalize workflow concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,13 +267,13 @@ jobs:
           name: test-logs-${{ matrix.service }}-${{ github.sha }}
           path: services/${{ matrix.service }}/build/reports/tests/test/
 
-  ci-summary:
-    name: CI Summary
+  validation-summary:
+    name: Validation Summary
     runs-on: ubuntu-latest
     needs: [buf-check, docker-lint, shellcheck, docs-check, frontend-checks, build-and-test, validation-gate]
     if: github.event_name == 'pull_request' && always()
     steps:
-      - name: 💬 Publish CI Summary Comment
+      - name: 💬 Publish Validation Summary Comment
         uses: actions/github-script@v8
         with:
           script: |
@@ -281,11 +281,11 @@ jobs:
               if (result === "success") return "✅";
               if (result === "failure") return "❌";
               if (result === "cancelled") return "⚪";
-              if (result === "pending" || result === "in_progress" || result === "queued") return "🟡";
               return "⏭️";
             };
 
             const validationChecks = [
+              ["Validation gate", "${{ needs.validation-gate.result }}"],
               ["Buf generation", "${{ needs.buf-check.result }}"],
               ["Dockerfile lint", "${{ needs.docker-lint.result }}"],
               ["ShellCheck", "${{ needs.shellcheck.result }}"],
@@ -294,46 +294,15 @@ jobs:
               ["Service build/test matrix", "${{ needs.build-and-test.result }}"],
             ];
 
-            const requiredChecks = [
-              "Validation Gate",
-              "Core Smoke Tests",
-              "Security Gate",
-              "CodeQL Analysis (java)",
-              "License Gate",
-            ];
-
-            const { data: checkRunsPage } = await github.rest.checks.listForRef({
-              ...context.repo,
-              ref: context.payload.pull_request.head.sha,
-              per_page: 100,
-            });
-
-            const normalizeStatus = (checkRun) => {
-              if (!checkRun) return "pending";
-              if (checkRun.status !== "completed") return checkRun.status;
-              return checkRun.conclusion ?? "pending";
-            };
-
-            const requiredCheckResults = requiredChecks.map((name) => {
-              const run = checkRunsPage.check_runs
-                .filter((checkRun) => checkRun.name === name)
-                .sort((a, b) => b.id - a.id)[0];
-              return [name, normalizeStatus(run)];
-            });
-
-            const failedChecks = requiredCheckResults.filter(([, result]) => result !== "success");
+            const failedChecks = validationChecks.filter(([, result]) => result !== "success");
             const headline = failedChecks.length === 0
-              ? "✅ All required CI checks passed"
-              : "❌ One or more required CI checks failed";
+              ? "✅ All validation checks passed"
+              : "❌ One or more validation checks failed";
 
             const body = [
-              "### CI Summary",
+              "### Validation Summary",
               headline,
               "",
-              "**Required merge gates**",
-              ...requiredCheckResults.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
-              "",
-              "**Validation breakdown**",
               ...validationChecks.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
               "",
               "Coverage reports and failure logs are available in the workflow artifacts."
@@ -341,9 +310,6 @@ jobs:
 
             await core.summary
               .addRaw(headline, true)
-              .addRaw("Required merge gates", true)
-              .addList(requiredCheckResults.map(([name, result]) => `${statusIcon(result)} ${name}: ${result}`))
-              .addRaw("Validation breakdown", true)
               .addList(validationChecks.map(([name, result]) => `${statusIcon(result)} ${name}: ${result}`))
               .write();
 
@@ -353,7 +319,7 @@ jobs:
             });
 
             const existing = comments.find(comment =>
-              comment.body.startsWith("### CI Summary")
+              comment.body.startsWith("### Validation Summary")
             );
 
             if (existing) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
   validation-summary:
     name: Validation Summary
     runs-on: ubuntu-latest
-    needs: [docs-check, frontend-checks, build-and-test]
+    needs: [buf-check, docker-lint, shellcheck, docs-check, frontend-checks, build-and-test]
     if: github.event_name == 'pull_request' && always()
     steps:
       - name: 💬 Publish Validation Summary Comment
@@ -285,6 +285,9 @@ jobs:
             };
 
             const checks = [
+              ["Buf generation", "${{ needs.buf-check.result }}"],
+              ["Dockerfile lint", "${{ needs.docker-lint.result }}"],
+              ["ShellCheck", "${{ needs.shellcheck.result }}"],
               ["Docs and links", "${{ needs.docs-check.result }}"],
               ["Frontend checks", "${{ needs.frontend-checks.result }}"],
               ["Service build/test matrix", "${{ needs.build-and-test.result }}"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,13 +267,13 @@ jobs:
           name: test-logs-${{ matrix.service }}-${{ github.sha }}
           path: services/${{ matrix.service }}/build/reports/tests/test/
 
-  validation-summary:
-    name: Validation Summary
+  ci-summary:
+    name: CI Summary
     runs-on: ubuntu-latest
-    needs: [buf-check, docker-lint, shellcheck, docs-check, frontend-checks, build-and-test]
+    needs: [buf-check, docker-lint, shellcheck, docs-check, frontend-checks, build-and-test, validation-gate]
     if: github.event_name == 'pull_request' && always()
     steps:
-      - name: 💬 Publish Validation Summary Comment
+      - name: 💬 Publish CI Summary Comment
         uses: actions/github-script@v8
         with:
           script: |
@@ -281,10 +281,11 @@ jobs:
               if (result === "success") return "✅";
               if (result === "failure") return "❌";
               if (result === "cancelled") return "⚪";
+              if (result === "pending" || result === "in_progress" || result === "queued") return "🟡";
               return "⏭️";
             };
 
-            const checks = [
+            const validationChecks = [
               ["Buf generation", "${{ needs.buf-check.result }}"],
               ["Dockerfile lint", "${{ needs.docker-lint.result }}"],
               ["ShellCheck", "${{ needs.shellcheck.result }}"],
@@ -293,23 +294,57 @@ jobs:
               ["Service build/test matrix", "${{ needs.build-and-test.result }}"],
             ];
 
-            const failedChecks = checks.filter(([, result]) => result !== "success");
+            const requiredChecks = [
+              "Validation Gate",
+              "Core Smoke Tests",
+              "Security Gate",
+              "CodeQL Analysis (java)",
+              "License Gate",
+            ];
+
+            const { data: checkRunsPage } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref: context.payload.pull_request.head.sha,
+              per_page: 100,
+            });
+
+            const normalizeStatus = (checkRun) => {
+              if (!checkRun) return "pending";
+              if (checkRun.status !== "completed") return checkRun.status;
+              return checkRun.conclusion ?? "pending";
+            };
+
+            const requiredCheckResults = requiredChecks.map((name) => {
+              const run = checkRunsPage.check_runs
+                .filter((checkRun) => checkRun.name === name)
+                .sort((a, b) => b.id - a.id)[0];
+              return [name, normalizeStatus(run)];
+            });
+
+            const failedChecks = requiredCheckResults.filter(([, result]) => result !== "success");
             const headline = failedChecks.length === 0
-              ? "✅ All validation checks passed"
-              : "❌ One or more validation checks failed";
+              ? "✅ All required CI checks passed"
+              : "❌ One or more required CI checks failed";
 
             const body = [
-              "### Validation Summary",
+              "### CI Summary",
               headline,
               "",
-              ...checks.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
+              "**Required merge gates**",
+              ...requiredCheckResults.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
+              "",
+              "**Validation breakdown**",
+              ...validationChecks.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
               "",
               "Coverage reports and failure logs are available in the workflow artifacts."
             ].join("\n");
 
             await core.summary
               .addRaw(headline, true)
-              .addList(checks.map(([name, result]) => `${statusIcon(result)} ${name}: ${result}`))
+              .addRaw("Required merge gates", true)
+              .addList(requiredCheckResults.map(([name, result]) => `${statusIcon(result)} ${name}: ${result}`))
+              .addRaw("Validation breakdown", true)
+              .addList(validationChecks.map(([name, result]) => `${statusIcon(result)} ${name}: ${result}`))
               .write();
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -318,7 +353,7 @@ jobs:
             });
 
             const existing = comments.find(comment =>
-              comment.body.startsWith("### Validation Summary")
+              comment.body.startsWith("### CI Summary")
             );
 
             if (existing) {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: CodeQL Analysis
 
 on:
   push:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL Analysis

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: docker-images-${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,4 +1,4 @@
-name: Build Docker Images
+name: Build and Publish Docker Images
 
 on:
   workflow_run:

--- a/.github/workflows/erd.yml
+++ b/.github/workflows/erd.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: erd-${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-erd:
     name: Generate ERD Diagrams

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -19,6 +19,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: license-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ort-scan:
     name: License Gate

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -73,3 +73,87 @@ jobs:
             echo "### 📜 License Scan Summary" >> $GITHUB_STEP_SUMMARY
             cat "$SUMMARY_FILE" >> $GITHUB_STEP_SUMMARY
           fi
+
+  static-analysis-summary:
+    name: Static Analysis Summary
+    runs-on: ubuntu-latest
+    needs: [ort-scan]
+    if: github.event_name == 'pull_request' && always()
+    steps:
+      - name: 💬 Publish Static Analysis Summary Comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const statusIcon = (value) => {
+              if (value === "success") return "✅";
+              if (value === "failure") return "❌";
+              if (value === "cancelled") return "⚪";
+              if (value === "pending" || value === "in_progress" || value === "queued") return "🟡";
+              return "⏭️";
+            };
+
+            const { data: checkRunsPage } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref: context.payload.pull_request.head.sha,
+              per_page: 100,
+            });
+
+            const normalizeStatus = (checkRun) => {
+              if (!checkRun) return "pending";
+              if (checkRun.status !== "completed") return checkRun.status;
+              return checkRun.conclusion ?? "pending";
+            };
+
+            const latestCheckRun = (name) =>
+              checkRunsPage.check_runs
+                .filter((checkRun) => checkRun.name === name)
+                .sort((a, b) => b.id - a.id)[0];
+
+            const checks = [
+              ["CodeQL analysis", normalizeStatus(latestCheckRun("CodeQL Analysis (java)"))],
+              ["License gate", "${{ needs.ort-scan.result }}"],
+            ];
+
+            const failedChecks = checks.filter(([, result]) =>
+              ["failure", "cancelled", "timed_out", "action_required"].includes(result)
+            );
+            const pendingChecks = checks.filter(([, result]) =>
+              ["pending", "in_progress", "queued"].includes(result)
+            );
+
+            let headline = "✅ Static analysis checks passed";
+            if (failedChecks.length > 0) {
+              headline = "❌ Static analysis checks failed";
+            } else if (pendingChecks.length > 0) {
+              headline = "🟡 Static analysis checks are still running";
+            }
+
+            const body = [
+              "### Static Analysis Summary",
+              headline,
+              "",
+              ...checks.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+
+            const existing = comments.find(comment =>
+              comment.body.startsWith("### Static Analysis Summary")
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -1,4 +1,4 @@
-name: License Scan
+name: License Checks
 
 on:
   push:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: security-${{ github.workflow }}-${{ github.ref }}
@@ -96,3 +97,60 @@ jobs:
             echo "Security Gate failed because the filesystem Trivy scan did not succeed." >&2
             exit 1
           fi
+
+  security-summary:
+    name: Security Summary
+    runs-on: ubuntu-latest
+    needs: [trivy-scan, security-gate]
+    if: github.event_name == 'pull_request' && always()
+    steps:
+      - name: 💬 Publish Security Summary Comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const statusIcon = (value) => {
+              if (value === "success") return "✅";
+              if (value === "failure") return "❌";
+              if (value === "cancelled") return "⚪";
+              return "⏭️";
+            };
+
+            const checks = [
+              ["Security gate", "${{ needs.security-gate.result }}"],
+              ["Trivy filesystem scan", "${{ needs.trivy-scan.result }}"],
+            ];
+
+            const failedChecks = checks.filter(([, result]) => result !== "success");
+            const headline = failedChecks.length === 0
+              ? "✅ Security checks passed"
+              : "❌ Security checks failed";
+
+            const body = [
+              "### Security Summary",
+              headline,
+              "",
+              ...checks.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+
+            const existing = comments.find(comment =>
+              comment.body.startsWith("### Security Summary")
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: smoke-${{ github.workflow }}-${{ github.ref }}
@@ -70,3 +71,55 @@ jobs:
       - name: 🧹 Stop Dev Stack (devDown)
         if: always()
         run: ./gradlew devDown
+
+  smoke-summary:
+    name: Smoke Summary
+    runs-on: ubuntu-latest
+    needs: [smoke-core]
+    if: github.event_name == 'pull_request' && always()
+    steps:
+      - name: 💬 Publish Smoke Summary Comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const result = "${{ needs.smoke-core.result }}";
+            const statusIcon = (value) => {
+              if (value === "success") return "✅";
+              if (value === "failure") return "❌";
+              if (value === "cancelled") return "⚪";
+              return "⏭️";
+            };
+
+            const headline = result === "success"
+              ? "✅ Smoke tests passed"
+              : "❌ Smoke tests failed";
+
+            const body = [
+              "### Smoke Summary",
+              headline,
+              "",
+              `- ${statusIcon(result)} Core Smoke Tests: \`${result}\``,
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+
+            const existing = comments.find(comment =>
+              comment.body.startsWith("### Smoke Summary")
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,6 +227,12 @@ subprojects {
         enabled = fullCheck
         excludeFilter.set(rootProject.file("config/spotbugs/spotbugs-exclude.xml"))
         setIgnoreFailures(true)
+        when (name) {
+            "spotbugsMain" -> dependsOn("compileJava", "processResources")
+            "spotbugsTest" -> dependsOn("compileTestJava", "processTestResources")
+            "spotbugsIntegrationTest" -> dependsOn("compileIntegrationTestJava", "processIntegrationTestResources")
+            "spotbugsCrossServiceTest" -> dependsOn("compileCrossServiceTestJava", "processCrossServiceTestResources")
+        }
         // Exclude generated sources and protobuf-generated packages from analysis
         val generatedDir = "${File.separator}generated${File.separator}"
         val protoPackages = listOf("net/firedevops/firemud/**/v1/**")
@@ -242,14 +248,6 @@ subprojects {
                 .map { fileTree(it) { exclude(protoPackages) } }
         )
         auxClassPaths.from(originalClassDirs)
-    }
-
-    // Ensure SpotBugs runs after compilation
-    tasks.named("spotbugsMain") {
-        dependsOn("compileJava", "processResources")
-    }
-    tasks.named("spotbugsTest") {
-        dependsOn("compileTestJava", "processTestResources")
     }
 
     // Gate Spotless checks behind fullCheck (CI or -PfullCheck)

--- a/services/common-data-runtime/src/main/java/net/firedevops/firemud/cache/RedisLookCacheService.java
+++ b/services/common-data-runtime/src/main/java/net/firedevops/firemud/cache/RedisLookCacheService.java
@@ -5,16 +5,10 @@ import java.time.Duration;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 
-@Service
-@ConditionalOnBean(RedisTemplate.class)
-@ConditionalOnMissingBean(LookCacheService.class)
 @RequiredArgsConstructor
 @SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",

--- a/services/common-data-runtime/src/main/java/net/firedevops/firemud/common/config/CommonAutoConfiguration.java
+++ b/services/common-data-runtime/src/main/java/net/firedevops/firemud/common/config/CommonAutoConfiguration.java
@@ -1,14 +1,36 @@
 package net.firedevops.firemud.common.config;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import net.firedevops.firemud.cache.LookCacheService;
 import net.firedevops.firemud.cache.RedisLookCacheService;
+import net.firedevops.firemud.common.conflict.ConflictTracker;
 import net.firedevops.firemud.common.conflict.RedisConflictTracker;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import tools.jackson.databind.ObjectMapper;
 
 @AutoConfiguration
-@Import({
-  CommonCoreAutoConfiguration.class,
-  RedisConflictTracker.class,
-  RedisLookCacheService.class
-})
-public class CommonAutoConfiguration {}
+@Import(CommonCoreAutoConfiguration.class)
+public class CommonAutoConfiguration {
+
+  @Bean
+  @ConditionalOnBean(StringRedisTemplate.class)
+  @ConditionalOnMissingBean(ConflictTracker.class)
+  public ConflictTracker conflictTracker(
+      StringRedisTemplate stringRedisTemplate, MeterRegistry meterRegistry) {
+    return new RedisConflictTracker(stringRedisTemplate, meterRegistry);
+  }
+
+  @Bean
+  @ConditionalOnBean(RedisTemplate.class)
+  @ConditionalOnMissingBean(LookCacheService.class)
+  public LookCacheService lookCacheService(
+      RedisTemplate<String, String> redisTemplate, ObjectMapper objectMapper) {
+    return new RedisLookCacheService(redisTemplate, objectMapper);
+  }
+}

--- a/services/common-data-runtime/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
+++ b/services/common-data-runtime/src/main/java/net/firedevops/firemud/common/conflict/RedisConflictTracker.java
@@ -7,14 +7,10 @@ import lombok.RequiredArgsConstructor;
 import net.firedevops.firemud.common.LoggingUtil;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Component;
 
 /** Records conflict metadata in Redis for hotspot detection. */
-@Component
 @RequiredArgsConstructor
-@ConditionalOnBean(StringRedisTemplate.class)
 @SuppressFBWarnings(
     value = "EI_EXPOSE_REP2",
     justification = "Injected dependencies are safe to store without defensive copies")

--- a/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/tcpproxy/config/TelnetRedisConfiguration.java
+++ b/services/tcp-proxy-service/src/main/java/net/firedevops/firemud/tcpproxy/config/TelnetRedisConfiguration.java
@@ -1,12 +1,10 @@
 package net.firedevops.firemud.tcpproxy.config;
 
-import net.firedevops.firemud.cache.RedisLookCacheService;
 import net.firedevops.firemud.common.config.RedisProperties;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,7 +16,6 @@ import org.springframework.data.redis.core.RedisTemplate;
     havingValue = "true",
     matchIfMissing = true)
 @EnableConfigurationProperties(RedisProperties.class)
-@Import(RedisLookCacheService.class)
 public class TelnetRedisConfiguration {
   @Bean
   public RedisConnectionFactory redisConnectionFactory(RedisProperties redis) {


### PR DESCRIPTION
## Summary
This PR normalizes workflow-level concurrency across the remaining CI-adjacent workflows and fixes the CI regressions that showed up while validating that change.

## What changed
- adds `concurrency` with `cancel-in-progress: true` to:
  - `CodeQL`
  - `License Scan`
  - `Build Docker Images`
  - `Generate ERD Diagrams`
- adds explicit SpotBugs task dependencies for categorized test source sets so `tcp-proxy-service` full-check validation no longer fails on Gradle task validation
- fixes Redis-dependent auto-configuration so smoke/runtime startup and test slices do not fail on missing `ConflictTracker` / forced Redis look-cache wiring
- splits PR summary comments by workflow domain:
  - `Validation Summary`
  - `Smoke Summary`
  - `Security Summary`
  - `Static Analysis Summary`

## Validation
- `./gradlew check`
- `./gradlew linkCheck lintMarkdown`
- `./gradlew -PfullCheck :tcp-proxy-service:check`
