### PR TITLE
Add template-scoped authored help topics

### DIFF
--- a/design/project-management/vertical-slices/04.6.1-task-list-game-authored-help-storage-and-layering-vertical-slice.md
+++ b/design/project-management/vertical-slices/04.6.1-task-list-game-authored-help-storage-and-layering-vertical-slice.md
@@ -2,7 +2,7 @@
 
 ## Goal and Status
 
-Extend the built-in `HELP` system with a canonical storage and lookup model for game-authored help topics so each game template can override or extend platform-default help content without changing code. Status: in progress.
+Extend the built-in `HELP` system with a canonical storage and lookup model for game-authored help topics so each game template can override or extend platform-default help content without changing code. Status: implementation complete, pending CI and review.
 
 ## Checklist
 

--- a/design/project-management/vertical-slices/04.6.1-task-list-game-authored-help-storage-and-layering-vertical-slice.md
+++ b/design/project-management/vertical-slices/04.6.1-task-list-game-authored-help-storage-and-layering-vertical-slice.md
@@ -2,13 +2,13 @@
 
 ## Goal and Status
 
-Extend the built-in `HELP` system with a canonical storage and lookup model for game-authored help topics so each game can override or extend platform-default help content without changing code. Status: planned.
+Extend the built-in `HELP` system with a canonical storage and lookup model for game-authored help topics so each game template can override or extend platform-default help content without changing code. Status: in progress.
 
 ## Checklist
 
-- [ ] Define target-state behavior and scope.
-- [ ] Implement the slice end-to-end.
-- [ ] Verify and close any follow-ups.
+- [x] Define target-state behavior and scope.
+- [x] Implement the slice end-to-end.
+- [x] Verify and close any follow-ups.
 
 ## Implementation Notes
 
@@ -55,7 +55,7 @@ The first storage-backed model should center on:
 - `body`
 - `tags` / aliases
 - `tenantId`
-- `gameId` or equivalent game-scoped ownership key
+- `gameTemplateId` as the authored-content ownership key
 - `published` / lifecycle state
 
 The platform should also keep a built-in default corpus that is not stored as mutable per-game data.
@@ -75,9 +75,9 @@ This keeps platform defaults usable while allowing game content to replace or ex
 ## Ownership Boundaries
 
 - Platform-default help remains platform-owned and code/resource-backed.
-- Game-authored help is game-scoped data.
+- Game-authored help is scoped by `tenantId` and `gameTemplateId`. `gameInstanceId` is only the runtime bridge used by Game Session to read the admitted instance's template identity; it is not the authored-content key.
 - Tenant ownership should remain explicit so a tenant cannot read or mutate another tenant's authored help corpus.
-- If multiple games can exist under one tenant, the read path must include game scope rather than only tenant scope.
+- If multiple templates can exist under one tenant, the read path must include `gameTemplateId` rather than only tenant scope.
 
 ## Likely Service / Module Home
 
@@ -117,7 +117,7 @@ The eventual runtime read path should be:
 
 1. `HELP <topic>` arrives in `game-session-service`
 2. built-in handler normalizes topic and current stage
-3. if runtime has game scope, query game-authored help resolver first
+3. if runtime has an admitted game instance with a template identity, query game-authored help by `tenantId` and `gameTemplateId` first
 4. if no authored match, fall back to platform-default built-in corpus
 5. return one canonical help output shape
 
@@ -136,3 +136,19 @@ The eventual runtime read path should be:
 - fuzzy search
 - moderation/versioning workflow beyond ordinary authored-content ownership
 - dynamic command-discovery metadata integration for creator-authored actions
+
+## Current Batch
+
+- The canonical authored-help key is `tenantId + gameTemplateId`; Game Session resolves the template from the admitted runtime game instance before calling Game Design.
+- Authored lookup uses normalized exact keys only, with canonical-topic precedence before alias precedence. Only published topics participate in player reads.
+- Game Session falls back to its platform corpus when no admitted template exists, no published authored topic matches, or Game Design is unavailable.
+- Game Design exposes authenticated gRPC topic resolution plus admin-gated put, list, and delete operations. The storage model rejects canonical/alias collisions so each normalized topic key resolves deterministically.
+- Focused proof passed for Game Design canonical and alias resolution, published-only reads, admin error mapping, Game Session template bridging, tenant isolation, and platform override behavior.
+
+## Validation
+
+- `./gradlew spotlessApply`
+- `bash dev-tools/validation/run-locked-gradle.sh :game-design-service:check :game-session-service:check -PfullCheck`
+- `./gradlew linkCheck lintMarkdown`
+
+Docker-backed Game Design integration and Game Session cross-service tests were skipped locally because Docker was unavailable. The runnable service tests, formatting, Checkstyle, SpotBugs, and documentation checks passed.

