### PR TITLE
Add email login OTP challenge authority

### DIFF
--- a/design/project-management/vertical-slices/02.1.1-task-list-email-otp-and-text-auth-options-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.1.1-task-list-email-otp-and-text-auth-options-vertical-slice.md
@@ -2,7 +2,7 @@
 
 ## Goal and Status
 
-Goal: define the canonical text-client authentication model around account-selected login modes, a shared account-level OTP secret, and a text-first `LOGIN <email> [secret]` flow that supports password, emailed OTP, and later authenticator-app TOTP without fragmenting the auth system. Status: planned.
+Goal: define the canonical text-client authentication model around account-selected login modes, a shared account-level OTP secret, and a text-first `LOGIN <email> [secret]` flow that supports password, emailed OTP, and later authenticator-app TOTP without fragmenting the auth system. Status: backend challenge lifecycle in progress; Game Session command adoption and account-mode policy remain pending.
 
 ## Checklist
 
@@ -12,7 +12,7 @@ Goal: define the canonical text-client authentication model around account-selec
 
 ## Implementation Notes
 
-This slice is still target-state auth design, not current live behavior.
+The first additive backend batch is now live in Account Service: it owns neutral email-login OTP challenge initiation, persists one short-lived hashed code per account with resend cooldown and bounded failed attempts, and verifies a single-use code into the existing authenticated session/token result. It intentionally preserves password login and does not yet claim account-mode selection, TOTP enrollment, or Game Session `LOGIN` grammar adoption.
 
 Current live implementation still uses the older password-first model:
 

