### PR TITLE
ci: auto-merge dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -10,6 +11,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/config/openapi"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -18,6 +20,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/web-client"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -26,6 +29,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "sunday"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    name: Dependabot Auto Merge
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'benhook1013/FireMUD' &&
+      !github.event.pull_request.draft
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve Dependabot PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
+      - name: Enable auto-merge for Dependabot PR
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/ort-advisory.yml
+++ b/.github/workflows/ort-advisory.yml
@@ -1,23 +1,20 @@
-name: License Checks
+name: ORT Advisory Scan
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  schedule:
+    - cron: '0 6 * * 0'  # Weekly on Sundays at 06:00 UTC
   workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
-  group: license-${{ github.workflow }}-${{ github.ref }}
+  group: ort-advisory-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  ort-scan:
-    name: License Gate
+  ort-advisory:
+    name: ORT Advisory Scan
     runs-on: ubuntu-latest
     steps:
       - name: Use HTTPS for Git
@@ -47,26 +44,18 @@ jobs:
         with:
           cache-read-only: false
 
-      - name: Run ORT License Scan
+      - name: Run ORT advisory scan
         id: ort
         uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
           ort-cli-args: '-P ort.analyzer.enabledPackageManagers=Gradle,NPM'
-          run: 'cache-dependencies,labels,analyzer,evaluator,reporter,upload-results'
-          fail-on: policy-violation
+          run: 'cache-dependencies,labels,analyzer,evaluator,advisor,reporter,upload-results'
+          fail-on: 'violations'
           report-formats: 'CycloneDx,WebApp'
           ort-cli-report-args: '-O CycloneDX=output.file.formats=json,xml'
 
-      - name: Upload ORT results
+      - name: Upload ORT advisory results
         uses: actions/upload-artifact@v7
         with:
-          name: ort-result-${{ github.sha }}
+          name: ort-advisory-result-${{ github.sha }}
           path: ${{ steps.ort.outputs.results-path }}
-      - name: Summarize ORT report
-        if: github.event_name == 'pull_request'
-        run: |
-          SUMMARY_FILE=$(ls "${{ steps.ort.outputs.results-path }}/scan-summary-*.md" 2>/dev/null | head -n 1)
-          if [ -f "$SUMMARY_FILE" ]; then
-            echo "### 📜 License Scan Summary" >> $GITHUB_STEP_SUMMARY
-            cat "$SUMMARY_FILE" >> $GITHUB_STEP_SUMMARY
-          fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,6 +38,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: preview-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   preview-plan:
     name: Preview Plan

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -323,16 +323,7 @@ tasks.register("codeqlClasses") {
     description = "Compiles the source sets needed for CodeQL analysis without running tests."
     dependsOn(
         subprojects.flatMap { project ->
-            buildList {
-                add("${project.path}:classes")
-                add("${project.path}:testClasses")
-                if (project.file("src/test/java/integration").exists()) {
-                    add("${project.path}:integrationTestClasses")
-                }
-                if (project.file("src/test/java/crossservice").exists()) {
-                    add("${project.path}:crossServiceTestClasses")
-                }
-            }
+            listOf("${project.path}:classes", "${project.path}:testClasses")
         }
     )
 }


### PR DESCRIPTION
## Summary
This PR rolls the current `feature/design-and-vip` branch forward on top of `develop` and brings the codebase, docs, shared runtime modules, and GitHub Actions layout into the current target shape.

The branch is intentionally broad. It includes the current Spring Boot 4 / Framework 7 migration work, extraction of shared backend runtime/build modules, service package cleanup, major architecture documentation refreshes, and the CI restructuring needed to keep validation, smoke, security, and code scanning reliable.

## What changed
- migrates the active backend stack onto the Boot 4 / Framework 7 baseline and updates service tests, probes, and runtime wiring to match
- extracts and adopts shared backend modules and build conventions, including split platform/data/saga/web/JWT/test support pieces
- cleans up service package/layout conventions across multiple services, including `tcp-proxy-service`, `world-management-service`, and related shared runtime paths
- refreshes a large set of architecture and operational docs to describe the current target state directly
- restructures CI into clearer workflow domains:
  - `CI — Validation`
  - `Smoke Tests`
  - `Security Checks`
  - `CodeQL Analysis`
  - `License Checks`
- adds gate jobs and PR summaries so merge protection can target stable high-level checks instead of matrix legs
- expands CodeQL to scan both Java and JavaScript/TypeScript, adds a `CodeQL Gate`, and finalizes the cross-workflow static-analysis summary flow
- folds `Secret Compliance Validation` into the security domain so `Security Gate` and `Security Summary` cover both filesystem scanning and secret compliance policy
- replaces repeated saga entity bootstrap `@EntityScan` wiring in saga-backed services with a shared `common-saga` annotation
- fixes the follow-on CI regressions exposed during this branch:
  - smoke stack startup and Redis/shared auto-config issues
  - stale static-analysis summary behavior
  - docs publishing Lychee ignore path
  - Docker image publishing missing prebuilt JARs

## Validation
- `./gradlew spotlessApply`
- `./gradlew check`
- `./gradlew linkCheck lintMarkdown`
- `./gradlew :account-service:check :automation-scripting-service:check :game-design-service:check :game-session-service:check :logging-admin-service:check :social-groups-service:check :world-management-service:check`
- `./gradlew check -x lintMarkdown -x linkCheck --no-daemon --no-configuration-cache`
- targeted local smoke verification via `./gradlew devUp` / `./gradlew devDown` and the TCP proxy telnet smoke path
- GitHub Actions on this branch covering validation, smoke, security, CodeQL, and license checks

## Notes
- This branch is not a narrow slice; the PR body is intentionally high-level rather than file-by-file.
- Merge protection should target the stable gate checks:
  - `Validation Gate`
  - `Security Gate`
  - `Smoke Gate`
  - `CodeQL Gate`
  - `License Gate`
