### PR TITLE
feature/design-and-vip -> develop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,3 +51,16 @@ jobs:
 
       - name: 📊 Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+
+  codeql-gate:
+    name: CodeQL Gate
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    if: always()
+    steps:
+      - name: Enforce successful CodeQL analysis
+        run: |
+          if [ "${{ needs.analyze.result }}" != "success" ]; then
+            echo "CodeQL analysis did not complete successfully: ${{ needs.analyze.result }}"
+            exit 1
+          fi

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -39,6 +39,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
       - name: Derive image tags
         id: meta
         env:
@@ -54,6 +61,8 @@ jobs:
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+      - name: Build service JAR
+        run: ./gradlew :${{ matrix.service }}:bootJar
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GHCR

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           LYCHEE_CACHE: true
         with:
-          args: --no-progress --verbose --exclude-file config/lychee/.lycheeignore './**/*.md' --exclude './**/node_modules/**' --exclude './**/build/**' --exclude './**/.gradle/**'
+          args: --no-progress --verbose --exclude-file .lycheeignore './**/*.md' --exclude './**/node_modules/**' --exclude './**/build/**' --exclude './**/.gradle/**'
           fail: true
           jobSummary: true
       - uses: actions/configure-pages@v5

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -5,14 +5,6 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - '**/build.gradle*'
-      - '**/pom.xml'
-      - '**/package.json'
-      - '**/yarn.lock'
-      - '**/requirements.txt'
-      - '**/setup.py'
-      - '.github/workflows/license-scan.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,26 +82,36 @@ jobs:
           name: trivy-report-${{ github.sha }}
           path: trivy-report.txt
 
+  secret-compliance:
+    name: Secret Compliance Validation
+    uses: ./.github/workflows/validate-secret-compliance.yml
+
   security-gate:
     name: Security Gate
     runs-on: ubuntu-latest
-    needs: [trivy-scan]
+    needs: [trivy-scan, secret-compliance]
     if: always()
     steps:
       - name: Enforce security success
         env:
           TRIVY_SCAN: ${{ needs.trivy-scan.result }}
+          SECRET_COMPLIANCE: ${{ needs.secret-compliance.result }}
         run: |
           echo "Trivy Filesystem Scan => $TRIVY_SCAN"
+          echo "Secret Compliance Validation => $SECRET_COMPLIANCE"
           if [ "$TRIVY_SCAN" != "success" ]; then
             echo "Security Gate failed because the filesystem Trivy scan did not succeed." >&2
+            exit 1
+          fi
+          if [ "$SECRET_COMPLIANCE" != "success" ]; then
+            echo "Security Gate failed because secret compliance validation did not succeed." >&2
             exit 1
           fi
 
   security-summary:
     name: Security Summary
     runs-on: ubuntu-latest
-    needs: [trivy-scan, security-gate]
+    needs: [trivy-scan, secret-compliance, security-gate]
     if: github.event_name == 'pull_request' && always()
     steps:
       - name: 💬 Publish Security Summary Comment
@@ -118,6 +128,7 @@ jobs:
             const checks = [
               ["Security gate", "${{ needs.security-gate.result }}"],
               ["Trivy filesystem scan", "${{ needs.trivy-scan.result }}"],
+              ["Secret compliance validation", "${{ needs.secret-compliance.result }}"],
             ];
 
             const failedChecks = checks.filter(([, result]) => result !== "success");

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -123,3 +123,16 @@ jobs:
                 body
               });
             }
+
+  smoke-gate:
+    name: Smoke Gate
+    runs-on: ubuntu-latest
+    needs: [smoke-core]
+    if: always()
+    steps:
+      - name: Enforce successful smoke tests
+        run: |
+          if [ "${{ needs.smoke-core.result }}" != "success" ]; then
+            echo "Smoke tests did not complete successfully: ${{ needs.smoke-core.result }}"
+            exit 1
+          fi

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -72,10 +72,23 @@ jobs:
         if: always()
         run: ./gradlew devDown
 