--- a/protos/game-design/v1/game_design_service.proto
+++ b/protos/game-design/v1/game_design_service.proto
@@ -61,6 +61,10 @@ service GameDesignService {
       returns (PutSettingsDomainOverrideResponse);
   rpc DeleteSettingsDomainOverride(DeleteSettingsDomainOverrideRequest)
       returns (DeleteSettingsDomainOverrideResponse);
+  rpc ResolveHelpTopic(ResolveHelpTopicRequest) returns (ResolveHelpTopicResponse);
+  rpc PutHelpTopic(PutHelpTopicRequest) returns (PutHelpTopicResponse);
+  rpc ListHelpTopics(ListHelpTopicsRequest) returns (ListHelpTopicsResponse);
+  rpc DeleteHelpTopic(DeleteHelpTopicRequest) returns (DeleteHelpTopicResponse);
 }
 
 message SaveRevisionRequest {
@@ -648,6 +652,57 @@ message DeleteSettingsDomainOverrideRequest {
 }
 
 message DeleteSettingsDomainOverrideResponse {
+  shared.v1.ErrorDetail error = 1;
+}
+
+message HelpTopicScope {
+  string tenant_id = 1;
+  int64 game_template_id = 2;
+}
+
+message HelpTopic {
+  string canonical_topic_id = 1;
+  string title = 2;
+  string body = 3;
+  repeated string aliases = 4;
+  bool published = 5;
+}
+
+message ResolveHelpTopicRequest {
+  HelpTopicScope scope = 1;
+  string topic = 2;
+}
+
+message ResolveHelpTopicResponse {
+  HelpTopic help_topic = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message PutHelpTopicRequest {
+  HelpTopicScope scope = 1;
+  HelpTopic help_topic = 2;
+}
+
+message PutHelpTopicResponse {
+  HelpTopic help_topic = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message ListHelpTopicsRequest {
+  HelpTopicScope scope = 1;
+}
+
+message ListHelpTopicsResponse {
+  repeated HelpTopic help_topics = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message DeleteHelpTopicRequest {
+  HelpTopicScope scope = 1;
+  string canonical_topic_id = 2;
+}
+
+message DeleteHelpTopicResponse {
   shared.v1.ErrorDetail error = 1;
 }
 

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/dto/HelpTopicDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/dto/HelpTopicDto.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.gamedesign.dto;
+
+import java.util.List;
+
+public record HelpTopicDto(
+    String canonicalTopicId, String title, String body, List<String> aliases, boolean published) {
+  public HelpTopicDto {
+    aliases = aliases == null ? List.of() : List.copyOf(aliases);
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/entity/GameAuthoredHelpTopic.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/entity/GameAuthoredHelpTopic.java
@@ -1,0 +1,19 @@
+package net.firedevops.firemud.gamedesign.entity;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class GameAuthoredHelpTopic {
+  private Long id;
+  private String tenantId;
+  private Long gameTemplateId;
+  private String canonicalTopicKey;
+  private String title;
+  private String body;
+  private List<String> aliases = List.of();
+  private boolean published;
+  private Instant createdAt;
+  private Instant updatedAt;
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/GameAuthoredHelpTopicRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/GameAuthoredHelpTopicRepository.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Repository;
     justification = "Injected DSLContext is an internal Spring collaborator.")
 public class GameAuthoredHelpTopicRepository {
   private static final Table<?> TOPIC_TABLE = DSL.table(DSL.name("game_authored_help_topic"));
-  private static final Table<?> ALIAS_TABLE = DSL.table(DSL.name("game_authored_help_topic_alias"));
+  private static final Table<?> KEY_TABLE = DSL.table(DSL.name("game_authored_help_topic_key"));
   private static final Field<Long> ID =
       DSL.field(DSL.name("game_authored_help_topic", "id"), Long.class);
   private static final Field<String> TENANT_ID =
@@ -39,10 +39,14 @@ public class GameAuthoredHelpTopicRepository {
       DSL.field(DSL.name("game_authored_help_topic", "created_at"), Timestamp.class);
   private static final Field<Timestamp> UPDATED_AT =
       DSL.field(DSL.name("game_authored_help_topic", "updated_at"), Timestamp.class);
-  private static final Field<Long> ALIAS_TOPIC_ID =
-      DSL.field(DSL.name("game_authored_help_topic_alias", "help_topic_id"), Long.class);
-  private static final Field<String> ALIAS_KEY =
-      DSL.field(DSL.name("game_authored_help_topic_alias", "alias_key"), String.class);
+  private static final Field<Long> KEY_TOPIC_ID =
+      DSL.field(DSL.name("game_authored_help_topic_key", "help_topic_id"), Long.class);
+  private static final Field<String> LOOKUP_KEY =
+      DSL.field(DSL.name("game_authored_help_topic_key", "lookup_key"), String.class);
+  private static final Field<String> KEY_TENANT_ID =
+      DSL.field(DSL.name("game_authored_help_topic_key", "tenant_id"), String.class);
+  private static final Field<Long> KEY_GAME_TEMPLATE_ID =
+      DSL.field(DSL.name("game_authored_help_topic_key", "game_template_id"), Long.class);
 
   private final DSLContext dsl;
 
@@ -64,11 +68,11 @@ public class GameAuthoredHelpTopicRepository {
   public Optional<GameAuthoredHelpTopic> findPublishedByAliasKey(
       String tenantId, long gameTemplateId, String aliasKey) {
     return findOne(
-        TOPIC_TABLE.join(ALIAS_TABLE).on(ID.eq(ALIAS_TOPIC_ID)),
+        TOPIC_TABLE.join(KEY_TABLE).on(ID.eq(KEY_TOPIC_ID)),
         TENANT_ID
             .eq(tenantId)
             .and(GAME_TEMPLATE_ID.eq(gameTemplateId))
-            .and(ALIAS_KEY.eq(aliasKey))
+            .and(LOOKUP_KEY.eq(aliasKey))
             .and(PUBLISHED.isTrue()));
   }
 
@@ -85,11 +89,11 @@ public class GameAuthoredHelpTopicRepository {
   public Optional<GameAuthoredHelpTopic> findByScopeAndAliasKey(
       String tenantId, long gameTemplateId, String aliasKey) {
     return findOne(
-        TOPIC_TABLE.join(ALIAS_TABLE).on(ID.eq(ALIAS_TOPIC_ID)),
+        TOPIC_TABLE.join(KEY_TABLE).on(ID.eq(KEY_TOPIC_ID)),
         TENANT_ID
             .eq(tenantId)
             .and(GAME_TEMPLATE_ID.eq(gameTemplateId))
-            .and(ALIAS_KEY.eq(aliasKey)));
+            .and(LOOKUP_KEY.eq(aliasKey)));
   }
 
   public List<GameAuthoredHelpTopic> findAllByScope(String tenantId, long gameTemplateId) {
@@ -130,14 +134,14 @@ public class GameAuthoredHelpTopicRepository {
     return findById(topic.getId()).orElseThrow();
   }
 
-  public void replaceAliases(GameAuthoredHelpTopic topic, List<String> aliases) {
-    dsl.deleteFrom(ALIAS_TABLE).where(ALIAS_TOPIC_ID.eq(topic.getId())).execute();
-    for (String alias : aliases) {
-      dsl.insertInto(ALIAS_TABLE)
-          .set(ALIAS_TOPIC_ID, topic.getId())
-          .set(TENANT_ID, topic.getTenantId())
-          .set(GAME_TEMPLATE_ID, topic.getGameTemplateId())
-          .set(ALIAS_KEY, alias)
+  public void replaceLookupKeys(GameAuthoredHelpTopic topic, List<String> aliases) {
+    dsl.deleteFrom(KEY_TABLE).where(KEY_TOPIC_ID.eq(topic.getId())).execute();
+    for (String key : lookupKeys(topic.getCanonicalTopicKey(), aliases)) {
+      dsl.insertInto(KEY_TABLE)
+          .set(KEY_TOPIC_ID, topic.getId())
+          .set(KEY_TENANT_ID, topic.getTenantId())
+          .set(KEY_GAME_TEMPLATE_ID, topic.getGameTemplateId())
+          .set(LOOKUP_KEY, key)
           .execute();
     }
   }
@@ -171,11 +175,18 @@ public class GameAuthoredHelpTopicRepository {
     Timestamp updatedAt = record.get(UPDATED_AT);
     topic.setUpdatedAt(updatedAt == null ? null : updatedAt.toInstant());
     topic.setAliases(
-        dsl.select(ALIAS_KEY)
-            .from(ALIAS_TABLE)
-            .where(ALIAS_TOPIC_ID.eq(topic.getId()))
-            .orderBy(ALIAS_KEY.asc())
-            .fetch(ALIAS_KEY));
+        dsl.select(LOOKUP_KEY)
+            .from(KEY_TABLE)
+            .where(KEY_TOPIC_ID.eq(topic.getId()).and(LOOKUP_KEY.ne(topic.getCanonicalTopicKey())))
+            .orderBy(LOOKUP_KEY.asc())
+            .fetch(LOOKUP_KEY));
     return topic;
+  }
+
+  private List<String> lookupKeys(String canonicalTopicKey, List<String> aliases) {
+    java.util.ArrayList<String> keys = new java.util.ArrayList<>();
+    keys.add(canonicalTopicKey);
+    keys.addAll(aliases);
+    return List.copyOf(keys);
   }
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/GameAuthoredHelpTopicRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/GameAuthoredHelpTopicRepository.java
@@ -1,0 +1,181 @@
+package net.firedevops.firemud.gamedesign.repository;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import net.firedevops.firemud.gamedesign.entity.GameAuthoredHelpTopic;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Table;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected DSLContext is an internal Spring collaborator.")
+public class GameAuthoredHelpTopicRepository {
+  private static final Table<?> TOPIC_TABLE = DSL.table(DSL.name("game_authored_help_topic"));
+  private static final Table<?> ALIAS_TABLE = DSL.table(DSL.name("game_authored_help_topic_alias"));
+  private static final Field<Long> ID =
+      DSL.field(DSL.name("game_authored_help_topic", "id"), Long.class);
+  private static final Field<String> TENANT_ID =
+      DSL.field(DSL.name("game_authored_help_topic", "tenant_id"), String.class);
+  private static final Field<Long> GAME_TEMPLATE_ID =
+      DSL.field(DSL.name("game_authored_help_topic", "game_template_id"), Long.class);
+  private static final Field<String> CANONICAL_TOPIC_KEY =
+      DSL.field(DSL.name("game_authored_help_topic", "canonical_topic_key"), String.class);
+  private static final Field<String> TITLE =
+      DSL.field(DSL.name("game_authored_help_topic", "title"), String.class);
+  private static final Field<String> BODY =
+      DSL.field(DSL.name("game_authored_help_topic", "body"), String.class);
+  private static final Field<Boolean> PUBLISHED =
+      DSL.field(DSL.name("game_authored_help_topic", "published"), Boolean.class);
+  private static final Field<Timestamp> CREATED_AT =
+      DSL.field(DSL.name("game_authored_help_topic", "created_at"), Timestamp.class);
+  private static final Field<Timestamp> UPDATED_AT =
+      DSL.field(DSL.name("game_authored_help_topic", "updated_at"), Timestamp.class);
+  private static final Field<Long> ALIAS_TOPIC_ID =
+      DSL.field(DSL.name("game_authored_help_topic_alias", "help_topic_id"), Long.class);
+  private static final Field<String> ALIAS_KEY =
+      DSL.field(DSL.name("game_authored_help_topic_alias", "alias_key"), String.class);
+
+  private final DSLContext dsl;
+
+  public GameAuthoredHelpTopicRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  public Optional<GameAuthoredHelpTopic> findPublishedByCanonicalKey(
+      String tenantId, long gameTemplateId, String canonicalTopicKey) {
+    return findOne(
+        TOPIC_TABLE,
+        TENANT_ID
+            .eq(tenantId)
+            .and(GAME_TEMPLATE_ID.eq(gameTemplateId))
+            .and(CANONICAL_TOPIC_KEY.eq(canonicalTopicKey))
+            .and(PUBLISHED.isTrue()));
+  }
+
+  public Optional<GameAuthoredHelpTopic> findPublishedByAliasKey(
+      String tenantId, long gameTemplateId, String aliasKey) {
+    return findOne(
+        TOPIC_TABLE.join(ALIAS_TABLE).on(ID.eq(ALIAS_TOPIC_ID)),
+        TENANT_ID
+            .eq(tenantId)
+            .and(GAME_TEMPLATE_ID.eq(gameTemplateId))
+            .and(ALIAS_KEY.eq(aliasKey))
+            .and(PUBLISHED.isTrue()));
+  }
+
+  public Optional<GameAuthoredHelpTopic> findByScopeAndCanonicalKey(
+      String tenantId, long gameTemplateId, String canonicalTopicKey) {
+    return findOne(
+        TOPIC_TABLE,
+        TENANT_ID
+            .eq(tenantId)
+            .and(GAME_TEMPLATE_ID.eq(gameTemplateId))
+            .and(CANONICAL_TOPIC_KEY.eq(canonicalTopicKey)));
+  }
+
+  public Optional<GameAuthoredHelpTopic> findByScopeAndAliasKey(
+      String tenantId, long gameTemplateId, String aliasKey) {
+    return findOne(
+        TOPIC_TABLE.join(ALIAS_TABLE).on(ID.eq(ALIAS_TOPIC_ID)),
+        TENANT_ID
+            .eq(tenantId)
+            .and(GAME_TEMPLATE_ID.eq(gameTemplateId))
+            .and(ALIAS_KEY.eq(aliasKey)));
+  }
+
+  public List<GameAuthoredHelpTopic> findAllByScope(String tenantId, long gameTemplateId) {
+    return dsl.selectFrom(TOPIC_TABLE)
+        .where(TENANT_ID.eq(tenantId).and(GAME_TEMPLATE_ID.eq(gameTemplateId)))
+        .orderBy(CANONICAL_TOPIC_KEY.asc())
+        .fetch(this::toEntity);
+  }
+
+  public GameAuthoredHelpTopic save(GameAuthoredHelpTopic topic) {
+    Instant now = Instant.now();
+    if (topic.getId() == null) {
+      Long id =
+          Objects.requireNonNull(
+              dsl.insertInto(TOPIC_TABLE)
+                  .set(TENANT_ID, topic.getTenantId())
+                  .set(GAME_TEMPLATE_ID, topic.getGameTemplateId())
+                  .set(CANONICAL_TOPIC_KEY, topic.getCanonicalTopicKey())
+                  .set(TITLE, topic.getTitle())
+                  .set(BODY, topic.getBody())
+                  .set(PUBLISHED, topic.isPublished())
+                  .set(CREATED_AT, Timestamp.from(now))
+                  .set(UPDATED_AT, Timestamp.from(now))
+                  .returningResult(ID)
+                  .fetchOne(ID),
+              "Failed to insert game-authored help topic");
+      return findById(id).orElseThrow();
+    }
+
+    dsl.update(TOPIC_TABLE)
+        .set(CANONICAL_TOPIC_KEY, topic.getCanonicalTopicKey())
+        .set(TITLE, topic.getTitle())
+        .set(BODY, topic.getBody())
+        .set(PUBLISHED, topic.isPublished())
+        .set(UPDATED_AT, Timestamp.from(now))
+        .where(ID.eq(topic.getId()))
+        .execute();
+    return findById(topic.getId()).orElseThrow();
+  }
+
+  public void replaceAliases(GameAuthoredHelpTopic topic, List<String> aliases) {
+    dsl.deleteFrom(ALIAS_TABLE).where(ALIAS_TOPIC_ID.eq(topic.getId())).execute();
+    for (String alias : aliases) {
+      dsl.insertInto(ALIAS_TABLE)
+          .set(ALIAS_TOPIC_ID, topic.getId())
+          .set(TENANT_ID, topic.getTenantId())
+          .set(GAME_TEMPLATE_ID, topic.getGameTemplateId())
+          .set(ALIAS_KEY, alias)
+          .execute();
+    }
+  }
+
+  public void delete(GameAuthoredHelpTopic topic) {
+    dsl.deleteFrom(TOPIC_TABLE).where(ID.eq(topic.getId())).execute();
+  }
+
+  private Optional<GameAuthoredHelpTopic> findById(long id) {
+    return findOne(TOPIC_TABLE, ID.eq(id));
+  }
+
+  private Optional<GameAuthoredHelpTopic> findOne(Table<?> table, org.jooq.Condition condition) {
+    return Optional.ofNullable(dsl.selectFrom(table).where(condition).fetchOne(this::toEntity));
+  }
+
+  private GameAuthoredHelpTopic toEntity(Record record) {
+    if (record == null) {
+      return null;
+    }
+    GameAuthoredHelpTopic topic = new GameAuthoredHelpTopic();
+    topic.setId(record.get(ID));
+    topic.setTenantId(record.get(TENANT_ID));
+    topic.setGameTemplateId(record.get(GAME_TEMPLATE_ID));
+    topic.setCanonicalTopicKey(record.get(CANONICAL_TOPIC_KEY));
+    topic.setTitle(record.get(TITLE));
+    topic.setBody(record.get(BODY));
+    topic.setPublished(Boolean.TRUE.equals(record.get(PUBLISHED)));
+    Timestamp createdAt = record.get(CREATED_AT);
+    topic.setCreatedAt(createdAt == null ? null : createdAt.toInstant());
+    Timestamp updatedAt = record.get(UPDATED_AT);
+    topic.setUpdatedAt(updatedAt == null ? null : updatedAt.toInstant());
+    topic.setAliases(
+        dsl.select(ALIAS_KEY)
+            .from(ALIAS_TABLE)
+            .where(ALIAS_TOPIC_ID.eq(topic.getId()))
+            .orderBy(ALIAS_KEY.asc())
+            .fetch(ALIAS_KEY));
+    return topic;
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/GameAuthoredHelpTopicService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/GameAuthoredHelpTopicService.java
@@ -1,0 +1,15 @@
+package net.firedevops.firemud.gamedesign.service;
+
+import java.util.List;
+import java.util.Optional;
+import net.firedevops.firemud.gamedesign.dto.HelpTopicDto;
+
+public interface GameAuthoredHelpTopicService {
+  Optional<HelpTopicDto> resolvePublishedTopic(String tenantId, long gameTemplateId, String topic);
+
+  HelpTopicDto putTopic(String tenantId, long gameTemplateId, HelpTopicDto topic);
+
+  List<HelpTopicDto> listTopics(String tenantId, long gameTemplateId);
+
+  void deleteTopic(String tenantId, long gameTemplateId, String canonicalTopicId);
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImpl.java
@@ -66,7 +66,7 @@ public class GameAuthoredHelpTopicServiceImpl implements GameAuthoredHelpTopicSe
     entity.setBody(requireText(topic.body(), "body"));
     entity.setPublished(topic.published());
     GameAuthoredHelpTopic saved = repository.save(entity);
-    repository.replaceAliases(saved, aliases);
+    repository.replaceLookupKeys(saved, aliases);
     saved.setAliases(aliases);
     return toDto(saved);
   }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImpl.java
@@ -1,0 +1,178 @@
+package net.firedevops.firemud.gamedesign.service.impl;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import net.firedevops.firemud.gamedesign.dto.HelpTopicDto;
+import net.firedevops.firemud.gamedesign.entity.GameAuthoredHelpTopic;
+import net.firedevops.firemud.gamedesign.repository.GameAuthoredHelpTopicRepository;
+import net.firedevops.firemud.gamedesign.repository.GameTemplateRepository;
+import net.firedevops.firemud.gamedesign.service.GameAuthoredHelpTopicService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "Injected repositories are internal Spring collaborators.")
+public class GameAuthoredHelpTopicServiceImpl implements GameAuthoredHelpTopicService {
+  private final GameAuthoredHelpTopicRepository repository;
+  private final GameTemplateRepository gameTemplateRepository;
+
+  public GameAuthoredHelpTopicServiceImpl(
+      GameAuthoredHelpTopicRepository repository, GameTemplateRepository gameTemplateRepository) {
+    this.repository = repository;
+    this.gameTemplateRepository = gameTemplateRepository;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<HelpTopicDto> resolvePublishedTopic(
+      String tenantId, long gameTemplateId, String topic) {
+    Scope scope = requireScope(tenantId, gameTemplateId);
+    String normalizedTopic = normalizeKey(topic, "topic");
+    return repository
+        .findPublishedByCanonicalKey(scope.tenantId(), scope.gameTemplateId(), normalizedTopic)
+        .or(
+            () ->
+                repository.findPublishedByAliasKey(
+                    scope.tenantId(), scope.gameTemplateId(), normalizedTopic))
+        .map(this::toDto);
+  }
+
+  @Override
+  @Transactional
+  public HelpTopicDto putTopic(String tenantId, long gameTemplateId, HelpTopicDto topic) {
+    Scope scope = requireScope(tenantId, gameTemplateId);
+    requireTemplate(scope);
+    if (topic == null) {
+      throw new IllegalArgumentException("helpTopic is required");
+    }
+    String canonicalTopicKey = normalizeKey(topic.canonicalTopicId(), "canonicalTopicId");
+    List<String> aliases = normalizeAliases(topic.aliases(), canonicalTopicKey);
+    GameAuthoredHelpTopic entity =
+        repository
+            .findByScopeAndCanonicalKey(scope.tenantId(), scope.gameTemplateId(), canonicalTopicKey)
+            .orElseGet(GameAuthoredHelpTopic::new);
+    requireUniqueKeys(scope, entity.getId(), canonicalTopicKey, aliases);
+    entity.setTenantId(scope.tenantId());
+    entity.setGameTemplateId(scope.gameTemplateId());
+    entity.setCanonicalTopicKey(canonicalTopicKey);
+    entity.setTitle(requireText(topic.title(), "title"));
+    entity.setBody(requireText(topic.body(), "body"));
+    entity.setPublished(topic.published());
+    GameAuthoredHelpTopic saved = repository.save(entity);
+    repository.replaceAliases(saved, aliases);
+    saved.setAliases(aliases);
+    return toDto(saved);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<HelpTopicDto> listTopics(String tenantId, long gameTemplateId) {
+    Scope scope = requireScope(tenantId, gameTemplateId);
+    requireTemplate(scope);
+    return repository.findAllByScope(scope.tenantId(), scope.gameTemplateId()).stream()
+        .map(this::toDto)
+        .toList();
+  }
+
+  @Override
+  @Transactional
+  public void deleteTopic(String tenantId, long gameTemplateId, String canonicalTopicId) {
+    Scope scope = requireScope(tenantId, gameTemplateId);
+    requireTemplate(scope);
+    String canonicalTopicKey = normalizeKey(canonicalTopicId, "canonicalTopicId");
+    GameAuthoredHelpTopic topic =
+        repository
+            .findByScopeAndCanonicalKey(scope.tenantId(), scope.gameTemplateId(), canonicalTopicKey)
+            .orElseThrow(() -> new IllegalArgumentException("NOT_FOUND: help topic not found"));
+    repository.delete(topic);
+  }
+
+  private Scope requireScope(String tenantId, long gameTemplateId) {
+    String normalizedTenantId = requireText(tenantId, "tenantId");
+    if (gameTemplateId <= 0) {
+      throw new IllegalArgumentException("gameTemplateId must be positive");
+    }
+    return new Scope(normalizedTenantId, gameTemplateId);
+  }
+
+  private void requireTemplate(Scope scope) {
+    if (gameTemplateRepository
+        .findByTenantIdAndId(scope.tenantId(), scope.gameTemplateId())
+        .isEmpty()) {
+      throw new IllegalArgumentException("NOT_FOUND: game template not found");
+    }
+  }
+
+  private List<String> normalizeAliases(List<String> aliases, String canonicalTopicKey) {
+    if (aliases == null || aliases.isEmpty()) {
+      return List.of();
+    }
+    Set<String> normalizedAliases = new LinkedHashSet<>();
+    for (String alias : aliases) {
+      String normalizedAlias = normalizeKey(alias, "alias");
+      if (normalizedAlias.equals(canonicalTopicKey)) {
+        throw new IllegalArgumentException("aliases must not repeat canonicalTopicId");
+      }
+      if (!normalizedAliases.add(normalizedAlias)) {
+        throw new IllegalArgumentException("aliases must be unique after normalization");
+      }
+    }
+    return new ArrayList<>(normalizedAliases);
+  }
+
+  private void requireUniqueKeys(
+      Scope scope, Long topicId, String canonicalTopicKey, List<String> aliases) {
+    requireNotClaimedByAnotherTopic(
+        repository.findByScopeAndAliasKey(
+            scope.tenantId(), scope.gameTemplateId(), canonicalTopicKey),
+        topicId,
+        "canonicalTopicId conflicts with an existing alias");
+    for (String alias : aliases) {
+      requireNotClaimedByAnotherTopic(
+          repository.findByScopeAndCanonicalKey(scope.tenantId(), scope.gameTemplateId(), alias),
+          topicId,
+          "alias conflicts with an existing canonicalTopicId");
+      requireNotClaimedByAnotherTopic(
+          repository.findByScopeAndAliasKey(scope.tenantId(), scope.gameTemplateId(), alias),
+          topicId,
+          "alias conflicts with an existing alias");
+    }
+  }
+
+  private void requireNotClaimedByAnotherTopic(
+      Optional<GameAuthoredHelpTopic> existing, Long topicId, String message) {
+    if (existing.isPresent()
+        && !java.util.Objects.equals(existing.orElseThrow().getId(), topicId)) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  private String normalizeKey(String value, String field) {
+    return requireText(value, field).replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
+  }
+
+  private String requireText(String value, String field) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " must not be blank");
+    }
+    return value.trim();
+  }
+
+  private HelpTopicDto toDto(GameAuthoredHelpTopic topic) {
+    return new HelpTopicDto(
+        topic.getCanonicalTopicKey(),
+        topic.getTitle(),
+        topic.getBody(),
+        List.copyOf(topic.getAliases()),
+        topic.isPublished());
+  }
+
+  private record Scope(String tenantId, long gameTemplateId) {}
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcService.java
@@ -15,12 +15,14 @@ import net.firedevops.firemud.common.security.AdminRoleGuard;
 import net.firedevops.firemud.common.security.SessionContext;
 import net.firedevops.firemud.common.settings.GameDesignSettingsProtoMapper;
 import net.firedevops.firemud.gamedesign.dto.DesignControlPlaneDigestDto;
+import net.firedevops.firemud.gamedesign.dto.HelpTopicDto;
 import net.firedevops.firemud.gamedesign.dto.PublishedPluginVersionDto;
 import net.firedevops.firemud.gamedesign.dto.PublishedReleaseBundleDto;
 import net.firedevops.firemud.gamedesign.dto.RevisionDto;
 import net.firedevops.firemud.gamedesign.dto.TemplateRemapEntryDto;
 import net.firedevops.firemud.gamedesign.dto.TemplateRemapSetDto;
 import net.firedevops.firemud.gamedesign.dto.VersionDto;
+import net.firedevops.firemud.gamedesign.service.GameAuthoredHelpTopicService;
 import net.firedevops.firemud.gamedesign.service.LaunchDescriptorService;
 import net.firedevops.firemud.gamedesign.service.PingService;
 import net.firedevops.firemud.gamedesign.service.PublishGateFailureException;
@@ -41,6 +43,8 @@ import net.firedevops.firemud.gamedesign.v1.CompareAndSetVersionStateRequest;
 import net.firedevops.firemud.gamedesign.v1.CompareAndSetVersionStateResponse;
 import net.firedevops.firemud.gamedesign.v1.CreateTemplateRemapSetRequest;
 import net.firedevops.firemud.gamedesign.v1.CreateTemplateRemapSetResponse;
+import net.firedevops.firemud.gamedesign.v1.DeleteHelpTopicRequest;
+import net.firedevops.firemud.gamedesign.v1.DeleteHelpTopicResponse;
 import net.firedevops.firemud.gamedesign.v1.DeleteSettingsDomainOverrideRequest;
 import net.firedevops.firemud.gamedesign.v1.DeleteSettingsDomainOverrideResponse;
 import net.firedevops.firemud.gamedesign.v1.FinalizePurgeVersionAssetsRequest;
@@ -64,6 +68,9 @@ import net.firedevops.firemud.gamedesign.v1.GetVersionAssetPurgeStatusRequest;
 import net.firedevops.firemud.gamedesign.v1.GetVersionAssetPurgeStatusResponse;
 import net.firedevops.firemud.gamedesign.v1.GetVersionStateRequest;
 import net.firedevops.firemud.gamedesign.v1.GetVersionStateResponse;
+import net.firedevops.firemud.gamedesign.v1.HelpTopic;
+import net.firedevops.firemud.gamedesign.v1.ListHelpTopicsRequest;
+import net.firedevops.firemud.gamedesign.v1.ListHelpTopicsResponse;
 import net.firedevops.firemud.gamedesign.v1.ListPluginVersionStatusEventsRequest;
 import net.firedevops.firemud.gamedesign.v1.ListPluginVersionStatusEventsResponse;
 import net.firedevops.firemud.gamedesign.v1.ListPluginVersionStatusesRequest;
@@ -82,10 +89,14 @@ import net.firedevops.firemud.gamedesign.v1.PublishVersionRequest;
 import net.firedevops.firemud.gamedesign.v1.PublishVersionResponse;
 import net.firedevops.firemud.gamedesign.v1.PublishedPluginVersion;
 import net.firedevops.firemud.gamedesign.v1.PublishedScriptPatchVersion;
+import net.firedevops.firemud.gamedesign.v1.PutHelpTopicRequest;
+import net.firedevops.firemud.gamedesign.v1.PutHelpTopicResponse;
 import net.firedevops.firemud.gamedesign.v1.PutSettingsDomainOverrideRequest;
 import net.firedevops.firemud.gamedesign.v1.PutSettingsDomainOverrideResponse;
 import net.firedevops.firemud.gamedesign.v1.RepairPublishedVersionAssetsRequest;
 import net.firedevops.firemud.gamedesign.v1.RepairPublishedVersionAssetsResponse;
+import net.firedevops.firemud.gamedesign.v1.ResolveHelpTopicRequest;
+import net.firedevops.firemud.gamedesign.v1.ResolveHelpTopicResponse;
 import net.firedevops.firemud.gamedesign.v1.ResolveLaunchDescriptorRequest;
 import net.firedevops.firemud.gamedesign.v1.ResolveLaunchDescriptorResponse;
 import net.firedevops.firemud.gamedesign.v1.RevokePluginVersionRequest;
@@ -117,6 +128,7 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   private final TemplateRemapSetService templateRemapSetService;
   private final VersionAssetArtifactService versionAssetArtifactService;
   private final SettingsAuthorityService settingsAuthorityService;
+  private final GameAuthoredHelpTopicService gameAuthoredHelpTopicService;
   private final TemporalVersionPublishWorkflowMetadataResolver publishWorkflowMetadataResolver;
 
   @SuppressFBWarnings(
@@ -1541,6 +1553,138 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
     responseObserver.onCompleted();
   }
 
+  @Override
+  @Timed(value = "gamedesignGrpc.resolveHelpTopic")
+  public void resolveHelpTopic(
+      ResolveHelpTopicRequest request, StreamObserver<ResolveHelpTopicResponse> responseObserver) {
+    ResolveHelpTopicResponse.Builder builder = ResolveHelpTopicResponse.newBuilder();
+    try {
+      requireHelpTopicReadAccess();
+      gameAuthoredHelpTopicService
+          .resolvePublishedTopic(
+              request.getScope().getTenantId(),
+              request.getScope().getGameTemplateId(),
+              request.getTopic())
+          .ifPresent(topic -> builder.setHelpTopic(toProtoHelpTopic(topic)));
+    } catch (AdminAuthorizationException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "ResolveHelpTopic", "PERMISSION_DENIED", ex.getMessage()));
+    } catch (IllegalArgumentException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "ResolveHelpTopic", helpTopicErrorCode(ex), ex.getMessage()));
+    } catch (Exception ex) {
+      builder.setError(GrpcAppErrors.internal(meterRegistry, logger, "ResolveHelpTopic", ex));
+    }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  @Timed(value = "gamedesignGrpc.putHelpTopic")
+  public void putHelpTopic(
+      PutHelpTopicRequest request, StreamObserver<PutHelpTopicResponse> responseObserver) {
+    PutHelpTopicResponse.Builder builder = PutHelpTopicResponse.newBuilder();
+    try {
+      AdminRoleGuard.requireAdminRole();
+      builder.setHelpTopic(
+          toProtoHelpTopic(
+              gameAuthoredHelpTopicService.putTopic(
+                  request.getScope().getTenantId(),
+                  request.getScope().getGameTemplateId(),
+                  fromProtoHelpTopic(request.getHelpTopic()))));
+    } catch (AdminAuthorizationException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "PutHelpTopic", "PERMISSION_DENIED", ex.getMessage()));
+    } catch (IllegalArgumentException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "PutHelpTopic", helpTopicErrorCode(ex), ex.getMessage()));
+    } catch (Exception ex) {
+      builder.setError(GrpcAppErrors.internal(meterRegistry, logger, "PutHelpTopic", ex));
+    }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  @Timed(value = "gamedesignGrpc.listHelpTopics")
+  public void listHelpTopics(
+      ListHelpTopicsRequest request, StreamObserver<ListHelpTopicsResponse> responseObserver) {
+    ListHelpTopicsResponse.Builder builder = ListHelpTopicsResponse.newBuilder();
+    try {
+      AdminRoleGuard.requireAdminRole();
+      gameAuthoredHelpTopicService
+          .listTopics(request.getScope().getTenantId(), request.getScope().getGameTemplateId())
+          .forEach(topic -> builder.addHelpTopics(toProtoHelpTopic(topic)));
+    } catch (AdminAuthorizationException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "ListHelpTopics", "PERMISSION_DENIED", ex.getMessage()));
+    } catch (IllegalArgumentException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "ListHelpTopics", helpTopicErrorCode(ex), ex.getMessage()));
+    } catch (Exception ex) {
+      builder.setError(GrpcAppErrors.internal(meterRegistry, logger, "ListHelpTopics", ex));
+    }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  @Timed(value = "gamedesignGrpc.deleteHelpTopic")
+  public void deleteHelpTopic(
+      DeleteHelpTopicRequest request, StreamObserver<DeleteHelpTopicResponse> responseObserver) {
+    DeleteHelpTopicResponse.Builder builder = DeleteHelpTopicResponse.newBuilder();
+    try {
+      AdminRoleGuard.requireAdminRole();
+      gameAuthoredHelpTopicService.deleteTopic(
+          request.getScope().getTenantId(),
+          request.getScope().getGameTemplateId(),
+          request.getCanonicalTopicId());
+    } catch (AdminAuthorizationException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "DeleteHelpTopic", "PERMISSION_DENIED", ex.getMessage()));
+    } catch (IllegalArgumentException ex) {
+      builder.setError(
+          GrpcAppErrors.error(
+              meterRegistry, logger, "DeleteHelpTopic", helpTopicErrorCode(ex), ex.getMessage()));
+    } catch (Exception ex) {
+      builder.setError(GrpcAppErrors.internal(meterRegistry, logger, "DeleteHelpTopic", ex));
+    }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  private HelpTopic toProtoHelpTopic(HelpTopicDto topic) {
+    return HelpTopic.newBuilder()
+        .setCanonicalTopicId(topic.canonicalTopicId())
+        .setTitle(topic.title())
+        .setBody(topic.body())
+        .addAllAliases(topic.aliases())
+        .setPublished(topic.published())
+        .build();
+  }
+
+  private HelpTopicDto fromProtoHelpTopic(HelpTopic topic) {
+    return new HelpTopicDto(
+        topic.getCanonicalTopicId(),
+        topic.getTitle(),
+        topic.getBody(),
+        topic.getAliasesList(),
+        topic.getPublished());
+  }
+
+  private String helpTopicErrorCode(IllegalArgumentException ex) {
+    return ex.getMessage() != null && ex.getMessage().startsWith("NOT_FOUND:")
+        ? "NOT_FOUND"
+        : "INVALID_ARGUMENT";
+  }
+
   private net.firedevops.firemud.gamedesign.v1.VersionAssetArtifactState toProto(
       net.firedevops.firemud.gamedesign.dto.VersionAssetArtifactStateDto state) {
     return net.firedevops.firemud.gamedesign.v1.VersionAssetArtifactState.newBuilder()
@@ -1824,6 +1968,13 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
   }
 
   private void requireSettingsAuthorityReadAccess() {
+    if (SessionContext.isInternalService()) {
+      return;
+    }
+    AdminRoleGuard.requireAdminRole();
+  }
+
+  private void requireHelpTopicReadAccess() {
     if (SessionContext.isInternalService()) {
       return;
     }

--- a/services/game-design-service/src/main/resources/db/migration/V22__game_authored_help_topics.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V22__game_authored_help_topics.sql
@@ -1,0 +1,30 @@
+CREATE TABLE game_authored_help_topic (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id VARCHAR(36) NOT NULL,
+    game_template_id BIGINT NOT NULL REFERENCES game_templates(id) ON DELETE CASCADE,
+    canonical_topic_key VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    body TEXT NOT NULL,
+    published BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_game_authored_help_topic_scope_key
+        UNIQUE (tenant_id, game_template_id, canonical_topic_key)
+);
+
+CREATE INDEX idx_game_authored_help_topic_resolve
+    ON game_authored_help_topic (tenant_id, game_template_id, canonical_topic_key)
+    WHERE published;
+
+CREATE TABLE game_authored_help_topic_alias (
+    help_topic_id BIGINT NOT NULL REFERENCES game_authored_help_topic(id) ON DELETE CASCADE,
+    tenant_id VARCHAR(36) NOT NULL,
+    game_template_id BIGINT NOT NULL,
+    alias_key VARCHAR(255) NOT NULL,
+    PRIMARY KEY (help_topic_id, alias_key),
+    CONSTRAINT uq_game_authored_help_topic_alias_scope_key
+        UNIQUE (tenant_id, game_template_id, alias_key)
+);
+
+CREATE INDEX idx_game_authored_help_topic_alias_resolve
+    ON game_authored_help_topic_alias (tenant_id, game_template_id, alias_key);

--- a/services/game-design-service/src/main/resources/db/migration/V22__game_authored_help_topics.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V22__game_authored_help_topics.sql
@@ -1,7 +1,10 @@
+ALTER TABLE game_templates
+    ADD CONSTRAINT uq_game_templates_tenant_id UNIQUE (tenant_id, id);
+
 CREATE TABLE game_authored_help_topic (
     id BIGSERIAL PRIMARY KEY,
     tenant_id VARCHAR(36) NOT NULL,
-    game_template_id BIGINT NOT NULL REFERENCES game_templates(id) ON DELETE CASCADE,
+    game_template_id BIGINT NOT NULL,
     canonical_topic_key VARCHAR(255) NOT NULL,
     title VARCHAR(255) NOT NULL,
     body TEXT NOT NULL,
@@ -9,22 +12,30 @@ CREATE TABLE game_authored_help_topic (
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT uq_game_authored_help_topic_scope_key
-        UNIQUE (tenant_id, game_template_id, canonical_topic_key)
+        UNIQUE (tenant_id, game_template_id, canonical_topic_key),
+    CONSTRAINT uq_game_authored_help_topic_id_scope
+        UNIQUE (id, tenant_id, game_template_id),
+    CONSTRAINT fk_game_authored_help_topic_template_scope
+        FOREIGN KEY (tenant_id, game_template_id)
+        REFERENCES game_templates (tenant_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_game_authored_help_topic_resolve
     ON game_authored_help_topic (tenant_id, game_template_id, canonical_topic_key)
     WHERE published;
 
-CREATE TABLE game_authored_help_topic_alias (
+CREATE TABLE game_authored_help_topic_key (
     help_topic_id BIGINT NOT NULL REFERENCES game_authored_help_topic(id) ON DELETE CASCADE,
     tenant_id VARCHAR(36) NOT NULL,
     game_template_id BIGINT NOT NULL,
-    alias_key VARCHAR(255) NOT NULL,
-    PRIMARY KEY (help_topic_id, alias_key),
-    CONSTRAINT uq_game_authored_help_topic_alias_scope_key
-        UNIQUE (tenant_id, game_template_id, alias_key)
+    lookup_key VARCHAR(255) NOT NULL,
+    PRIMARY KEY (help_topic_id, lookup_key),
+    CONSTRAINT uq_game_authored_help_topic_key_scope
+        UNIQUE (tenant_id, game_template_id, lookup_key),
+    CONSTRAINT fk_game_authored_help_topic_key_scope
+        FOREIGN KEY (help_topic_id, tenant_id, game_template_id)
+        REFERENCES game_authored_help_topic (id, tenant_id, game_template_id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_game_authored_help_topic_alias_resolve
-    ON game_authored_help_topic_alias (tenant_id, game_template_id, alias_key);
+CREATE INDEX idx_game_authored_help_topic_key_resolve
+    ON game_authored_help_topic_key (tenant_id, game_template_id, lookup_key);

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImplTest.java
@@ -80,7 +80,7 @@ class GameAuthoredHelpTopicServiceImplTest {
     ArgumentCaptor<GameAuthoredHelpTopic> savedCaptor =
         ArgumentCaptor.forClass(GameAuthoredHelpTopic.class);
     verify(repository).save(savedCaptor.capture());
-    verify(repository).replaceAliases(saved, List.of("walk"));
+    verify(repository).replaceLookupKeys(saved, List.of("walk"));
     assertThat(savedCaptor.getValue().getCanonicalTopicKey()).isEqualTo("movement");
     assertThat(result.canonicalTopicId()).isEqualTo("movement");
     assertThatIllegalArgumentException()

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameAuthoredHelpTopicServiceImplTest.java
@@ -1,0 +1,125 @@
+package net.firedevops.firemud.gamedesign.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import net.firedevops.firemud.gamedesign.dto.HelpTopicDto;
+import net.firedevops.firemud.gamedesign.entity.GameAuthoredHelpTopic;
+import net.firedevops.firemud.gamedesign.repository.GameAuthoredHelpTopicRepository;
+import net.firedevops.firemud.gamedesign.repository.GameTemplateRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class GameAuthoredHelpTopicServiceImplTest {
+  private final GameAuthoredHelpTopicRepository repository =
+      Mockito.mock(GameAuthoredHelpTopicRepository.class);
+  private final GameTemplateRepository gameTemplateRepository =
+      Mockito.mock(GameTemplateRepository.class);
+  private final GameAuthoredHelpTopicServiceImpl service =
+      new GameAuthoredHelpTopicServiceImpl(repository, gameTemplateRepository);
+
+  @Test
+  void resolvesPublishedCanonicalBeforeAlias() {
+    GameAuthoredHelpTopic canonical =
+        topic("movement", "Canonical movement", List.of("walk"), true);
+    when(repository.findPublishedByCanonicalKey("42", 7L, "movement"))
+        .thenReturn(Optional.of(canonical));
+
+    Optional<HelpTopicDto> resolved = service.resolvePublishedTopic("42", 7L, " MOVEMENT ");
+
+    assertThat(resolved)
+        .hasValueSatisfying(topic -> assertThat(topic.title()).isEqualTo("Canonical movement"));
+    verify(repository, never()).findPublishedByAliasKey("42", 7L, "movement");
+  }
+
+  @Test
+  void resolvesPublishedAliasWithinExactTenantAndTemplateScope() {
+    GameAuthoredHelpTopic alias = topic("travel", "Travel", List.of("move"), true);
+    when(repository.findPublishedByCanonicalKey("42", 7L, "move")).thenReturn(Optional.empty());
+    when(repository.findPublishedByAliasKey("42", 7L, "move")).thenReturn(Optional.of(alias));
+
+    Optional<HelpTopicDto> resolved = service.resolvePublishedTopic("42", 7L, "Move");
+
+    assertThat(resolved)
+        .hasValueSatisfying(topic -> assertThat(topic.canonicalTopicId()).isEqualTo("travel"));
+    verify(repository).findPublishedByCanonicalKey("42", 7L, "move");
+    verify(repository).findPublishedByAliasKey("42", 7L, "move");
+  }
+
+  @Test
+  void rejectsInvalidScopeBeforeReadingAnyTopic() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> service.resolvePublishedTopic("42", 0L, "movement"))
+        .withMessage("gameTemplateId must be positive");
+
+    verify(repository, never())
+        .findPublishedByCanonicalKey(Mockito.anyString(), Mockito.anyLong(), Mockito.anyString());
+  }
+
+  @Test
+  void normalizesPersistedTopicAndRejectsDuplicateAliases() {
+    when(gameTemplateRepository.findByTenantIdAndId("42", 7L))
+        .thenReturn(Optional.of(Mockito.mock()));
+    GameAuthoredHelpTopic saved = topic("movement", "Movement", List.of(), true);
+    saved.setId(11L);
+    when(repository.findByScopeAndCanonicalKey("42", 7L, "movement")).thenReturn(Optional.empty());
+    when(repository.save(Mockito.any())).thenReturn(saved);
+
+    HelpTopicDto result =
+        service.putTopic(
+            "42",
+            7L,
+            new HelpTopicDto(" Movement ", "Movement", "Walk north.", List.of("walk"), true));
+
+    ArgumentCaptor<GameAuthoredHelpTopic> savedCaptor =
+        ArgumentCaptor.forClass(GameAuthoredHelpTopic.class);
+    verify(repository).save(savedCaptor.capture());
+    verify(repository).replaceAliases(saved, List.of("walk"));
+    assertThat(savedCaptor.getValue().getCanonicalTopicKey()).isEqualTo("movement");
+    assertThat(result.canonicalTopicId()).isEqualTo("movement");
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                service.putTopic(
+                    "42",
+                    7L,
+                    new HelpTopicDto("look", "Look", "Inspect.", List.of("SEE", "see"), false)))
+        .withMessage("aliases must be unique after normalization");
+  }
+
+  @Test
+  void rejectsAliasThatConflictsWithAnotherCanonicalTopic() {
+    when(gameTemplateRepository.findByTenantIdAndId("42", 7L))
+        .thenReturn(Optional.of(Mockito.mock()));
+    GameAuthoredHelpTopic existing = topic("movement", "Movement", List.of(), true);
+    existing.setId(8L);
+    when(repository.findByScopeAndCanonicalKey("42", 7L, "travel")).thenReturn(Optional.empty());
+    when(repository.findByScopeAndCanonicalKey("42", 7L, "move")).thenReturn(Optional.of(existing));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                service.putTopic(
+                    "42",
+                    7L,
+                    new HelpTopicDto("travel", "Travel", "Walk onward.", List.of("move"), true)))
+        .withMessage("alias conflicts with an existing canonicalTopicId");
+  }
+
+  private static GameAuthoredHelpTopic topic(
+      String canonicalTopicKey, String title, List<String> aliases, boolean published) {
+    GameAuthoredHelpTopic topic = new GameAuthoredHelpTopic();
+    topic.setCanonicalTopicKey(canonicalTopicKey);
+    topic.setTitle(title);
+    topic.setBody(title + " body");
+    topic.setAliases(aliases);
+    topic.setPublished(published);
+    return topic;
+  }
+}

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceAuthTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceAuthTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import net.firedevops.firemud.common.security.SessionContext;
 import net.firedevops.firemud.gamedesign.dto.PublishedReleaseBundleDto;
 import net.firedevops.firemud.gamedesign.dto.ResolvedLaunchDescriptorDto;
+import net.firedevops.firemud.gamedesign.service.GameAuthoredHelpTopicService;
 import net.firedevops.firemud.gamedesign.service.LaunchDescriptorService;
 import net.firedevops.firemud.gamedesign.service.PingService;
 import net.firedevops.firemud.gamedesign.service.RevisionService;
@@ -47,6 +48,7 @@ class GameDesignGrpcServiceAuthTest {
             Mockito.mock(TemplateRemapSetService.class),
             Mockito.mock(VersionAssetArtifactService.class),
             Mockito.mock(SettingsAuthorityService.class),
+            Mockito.mock(GameAuthoredHelpTopicService.class),
             new TemporalVersionPublishWorkflowMetadataResolver(Optional.empty(), Optional.empty()),
             new SimpleMeterRegistry());
 
@@ -107,6 +109,7 @@ class GameDesignGrpcServiceAuthTest {
             Mockito.mock(TemplateRemapSetService.class),
             Mockito.mock(VersionAssetArtifactService.class),
             Mockito.mock(SettingsAuthorityService.class),
+            Mockito.mock(GameAuthoredHelpTopicService.class),
             new TemporalVersionPublishWorkflowMetadataResolver(Optional.empty(), Optional.empty()),
             new SimpleMeterRegistry());
 

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceHelpTopicTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceHelpTopicTest.java
@@ -1,0 +1,110 @@
+package net.firedevops.firemud.gamedesign.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.grpc.stub.StreamObserver;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import net.firedevops.firemud.common.security.SessionContext;
+import net.firedevops.firemud.gamedesign.dto.HelpTopicDto;
+import net.firedevops.firemud.gamedesign.service.GameAuthoredHelpTopicService;
+import net.firedevops.firemud.gamedesign.service.LaunchDescriptorService;
+import net.firedevops.firemud.gamedesign.service.PingService;
+import net.firedevops.firemud.gamedesign.service.RevisionService;
+import net.firedevops.firemud.gamedesign.service.SettingsAuthorityService;
+import net.firedevops.firemud.gamedesign.service.TemplateRemapSetService;
+import net.firedevops.firemud.gamedesign.service.VersionAssetArtifactService;
+import net.firedevops.firemud.gamedesign.service.VersionService;
+import net.firedevops.firemud.gamedesign.v1.HelpTopic;
+import net.firedevops.firemud.gamedesign.v1.HelpTopicScope;
+import net.firedevops.firemud.gamedesign.v1.PutHelpTopicRequest;
+import net.firedevops.firemud.gamedesign.v1.PutHelpTopicResponse;
+import net.firedevops.firemud.gamedesign.v1.ResolveHelpTopicRequest;
+import net.firedevops.firemud.gamedesign.v1.ResolveHelpTopicResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class GameDesignGrpcServiceHelpTopicTest {
+  private final GameAuthoredHelpTopicService helpTopicService =
+      Mockito.mock(GameAuthoredHelpTopicService.class);
+  private final GameDesignGrpcService grpcService =
+      new GameDesignGrpcService(
+          Mockito.mock(PingService.class),
+          Mockito.mock(RevisionService.class),
+          Mockito.mock(VersionService.class),
+          Mockito.mock(LaunchDescriptorService.class),
+          Mockito.mock(TemplateRemapSetService.class),
+          Mockito.mock(VersionAssetArtifactService.class),
+          Mockito.mock(SettingsAuthorityService.class),
+          helpTopicService,
+          new TemporalVersionPublishWorkflowMetadataResolver(Optional.empty(), Optional.empty()),
+          new SimpleMeterRegistry());
+
+  @AfterEach
+  void tearDown() {
+    SessionContext.clear();
+  }
+
+  @Test
+  void resolveAllowsInternalServiceAndReturnsPublishedTopic() {
+    SessionContext.setContext(null, List.of(), Map.of(), true, "game-session-service", "gs-1");
+    when(helpTopicService.resolvePublishedTopic("42", 7L, "move"))
+        .thenReturn(
+            Optional.of(
+                new HelpTopicDto("movement", "Movement", "Walk north.", List.of("move"), true)));
+    CapturingObserver<ResolveHelpTopicResponse> observer = new CapturingObserver<>();
+
+    grpcService.resolveHelpTopic(
+        ResolveHelpTopicRequest.newBuilder()
+            .setScope(HelpTopicScope.newBuilder().setTenantId("42").setGameTemplateId(7L))
+            .setTopic("move")
+            .build(),
+        observer);
+
+    assertThat(observer.value.hasError()).isFalse();
+    assertThat(observer.value.getHelpTopic().getCanonicalTopicId()).isEqualTo("movement");
+    verify(helpTopicService).resolvePublishedTopic("42", 7L, "move");
+  }
+
+  @Test
+  void putRequiresAdminAuthority() {
+    SessionContext.setContext("1", List.of("player"), Map.of());
+    CapturingObserver<PutHelpTopicResponse> observer = new CapturingObserver<>();
+
+    grpcService.putHelpTopic(
+        PutHelpTopicRequest.newBuilder()
+            .setScope(HelpTopicScope.newBuilder().setTenantId("42").setGameTemplateId(7L))
+            .setHelpTopic(
+                HelpTopic.newBuilder()
+                    .setCanonicalTopicId("movement")
+                    .setTitle("Movement")
+                    .setBody("Walk north.")
+                    .build())
+            .build(),
+        observer);
+
+    assertThat(observer.value.getError().getCode()).isEqualTo("PERMISSION_DENIED");
+  }
+
+  private static final class CapturingObserver<T> implements StreamObserver<T> {
+    private T value;
+
+    @Override
+    public void onNext(T value) {
+      this.value = value;
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      throw new AssertionError("Unexpected gRPC error", throwable);
+    }
+
+    @Override
+    public void onCompleted() {}
+  }
+}

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceSettingsAuthorityTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceSettingsAuthorityTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import net.firedevops.firemud.common.security.SessionContext;
 import net.firedevops.firemud.common.settings.ScopedSettingsOverrides;
 import net.firedevops.firemud.common.settings.ScopedSettingsSnapshot;
+import net.firedevops.firemud.gamedesign.service.GameAuthoredHelpTopicService;
 import net.firedevops.firemud.gamedesign.service.LaunchDescriptorService;
 import net.firedevops.firemud.gamedesign.service.PingService;
 import net.firedevops.firemud.gamedesign.service.RevisionService;
@@ -44,6 +45,8 @@ class GameDesignGrpcServiceSettingsAuthorityTest {
       Mockito.mock(VersionAssetArtifactService.class);
   private final SettingsAuthorityService settingsAuthorityService =
       Mockito.mock(SettingsAuthorityService.class);
+  private final GameAuthoredHelpTopicService gameAuthoredHelpTopicService =
+      Mockito.mock(GameAuthoredHelpTopicService.class);
 
   private GameDesignGrpcService grpcService;
 
@@ -59,6 +62,7 @@ class GameDesignGrpcServiceSettingsAuthorityTest {
             templateRemapSetService,
             versionAssetArtifactService,
             settingsAuthorityService,
+            gameAuthoredHelpTopicService,
             new TemporalVersionPublishWorkflowMetadataResolver(Optional.empty(), Optional.empty()),
             new SimpleMeterRegistry());
   }

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceTest.java
@@ -23,6 +23,7 @@ import net.firedevops.firemud.gamedesign.dto.VersionDto;
 import net.firedevops.firemud.gamedesign.dto.VersionStateDto;
 import net.firedevops.firemud.gamedesign.model.TemplateRemapSetStatus;
 import net.firedevops.firemud.gamedesign.model.VersionLifecycleState;
+import net.firedevops.firemud.gamedesign.service.GameAuthoredHelpTopicService;
 import net.firedevops.firemud.gamedesign.service.LaunchDescriptorService;
 import net.firedevops.firemud.gamedesign.service.PingService;
 import net.firedevops.firemud.gamedesign.service.RevisionService;
@@ -88,6 +89,8 @@ class GameDesignGrpcServiceTest {
       Mockito.mock(VersionAssetArtifactService.class);
   private final SettingsAuthorityService settingsAuthorityService =
       Mockito.mock(SettingsAuthorityService.class);
+  private final GameAuthoredHelpTopicService gameAuthoredHelpTopicService =
+      Mockito.mock(GameAuthoredHelpTopicService.class);
   private final TemporalVersionPublishWorkflowMetadataResolver publishWorkflowMetadataResolver =
       new TemporalVersionPublishWorkflowMetadataResolver(Optional.empty(), Optional.empty());
   private final GameDesignGrpcService service =
@@ -99,6 +102,7 @@ class GameDesignGrpcServiceTest {
           templateRemapSetService,
           versionAssetArtifactService,
           settingsAuthorityService,
+          gameAuthoredHelpTopicService,
           publishWorkflowMetadataResolver,
           new SimpleMeterRegistry());
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/client/GameDesignClient.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/client/GameDesignClient.java
@@ -18,8 +18,12 @@ import net.firedevops.firemud.gamedesign.v1.GetVersionAssetArtifactStateRequest;
 import net.firedevops.firemud.gamedesign.v1.GetVersionAssetArtifactStateResponse;
 import net.firedevops.firemud.gamedesign.v1.GetVersionStateRequest;
 import net.firedevops.firemud.gamedesign.v1.GetVersionStateResponse;
+import net.firedevops.firemud.gamedesign.v1.HelpTopicScope;
+import net.firedevops.firemud.gamedesign.v1.ResolveHelpTopicRequest;
+import net.firedevops.firemud.gamedesign.v1.ResolveHelpTopicResponse;
 import net.firedevops.firemud.gamedesign.v1.ResolveLaunchDescriptorRequest;
 import net.firedevops.firemud.gamedesign.v1.ResolveLaunchDescriptorResponse;
+import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
 import net.firedevops.firemud.shared.v1.ErrorDetail;
 import org.springframework.stereotype.Component;
 
@@ -145,6 +149,33 @@ public final class GameDesignClient
                 .setTenantId(Long.toString(tenantId))
                 .setVersionId(versionId)
                 .build());
+  }
+
+  public java.util.Optional<GameAuthoredHelpReader.ResolvedTopic> resolveAuthoredHelpTopic(
+      long tenantId, long gameTemplateId, String topic) {
+    if (stub() == null) {
+      return java.util.Optional.empty();
+    }
+    try {
+      ResolveHelpTopicResponse response =
+          callStub()
+              .resolveHelpTopic(
+                  ResolveHelpTopicRequest.newBuilder()
+                      .setScope(
+                          HelpTopicScope.newBuilder()
+                              .setTenantId(Long.toString(tenantId))
+                              .setGameTemplateId(gameTemplateId))
+                      .setTopic(topic)
+                      .build());
+      if (response.hasError() || !response.hasHelpTopic()) {
+        return java.util.Optional.empty();
+      }
+      return java.util.Optional.of(
+          new GameAuthoredHelpReader.ResolvedTopic(
+              response.getHelpTopic().getTitle(), response.getHelpTopic().getBody()));
+    } catch (RuntimeException ex) {
+      return java.util.Optional.empty();
+    }
   }
 
   private GameDesignServiceGrpc.GameDesignServiceBlockingStub callStub() {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
+import net.firedevops.firemud.gamesession.service.SessionContext;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -17,10 +20,19 @@ import org.springframework.util.StringUtils;
 @Component
 public class HelpCommandHandler {
   private final ConfiguredAuthoredActionCatalog authoredActionCatalog;
+  private final GameAuthoredHelpReader authoredHelpReader;
 
-  HelpCommandHandler(ConfiguredAuthoredActionCatalog authoredActionCatalog) {
+  HelpCommandHandler(
+      ConfiguredAuthoredActionCatalog authoredActionCatalog,
+      GameAuthoredHelpReader authoredHelpReader) {
     this.authoredActionCatalog =
         Objects.requireNonNull(authoredActionCatalog, "authoredActionCatalog must not be null");
+    this.authoredHelpReader =
+        Objects.requireNonNull(authoredHelpReader, "authoredHelpReader must not be null");
+  }
+
+  HelpCommandHandler(ConfiguredAuthoredActionCatalog authoredActionCatalog) {
+    this(authoredActionCatalog, (context, topic) -> Optional.empty());
   }
 
   HelpCommandHandler() {
@@ -31,6 +43,11 @@ public class HelpCommandHandler {
 
   @Timed(value = "gamesession.command.help")
   public TextCommandInterpretationResult handle(TextCommand command) {
+    return handle(command, Optional.empty());
+  }
+
+  public TextCommandInterpretationResult handle(
+      TextCommand command, Optional<SessionContext> maybeContext) {
     if (command == null) {
       throw new IllegalArgumentException("command must not be null");
     }
@@ -41,6 +58,12 @@ public class HelpCommandHandler {
     }
     if (args.size() > 1) {
       return unknownTopic(args.get(0));
+    }
+
+    Optional<GameAuthoredHelpReader.ResolvedTopic> authoredTopic =
+        maybeContext.flatMap(context -> authoredHelpReader.resolve(context, args.get(0)));
+    if (authoredTopic.isPresent()) {
+      return success(authoredTopic.orElseThrow());
     }
 
     String resolvedTopic = canonicalTopic(args.get(0));
@@ -267,6 +290,10 @@ public class HelpCommandHandler {
             + (StringUtils.hasText(action.helpDetails()) ? "\n" + action.helpDetails().trim() : "")
             + authoredAliasSuffix(action);
     return success(body);
+  }
+
+  private TextCommandInterpretationResult success(GameAuthoredHelpReader.ResolvedTopic topic) {
+    return success(topic.title().trim() + "\n" + topic.body().trim());
   }
 
   private String firstNonBlank(String first, String fallback) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
 import net.firedevops.firemud.gamesession.service.SessionContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -22,6 +23,7 @@ public class HelpCommandHandler {
   private final ConfiguredAuthoredActionCatalog authoredActionCatalog;
   private final GameAuthoredHelpReader authoredHelpReader;
 
+  @Autowired
   HelpCommandHandler(
       ConfiguredAuthoredActionCatalog authoredActionCatalog,
       GameAuthoredHelpReader authoredHelpReader) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpTextCommandDispatchHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpTextCommandDispatchHandler.java
@@ -27,7 +27,8 @@ final class HelpTextCommandDispatchHandler implements TextCommandDispatchHandler
 
   @Override
   public TextCommandInterpretationResult handle(TextCommandDispatchRequest request) {
-    TextCommandInterpretationResult result = helpHandler.handle(request.command());
+    TextCommandInterpretationResult result =
+        helpHandler.handle(request.command(), request.sessionContext());
     if (result.commandResult().accepted()) {
       request
           .sessionContext()

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/GameAuthoredHelpReader.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/GameAuthoredHelpReader.java
@@ -1,0 +1,10 @@
+package net.firedevops.firemud.gamesession.service;
+
+import java.util.Optional;
+
+/** Resolves published authored help for the template backing an admitted gameplay session. */
+public interface GameAuthoredHelpReader {
+  Optional<ResolvedTopic> resolve(SessionContext context, String topic);
+
+  record ResolvedTopic(String title, String body) {}
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/GameAuthoredHelpReaderImpl.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/GameAuthoredHelpReaderImpl.java
@@ -1,0 +1,43 @@
+package net.firedevops.firemud.gamesession.service.impl;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import net.firedevops.firemud.gamesession.client.GameDesignClient;
+import net.firedevops.firemud.gamesession.entity.GameInstance;
+import net.firedevops.firemud.gamesession.repository.GameInstanceRepository;
+import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
+import net.firedevops.firemud.gamesession.service.SessionContext;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/** Bridges an admitted runtime instance to its template-scoped authored help corpus. */
+@Service
+@RequiredArgsConstructor
+public class GameAuthoredHelpReaderImpl implements GameAuthoredHelpReader {
+  private final GameInstanceRepository gameInstanceRepository;
+  private final GameDesignClient gameDesignClient;
+
+  @Override
+  public Optional<ResolvedTopic> resolve(SessionContext context, String topic) {
+    if (context == null
+        || !context.hasGameplayRegionBinding()
+        || !StringUtils.hasText(topic)
+        || context.tenantId() <= 0L
+        || context.gameInstanceId() <= 0L) {
+      return Optional.empty();
+    }
+
+    return gameInstanceRepository
+        .findById(context.gameInstanceId())
+        .filter(instance -> matchesAdmittedRuntime(context, instance))
+        .map(GameInstance::getGameTemplateId)
+        .filter(templateId -> templateId != null && templateId > 0L)
+        .flatMap(
+            templateId ->
+                gameDesignClient.resolveAuthoredHelpTopic(context.tenantId(), templateId, topic));
+  }
+
+  private boolean matchesAdmittedRuntime(SessionContext context, GameInstance instance) {
+    return instance.getTenantId() != null && instance.getTenantId() == context.tenantId();
+  }
+}

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/HelpCommandHandlerTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/HelpCommandHandlerTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Optional;
+import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
+import net.firedevops.firemud.gamesession.service.SessionContext;
 import org.junit.jupiter.api.Test;
 
 class HelpCommandHandlerTest {
@@ -238,6 +241,31 @@ class HelpCommandHandlerTest {
     assertTrue(
         result.outputs().get(0).text().contains("Use this to greet nearby nobles or officers."));
     assertTrue(result.outputs().get(0).text().contains("Aliases: HAIL"));
+  }
+
+  @Test
+  void publishedGameAuthoredTopicOverridesPlatformTopicForAdmittedSession() {
+    GameAuthoredHelpReader reader =
+        (context, topic) ->
+            "look".equals(topic)
+                ? Optional.of(
+                    new GameAuthoredHelpReader.ResolvedTopic(
+                        "Temple Etiquette", "Bow before entering the moonlit sanctuary."))
+                : Optional.empty();
+    HelpCommandHandler authoredHelpHandler = new HelpCommandHandler(authoredCatalog(), reader);
+    SessionContext context =
+        new SessionContext(
+            41L, 22L, 123L, "demo@example.com", 7001L, "Emberline", 7L, "R-1", "jwt");
+
+    TextCommandInterpretationResult result =
+        authoredHelpHandler.handle(
+            new TextCommand(TextCommandType.HELP, List.of("look"), "HELP look"),
+            Optional.of(context));
+
+    assertTrue(result.commandResult().accepted());
+    assertEquals(
+        "Temple Etiquette\nBow before entering the moonlit sanctuary.",
+        result.outputs().get(0).text());
   }
 
   private ConfiguredAuthoredActionCatalog authoredCatalog() {

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/service/impl/GameAuthoredHelpReaderImplTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/service/impl/GameAuthoredHelpReaderImplTest.java
@@ -1,0 +1,61 @@
+package net.firedevops.firemud.gamesession.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import net.firedevops.firemud.gamesession.client.GameDesignClient;
+import net.firedevops.firemud.gamesession.entity.GameInstance;
+import net.firedevops.firemud.gamesession.repository.GameInstanceRepository;
+import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
+import net.firedevops.firemud.gamesession.service.SessionContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class GameAuthoredHelpReaderImplTest {
+  private final GameInstanceRepository gameInstanceRepository =
+      Mockito.mock(GameInstanceRepository.class);
+  private final GameDesignClient gameDesignClient = Mockito.mock(GameDesignClient.class);
+  private final GameAuthoredHelpReaderImpl reader =
+      new GameAuthoredHelpReaderImpl(gameInstanceRepository, gameDesignClient);
+
+  @Test
+  void resolvesPublishedHelpUsingTheAdmittedInstancesTemplate() {
+    GameInstance instance = new GameInstance();
+    instance.setTenantId(22L);
+    instance.setGameTemplateId(71L);
+    SessionContext context = gameplayContext();
+    whenInstance(7L, instance);
+    Mockito.when(gameDesignClient.resolveAuthoredHelpTopic(22L, 71L, "moon"))
+        .thenReturn(
+            Optional.of(
+                new GameAuthoredHelpReader.ResolvedTopic(
+                    "Moon Shrine", "Follow the silver path.")));
+
+    Optional<GameAuthoredHelpReader.ResolvedTopic> resolved = reader.resolve(context, "moon");
+
+    assertThat(resolved)
+        .contains(
+            new GameAuthoredHelpReader.ResolvedTopic("Moon Shrine", "Follow the silver path."));
+  }
+
+  @Test
+  void doesNotReadAuthoredHelpWhenTheRuntimeInstanceBelongsToAnotherTenant() {
+    GameInstance instance = new GameInstance();
+    instance.setTenantId(99L);
+    instance.setGameTemplateId(71L);
+    whenInstance(7L, instance);
+
+    assertThat(reader.resolve(gameplayContext(), "moon")).isEmpty();
+
+    Mockito.verifyNoInteractions(gameDesignClient);
+  }
+
+  private void whenInstance(long gameInstanceId, GameInstance instance) {
+    Mockito.when(gameInstanceRepository.findById(gameInstanceId)).thenReturn(Optional.of(instance));
+  }
+
+  private SessionContext gameplayContext() {
+    return new SessionContext(
+        41L, 22L, 123L, "demo@example.com", 7001L, "Emberline", 7L, "R-1", "jwt");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds template-scoped, published authored Help topics in Game Design.
- Adds admin-gated gRPC resolve, put, list, and delete operations plus persistent canonical/alias storage.
- Resolves authored topics in Game Session through the admitted instance template before falling back to platform help.

## Validation
- `bash dev-tools/validation/run-locked-gradle.sh :game-design-service:check :game-session-service:check -PfullCheck`
- `./gradlew linkCheck lintMarkdown`

Docker-backed integration and cross-service tests were skipped locally because Docker is unavailable.
