### PR TITLE
Seed local smoke env and docs CI Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,11 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: ⚙️ Set Up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24.18.0'
+
       - name: ⚙️ Set Up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 }
 
 node {
-    version.set("20.11.0")
+    version.set("24.18.0")
     // Don't download Node in CI; use the version provided by the environment
     download.set(System.getenv("CI") == null)
 }

--- a/design/architecture/system-architecture-cicd.md
+++ b/design/architecture/system-architecture-cicd.md
@@ -46,7 +46,7 @@ The main [`ci.yml`](../../.github/workflows/ci.yml) workflow:
 - Runs formatting and lint steps (Spotless, markdownlint, link checks).
 - Executes a matrix of Gradle `check` tasks (one per microservice) with SpotBugs, Checkstyle, and tests enabled.
 - Generates coverage with JaCoCo, uploads per-service coverage reports to Codecov using GitHub OIDC, and runs Trivy scans over the workspace.
-- Uses Node 20 to lint OpenAPI specs, run React linters, and execute an accessibility audit using headless Chrome.
+- Uses Node 24 to lint OpenAPI specs, run React linters, and execute an accessibility audit using headless Chrome.
 - Validates tracked Bash scripts across the repository with ShellCheck and validates tracked Python scripts by compiling them with `py_compile` so syntax regressions fail fast in CI.
 - Invokes a dedicated `generate-erd` job that runs [`dev-tools/docs/generate-erd.sh`](../../dev-tools/docs/generate-erd.sh) to build ERD diagrams from service migrations and upload them as artifacts.
 - Caches Buf modules, Node dependencies, Trivy database, and Gradle artifacts to speed up repeat workflow runs.
@@ -80,7 +80,7 @@ jobs:
           java-version: '21'
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Check Formatting
         run: ./gradlew spotlessCheck
       - name: Lint Docs and Links

--- a/dev-tools/verify-smoke-images.sh
+++ b/dev-tools/verify-smoke-images.sh
@@ -53,7 +53,6 @@ merge_env_vars() {
     upsert_env_var "$target_file" "$key" "$value"
   done <"$source_file"
 }
-
 upsert_env_var() {
   local file="$1"
   local key="$2"
@@ -92,6 +91,11 @@ fi
 if [[ -f "$ROOT_ENV_FILE" ]]; then
   ROOT_ENV_BACKUP="$(mktemp)"
   cp "$ROOT_ENV_FILE" "$ROOT_ENV_BACKUP"
+elif [[ -f "$ROOT_ENV_SAMPLE" ]]; then
+  cp "$ROOT_ENV_SAMPLE" "$ROOT_ENV_FILE"
+else
+  echo ".env.sample is missing; cannot seed local compose defaults for smoke images." >&2
+  exit 1
 fi
 
 if [[ -f "$ROOT_ENV_SAMPLE" ]]; then


### PR DESCRIPTION
## Summary

- seed root `.env` from `.env.sample` for image-smoke verification when missing
- provision Node explicitly before Markdown/link checks in CI

## Validation

- `bash dev-tools/validation/lint-yaml.sh`
- `./gradlew linkCheck lintMarkdown`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Smoke-image verification:** Seeds and restores the root `.env` for Docker Compose image smoke tests, merging existing values safely and failing clearly if `.env.sample` is unavailable.
- **CI workflow:** Provisions Node.js 24.18.0 before Gradle-based gRPC transport checks and documentation validation.
- **Validation:** YAML linting and `./gradlew linkCheck lintMarkdown` were run. No API, schema, migration, or service contract changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->