### PR TITLE
Require substantive CodeRabbit review evidence

### DIFF
--- a/dev-tools/tests/coderabbit-review-contract.sh
+++ b/dev-tools/tests/coderabbit-review-contract.sh
@@ -49,7 +49,7 @@ cat >"$TMP_DIR/pass.json" <<'JSON'
               "author": {
                 "login": "coderabbitai"
               },
-              "body": "Review finished.",
+              "body": "<!-- walkthrough_start -->",
               "createdAt": "2026-07-03T02:40:05Z",
               "url": "https://example.test/finished"
             }
@@ -104,7 +104,7 @@ cat >"$TMP_DIR/unresolved-outdated.json" <<'JSON'
               "author": {
                 "login": "coderabbitai"
               },
-              "body": "Review finished.",
+              "body": "<!-- walkthrough_start -->",
               "createdAt": "2026-07-03T02:40:05Z",
               "url": "https://example.test/finished"
             }
@@ -149,7 +149,7 @@ cat >"$TMP_DIR/stale-review.json" <<'JSON'
               "author": {
                 "login": "coderabbitai"
               },
-              "body": "Review finished.",
+              "body": "<!-- walkthrough_start -->",
               "createdAt": "2026-07-03T02:20:05Z",
               "url": "https://example.test/finished"
             }
@@ -204,7 +204,7 @@ cat >"$TMP_DIR/unresolved-non-outdated.json" <<'JSON'
               "author": {
                 "login": "coderabbitai"
               },
-              "body": "Review finished.",
+              "body": "<!-- walkthrough_start -->",
               "createdAt": "2026-07-03T02:40:05Z",
               "url": "https://example.test/finished"
             }
@@ -244,6 +244,96 @@ cat >"$TMP_DIR/review-not-finished.json" <<'JSON'
               "body": "@coderabbitai review",
               "createdAt": "2026-07-03T02:40:00Z",
               "url": "https://example.test/review"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+
+cat >"$TMP_DIR/review-command-noop.json" <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "headRefOid": "abc123",
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "oid": "abc123",
+                "committedDate": "2026-07-03T02:31:07Z"
+              }
+            }
+          ]
+        },
+        "reviewThreads": {
+          "nodes": []
+        },
+        "comments": {
+          "nodes": [
+            {
+              "author": {
+                "login": "benhook1013"
+              },
+              "body": "@coderabbitai review",
+              "createdAt": "2026-07-03T02:40:00Z",
+              "url": "https://example.test/review"
+            },
+            {
+              "author": {
+                "login": "coderabbitai"
+              },
+              "body": "Review finished. Note: CodeRabbit does not re-review already reviewed commits.",
+              "createdAt": "2026-07-03T02:40:05Z",
+              "url": "https://example.test/noop"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+
+cat >"$TMP_DIR/review-rate-limited.json" <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "headRefOid": "abc123",
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "oid": "abc123",
+                "committedDate": "2026-07-03T02:31:07Z"
+              }
+            }
+          ]
+        },
+        "reviewThreads": {
+          "nodes": []
+        },
+        "comments": {
+          "nodes": [
+            {
+              "author": {
+                "login": "benhook1013"
+              },
+              "body": "@coderabbitai review",
+              "createdAt": "2026-07-03T02:40:00Z",
+              "url": "https://example.test/review"
+            },
+            {
+              "author": {
+                "login": "coderabbitai"
+              },
+              "body": "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->",
+              "createdAt": "2026-07-03T02:40:05Z",
+              "url": "https://example.test/rate-limited"
             }
           ]
         }
@@ -294,7 +384,7 @@ cat >"$TMP_DIR/outside-diff-actionable.json" <<'JSON'
               "author": {
                 "login": "coderabbitai"
               },
-              "body": "Review finished.",
+              "body": "<!-- walkthrough_start -->",
               "createdAt": "2026-07-03T02:40:05Z",
               "url": "https://example.test/finished"
             }
@@ -324,6 +414,8 @@ grep -q "unresolved_outdated=0" <<<"$pass_output"
 grep -q "unresolved_total=0" <<<"$pass_output"
 grep -q "explicit_review_after_latest_commit=true" <<<"$pass_output"
 grep -q "review_finished_after_latest_request=true" <<<"$pass_output"
