### PR TITLE
Fix dev-demo TCP default session config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: Enforce successful CodeQL analysis
         run: |
-          if [ "${{ needs.analyze.result }}" != "success" ]; then
+          if [ "${{ needs.analyze.result }}" != "success" ] && [ "${{ needs.analyze.result }}" != "skipped" ]; then
             echo "CodeQL analysis did not complete successfully: ${{ needs.analyze.result }}"
             exit 1
           fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,6 +61,7 @@ jobs:
       hostname: ${{ steps.derive.outputs.hostname }}
       image_tag: ${{ steps.derive.outputs.image_tag }}
       head_sha: ${{ steps.derive.outputs.head_sha }}
+      base_sha: ${{ steps.derive.outputs.base_sha }}
     steps:
       - name: Resolve preview eligibility
         id: eligibility
@@ -93,6 +94,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
             PREVIEW_DOMAIN="preview.firedevops.net"
             if [ "${{ github.event.action }}" = "closed" ]; then
               ACTION="destroy"
@@ -102,6 +104,7 @@ jobs:
           else
             PR_NUMBER="${{ inputs.pr_number }}"
             HEAD_SHA="${{ inputs.head_sha }}"
+            BASE_SHA=""
             PREVIEW_DOMAIN="${{ inputs.preview_domain }}"
             ACTION="${{ inputs.action }}"
             IMAGE_TAG="${{ inputs.image_tag }}"
@@ -120,6 +123,7 @@ jobs:
             echo "hostname=pr-${PR_NUMBER}.${PREVIEW_DOMAIN}"
             echo "image_tag=${IMAGE_TAG}"
             echo "head_sha=${HEAD_SHA}"
+            echo "base_sha=${BASE_SHA}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Explain preview skip
@@ -283,9 +287,13 @@ jobs:
 
       - name: Resolve exact preview image tag
         id: effective-image-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           EFFECTIVE_IMAGE_TAG="$(bash ./dev-tools/preview/resolve-preview-image-tag.sh \
-            "${{ needs.preview-plan.outputs.image_tag }}")"
+            "${{ needs.preview-plan.outputs.image_tag }}" \
+            "${{ needs.preview-plan.outputs.pr_number }}" \
+            "${{ needs.preview-plan.outputs.base_sha }}")"
           echo "image_tag=${EFFECTIVE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Cancel if preview target was superseded before image wait

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -70,7 +70,6 @@ jobs:
               "gradle/",
               "protos/",
               "docker/",
-              "dev-tools/",
               "services/account-service/",
               "services/automation-scripting-service/",
               "services/common-data-runtime/",
@@ -97,6 +96,12 @@ jobs:
               ".github/workflows/smoke.yml",
               ".github/workflows/smoke-full.yml",
               ".github/workflows/runtime-images.yml",
+              "dev-tools/build-compose-service-jars.sh",
+              "dev-tools/generate-dev-certs.sh",
+              "dev-tools/verify-compose-health.sh",
+              "dev-tools/verify-fresh-bootstrap.sh",
+              "dev-tools/verify-restart-state.sh",
+              "dev-tools/verify-smoke-images.sh",
             ]);
 
             const nonDocFiles = files.filter((file) => !docsOnlyPredicate(file));

--- a/dev-tools/preview/resolve-preview-image-tag.sh
+++ b/dev-tools/preview/resolve-preview-image-tag.sh
@@ -2,15 +2,60 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "usage: $0 <requested_image_tag>" >&2
+  echo "usage: $0 <requested_image_tag> [pr_number] [base_image_tag]" >&2
   exit 1
 fi
 
 requested_image_tag="$1"
+pr_number="${2:-}"
+base_image_tag="${3:-}"
 
 if [[ -z "${requested_image_tag}" ]]; then
   echo "requested image tag must not be empty" >&2
   exit 1
+fi
+
+runtime_relevant() {
+  local file="$1"
+
+  case "${file}" in
+    build.gradle.kts | settings.gradle.kts | gradle.properties)
+      return 0
+      ;;
+    .github/workflows/runtime-images.yml | .github/workflows/smoke.yml | .github/workflows/smoke-full.yml)
+      return 0
+      ;;
+    buildSrc/* | gradle/* | protos/* | docker/* | config/* | services/*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+if [[ -n "${pr_number}" && -n "${base_image_tag}" ]]; then
+  if [[ -z "${GH_TOKEN:-}" || -z "${GITHUB_REPOSITORY:-}" ]]; then
+    echo "GH_TOKEN and GITHUB_REPOSITORY are required when resolving PR file changes" >&2
+    exit 1
+  fi
+
+  mapfile -t changed_files < <(
+    gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" --paginate \
+      --jq '.[].filename'
+  )
+
+  has_runtime_change=false
+  for file in "${changed_files[@]}"; do
+    if runtime_relevant "${file}"; then
+      has_runtime_change=true
+      break
+    fi
+  done
+
+  if [[ "${has_runtime_change}" == "false" ]]; then
+    echo "${base_image_tag}"
+    exit 0
+  fi
 fi
 
 echo "${requested_image_tag}"

--- a/k8s/helm/firemud/values-dev-demo.example.yaml
+++ b/k8s/helm/firemud/values-dev-demo.example.yaml
@@ -389,8 +389,8 @@ previewStack:
       extraEnv:
         GATEWAY_WS_URL: ws://spring-cloud-gateway/ws/game
         TCP_PROXY_GATEWAY_BASE_URL: http://spring-cloud-gateway
-        FIREMUD_GAMEPLAY_DEFAULT_TENANT_ID: "1"
-        FIREMUD_GAMEPLAY_DEFAULT_WORLD_ID: "demo"
+        TCP_PROXY_DEFAULT_GAME_INSTANCE_ID: "1"
+        TCP_PROXY_DEFAULT_TENANT_ID: "1"
       ports:
         - port: 8080
           targetPort: 8080


### PR DESCRIPTION
## Summary
- fix dev-demo TCP Proxy defaults so Telnet login sends the canonical tenant/game-instance context to the gateway
- remove the unused dev-demo `FIREMUD_GAMEPLAY_DEFAULT_*` values from the Helm example
- allow CodeQL PR gating to pass when the matrix is intentionally skipped for irrelevant changes
- make preview deploys reuse the base branch runtime image tag for PRs that do not change runtime-image inputs
- narrow full-smoke detection so preview-only dev-tools changes do not wait forever for nonexistent runtime-image/full-smoke runs

## Validation
- `bash dev-tools/lint-yaml.sh`
- `shellcheck dev-tools/preview/resolve-preview-image-tag.sh`
- live dev-demo TCP `LOGIN -> PLAY -> LOOK` smoke passed after applying the same TCP defaults on the preview host