--- a/protos/account/v1/account_service.proto
+++ b/protos/account/v1/account_service.proto
@@ -11,6 +11,8 @@ service AccountService {
   rpc Ping(PingRequest) returns (PingResponse);
   rpc CreateAccount(CreateAccountRequest) returns (CreateAccountResponse);
   rpc Authenticate(AuthenticateRequest) returns (AuthenticateResponse);
+  rpc RequestEmailLoginOtp(RequestEmailLoginOtpRequest) returns (RequestEmailLoginOtpResponse);
+  rpc VerifyEmailLoginOtp(VerifyEmailLoginOtpRequest) returns (AuthenticateResponse);
   rpc GetTenantMembershipForRuntime(GetTenantMembershipForRuntimeRequest) returns (GetTenantMembershipForRuntimeResponse);
   rpc GetRealmAccessGrantForRuntime(GetRealmAccessGrantForRuntimeRequest) returns (GetRealmAccessGrantForRuntimeResponse);
   rpc EnsurePublicProductionPlayerMembership(EnsurePublicProductionPlayerMembershipRequest) returns (EnsurePublicProductionPlayerMembershipResponse);
@@ -69,6 +71,22 @@ message AuthenticateResponse {
   string auth_token = 1;
   string account_id = 2;
   shared.v1.ErrorDetail error = 3;
+}
+
+message RequestEmailLoginOtpRequest {
+  string tenant_id = 1;
+  string email = 2;
+}
+
+message RequestEmailLoginOtpResponse {
+  bool accepted = 1;
+  shared.v1.ErrorDetail error = 2;
+}
+
+message VerifyEmailLoginOtpRequest {
+  string tenant_id = 1;
+  string email = 2;
+  string code = 3;
 }
 
 message GetTenantMembershipForRuntimeRequest {

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountEmailLoginChallenge.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountEmailLoginChallenge.java
@@ -1,0 +1,16 @@
+package net.firedevops.firemud.accountservice.entity;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class AccountEmailLoginChallenge {
+  private Long id;
+  private Long accountId;
+  private String codeHash;
+  private LocalDateTime expiresAt;
+  private LocalDateTime resendAvailableAt;
+  private int invalidAttemptCount;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountEmailLoginChallengeRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountEmailLoginChallengeRepository.java
@@ -1,0 +1,80 @@
+package net.firedevops.firemud.accountservice.repository;
+
+import static net.firedevops.firemud.accountservice.jooq.Tables.ACCOUNT_EMAIL_LOGIN_CHALLENGE;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Optional;
+import net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP2",
+    justification = "DSLContext is an internal collaborator")
+public class AccountEmailLoginChallengeRepository {
+  private final DSLContext dsl;
+
+  public AccountEmailLoginChallengeRepository(DSLContext dsl) {
+    this.dsl = dsl;
+  }
+
+  public Optional<AccountEmailLoginChallenge> findByAccountId(long accountId) {
+    return Optional.ofNullable(
+        dsl.selectFrom(ACCOUNT_EMAIL_LOGIN_CHALLENGE)
+            .where(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ACCOUNT_ID.eq(accountId))
+            .fetchOne(this::toEntity));
+  }
+
+  public AccountEmailLoginChallenge save(AccountEmailLoginChallenge entity) {
+    if (entity.getId() == null) {
+      Long id =
+          dsl.insertInto(ACCOUNT_EMAIL_LOGIN_CHALLENGE)
+              .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ACCOUNT_ID, entity.getAccountId())
+              .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.CODE_HASH, entity.getCodeHash())
+              .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.EXPIRES_AT, entity.getExpiresAt())
+              .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.RESEND_AVAILABLE_AT, entity.getResendAvailableAt())
+              .set(
+                  ACCOUNT_EMAIL_LOGIN_CHALLENGE.INVALID_ATTEMPT_COUNT,
+                  entity.getInvalidAttemptCount())
+              .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.CREATED_AT, entity.getCreatedAt())
+              .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.UPDATED_AT, entity.getUpdatedAt())
+              .returningResult(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ID)
+              .fetchOne(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ID);
+      entity.setId(id);
+      return entity;
+    }
+    dsl.update(ACCOUNT_EMAIL_LOGIN_CHALLENGE)
+        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.CODE_HASH, entity.getCodeHash())
+        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.EXPIRES_AT, entity.getExpiresAt())
+        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.RESEND_AVAILABLE_AT, entity.getResendAvailableAt())
+        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.INVALID_ATTEMPT_COUNT, entity.getInvalidAttemptCount())
+        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.UPDATED_AT, entity.getUpdatedAt())
+        .where(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ID.eq(entity.getId()))
+        .execute();
+    return entity;
+  }
+
+  public void delete(AccountEmailLoginChallenge entity) {
+    if (entity != null && entity.getId() != null) {
+      dsl.deleteFrom(ACCOUNT_EMAIL_LOGIN_CHALLENGE)
+          .where(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ID.eq(entity.getId()))
+          .execute();
+    }
+  }
+
+  private AccountEmailLoginChallenge toEntity(
+      net.firedevops.firemud.accountservice.jooq.tables.records.AccountEmailLoginChallengeRecord
+          record) {
+    AccountEmailLoginChallenge entity = new AccountEmailLoginChallenge();
+    entity.setId(record.getId());
+    entity.setAccountId(record.getAccountId());
+    entity.setCodeHash(record.getCodeHash());
+    entity.setExpiresAt(record.getExpiresAt());
+    entity.setResendAvailableAt(record.getResendAvailableAt());
+    entity.setInvalidAttemptCount(record.getInvalidAttemptCount());
+    entity.setCreatedAt(record.getCreatedAt());
+    entity.setUpdatedAt(record.getUpdatedAt());
+    return entity;
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountEmailLoginChallengeRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountEmailLoginChallengeRepository.java
@@ -44,14 +44,21 @@ public class AccountEmailLoginChallengeRepository {
       entity.setId(id);
       return entity;
     }
-    dsl.update(ACCOUNT_EMAIL_LOGIN_CHALLENGE)
-        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.CODE_HASH, entity.getCodeHash())
-        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.EXPIRES_AT, entity.getExpiresAt())
-        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.RESEND_AVAILABLE_AT, entity.getResendAvailableAt())
-        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.INVALID_ATTEMPT_COUNT, entity.getInvalidAttemptCount())
-        .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.UPDATED_AT, entity.getUpdatedAt())
-        .where(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ID.eq(entity.getId()))
-        .execute();
+    int updated =
+        dsl.update(ACCOUNT_EMAIL_LOGIN_CHALLENGE)
+            .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.CODE_HASH, entity.getCodeHash())
+            .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.EXPIRES_AT, entity.getExpiresAt())
+            .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.RESEND_AVAILABLE_AT, entity.getResendAvailableAt())
+            .set(
+                ACCOUNT_EMAIL_LOGIN_CHALLENGE.INVALID_ATTEMPT_COUNT,
+                entity.getInvalidAttemptCount())
+            .set(ACCOUNT_EMAIL_LOGIN_CHALLENGE.UPDATED_AT, entity.getUpdatedAt())
+            .where(ACCOUNT_EMAIL_LOGIN_CHALLENGE.ID.eq(entity.getId()))
+            .execute();
+    if (updated != 1) {
+      throw JooqAccountRepositorySupport.staleWrite(
+          "account_email_login_challenge", entity.getId());
+    }
     return entity;
   }
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/AccountService.java
@@ -26,6 +26,11 @@ public interface AccountService {
   net.firedevops.firemud.accountservice.dto.AuthenticationResult authenticate(
       Long tenantId, String username, String password, String otp);
 
+  void requestEmailLoginOtp(Long tenantId, String email);
+
+  net.firedevops.firemud.accountservice.dto.AuthenticationResult verifyEmailLoginOtp(
+      Long tenantId, String email, String code);
+
   PlayerBootstrapResult issuePlayerBootstrap(
       Long tenantId, String username, String password, String otp);
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountGrpcService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountGrpcService.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.stub.StreamObserver;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
+import net.firedevops.firemud.account.AuthenticationErrorCodes;
 import net.firedevops.firemud.account.v1.AccountServiceGrpc;
 import net.firedevops.firemud.account.v1.AuthenticateRequest;
 import net.firedevops.firemud.account.v1.AuthenticateResponse;
@@ -27,8 +28,11 @@ import net.firedevops.firemud.account.v1.GetTenantMembershipForRuntimeRequest;
 import net.firedevops.firemud.account.v1.GetTenantMembershipForRuntimeResponse;
 import net.firedevops.firemud.account.v1.PingRequest;
 import net.firedevops.firemud.account.v1.PingResponse;
+import net.firedevops.firemud.account.v1.RequestEmailLoginOtpRequest;
+import net.firedevops.firemud.account.v1.RequestEmailLoginOtpResponse;
 import net.firedevops.firemud.account.v1.UpdateProfileRequest;
 import net.firedevops.firemud.account.v1.UpdateProfileResponse;
+import net.firedevops.firemud.account.v1.VerifyEmailLoginOtpRequest;
 import net.firedevops.firemud.accountservice.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.accountservice.dto.PasswordResetRequest;
 import net.firedevops.firemud.accountservice.entity.ProfilePresenceVisibilityPolicy;
@@ -149,6 +153,57 @@ public class AccountGrpcService extends AccountServiceGrpc.AccountServiceImplBas
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     }
+  }
+
+  @Override
+  @Timed(value = "accountGrpc.requestEmailLoginOtp")
+  public void requestEmailLoginOtp(
+      RequestEmailLoginOtpRequest request,
+      StreamObserver<RequestEmailLoginOtpResponse> responseObserver) {
+    try {
+      accountService.requestEmailLoginOtp(
+          requirePositiveRequestId(request.getTenantId(), "tenantId"), request.getEmail());
+      responseObserver.onNext(RequestEmailLoginOtpResponse.newBuilder().setAccepted(true).build());
+    } catch (InvalidRequestException ex) {
+      responseObserver.onNext(
+          RequestEmailLoginOtpResponse.newBuilder()
+              .setError(appError("RequestEmailLoginOtp", "INVALID_ARGUMENT", ex.getMessage()))
+              .build());
+    }
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  @Timed(value = "accountGrpc.verifyEmailLoginOtp")
+  public void verifyEmailLoginOtp(
+      VerifyEmailLoginOtpRequest request, StreamObserver<AuthenticateResponse> responseObserver) {
+    try {
+      var result =
+          accountService.verifyEmailLoginOtp(
+              requirePositiveRequestId(request.getTenantId(), "tenantId"),
+              request.getEmail(),
+              request.getCode());
+      responseObserver.onNext(
+          AuthenticateResponse.newBuilder()
+              .setAuthToken(result.authToken())
+              .setAccountId(String.valueOf(result.accountId()))
+              .build());
+    } catch (InvalidRequestException ex) {
+      responseObserver.onNext(
+          AuthenticateResponse.newBuilder()
+              .setError(appError("VerifyEmailLoginOtp", "INVALID_ARGUMENT", ex.getMessage()))
+              .build());
+    } catch (AuthenticationException | IllegalArgumentException ex) {
+      responseObserver.onNext(
+          AuthenticateResponse.newBuilder()
+              .setError(
+                  appError(
+                      "VerifyEmailLoginOtp",
+                      AuthenticationErrorCodes.INVALID_CREDENTIALS,
+                      "Invalid credentials"))
+              .build());
+    }
+    responseObserver.onCompleted();
   }
 
   @Override

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
@@ -12,7 +12,9 @@ import io.micrometer.core.annotation.Timed;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -47,6 +49,7 @@ import net.firedevops.firemud.accountservice.dto.UpdateProfileRequest;
 import net.firedevops.firemud.accountservice.dto.UsernameRecoveryRequest;
 import net.firedevops.firemud.accountservice.dto.VerifyEmailRequest;
 import net.firedevops.firemud.accountservice.entity.Account;
+import net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge;
 import net.firedevops.firemud.accountservice.entity.AccountRealmAccessGrant;
 import net.firedevops.firemud.accountservice.entity.AccountTenantMembership;
 import net.firedevops.firemud.accountservice.entity.EmailVerificationToken;
@@ -54,6 +57,7 @@ import net.firedevops.firemud.accountservice.entity.Profile;
 import net.firedevops.firemud.accountservice.entity.ProfilePresenceVisibilityPolicy;
 import net.firedevops.firemud.accountservice.mapper.AccountMapper;
 import net.firedevops.firemud.accountservice.mapper.ProfileMapper;
+import net.firedevops.firemud.accountservice.repository.AccountEmailLoginChallengeRepository;
 import net.firedevops.firemud.accountservice.repository.AccountRealmAccessGrantRepository;
 import net.firedevops.firemud.accountservice.repository.AccountRepository;
 import net.firedevops.firemud.accountservice.repository.AccountTenantMembershipRepository;
@@ -91,8 +95,11 @@ public class AccountServiceImpl implements AccountService {
       "Selected gameplay target is no longer admissible; rerun bootstrap discovery and request a fresh connect scope";
   private static final String INVALID_CONNECT_SCOPE_MESSAGE =
       "Connect scope is invalid or expired; rerun bootstrap discovery and request a fresh connect scope";
+  private static final int EMAIL_LOGIN_OTP_MAX_ATTEMPTS = 5;
+  private static final SecureRandom EMAIL_LOGIN_OTP_RANDOM = new SecureRandom();
 
   private final AccountRepository accountRepository;
+  private final AccountEmailLoginChallengeRepository accountEmailLoginChallengeRepository;
   private final AccountRealmAccessGrantRepository accountRealmAccessGrantRepository;
   private final AccountTenantMembershipRepository accountTenantMembershipRepository;
   private final AccountMapper accountMapper;
@@ -120,6 +127,7 @@ public class AccountServiceImpl implements AccountService {
       justification = "Dependencies are injected and kept internal")
   public AccountServiceImpl(
       AccountRepository accountRepository,
+      AccountEmailLoginChallengeRepository accountEmailLoginChallengeRepository,
       AccountRealmAccessGrantRepository accountRealmAccessGrantRepository,
       AccountTenantMembershipRepository accountTenantMembershipRepository,
       AccountMapper accountMapper,
@@ -142,6 +150,7 @@ public class AccountServiceImpl implements AccountService {
       net.firedevops.firemud.accountservice.service.session.SessionService sessionService,
       SagaRunner sagaRunner) {
     this.accountRepository = accountRepository;
+    this.accountEmailLoginChallengeRepository = accountEmailLoginChallengeRepository;
     this.accountRealmAccessGrantRepository = accountRealmAccessGrantRepository;
     this.accountTenantMembershipRepository = accountTenantMembershipRepository;
     this.accountMapper = accountMapper;
@@ -217,6 +226,71 @@ public class AccountServiceImpl implements AccountService {
       Long tenantId, String username, String password, String otp) {
     Account account = authenticateAccountIdentity(username, password, otp);
     requireGameplayMembership(account.getId(), tenantId, "Invalid credentials");
+    String token =
+        jwtUtil.generateToken(
+            account.getId().toString(),
+            Map.of(
+                "accountId", account.getId(), "globalRoles", java.util.List.of(account.getRole())));
+    sessionService.storeSession(tenantId, account.getId(), token);
+    return new net.firedevops.firemud.accountservice.dto.AuthenticationResult(
+        account.getId(), token);
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.request_email_login_otp")
+  public void requestEmailLoginOtp(Long tenantId, String email) {
+    Optional<Account> account = accountRepository.findByEmail(email == null ? "" : email.trim());
+    if (account.isEmpty() || !account.orElseThrow().isEmailVerified()) {
+      return;
+    }
+    Account resolvedAccount = account.orElseThrow();
+    try {
+      requireGameplayMembership(resolvedAccount.getId(), tenantId, "Invalid credentials");
+    } catch (IllegalArgumentException ex) {
+      return;
+    }
+    LocalDateTime now = LocalDateTime.now();
+    Optional<AccountEmailLoginChallenge> existing =
+        accountEmailLoginChallengeRepository.findByAccountId(resolvedAccount.getId());
+    if (existing.filter(challenge -> challenge.getResendAvailableAt().isAfter(now)).isPresent()) {
+      return;
+    }
+    existing.ifPresent(accountEmailLoginChallengeRepository::delete);
+    String code = String.format("%06d", EMAIL_LOGIN_OTP_RANDOM.nextInt(1_000_000));
+    AccountEmailLoginChallenge challenge = new AccountEmailLoginChallenge();
+    challenge.setAccountId(resolvedAccount.getId());
+    challenge.setCodeHash(hashPassword(code));
+    challenge.setExpiresAt(now.plusMinutes(10));
+    challenge.setResendAvailableAt(now.plusSeconds(60));
+    challenge.setCreatedAt(now);
+    challenge.setUpdatedAt(now);
+    accountEmailLoginChallengeRepository.save(challenge);
+    runAfterCommit(() -> safeSendEmailLoginOtp(resolvedAccount.getEmail(), code));
+  }
+
+  @Override
+  @Transactional
+  @Timed(value = "account.verify_email_login_otp")
+  public net.firedevops.firemud.accountservice.dto.AuthenticationResult verifyEmailLoginOtp(
+      Long tenantId, String email, String code) {
+    Account account =
+        accountRepository
+            .findByEmail(email == null ? "" : email.trim())
+            .orElseThrow(this::invalidCredentials);
+    AccountEmailLoginChallenge challenge =
+        accountEmailLoginChallengeRepository
+            .findByAccountId(account.getId())
+            .orElseThrow(this::invalidCredentials);
+    LocalDateTime now = LocalDateTime.now();
+    if (challenge.getExpiresAt().isBefore(now)
+        || challenge.getInvalidAttemptCount() >= EMAIL_LOGIN_OTP_MAX_ATTEMPTS
+        || !verifyPassword(code == null ? "" : code, challenge.getCodeHash())) {
+      recordFailedEmailLoginAttempt(challenge, now);
+      throw invalidCredentials();
+    }
+    requireGameplayMembership(account.getId(), tenantId, "Invalid credentials");
+    accountEmailLoginChallengeRepository.delete(challenge);
     String token =
         jwtUtil.generateToken(
             account.getId().toString(),
@@ -1310,6 +1384,34 @@ public class AccountServiceImpl implements AccountService {
       return argon2.verify(hash, chars);
     } finally {
       argon2.wipeArray(chars);
+    }
+  }
+
+  private AuthenticationException invalidCredentials() {
+    return new AuthenticationException(
+        AuthenticationErrorCodes.INVALID_CREDENTIALS, "Invalid credentials");
+  }
+
+  private void recordFailedEmailLoginAttempt(
+      AccountEmailLoginChallenge challenge, LocalDateTime now) {
+    challenge.setInvalidAttemptCount(challenge.getInvalidAttemptCount() + 1);
+    challenge.setUpdatedAt(now);
+    if (challenge.getInvalidAttemptCount() >= EMAIL_LOGIN_OTP_MAX_ATTEMPTS
+        || challenge.getExpiresAt().isBefore(now)) {
+      accountEmailLoginChallengeRepository.delete(challenge);
+      return;
+    }
+    accountEmailLoginChallengeRepository.save(challenge);
+  }
+
+  private void safeSendEmailLoginOtp(String email, String code) {
+    try {
+      emailService.sendEmail(
+          email,
+          "Your FireMUD login code",
+          "Your FireMUD login code is " + code + ". It expires in 10 minutes.");
+    } catch (RuntimeException ex) {
+      logger.warn("Email login code delivery failed");
     }
   }
 

--- a/services/account-service/src/main/resources/application-prod.yml
+++ b/services/account-service/src/main/resources/application-prod.yml
@@ -69,6 +69,8 @@ firemud:
     grpc:
       public-methods:
         - account.v1.AccountService/Authenticate
+        - account.v1.AccountService/RequestEmailLoginOtp
+        - account.v1.AccountService/VerifyEmailLoginOtp
         - account.v1.AccountService/Ping
         - account.v1.AccountService/GetTenantMembershipForRuntime
         - account.v1.AccountService/EnsurePublicProductionPlayerMembership

--- a/services/account-service/src/main/resources/application.yml
+++ b/services/account-service/src/main/resources/application.yml
@@ -87,6 +87,8 @@ firemud:
     grpc:
       public-methods:
         - account.v1.AccountService/Authenticate
+        - account.v1.AccountService/RequestEmailLoginOtp
+        - account.v1.AccountService/VerifyEmailLoginOtp
         - account.v1.AccountService/Ping
         - account.v1.AccountService/GetTenantMembershipForRuntime
         - account.v1.AccountService/EnsurePublicProductionPlayerMembership

--- a/services/account-service/src/main/resources/db/migration/V18__account_email_login_challenges.sql
+++ b/services/account-service/src/main/resources/db/migration/V18__account_email_login_challenges.sql
@@ -1,0 +1,13 @@
+CREATE TABLE account_email_login_challenge (
+    id BIGSERIAL PRIMARY KEY,
+    account_id BIGINT NOT NULL UNIQUE REFERENCES accounts(id),
+    code_hash VARCHAR(256) NOT NULL,
+    expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    resend_available_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    invalid_attempt_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_account_email_login_challenge_expires_at
+    ON account_email_login_challenge(expires_at);

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.mkammerer.argon2.Argon2;
@@ -36,6 +37,7 @@ import net.firedevops.firemud.accountservice.entity.ProfilePresenceVisibilityPol
 import net.firedevops.firemud.accountservice.entity.Subscription;
 import net.firedevops.firemud.accountservice.mapper.AccountMapper;
 import net.firedevops.firemud.accountservice.mapper.ProfileMapper;
+import net.firedevops.firemud.accountservice.repository.AccountEmailLoginChallengeRepository;
 import net.firedevops.firemud.accountservice.repository.AccountRealmAccessGrantRepository;
 import net.firedevops.firemud.accountservice.repository.AccountRepository;
 import net.firedevops.firemud.accountservice.repository.AccountTenantMembershipRepository;
@@ -62,6 +64,7 @@ import org.mockito.MockitoAnnotations;
 class AccountServiceImplTest {
   private static final String JWT_SECRET = "mysecretkey123456789012345678901";
   @Mock private AccountRepository accountRepository;
+  @Mock private AccountEmailLoginChallengeRepository accountEmailLoginChallengeRepository;
   @Mock private AccountRealmAccessGrantRepository accountRealmAccessGrantRepository;
   @Mock private AccountTenantMembershipRepository accountTenantMembershipRepository;
   @Mock private ProfileRepository profileRepository;
@@ -155,6 +158,7 @@ class AccountServiceImplTest {
     service =
         new AccountServiceImpl(
             accountRepository,
+            accountEmailLoginChallengeRepository,
             accountRealmAccessGrantRepository,
             accountTenantMembershipRepository,
             mapper,
@@ -198,6 +202,28 @@ class AccountServiceImplTest {
     assertEquals(1L, dto.id());
     assertEquals("demo", dto.username());
     org.mockito.Mockito.verify(sagaRunner).run(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void emailLoginOtpRequestIsNeutralForUnknownEmail() {
+    when(accountRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+    service.requestEmailLoginOtp(7L, "unknown@example.com");
+
+    verifyNoInteractions(emailService, accountEmailLoginChallengeRepository);
+  }
+
+  @Test
+  void emailLoginOtpVerificationFailsClosedForUnknownEmail() {
+    when(accountRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+    AuthenticationException exception =
+        assertThrows(
+            AuthenticationException.class,
+            () -> service.verifyEmailLoginOtp(7L, "unknown@example.com", "123456"));
+
+    assertEquals(AuthenticationErrorCodes.INVALID_CREDENTIALS, exception.getCode());
+    verifyNoInteractions(accountEmailLoginChallengeRepository, sessionService);
   }
 
   @Test
@@ -363,6 +389,7 @@ class AccountServiceImplTest {
     service =
         new AccountServiceImpl(
             accountRepository,
+            accountEmailLoginChallengeRepository,
             accountRealmAccessGrantRepository,
             accountTenantMembershipRepository,
             Mappers.getMapper(AccountMapper.class),

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.accountservice.service.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -211,6 +212,39 @@ class AccountServiceImplTest {
     service.requestEmailLoginOtp(7L, "unknown@example.com");
 
     verifyNoInteractions(emailService, accountEmailLoginChallengeRepository);
+  }
+
+  @Test
+  void emailLoginOtpRequestPersistsOnlyHashedChallengeAndSendsSixDigitCode() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setEmail("verified@example.com");
+    account.setEmailVerified(true);
+    AccountTenantMembership membership = new AccountTenantMembership();
+    membership.setGameplayAdmissionAllowed(true);
+    when(accountRepository.findByEmail("verified@example.com")).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(9L, 7L))
+        .thenReturn(Optional.of(membership));
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L)).thenReturn(Optional.empty());
+    when(accountEmailLoginChallengeRepository.save(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.requestEmailLoginOtp(7L, "verified@example.com");
+
+    org.mockito.ArgumentCaptor<
+            net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge>
+        challengeCaptor =
+            org.mockito.ArgumentCaptor.forClass(
+                net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge.class);
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository)
+        .save(challengeCaptor.capture());
+    assertEquals(9L, challengeCaptor.getValue().getAccountId());
+    assertFalse(challengeCaptor.getValue().getCodeHash().matches("\\d{6}"));
+    org.mockito.Mockito.verify(emailService)
+        .sendEmail(
+            org.mockito.ArgumentMatchers.eq("verified@example.com"),
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.matches(".*\\b\\d{6}\\b.*"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add neutral Account Service email-login OTP challenge initiation and persisted hashed challenge lifecycle
- enforce expiry, resend cooldown, bounded failed attempts, single-use verification, and existing membership checks
- expose dedicated public gRPC request/verify methods while preserving the existing password authentication contract
- document this as the additive backend batch before Game Session command adoption and account-mode policy

## Validation
- `./gradlew spotlessApply`
- `./gradlew :account-service:test --tests 'net.firedevops.firemud.accountservice.service.impl.AccountServiceImplTest'`
- `bash dev-tools/validation/run-locked-gradle.sh :account-service:check -PfullCheck`
- `./gradlew linkCheck lintMarkdown`
