### PR TITLE
Keep auto-AFK tied to gameplay activity

### DIFF
--- a/design/project-management/vertical-slices/02.13.7-task-list-action-classification-and-activity-semantics-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.7-task-list-action-classification-and-activity-semantics-vertical-slice.md
@@ -119,5 +119,6 @@ Tags should answer questions like:
 - [x] Hook the activity/presence engine to action classification.
 - [x] Define which built-in commands count as meaningful gameplay actions in the first pass.
 - Current first-pass rule: only `GAMEPLAY` category commands update the meaningful-activity timestamp; `SOCIAL`, `META`, `ADMIN`, and `SYSTEM` commands still update last-command activity without clearing future AFK/idle consumers.
+- Auto-AFK now derives inactivity exclusively from meaningful gameplay activity, falling back to connection time when none exists; accepted non-gameplay commands remain observable in command activity without postponing idle state.
 - [x] Extend creator-authored actions to declare their category and tags.
 - Remaining: extend category/tag truth into broader policy consumers beyond the first scripting, richer-client envelope, and classic text-rendering seams instead of leaving that metadata usable only at ingress binding resolution.

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/GameplayPresenceActivityResolver.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/GameplayPresenceActivityResolver.java
@@ -35,9 +35,7 @@ public final class GameplayPresenceActivityResolver {
     long mostRecentActivity =
         presence.lastMeaningfulActivityAtEpochMs() != null
             ? presence.lastMeaningfulActivityAtEpochMs()
-            : presence.lastAcceptedCommandAtEpochMs() != null
-                ? presence.lastAcceptedCommandAtEpochMs()
-                : presence.connectedAtEpochMs();
+            : presence.connectedAtEpochMs();
     long inactivityMs = currentTimeMillisSupplier.getAsLong() - mostRecentActivity;
     return inactivityMs >= presenceProperties.getAutoAfkThresholdMs()
         ? GameplayPresenceActivityState.AUTO_AFK

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/service/GameplayPresenceActivityResolverTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/service/GameplayPresenceActivityResolverTest.java
@@ -36,7 +36,7 @@ class GameplayPresenceActivityResolverTest {
   }
 
   @Test
-  void autoAfkUsesLastMeaningfulOrAcceptedActivity() {
+  void autoAfkIgnoresAcceptedNonGameplayActivity() {
     PresenceProperties properties = new PresenceProperties();
     properties.setAutoAfkEnabled(true);
     properties.setAutoAfkThresholdMs(100L);
@@ -44,7 +44,7 @@ class GameplayPresenceActivityResolverTest {
     GameplayPresenceActivityResolver resolver =
         new GameplayPresenceActivityResolver(properties, now::get);
 
-    GameplayPresence activeFromAccepted =
+    GameplayPresence acceptedOnly =
         new GameplayPresence(
             1L,
             22L,
@@ -59,7 +59,24 @@ class GameplayPresenceActivityResolverTest {
             null,
             150L,
             null);
-    assertEquals(GameplayPresenceActivityState.ACTIVE, resolver.resolve(activeFromAccepted));
+    assertEquals(GameplayPresenceActivityState.AUTO_AFK, resolver.resolve(acceptedOnly));
+
+    GameplayPresence activeFromMeaningful =
+        new GameplayPresence(
+            1L,
+            22L,
+            7L,
+            "demo",
+            "production",
+            2L,
+            102L,
+            "Ben",
+            GameplayPresenceRole.PLAYER,
+            50L,
+            null,
+            60L,
+            150L);
+    assertEquals(GameplayPresenceActivityState.ACTIVE, resolver.resolve(activeFromMeaningful));
 
     GameplayPresence autoAfk =
         new GameplayPresence(
@@ -77,5 +94,32 @@ class GameplayPresenceActivityResolverTest {
             60L,
             60L);
     assertEquals(GameplayPresenceActivityState.AUTO_AFK, resolver.resolve(autoAfk));
+  }
+
+  @Test
+  void autoAfkFallsBackToConnectionTimeWhenNoGameplayActivityExists() {
+    PresenceProperties properties = new PresenceProperties();
+    properties.setAutoAfkEnabled(true);
+    properties.setAutoAfkThresholdMs(100L);
+    GameplayPresenceActivityResolver resolver =
+        new GameplayPresenceActivityResolver(properties, () -> 200L);
+
+    GameplayPresence presence =
+        new GameplayPresence(
+            1L,
+            22L,
+            7L,
+            "demo",
+            "production",
+            2L,
+            102L,
+            "Ben",
+            GameplayPresenceRole.PLAYER,
+            150L,
+            null,
+            190L,
+            null);
+
+    assertEquals(GameplayPresenceActivityState.ACTIVE, resolver.resolve(presence));
   }
 }


### PR DESCRIPTION
## Summary

- Keep auto-AFK derived strictly from meaningful `GAMEPLAY` activity, falling back to connection time.
- Preserve accepted non-gameplay activity as observability data without letting it defer idle state.
- Add resolver coverage for accepted-only, meaningful-activity, and connection-time paths.

## Validation

- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:test --tests 'net.firedevops.firemud.gamesession.service.GameplayPresenceActivityResolverTest'`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:check -PfullCheck`
- `./gradlew spotlessApply`
- `./gradlew linkCheck lintMarkdown`

Docker-dependent integration and cross-service tests are skipped locally because the Docker socket is unavailable.
