### PR TITLE
Enable CodeQL PR file coverage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  CODEQL_ACTION_FILE_COVERAGE_ON_PRS: "true"
+
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Keep CodeQL pull-request file coverage enabled by setting `CODEQL_ACTION_FILE_COVERAGE_ON_PRS=true` at workflow scope.
- This opts out of the April 2026 CodeQL Action default that skips PR file coverage computation.

## Validation
- `bash dev-tools/lint-yaml.sh`

## Follow-on Runway
- Continue audit-derived architecture/code convergence now that the large audit-hardening PR is merged.
- Prefer broad, canonical fixes over per-service workarounds when more common-module, seed, preview, or smoke seams appear.
- Keep CI and preview checks watched early in the branch so runtime/deploy regressions are fixed before the branch grows again.