+grep -q "substantive_review_after_latest_commit=true" <<<"$pass_output"
+grep -q "latest_review_request_noop=false" <<<"$pass_output"
 grep -q "retrigger_review_allowed=true" <<<"$pass_output"
 grep -q "must_resolve_outdated_threads=false" <<<"$pass_output"
 grep -q "ok=true" <<<"$pass_output"
@@ -354,7 +446,21 @@ expect_failure_output "$TMP_DIR/review-not-finished.json" "$TMP_DIR/review-not-f
 [[ $EXPECT_FAILURE_STATUS -ne 0 ]]
 grep -q "review_finished_after_latest_request=false" "$TMP_DIR/review-not-finished.out"
 grep -q "retrigger_review_allowed=false" "$TMP_DIR/review-not-finished.out"
-grep -q "reason=no completed CodeRabbit review found after the latest explicit review request" "$TMP_DIR/review-not-finished.out"
+grep -q "reason=no substantive CodeRabbit review summary found after the latest explicit review request" "$TMP_DIR/review-not-finished.out"
+
+expect_failure_output "$TMP_DIR/review-command-noop.json" "$TMP_DIR/review-command-noop.out"
+[[ $EXPECT_FAILURE_STATUS -ne 0 ]]
+grep -q "review_finished_after_latest_request=false" "$TMP_DIR/review-command-noop.out"
+grep -q "substantive_review_after_latest_commit=false" "$TMP_DIR/review-command-noop.out"
+grep -q "latest_review_request_noop=true" "$TMP_DIR/review-command-noop.out"
+grep -q "retrigger_review_allowed=false" "$TMP_DIR/review-command-noop.out"
+grep -q "reason=latest explicit CodeRabbit review request was acknowledged without reviewing commits" "$TMP_DIR/review-command-noop.out"
+
+expect_failure_output "$TMP_DIR/review-rate-limited.json" "$TMP_DIR/review-rate-limited.out"
+[[ $EXPECT_FAILURE_STATUS -ne 0 ]]
+grep -q "latest_review_request_rate_limited=true" "$TMP_DIR/review-rate-limited.out"
+grep -q "retrigger_review_allowed=false" "$TMP_DIR/review-rate-limited.out"
+grep -q "reason=latest explicit CodeRabbit review request was rate limited; do not retrigger yet" "$TMP_DIR/review-rate-limited.out"
 
 expect_failure_output "$TMP_DIR/outside-diff-actionable.json" "$TMP_DIR/outside-diff-actionable.out"
 [[ $EXPECT_FAILURE_STATUS -ne 0 ]]

--- a/dev-tools/tests/coderabbit-review-contract.sh
+++ b/dev-tools/tests/coderabbit-review-contract.sh
@@ -424,6 +424,7 @@ expect_failure_output "$TMP_DIR/stale-review.json" "$TMP_DIR/stale-review.out"
 [[ $EXPECT_FAILURE_STATUS -ne 0 ]]
 grep -q "explicit_review_after_latest_commit=false" "$TMP_DIR/stale-review.out"
 grep -q "retrigger_review_allowed=true" "$TMP_DIR/stale-review.out"
+grep -q "warning=A SMALL FOLLOW-UP MAY MERGE WITHOUT A FRESH CODERABBIT RUN ONLY WHEN EVERY POST-REVIEW COMMIT DIRECTLY ADDRESSES REVIEW FINDINGS; VERIFY THAT SCOPE AND GREEN CI MANUALLY" "$TMP_DIR/stale-review.out"
 grep -q "reason=no explicit CodeRabbit review request found after the latest PR commit" "$TMP_DIR/stale-review.out"
 
 expect_failure_output "$TMP_DIR/unresolved-non-outdated.json" "$TMP_DIR/unresolved-non-outdated.out"

--- a/dev-tools/tests/coderabbit-review-contract.sh
+++ b/dev-tools/tests/coderabbit-review-contract.sh
@@ -335,6 +335,67 @@ cat >"$TMP_DIR/review-rate-limited.json" <<'JSON'
 }
 JSON
 
