### PR TITLE
ci: fix docs publishing and weekly scan follow-ups

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
       - name: Cache link check results
         uses: actions/cache@v5
         with:
@@ -35,14 +39,15 @@ jobs:
           fail: true
           jobSummary: true
       - uses: actions/configure-pages@v5
+      - name: Install MkDocs
+        run: python3 -m pip install --disable-pip-version-check mkdocs
       - name: Build documentation
         run: |
-          mkdir -p public/design
-          cp -r design/* public/design/
-          cp README.md public/index.md
+          python3 dev-tools/docs/build_pages_site.py
+          python3 -m mkdocs build --clean
       - uses: actions/upload-pages-artifact@v4
         with:
-          path: ./public
+          path: ./build/public-site
 
   deploy:
     needs: build

--- a/.github/workflows/ort-advisory.yml
+++ b/.github/workflows/ort-advisory.yml
@@ -1,4 +1,4 @@
-name: ORT Advisory Scan
+name: Weekly ORT Advisory Scan
 
 on:
   schedule:
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   ort-advisory:
-    name: ORT Advisory Scan
+    name: Weekly ORT Advisory Scan
     runs-on: ubuntu-latest
     steps:
       - name: Use HTTPS for Git

--- a/.github/workflows/publish-base-image.yml
+++ b/.github/workflows/publish-base-image.yml
@@ -1,6 +1,8 @@
 name: Publish FireMUD Base Image
 
 on:
+  schedule:
+    - cron: '0 2 * * 0'  # Weekly on Sundays at 02:00 UTC
   push:
     branches:
       - develop

--- a/.github/workflows/publish-base-image.yml
+++ b/.github/workflows/publish-base-image.yml
@@ -1,4 +1,4 @@
-name: Publish FireMUD Base Image
+name: Weekly FireMUD Base Image Refresh
 
 on:
   schedule:

--- a/.github/workflows/weekly-security-scan.yml
+++ b/.github/workflows/weekly-security-scan.yml
@@ -42,3 +42,4 @@ jobs:
           format: 'table'
           output: 'trivy-report.txt'
           exit-code: '1'
+          severity: 'HIGH,CRITICAL'

--- a/config/openapi/package-lock.json
+++ b/config/openapi/package-lock.json
@@ -1196,9 +1196,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
-      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "dev": true,
       "funding": [
         {
@@ -1208,13 +1208,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.2"
+        "path-expression-matcher": "^1.1.3"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.1.tgz",
-      "integrity": "sha512-JTpMz8P5mDoNYzXTmTT/xzWjFiCWi0U+UQTJtrFH9muXsr2RqtXZPbnCW5h2mKsOd4u3XcPWCvDSrnaBPlUcMQ==",
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
       "dev": true,
       "funding": [
         {
@@ -1224,9 +1224,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.0",
-        "path-expression-matcher": "^1.1.2",
-        "strnum": "^2.1.2"
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2662,9 +2662,9 @@
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz",
-      "integrity": "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "dev": true,
       "funding": [
         {

--- a/dev-tools/docs/build_pages_site.py
+++ b/dev-tools/docs/build_pages_site.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_DIR = REPO_ROOT / "build"
+STAGING_DIR = BUILD_DIR / "pages-docs"
+INCLUDE_ROOT_DOCS = {
+    "README.md": "index.md",
+    "AGENTS.md": "AGENTS.md",
+    "FAQ.md": "FAQ.md",
+    "LICENSE.md": "LICENSE.md",
+    "NOTICE.md": "NOTICE.md",
+    "CONTRIBUTING.md": "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md": "CODE_OF_CONDUCT.md",
+    "DEVELOPER_SETUP.md": "DEVELOPER_SETUP.md",
+    "SECURITY.md": "SECURITY.md",
+}
+INCLUDE_DIRS = ("design",)
+EXCLUDED_NAME_SUFFIXES = (
+    ".pre-doc-refactor-backup.md",
+)
+EXCLUDED_PATH_PARTS = {
+    ".git",
+    ".gradle",
+    "build",
+    "node_modules",
+}
+
+
+def reset_staging_dir() -> None:
+    if STAGING_DIR.exists():
+        shutil.rmtree(STAGING_DIR)
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    STAGING_DIR.mkdir(parents=True)
+
+
+def should_copy(path: Path) -> bool:
+    if any(part in EXCLUDED_PATH_PARTS for part in path.parts):
+        return False
+    if path.name.endswith(EXCLUDED_NAME_SUFFIXES):
+        return False
+    return True
+
+
+def copy_root_docs() -> None:
+    for source_name, target_name in INCLUDE_ROOT_DOCS.items():
+        source = REPO_ROOT / source_name
+        if not source.exists():
+            continue
+        target = STAGING_DIR / target_name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def copy_tree(source_root: Path) -> None:
+    for source in source_root.rglob("*"):
+        if source.is_dir() or not should_copy(source):
+            continue
+        relative_path = source.relative_to(REPO_ROOT)
+        target = STAGING_DIR / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def main() -> None:
+    reset_staging_dir()
+    copy_root_docs()
+    for directory in INCLUDE_DIRS:
+        copy_tree(REPO_ROOT / directory)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: FireMUD Documentation
+site_url: https://benhook1013.github.io/FireMUD/
+repo_url: https://github.com/benhook1013/FireMUD
+repo_name: benhook1013/FireMUD
+docs_dir: build/pages-docs
+site_dir: build/public-site
+use_directory_urls: true
+
+theme:
+  name: mkdocs
+
+plugins:
+  - search
+
+markdown_extensions:
+  - tables
+  - toc:
+      permalink: true

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -3170,9 +3170,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary
- fix GitHub Pages publishing by building static HTML with MkDocs instead of uploading raw markdown
- rename and schedule the weekly maintenance workflows more clearly
- narrow the weekly Trivy gate to fail on `HIGH,CRITICAL`
- refresh two vulnerable transitive npm packages that ORT flagged and that were safe to update without hacky overrides

## Details
- `Publish Documentation` now stages repo docs through `dev-tools/docs/build_pages_site.py` and builds HTML via `mkdocs`
- `ORT Advisory Scan` is renamed to `Weekly ORT Advisory Scan`
- `Publish FireMUD Base Image` is renamed to `Weekly FireMUD Base Image Refresh` and now also runs weekly
- `fast-xml-parser` updated in `config/openapi/package-lock.json`
- `flatted` updated in `web-client/package-lock.json`

## Validation
- `python3 dev-tools/docs/build_pages_site.py && python3 -m mkdocs build --clean`
- `./gradlew linkCheck lintMarkdown`