+  smoke-gate:
+    name: Smoke Gate
+    runs-on: ubuntu-latest
+    needs: [smoke-core]
+    if: always()
+    steps:
+      - name: Enforce successful smoke tests
+        run: |
+          if [ "${{ needs.smoke-core.result }}" != "success" ]; then
+            echo "Smoke tests did not complete successfully: ${{ needs.smoke-core.result }}"
+            exit 1
+          fi
+
   smoke-summary:
     name: Smoke Summary
     runs-on: ubuntu-latest
-    needs: [smoke-core]
+    needs: [smoke-core, smoke-gate]
     if: github.event_name == 'pull_request' && always()
     steps:
       - name: 💬 Publish Smoke Summary Comment
@@ -123,16 +136,3 @@ jobs:
                 body
               });
             }
-
-  smoke-gate:
-    name: Smoke Gate
-    runs-on: ubuntu-latest
-    needs: [smoke-core]
-    if: always()
-    steps:
-      - name: Enforce successful smoke tests
-        run: |
-          if [ "${{ needs.smoke-core.result }}" != "success" ]; then
-            echo "Smoke tests did not complete successfully: ${{ needs.smoke-core.result }}"
-            exit 1
-          fi

--- a/.github/workflows/static-analysis-summary.yml
+++ b/.github/workflows/static-analysis-summary.yml
@@ -65,6 +65,30 @@ jobs:
               return checkRun.conclusion ?? "pending";
             };
 
