### PR TITLE
Reject malformed movement command operands

### DIFF
--- a/design/project-management/vertical-slices/02.13.6-task-list-command-interpretation-and-alias-matching-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.6-task-list-command-interpretation-and-alias-matching-vertical-slice.md
@@ -119,6 +119,8 @@ Handlers should receive canonical command ids and typed arguments, not perform f
 
 The next urgent implementation follow-up should therefore be a built-in command registry and dispatcher rollout so the active command surface can keep growing without hardening the current interpreter-owned branching model. See `02.13.8-task-list-built-in-command-registry-and-dispatch-rollout-vertical-slice.md`.
 
+The first bounded parser follow-through now also keeps built-in movement fail-closed: `MOVE` accepts one canonical direction only, including `GO <direction>` and one-token directional aliases. Invalid directions or trailing operands remain malformed parsed input and the movement dispatcher rejects them before durable command enqueue.
+
 ## Instance Reference Model
 
 FireMUD should distinguish between:

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/MoveTextCommandDispatchHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/MoveTextCommandDispatchHandler.java
@@ -1,6 +1,8 @@
 package net.firedevops.firemud.gamesession.command.text;
 
 import java.util.List;
+import net.firedevops.firemud.gamesession.dto.CommandEnqueueResult;
+import net.firedevops.firemud.gamesession.presentation.PlayerOutput;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,9 +21,25 @@ final class MoveTextCommandDispatchHandler implements TextCommandDispatchHandler
 
   @Override
   public TextCommandInterpretationResult handle(TextCommandDispatchRequest request) {
-    net.firedevops.firemud.gamesession.dto.CommandEnqueueResult enqueueResult =
+    if (!hasExactlyOneCanonicalDirection(request.command())) {
+      return new TextCommandInterpretationResult(
+          CommandEnqueueResult.failure("INVALID_ARGUMENT", "MOVE requires exactly one direction."),
+          List.of(PlayerOutput.error("INVALID_ARGUMENT", "MOVE requires exactly one direction.")));
+    }
+    CommandEnqueueResult enqueueResult =
         commandService.enqueue(
             request.sessionId(), request.command().rawLine(), request.requiresSoloTick());
     return new TextCommandInterpretationResult(enqueueResult, List.of());
+  }
+
+  private boolean hasExactlyOneCanonicalDirection(TextCommand command) {
+    if (command.args().size() != 1 || command.directionalPayload().isEmpty()) {
+      return false;
+    }
+    String argumentDirection = TextCommandDirections.canonicalDirection(command.args().get(0));
+    String payloadDirection =
+        TextCommandDirections.canonicalDirection(
+            command.directionalPayload().orElseThrow().direction());
+    return !argumentDirection.isEmpty() && argumentDirection.equals(payloadDirection);
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandDirections.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandDirections.java
@@ -1,0 +1,21 @@
+package net.firedevops.firemud.gamesession.command.text;
+
+/** Canonicalizes the bounded direction vocabulary accepted by text movement commands. */
+final class TextCommandDirections {
+  private TextCommandDirections() {}
+
+  static String canonicalDirection(String token) {
+    if (token == null || token.isBlank()) {
+      return "";
+    }
+    return switch (token.trim().toUpperCase(java.util.Locale.ROOT)) {
+      case "N", "NORTH" -> "north";
+      case "S", "SOUTH" -> "south";
+      case "E", "EAST" -> "east";
+      case "W", "WEST" -> "west";
+      case "U", "UP" -> "up";
+      case "D", "DOWN" -> "down";
+      default -> "";
+    };
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandParser.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandParser.java
@@ -1,7 +1,6 @@
 package net.firedevops.firemud.gamesession.command.text;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -257,71 +256,21 @@ public class TextCommandParser {
   }
 
   private ParsedCommandData parseMove(String aliasUsed, String[] tokens) {
-    List<String> args = extractMoveArguments(tokens);
-    if (!args.isEmpty()) {
-      String canonicalDirection = canonicalDirection(args.get(0));
-      List<String> canonicalArgs =
-          canonicalDirection.isEmpty() ? args : List.of(canonicalDirection);
-      return new ParsedCommandData(
-          canonicalArgs,
-          new TextCommandPayload.Directional(
-              canonicalDirection.isEmpty()
-                  ? args.get(0).trim().toLowerCase()
-                  : canonicalDirection));
-    }
-    String canonicalAliasDirection = canonicalDirection(aliasUsed);
-    if (!canonicalAliasDirection.isEmpty()) {
+    String canonicalAliasDirection = TextCommandDirections.canonicalDirection(aliasUsed);
+    if (!canonicalAliasDirection.isEmpty() && tokens.length == 1) {
       return new ParsedCommandData(
           List.of(canonicalAliasDirection),
           new TextCommandPayload.Directional(canonicalAliasDirection));
     }
+    List<String> args = parseRemainingTokens(tokens);
+    if (args.size() == 1) {
+      String canonicalDirection = TextCommandDirections.canonicalDirection(args.get(0));
+      if (!canonicalDirection.isEmpty()) {
+        return new ParsedCommandData(
+            List.of(canonicalDirection), new TextCommandPayload.Directional(canonicalDirection));
+      }
+    }
     return new ParsedCommandData(args, new TextCommandPayload.Tokens(args));
-  }
-
-  private List<String> extractMoveArguments(String[] tokens) {
-    if (tokens.length == 0) {
-      return List.of();
-    }
-    String verb = tokens[0];
-    if (tokens.length == 1) {
-      String canonical = canonicalDirection(verb);
-      return canonical.isEmpty() ? List.of() : List.of(canonical);
-    }
-    return normalizeGoSyntax(verb, Arrays.copyOfRange(tokens, 1, tokens.length));
-  }
-
-  private List<String> normalizeGoSyntax(String verb, String[] remainingTokens) {
-    if (!verb.equalsIgnoreCase("go")) {
-      return List.of(remainingTokens);
-    }
-    if (remainingTokens.length == 0) {
-      return List.of();
-    }
-    String canonicalDirection = canonicalDirection(remainingTokens[0]);
-    if (canonicalDirection.isEmpty()) {
-      return List.of(remainingTokens);
-    }
-    ArrayList<String> normalized = new ArrayList<>();
-    normalized.add(canonicalDirection);
-    if (remainingTokens.length > 1) {
-      normalized.addAll(List.of(Arrays.copyOfRange(remainingTokens, 1, remainingTokens.length)));
-    }
-    return List.copyOf(normalized);
-  }
-
-  private String canonicalDirection(String token) {
-    if (token == null || token.isBlank()) {
-      return "";
-    }
-    return switch (token.trim().toUpperCase()) {
-      case "N", "NORTH" -> "north";
-      case "S", "SOUTH" -> "south";
-      case "E", "EAST" -> "east";
-      case "W", "WEST" -> "west";
-      case "U", "UP" -> "up";
-      case "D", "DOWN" -> "down";
-      default -> "";
-    };
   }
 
   private ParsedCommandData parseUnknown(String[] tokens) {

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/TextCommandInterpreterTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/TextCommandInterpreterTest.java
@@ -930,6 +930,25 @@ class TextCommandInterpreterTest {
   }
 
   @Test
+  void malformedMovementAfterPlayReturnsInvalidArgumentWithoutEnqueueing() {
+    interpreter.interpret("1", "LOGIN demo@example.com swordfish", false);
+    interpreter.interpret("1", "PLAY demo", false);
+    Mockito.clearInvocations(commandService);
+
+    for (String rawLine : List.of("north extra", "go west extra", "move sideways")) {
+      TextCommandInterpretationResult interpretation = interpreter.interpret("1", rawLine, false);
+
+      assertFalse(interpretation.commandResult().accepted());
+      assertEquals("INVALID_ARGUMENT", interpretation.commandResult().errorCode());
+      assertEquals(
+          "ERROR INVALID_ARGUMENT MOVE requires exactly one direction.",
+          renderedResponse(rawLine, interpretation));
+    }
+
+    verify(commandService, never()).enqueue(anyString(), anyString(), anyBoolean());
+  }
+
+  @Test
   void loginPlayAndLookFlowWorks() {
     TextCommandInterpretationResult login =
         interpreter.interpret("1", "LOGIN demo@example.com swordfish", false);

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/TextCommandParserTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/TextCommandParserTest.java
@@ -688,6 +688,16 @@ class TextCommandParserTest {
   }
 
   @Test
+  void malformedMovementDoesNotProduceDirectionalPayload() {
+    for (String rawLine : List.of("north extra", "go west extra", "move sideways")) {
+      TextCommand command = parser.parse(rawLine);
+
+      assertEquals(TextCommandType.MOVE, command.type());
+      assertTrue(command.directionalPayload().isEmpty());
+    }
+  }
+
+  @Test
   void blankInputIsIgnored() {
     TextCommand command = parser.parse("    ");
 


### PR DESCRIPTION
## Summary

- Define one shared canonical direction reader for text movement.
- Reject invalid directions and extra movement operands before durable command enqueue.
- Cover parser output and gameplay-stage rejection/no-enqueue behavior.

## Validation

- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:test --tests 'net.firedevops.firemud.gamesession.command.text.TextCommandParserTest' --tests 'net.firedevops.firemud.gamesession.command.text.TextCommandInterpreterTest'`
- `./gradlew spotlessApply`
- `./gradlew linkCheck lintMarkdown`
- `:game-session-service:check -PfullCheck` produced fresh green XML: 1,054 tests, 0 failures; Docker-dependent suites skipped because Docker is unavailable locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Game session service:** Added shared canonical direction parsing for `NORTH/SOUTH/EAST/WEST/UP/DOWN` and aliases.
- Movement commands now require exactly one valid direction; malformed or extra operands are rejected before durable command enqueue.
- **Documentation:** Updated the command interpretation vertical-slice task requirements to specify fail-closed movement handling.
- Added parser and gameplay-stage tests covering invalid directions, trailing operands, structured errors, and no-enqueue behavior.

## Validation

- Full check passed: 1,054 tests with no failures.
- Formatting and documentation/link checks passed.
- Docker-dependent suites were skipped because Docker was unavailable locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->