+cat >"$TMP_DIR/superseded-review-outcome.json" <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "headRefOid": "abc123",
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "oid": "abc123",
+                "committedDate": "2026-07-03T02:31:07Z"
+              }
+            }
+          ]
+        },
+        "reviewThreads": {
+          "nodes": []
+        },
+        "comments": {
+          "nodes": [
+            {
+              "author": {
+                "login": "benhook1013"
+              },
+              "body": "@coderabbitai review",
+              "createdAt": "2026-07-03T02:40:00Z",
+              "url": "https://example.test/review"
+            },
+            {
+              "author": {
+                "login": "coderabbitai"
+              },
+              "body": "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->",
+              "createdAt": "2026-07-03T02:40:01Z",
+              "url": "https://example.test/rate-limited"
+            },
+            {
+              "author": {
+                "login": "coderabbitai"
+              },
+              "body": "Review finished. Note: CodeRabbit does not re-review already reviewed commits.",
+              "createdAt": "2026-07-03T02:40:02Z",
+              "url": "https://example.test/noop"
+            },
+            {
+              "author": {
+                "login": "coderabbitai"
+              },
+              "body": "<!-- walkthrough_start -->",
+              "createdAt": "2026-07-03T02:40:03Z",
+              "url": "https://example.test/walkthrough"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+JSON
+
 cat >"$TMP_DIR/outside-diff-actionable.json" <<'JSON'
 {
   "data": {
@@ -455,6 +516,14 @@ grep -q "explicit_review_after_latest_commit=false" "$TMP_DIR/review-rate-limite
 grep -q "latest_review_request_rate_limited=true" "$TMP_DIR/review-rate-limited.out"
 grep -q "retrigger_review_allowed=false" "$TMP_DIR/review-rate-limited.out"
 grep -q "reason=latest CodeRabbit review attempt after the PR commit was rate limited; do not retrigger yet" "$TMP_DIR/review-rate-limited.out"
+
+superseded_outcome_output="$(python3 "$SCRIPT" --repo benhook1013/FireMUD --pr 2364 --input "$TMP_DIR/superseded-review-outcome.json")"
+grep -q "review_finished_after_latest_request=true" <<<"$superseded_outcome_output"
+grep -q "substantive_review_after_latest_commit=true" <<<"$superseded_outcome_output"
+grep -q "latest_review_request_rate_limited=false" <<<"$superseded_outcome_output"
+grep -q "latest_review_request_noop=false" <<<"$superseded_outcome_output"
+grep -q "retrigger_review_allowed=true" <<<"$superseded_outcome_output"
+grep -q "ok=true" <<<"$superseded_outcome_output"
 
 expect_failure_output "$TMP_DIR/outside-diff-actionable.json" "$TMP_DIR/outside-diff-actionable.out"
 [[ $EXPECT_FAILURE_STATUS -ne 0 ]]

--- a/dev-tools/tests/coderabbit-review-contract.sh
+++ b/dev-tools/tests/coderabbit-review-contract.sh
@@ -321,14 +321,6 @@ cat >"$TMP_DIR/review-rate-limited.json" <<'JSON'
           "nodes": [
             {
               "author": {
-                "login": "benhook1013"
-              },
-              "body": "@coderabbitai review",
-              "createdAt": "2026-07-03T02:40:00Z",
-              "url": "https://example.test/review"
-            },
-            {
-              "author": {
                 "login": "coderabbitai"
               },
               "body": "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->",
@@ -458,9 +450,10 @@ grep -q "reason=latest explicit CodeRabbit review request was acknowledged witho
 
 expect_failure_output "$TMP_DIR/review-rate-limited.json" "$TMP_DIR/review-rate-limited.out"
 [[ $EXPECT_FAILURE_STATUS -ne 0 ]]
+grep -q "explicit_review_after_latest_commit=false" "$TMP_DIR/review-rate-limited.out"
 grep -q "latest_review_request_rate_limited=true" "$TMP_DIR/review-rate-limited.out"
 grep -q "retrigger_review_allowed=false" "$TMP_DIR/review-rate-limited.out"
-grep -q "reason=latest explicit CodeRabbit review request was rate limited; do not retrigger yet" "$TMP_DIR/review-rate-limited.out"
+grep -q "reason=latest CodeRabbit review attempt after the PR commit was rate limited; do not retrigger yet" "$TMP_DIR/review-rate-limited.out"
 
 expect_failure_output "$TMP_DIR/outside-diff-actionable.json" "$TMP_DIR/outside-diff-actionable.out"
 [[ $EXPECT_FAILURE_STATUS -ne 0 ]]

--- a/dev-tools/validation/check-coderabbit-review.py
+++ b/dev-tools/validation/check-coderabbit-review.py
@@ -5,7 +5,7 @@ This script does not trust the top-level CodeRabbit status badge. It verifies:
 1. unresolved non-outdated review threads are zero
 2. unresolved outdated review threads are zero
 3. an explicit CodeRabbit review command was posted after the latest PR commit
-4. CodeRabbit posted a "Review finished." reply after that command
+4. CodeRabbit published a substantive review summary after that command
 """
 
 from __future__ import annotations
@@ -28,7 +28,11 @@ REVIEW_COMMANDS = {
     "@coderabbitai full review",
 }
 
-REVIEW_FINISHED_MARKER = "Review finished."
+# A command acknowledgement can say "Review finished." while explicitly stating that no commits
+# were reviewed. The walkthrough is emitted only by CodeRabbit's actual review summary.
+SUBSTANTIVE_REVIEW_MARKER = "<!-- walkthrough_start -->"
+REVIEW_LIMIT_MARKER = "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->"
+NOOP_REVIEW_MARKER = "does not re-review already reviewed commits"
 ACTIONABLE_COMMENTS_MARKER = "**Actionable comments posted:"
 OUTSIDE_DIFF_MARKER = "Outside diff range comments"
 DUPLICATE_COMMENTS_MARKER = "Duplicate comments"
@@ -47,6 +51,9 @@ class ReviewSummary:
     latest_coderabbit_review_finished_at: str | None
     explicit_review_after_latest_commit: bool
     review_finished_after_latest_request: bool
+    substantive_review_after_latest_commit: bool
+    latest_review_request_rate_limited: bool
+    latest_review_request_noop: bool
     retrigger_review_allowed: bool
     must_resolve_outdated_threads: bool
     outside_diff_actionable_comments: int
@@ -285,6 +292,8 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
     latest_explicit_review_request_dt: datetime | None = None
     latest_coderabbit_review_finished_at: str | None = None
     latest_coderabbit_review_finished_dt: datetime | None = None
+    latest_review_request_rate_limited = False
+    latest_review_request_noop = False
     latest_actionable_comment_dt: datetime | None = None
     latest_actionable_comment_url: str | None = None
     outside_diff_actionable_comments = 0
@@ -302,7 +311,7 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
             ):
                 latest_explicit_review_request_dt = created_at_dt
                 latest_explicit_review_request_at = created_at
-        if author == "coderabbitai" and REVIEW_FINISHED_MARKER in body:
+        if author == "coderabbitai" and SUBSTANTIVE_REVIEW_MARKER in body:
             if (
                 latest_coderabbit_review_finished_dt is None
                 or created_at_dt > latest_coderabbit_review_finished_dt
@@ -320,6 +329,21 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
         and latest_coderabbit_review_finished_dt is not None
         and latest_coderabbit_review_finished_dt >= latest_explicit_review_request_dt
     )
+    substantive_review_after_latest_commit = (
+        latest_coderabbit_review_finished_dt is not None
+        and latest_commit_at_dt is not None
+        and latest_coderabbit_review_finished_dt >= latest_commit_at_dt
+    )
+    if latest_explicit_review_request_dt is not None:
+        for comment in pr["comments"]["nodes"]:
+            if (comment.get("author") or {}).get("login", "") != "coderabbitai":
+                continue
+            created_at_dt = parse_timestamp(comment.get("createdAt"))
+            if created_at_dt is None or created_at_dt < latest_explicit_review_request_dt:
+                continue
+            body = comment.get("body", "")
+            latest_review_request_rate_limited |= REVIEW_LIMIT_MARKER in body
+            latest_review_request_noop |= NOOP_REVIEW_MARKER in body
     for comment in pr["comments"]["nodes"]:
         author = (comment.get("author") or {}).get("login", "")
         body = comment.get("body", "")
@@ -341,12 +365,16 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
     latest_review_request_still_running = (
         explicit_review_after_latest_commit
         and not review_finished_after_latest_request
+        and not latest_review_request_rate_limited
+        and not latest_review_request_noop
     )
     retrigger_review_allowed = (
         unresolved_total == 0
         and outside_diff_actionable_comments == 0
         and duplicate_actionable_comments == 0
         and not latest_review_request_still_running
+        and not latest_review_request_rate_limited
+        and not latest_review_request_noop
     )
     must_resolve_outdated_threads = unresolved_outdated > 0
 
@@ -376,7 +404,15 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
         )
     if not review_finished_after_latest_request:
         reasons.append(
-            "no completed CodeRabbit review found after the latest explicit review request"
+            "no substantive CodeRabbit review summary found after the latest explicit review request"
+        )
+    if not substantive_review_after_latest_commit:
+        reasons.append("no substantive CodeRabbit review summary found after the latest PR commit")
+    if latest_review_request_rate_limited:
+        reasons.append("latest explicit CodeRabbit review request was rate limited; do not retrigger yet")
+    if latest_review_request_noop:
+        reasons.append(
+            "latest explicit CodeRabbit review request was acknowledged without reviewing commits"
         )
 
     return ReviewSummary(
@@ -391,6 +427,9 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
         latest_coderabbit_review_finished_at=latest_coderabbit_review_finished_at,
         explicit_review_after_latest_commit=explicit_review_after_latest_commit,
         review_finished_after_latest_request=review_finished_after_latest_request,
+        substantive_review_after_latest_commit=substantive_review_after_latest_commit,
+        latest_review_request_rate_limited=latest_review_request_rate_limited,
+        latest_review_request_noop=latest_review_request_noop,
         retrigger_review_allowed=retrigger_review_allowed,
         must_resolve_outdated_threads=must_resolve_outdated_threads,
         outside_diff_actionable_comments=outside_diff_actionable_comments,
@@ -424,6 +463,18 @@ def emit_text(summary: ReviewSummary) -> None:
     print(
         "review_finished_after_latest_request="
         f"{str(summary.review_finished_after_latest_request).lower()}"
+    )
+    print(
+        "substantive_review_after_latest_commit="
+        f"{str(summary.substantive_review_after_latest_commit).lower()}"
+    )
+    print(
+        "latest_review_request_rate_limited="
+        f"{str(summary.latest_review_request_rate_limited).lower()}"
+    )
+    print(
+        "latest_review_request_noop="
+        f"{str(summary.latest_review_request_noop).lower()}"
     )
     print(
         "retrigger_review_allowed="

--- a/dev-tools/validation/check-coderabbit-review.py
+++ b/dev-tools/validation/check-coderabbit-review.py
@@ -518,6 +518,16 @@ def emit_text(summary: ReviewSummary) -> None:
             "warning=DO NOT RETRIGGER @coderabbitai review WHILE ANY UNRESOLVED "
             "CODERABBIT THREADS REMAIN"
         )
+    if (
+        summary.unresolved_total == 0
+        and summary.latest_coderabbit_review_finished_at is not None
+        and not summary.substantive_review_after_latest_commit
+    ):
+        print(
+            "warning=A SMALL FOLLOW-UP MAY MERGE WITHOUT A FRESH CODERABBIT RUN ONLY WHEN "
+            "EVERY POST-REVIEW COMMIT DIRECTLY ADDRESSES REVIEW FINDINGS; VERIFY THAT SCOPE "
+            "AND GREEN CI MANUALLY"
+        )
     if summary.reasons:
         for reason in summary.reasons:
             print(f"reason={reason}")

--- a/dev-tools/validation/check-coderabbit-review.py
+++ b/dev-tools/validation/check-coderabbit-review.py
@@ -292,8 +292,8 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
     latest_explicit_review_request_dt: datetime | None = None
     latest_coderabbit_review_finished_at: str | None = None
     latest_coderabbit_review_finished_dt: datetime | None = None
-    latest_review_request_rate_limited = False
-    latest_review_request_noop = False
+    latest_review_outcome_dt: datetime | None = None
+    latest_review_outcome: str | None = None
     latest_actionable_comment_dt: datetime | None = None
     latest_actionable_comment_url: str | None = None
     outside_diff_actionable_comments = 0
@@ -341,13 +341,29 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
         if created_at_dt is None:
             continue
         body = comment.get("body", "")
-        if latest_commit_at_dt is not None and created_at_dt >= latest_commit_at_dt:
-            latest_review_request_rate_limited |= REVIEW_LIMIT_MARKER in body
-        if (
+        if latest_commit_at_dt is None or created_at_dt < latest_commit_at_dt:
+            continue
+
+        outcome: str | None = None
+        if SUBSTANTIVE_REVIEW_MARKER in body:
+            outcome = "substantive"
+        elif REVIEW_LIMIT_MARKER in body:
+            outcome = "rate_limited"
+        elif (
             latest_explicit_review_request_dt is not None
             and created_at_dt >= latest_explicit_review_request_dt
+            and NOOP_REVIEW_MARKER in body
         ):
-            latest_review_request_noop |= NOOP_REVIEW_MARKER in body
+            outcome = "noop"
+
+        if outcome is not None and (
+            latest_review_outcome_dt is None or created_at_dt >= latest_review_outcome_dt
+        ):
+            latest_review_outcome_dt = created_at_dt
+            latest_review_outcome = outcome
+
+    latest_review_request_rate_limited = latest_review_outcome == "rate_limited"
+    latest_review_request_noop = latest_review_outcome == "noop"
     for comment in pr["comments"]["nodes"]:
         author = (comment.get("author") or {}).get("login", "")
         body = comment.get("body", "")

--- a/dev-tools/validation/check-coderabbit-review.py
+++ b/dev-tools/validation/check-coderabbit-review.py
@@ -334,15 +334,19 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
         and latest_commit_at_dt is not None
         and latest_coderabbit_review_finished_dt >= latest_commit_at_dt
     )
-    if latest_explicit_review_request_dt is not None:
-        for comment in pr["comments"]["nodes"]:
-            if (comment.get("author") or {}).get("login", "") != "coderabbitai":
-                continue
-            created_at_dt = parse_timestamp(comment.get("createdAt"))
-            if created_at_dt is None or created_at_dt < latest_explicit_review_request_dt:
-                continue
-            body = comment.get("body", "")
+    for comment in pr["comments"]["nodes"]:
+        if (comment.get("author") or {}).get("login", "") != "coderabbitai":
+            continue
+        created_at_dt = parse_timestamp(comment.get("createdAt"))
+        if created_at_dt is None:
+            continue
+        body = comment.get("body", "")
+        if latest_commit_at_dt is not None and created_at_dt >= latest_commit_at_dt:
             latest_review_request_rate_limited |= REVIEW_LIMIT_MARKER in body
+        if (
+            latest_explicit_review_request_dt is not None
+            and created_at_dt >= latest_explicit_review_request_dt
+        ):
             latest_review_request_noop |= NOOP_REVIEW_MARKER in body
     for comment in pr["comments"]["nodes"]:
         author = (comment.get("author") or {}).get("login", "")
@@ -409,7 +413,7 @@ def summarize(repo: str, pr_number: int, payload: dict[str, Any]) -> ReviewSumma
     if not substantive_review_after_latest_commit:
         reasons.append("no substantive CodeRabbit review summary found after the latest PR commit")
     if latest_review_request_rate_limited:
-        reasons.append("latest explicit CodeRabbit review request was rate limited; do not retrigger yet")
+        reasons.append("latest CodeRabbit review attempt after the PR commit was rate limited; do not retrigger yet")
     if latest_review_request_noop:
         reasons.append(
             "latest explicit CodeRabbit review request was acknowledged without reviewing commits"


### PR DESCRIPTION
## Summary

Prevents `check-coderabbit-review.py` from treating CodeRabbit command acknowledgements as completed reviews.

- Requires a substantive CodeRabbit walkthrough summary, not the phrase `Review finished.` alone.
- Detects and blocks both automatic and explicit rate-limit responses, plus no-op command acknowledgements, from review-complete or retrigger-safe states.
- Adds contract coverage for the exact no-op response that incorrectly allowed PR `#2441` to merge.

## Validation

- `bash dev-tools/tests/coderabbit-review-contract.sh`
- `python3 -m py_compile dev-tools/validation/check-coderabbit-review.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated the CodeRabbit review validation workflow in `dev-tools/validation/check-coderabbit-review.py` to require substantive walkthrough evidence after the latest commit.
- Rate-limit responses and no-op review acknowledgements now block completion and retrigger eligibility.
- Expanded `dev-tools/tests/coderabbit-review-contract.sh` fixtures and assertions for substantive reviews, rate limits, no-op responses, and follow-up merge warnings.
- Added contract coverage for the no-op response that previously allowed PR `#2441` to merge.
- Validated with CodeRabbit contract tests and Python syntax compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->