+            const statusPriority = (value) => {
+              switch (value) {
+                case "in_progress":
+                  return 7;
+                case "queued":
+                  return 6;
+                case "pending":
+                  return 5;
+                case "success":
+                  return 4;
+                case "failure":
+                case "timed_out":
+                case "action_required":
+                  return 3;
+                case "neutral":
+                case "skipped":
+                  return 2;
+                case "cancelled":
+                  return 1;
+                default:
+                  return 0;
+              }
+            };
+
             const loadChecks = async () => {
               const { data } = await github.rest.checks.listForRef({
                 ...context.repo,
@@ -76,14 +100,24 @@ jobs:
 
             const resolveStatuses = (checkRuns) =>
               requiredChecks.map(([label, checkName]) => {
-                const latest = checkRuns
+                const candidates = checkRuns
                   .filter((checkRun) => checkRun.name === checkName)
-                  .sort((a, b) => b.id - a.id)[0];
-                return [label, normalizeStatus(latest)];
+                  .map((checkRun) => ({
+                    checkRun,
+                    status: normalizeStatus(checkRun),
+                  }))
+                  .sort((a, b) => {
+                    const priorityDiff = statusPriority(b.status) - statusPriority(a.status);
+                    if (priorityDiff !== 0) {
+                      return priorityDiff;
+                    }
+                    return b.checkRun.id - a.checkRun.id;
+                  });
+                return [label, candidates[0]?.status ?? "pending"];
               });
 
             let checks = resolveStatuses(await loadChecks());
-            for (let attempt = 0; attempt < 12; attempt += 1) {
+            for (let attempt = 0; attempt < 30; attempt += 1) {
               const allCompleted = checks.every(([, result]) => terminalConclusions.has(result));
               if (allCompleted) {
                 break;

--- a/.github/workflows/static-analysis-summary.yml
+++ b/.github/workflows/static-analysis-summary.yml
@@ -36,9 +36,12 @@ jobs:
             const pullRequest = pullRequests[0];
             const issueNumber = pullRequest.number;
             const headSha = context.payload.workflow_run.head_sha;
-            const requiredChecks = [
+            const detailChecks = [
               ["CodeQL analysis (java)", "CodeQL Analysis (java)"],
               ["CodeQL analysis (javascript-typescript)", "CodeQL Analysis (javascript-typescript)"],
+            ];
+            const gateChecks = [
+              ["CodeQL gate", "CodeQL Gate"],
               ["License gate", "License Gate"],
             ];
             const terminalConclusions = new Set([
@@ -99,7 +102,7 @@ jobs:
             };
 
             const resolveStatuses = (checkRuns) =>
-              requiredChecks.map(([label, checkName]) => {
+              [...gateChecks, ...detailChecks].map(([label, checkName]) => {
                 const candidates = checkRuns
                   .filter((checkRun) => checkRun.name === checkName)
                   .map((checkRun) => ({
@@ -126,10 +129,13 @@ jobs:
               checks = resolveStatuses(await loadChecks());
             }
 
-            const failedChecks = checks.filter(([, result]) =>
+            const gateResults = checks.slice(0, gateChecks.length);
+            const detailResults = checks.slice(gateChecks.length);
+
+            const failedChecks = gateResults.filter(([, result]) =>
               ["failure", "timed_out", "action_required"].includes(result)
             );
-            const pendingChecks = checks.filter(([, result]) =>
+            const pendingChecks = gateResults.filter(([, result]) =>
               ["pending", "in_progress", "queued"].includes(result)
             );
 
@@ -144,7 +150,11 @@ jobs:
               "### Static Analysis Summary",
               headline,
               "",
-              ...checks.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
+              ...gateResults.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
+              "",
+              "CodeQL breakdown",
+              "",
+              ...detailResults.map(([name, result]) => `- ${statusIcon(result)} ${name}: \`${result}\``),
             ].join("\n");
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/validate-secret-compliance.yml
+++ b/.github/workflows/validate-secret-compliance.yml
@@ -1,9 +1,8 @@
 name: Secret Compliance Checks
 
 on:
-  pull_request:
-  push:
-    branches: [develop, main]
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/pr-summary.md
+++ b/pr-summary.md
@@ -1,21 +1,39 @@
 ## Summary
-This PR finishes the current Spring Boot 4 migration slice on top of `develop` and fixes the CI regressions it exposed.
+This PR rolls the current `feature/design-and-vip` branch forward on top of `develop` and brings the codebase, docs, shared runtime modules, and GitHub Actions layout into the current target shape.
 
-The branch updates the affected runtime and test paths so the repo is consistently on Boot 4, the local/dev compose stack still starts cleanly, and the canonical CI smoke path is green again.
+The branch is intentionally broad. It includes the current Spring Boot 4 / Framework 7 migration work, extraction of shared backend runtime/build modules, service package cleanup, major architecture documentation refreshes, and the CI restructuring needed to keep validation, smoke, security, and code scanning reliable.
 
 ## What changed
-- migrates backend services onto the Spring Boot 4 / Spring Framework 7 compatible configuration and test path
-- stabilizes `tcp-proxy-service`, `spring-cloud-gateway`, and `game-session-service` integration and cross-service tests under Boot 4
-- adds shared Boot 4 test fixtures in `common-library` and removes the repeated `TestRestTemplate`-based simple HTTP probe pattern
-- fixes the Gatling plugin/version drift that broke root Gradle configuration for dependency submission and overlay-related validation
-- restores `Core Smoke Tests` by fixing runtime saga bootstrap assumptions and the new Spring gRPC server port config in the compose/dev stack
-- keeps preview/overlay CI scaffolding aligned with the current hosted-preview direction and recent dependency/tooling changes
+- migrates the active backend stack onto the Boot 4 / Framework 7 baseline and updates service tests, probes, and runtime wiring to match
+- extracts and adopts shared backend modules and build conventions, including split platform/data/saga/web/JWT/test support pieces
+- cleans up service package/layout conventions across multiple services, including `tcp-proxy-service`, `world-management-service`, and related shared runtime paths
+- refreshes a large set of architecture and operational docs to describe the current target state directly
+- restructures CI into clearer workflow domains:
+  - `CI — Validation`
+  - `Smoke Tests`
+  - `Security Checks`
+  - `CodeQL Analysis`
+  - `License Checks`
+- adds gate jobs and PR summaries so merge protection can target stable high-level checks instead of matrix legs
+- expands CodeQL to scan both Java and JavaScript/TypeScript, and adds a `CodeQL Gate`
+- fixes the follow-on CI regressions exposed during this branch:
+  - smoke stack startup and Redis/shared auto-config issues
+  - stale static-analysis summary behavior
+  - docs publishing Lychee ignore path
+  - Docker image publishing missing prebuilt JARs
 
 ## Validation
 - `./gradlew spotlessApply`
 - `./gradlew check`
-- `bash services/tcp-proxy-service/telnet-login-look-smoke.sh`
-- GitHub Actions `CI — Build and Security` run `23276107359` succeeded, including `Core Smoke Tests`
+- `./gradlew linkCheck lintMarkdown`
+- targeted local smoke verification via `./gradlew devUp` / `./gradlew devDown` and the TCP proxy telnet smoke path
+- GitHub Actions on this branch covering validation, smoke, security, CodeQL, and license checks
 
 ## Notes
-- This completes the current migration-and-fix pass. Larger follow-up refactors discussed during review, like shared runtime gRPC client/server abstractions or `common-library` splitting, are intentionally not part of this PR.
+- This branch is not a narrow slice; the PR body is intentionally high-level rather than file-by-file.
+- Merge protection should target the stable gate checks:
+  - `Validation Gate`
+  - `Security Gate`
+  - `Smoke Gate`
+  - `CodeQL Gate`
+  - `License Gate`

--- a/pr-summary.md
+++ b/pr-summary.md
@@ -15,7 +15,9 @@ The branch is intentionally broad. It includes the current Spring Boot 4 / Frame
   - `CodeQL Analysis`
   - `License Checks`
 - adds gate jobs and PR summaries so merge protection can target stable high-level checks instead of matrix legs
-- expands CodeQL to scan both Java and JavaScript/TypeScript, and adds a `CodeQL Gate`
+- expands CodeQL to scan both Java and JavaScript/TypeScript, adds a `CodeQL Gate`, and finalizes the cross-workflow static-analysis summary flow
+- folds `Secret Compliance Validation` into the security domain so `Security Gate` and `Security Summary` cover both filesystem scanning and secret compliance policy
+- replaces repeated saga entity bootstrap `@EntityScan` wiring in saga-backed services with a shared `common-saga` annotation
 - fixes the follow-on CI regressions exposed during this branch:
   - smoke stack startup and Redis/shared auto-config issues
   - stale static-analysis summary behavior
@@ -26,6 +28,8 @@ The branch is intentionally broad. It includes the current Spring Boot 4 / Frame
 - `./gradlew spotlessApply`
 - `./gradlew check`
 - `./gradlew linkCheck lintMarkdown`
+- `./gradlew :account-service:check :automation-scripting-service:check :game-design-service:check :game-session-service:check :logging-admin-service:check :social-groups-service:check :world-management-service:check`
+- `./gradlew check -x lintMarkdown -x linkCheck --no-daemon --no-configuration-cache`
 - targeted local smoke verification via `./gradlew devUp` / `./gradlew devDown` and the TCP proxy telnet smoke path
 - GitHub Actions on this branch covering validation, smoke, security, CodeQL, and license checks
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/AccountServiceApplication.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/AccountServiceApplication.java
@@ -3,16 +3,13 @@ package net.firedevops.firemud.accountservice;
 import net.firedevops.firemud.accountservice.config.AuthConfig;
 import net.firedevops.firemud.accountservice.config.MailConfig;
 import net.firedevops.firemud.accountservice.config.PaymentConfig;
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {AccountServiceApplication.class, SagaInstance.class, SagaStep.class})
+@EnableSagaEntityScan(basePackageClasses = AccountServiceApplication.class)
 @Import({AuthConfig.class, MailConfig.class, PaymentConfig.class})
 public class AccountServiceApplication {
   public static void main(String[] args) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/AccountServiceApplication.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/AccountServiceApplication.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = AccountServiceApplication.class)
+@EnableSagaEntityScan
 @Import({AuthConfig.class, MailConfig.class, PaymentConfig.class})
 public class AccountServiceApplication {
   public static void main(String[] args) {

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/automationscripting/AutomationScriptingServiceApplication.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/automationscripting/AutomationScriptingServiceApplication.java
@@ -1,20 +1,13 @@
 package net.firedevops.firemud.automationscripting;
 
 import net.firedevops.firemud.automationscripting.config.AuthProperties;
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {
-      AutomationScriptingServiceApplication.class,
-      SagaInstance.class,
-      SagaStep.class
-    })
+@EnableSagaEntityScan(basePackageClasses = AutomationScriptingServiceApplication.class)
 @EnableConfigurationProperties(AuthProperties.class)
 public class AutomationScriptingServiceApplication {
   public static void main(String[] args) {

--- a/services/automation-scripting-service/src/main/java/net/firedevops/firemud/automationscripting/AutomationScriptingServiceApplication.java
+++ b/services/automation-scripting-service/src/main/java/net/firedevops/firemud/automationscripting/AutomationScriptingServiceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = AutomationScriptingServiceApplication.class)
+@EnableSagaEntityScan
 @EnableConfigurationProperties(AuthProperties.class)
 public class AutomationScriptingServiceApplication {
   public static void main(String[] args) {

--- a/services/common-saga/src/main/java/net/firedevops/firemud/common/saga/persistence/EnableSagaEntityScan.java
+++ b/services/common-saga/src/main/java/net/firedevops/firemud/common/saga/persistence/EnableSagaEntityScan.java
@@ -1,0 +1,21 @@
+package net.firedevops.firemud.common.saga.persistence;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.core.annotation.AliasFor;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@EntityScan(basePackageClasses = {SagaInstance.class, SagaStep.class})
+public @interface EnableSagaEntityScan {
+
+  @AliasFor(annotation = EntityScan.class, attribute = "basePackageClasses")
+  Class<?>[] basePackageClasses() default {};
+}

--- a/services/common-saga/src/main/java/net/firedevops/firemud/common/saga/persistence/EnableSagaEntityScan.java
+++ b/services/common-saga/src/main/java/net/firedevops/firemud/common/saga/persistence/EnableSagaEntityScan.java
@@ -6,16 +6,11 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
-import org.springframework.core.annotation.AliasFor;
+import org.springframework.context.annotation.Import;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@EntityScan(basePackageClasses = {SagaInstance.class, SagaStep.class})
-public @interface EnableSagaEntityScan {
-
-  @AliasFor(annotation = EntityScan.class, attribute = "basePackageClasses")
-  Class<?>[] basePackageClasses() default {};
-}
+@Import(SagaEntityScanRegistrar.class)
+public @interface EnableSagaEntityScan {}

--- a/services/common-saga/src/main/java/net/firedevops/firemud/common/saga/persistence/SagaEntityScanRegistrar.java
+++ b/services/common-saga/src/main/java/net/firedevops/firemud/common/saga/persistence/SagaEntityScanRegistrar.java
@@ -1,0 +1,27 @@
+package net.firedevops.firemud.common.saga.persistence;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.persistence.autoconfigure.EntityScanPackages;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+
+final class SagaEntityScanRegistrar implements ImportBeanDefinitionRegistrar {
+
+  @Override
+  public void registerBeanDefinitions(
+      AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+    Set<String> packages = new LinkedHashSet<>();
+    packages.add(ClassUtils.getPackageName(importingClassMetadata.getClassName()));
+    packages.add(SagaInstance.class.getPackageName());
+    EntityScanPackages.register(registry, packages);
+  }
+
+  private static final class ClassUtils {
+    private static String getPackageName(String className) {
+      int packageSeparator = className.lastIndexOf('.');
+      return (packageSeparator >= 0) ? className.substring(0, packageSeparator) : "";
+    }
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/GameDesignServiceApplication.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/GameDesignServiceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = GameDesignServiceApplication.class)
+@EnableSagaEntityScan
 @EnableConfigurationProperties(AssetStoreProperties.class)
 public class GameDesignServiceApplication {
   public static void main(String[] args) {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/GameDesignServiceApplication.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/GameDesignServiceApplication.java
@@ -1,16 +1,13 @@
 package net.firedevops.firemud.gamedesign;
 
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import net.firedevops.firemud.gamedesign.config.AssetStoreProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {GameDesignServiceApplication.class, SagaInstance.class, SagaStep.class})
+@EnableSagaEntityScan(basePackageClasses = GameDesignServiceApplication.class)
 @EnableConfigurationProperties(AssetStoreProperties.class)
 public class GameDesignServiceApplication {
   public static void main(String[] args) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/GameSessionServiceApplication.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/GameSessionServiceApplication.java
@@ -1,18 +1,15 @@
 package net.firedevops.firemud.gamesession;
 
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import net.firedevops.firemud.gamesession.config.GameLogicProperties;
 import net.firedevops.firemud.gamesession.config.GameSessionProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {GameSessionServiceApplication.class, SagaInstance.class, SagaStep.class})
+@EnableSagaEntityScan(basePackageClasses = GameSessionServiceApplication.class)
 @EnableScheduling
 @EnableConfigurationProperties({GameSessionProperties.class, GameLogicProperties.class})
 public class GameSessionServiceApplication {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/GameSessionServiceApplication.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/GameSessionServiceApplication.java
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = GameSessionServiceApplication.class)
+@EnableSagaEntityScan
 @EnableScheduling
 @EnableConfigurationProperties({GameSessionProperties.class, GameLogicProperties.class})
 public class GameSessionServiceApplication {

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/loggingadmin/LoggingAdminServiceApplication.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/loggingadmin/LoggingAdminServiceApplication.java
@@ -2,17 +2,14 @@ package net.firedevops.firemud.loggingadmin;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import net.firedevops.firemud.loggingadmin.config.AuthConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {LoggingAdminServiceApplication.class, SagaInstance.class, SagaStep.class})
+@EnableSagaEntityScan(basePackageClasses = LoggingAdminServiceApplication.class)
 @OpenAPIDefinition(info = @Info(title = "Logging Admin Service", version = "v1"))
 @Import(AuthConfig.class)
 public class LoggingAdminServiceApplication {

--- a/services/logging-admin-service/src/main/java/net/firedevops/firemud/loggingadmin/LoggingAdminServiceApplication.java
+++ b/services/logging-admin-service/src/main/java/net/firedevops/firemud/loggingadmin/LoggingAdminServiceApplication.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = LoggingAdminServiceApplication.class)
+@EnableSagaEntityScan
 @OpenAPIDefinition(info = @Info(title = "Logging Admin Service", version = "v1"))
 @Import(AuthConfig.class)
 public class LoggingAdminServiceApplication {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/socialgroups/SocialGroupsServiceApplication.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/socialgroups/SocialGroupsServiceApplication.java
@@ -1,16 +1,13 @@
 package net.firedevops.firemud.socialgroups;
 
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import net.firedevops.firemud.socialgroups.config.ChatProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {SocialGroupsServiceApplication.class, SagaInstance.class, SagaStep.class})
+@EnableSagaEntityScan(basePackageClasses = SocialGroupsServiceApplication.class)
 @EnableConfigurationProperties(ChatProperties.class)
 public class SocialGroupsServiceApplication {
   public static void main(String[] args) {

--- a/services/social-groups-service/src/main/java/net/firedevops/firemud/socialgroups/SocialGroupsServiceApplication.java
+++ b/services/social-groups-service/src/main/java/net/firedevops/firemud/socialgroups/SocialGroupsServiceApplication.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = SocialGroupsServiceApplication.class)
+@EnableSagaEntityScan
 @EnableConfigurationProperties(ChatProperties.class)
 public class SocialGroupsServiceApplication {
   public static void main(String[] args) {

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/worldmanagement/WorldManagementServiceApplication.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/worldmanagement/WorldManagementServiceApplication.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableSagaEntityScan(basePackageClasses = WorldManagementServiceApplication.class)
+@EnableSagaEntityScan
 @OpenAPIDefinition(info = @Info(title = "World Management Service", version = "v1"))
 @EnableScheduling
 @Import(WorldConfig.class)

--- a/services/world-management-service/src/main/java/net/firedevops/firemud/worldmanagement/WorldManagementServiceApplication.java
+++ b/services/world-management-service/src/main/java/net/firedevops/firemud/worldmanagement/WorldManagementServiceApplication.java
@@ -2,22 +2,15 @@ package net.firedevops.firemud.worldmanagement;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import net.firedevops.firemud.common.saga.persistence.SagaInstance;
-import net.firedevops.firemud.common.saga.persistence.SagaStep;
+import net.firedevops.firemud.common.saga.persistence.EnableSagaEntityScan;
 import net.firedevops.firemud.worldmanagement.config.WorldConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EntityScan(
-    basePackageClasses = {
-      WorldManagementServiceApplication.class,
-      SagaInstance.class,
-      SagaStep.class
-    })
+@EnableSagaEntityScan(basePackageClasses = WorldManagementServiceApplication.class)
 @OpenAPIDefinition(info = @Info(title = "World Management Service", version = "v1"))
 @EnableScheduling
 @Import(WorldConfig.class)


### PR DESCRIPTION
## Summary
This PR rolls the current `feature/design-and-vip` branch forward on top of `develop` and brings the codebase, docs, shared runtime modules, and GitHub Actions layout into the current target shape.

The branch is intentionally broad. It includes the current Spring Boot 4 / Framework 7 migration work, extraction of shared backend runtime/build modules, service package cleanup, major architecture documentation refreshes, and the CI restructuring needed to keep validation, smoke, security, and code scanning reliable.

## What changed
- migrates the active backend stack onto the Boot 4 / Framework 7 baseline and updates service tests, probes, and runtime wiring to match
- extracts and adopts shared backend modules and build conventions, including split platform/data/saga/web/JWT/test support pieces
- cleans up service package/layout conventions across multiple services, including `tcp-proxy-service`, `world-management-service`, and related shared runtime paths
- refreshes a large set of architecture and operational docs to describe the current target state directly
- restructures CI into clearer workflow domains:
  - `CI — Validation`
  - `Smoke Tests`
  - `Security Checks`
  - `CodeQL Analysis`
  - `License Checks`
- adds gate jobs and PR summaries so merge protection can target stable high-level checks instead of matrix legs
- expands CodeQL to scan both Java and JavaScript/TypeScript, adds a `CodeQL Gate`, and finalizes the cross-workflow static-analysis summary flow
- folds `Secret Compliance Validation` into the security domain so `Security Gate` and `Security Summary` cover both filesystem scanning and secret compliance policy
- replaces repeated saga entity bootstrap `@EntityScan` wiring in saga-backed services with a shared `common-saga` annotation
- fixes the follow-on CI regressions exposed during this branch:
  - smoke stack startup and Redis/shared auto-config issues
  - stale static-analysis summary behavior
  - docs publishing Lychee ignore path
  - Docker image publishing missing prebuilt JARs

## Validation
- `./gradlew spotlessApply`
- `./gradlew check`
- `./gradlew linkCheck lintMarkdown`
- `./gradlew :account-service:check :automation-scripting-service:check :game-design-service:check :game-session-service:check :logging-admin-service:check :social-groups-service:check :world-management-service:check`
- `./gradlew check -x lintMarkdown -x linkCheck --no-daemon --no-configuration-cache`
- targeted local smoke verification via `./gradlew devUp` / `./gradlew devDown` and the TCP proxy telnet smoke path
- GitHub Actions on this branch covering validation, smoke, security, CodeQL, and license checks

## Notes
- This branch is not a narrow slice; the PR body is intentionally high-level rather than file-by-file.
- Merge protection should target the stable gate checks:
  - `Validation Gate`
  - `Security Gate`
  - `Smoke Gate`
  - `CodeQL Gate`
  - `License Gate`
