### PR TITLE
ci: simplify dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       day: "sunday"
       time: "04:00"
       timezone: "Pacific/Auckland"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,12 +27,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve Dependabot PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-
       - name: Enable auto-merge for Dependabot PR
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
## Summary
- stop Dependabot from reopening the incompatible `eslint` major bump in `/web-client`
- remove the failing self-approval step from Dependabot auto-merge and leave auto-merge enablement in place

## Testing
- not run (workflow/config-only change)
