### PR TITLE
Cover email login OTP verification

### DIFF
--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountGrpcServiceTest.java
@@ -32,8 +32,11 @@ import net.firedevops.firemud.account.v1.GetTenantMembershipForRuntimeRequest;
 import net.firedevops.firemud.account.v1.GetTenantMembershipForRuntimeResponse;
 import net.firedevops.firemud.account.v1.PingRequest;
 import net.firedevops.firemud.account.v1.PingResponse;
+import net.firedevops.firemud.account.v1.RequestEmailLoginOtpRequest;
+import net.firedevops.firemud.account.v1.RequestEmailLoginOtpResponse;
 import net.firedevops.firemud.account.v1.UpdateProfileRequest;
 import net.firedevops.firemud.account.v1.UpdateProfileResponse;
+import net.firedevops.firemud.account.v1.VerifyEmailLoginOtpRequest;
 import net.firedevops.firemud.accountservice.dto.AccountDto;
 import net.firedevops.firemud.accountservice.entity.ProfilePresenceVisibilityPolicy;
 import net.firedevops.firemud.accountservice.service.AccountService;
@@ -111,6 +114,69 @@ class AccountGrpcServiceTest {
 
     assertNotNull(ref.get());
     assertEquals(AuthenticationErrorCodes.INVALID_CREDENTIALS, ref.get().getError().getCode());
+  }
+
+  @Test
+  void requestEmailLoginOtpDispatchesNeutralChallengeRequest() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<RequestEmailLoginOtpResponse> ref = new AtomicReference<>();
+    service.requestEmailLoginOtp(
+        RequestEmailLoginOtpRequest.newBuilder()
+            .setTenantId("7")
+            .setEmail("demo@example.com")
+            .build(),
+        new StreamObserver<RequestEmailLoginOtpResponse>() {
+          @Override
+          public void onNext(RequestEmailLoginOtpResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertTrue(ref.get().getAccepted());
+    Mockito.verify(accountService).requestEmailLoginOtp(7L, "demo@example.com");
+  }
+
+  @Test
+  void verifyEmailLoginOtpReturnsAuthenticatedSession() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    Mockito.when(accountService.verifyEmailLoginOtp(7L, "demo@example.com", "123456"))
+        .thenReturn(new net.firedevops.firemud.accountservice.dto.AuthenticationResult(9L, "jwt"));
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+
+    AtomicReference<AuthenticateResponse> ref = new AtomicReference<>();
+    service.verifyEmailLoginOtp(
+        VerifyEmailLoginOtpRequest.newBuilder()
+            .setTenantId("7")
+            .setEmail("demo@example.com")
+            .setCode("123456")
+            .build(),
+        new StreamObserver<AuthenticateResponse>() {
+          @Override
+          public void onNext(AuthenticateResponse value) {
+            ref.set(value);
+          }
+
+          @Override
+          public void onError(Throwable t) {}
+
+          @Override
+          public void onCompleted() {}
+        });
+
+    assertNotNull(ref.get());
+    assertEquals("9", ref.get().getAccountId());
+    assertEquals("jwt", ref.get().getAuthToken());
   }
 
   @Test

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountGrpcServiceTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountGrpcServiceTest.java
@@ -147,6 +147,27 @@ class AccountGrpcServiceTest {
   }
 
   @Test
+  void requestEmailLoginOtpRejectsZeroTenantIdAsApplicationError() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+    RecordingObserver<RequestEmailLoginOtpResponse> observer = new RecordingObserver<>();
+
+    service.requestEmailLoginOtp(
+        RequestEmailLoginOtpRequest.newBuilder()
+            .setTenantId("0")
+            .setEmail("demo@example.com")
+            .build(),
+        observer);
+
+    assertNotNull(observer.response());
+    assertEquals("INVALID_ARGUMENT", observer.response().getError().getCode());
+    assertTrue(observer.completed());
+    assertFalse(observer.receivedTransportError());
+    Mockito.verifyNoInteractions(accountService);
+  }
+
+  @Test
   void verifyEmailLoginOtpReturnsAuthenticatedSession() {
     PingService pingService = Mockito.mock(PingService.class);
     AccountService accountService = Mockito.mock(AccountService.class);
@@ -177,6 +198,54 @@ class AccountGrpcServiceTest {
     assertNotNull(ref.get());
     assertEquals("9", ref.get().getAccountId());
     assertEquals("jwt", ref.get().getAuthToken());
+  }
+
+  @Test
+  void verifyEmailLoginOtpRejectsZeroTenantIdAsApplicationError() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+    RecordingObserver<AuthenticateResponse> observer = new RecordingObserver<>();
+
+    service.verifyEmailLoginOtp(
+        VerifyEmailLoginOtpRequest.newBuilder()
+            .setTenantId("0")
+            .setEmail("demo@example.com")
+            .setCode("123456")
+            .build(),
+        observer);
+
+    assertNotNull(observer.response());
+    assertEquals("INVALID_ARGUMENT", observer.response().getError().getCode());
+    assertTrue(observer.completed());
+    assertFalse(observer.receivedTransportError());
+    Mockito.verifyNoInteractions(accountService);
+  }
+
+  @Test
+  void verifyEmailLoginOtpReturnsInvalidCredentialsAsApplicationError() {
+    PingService pingService = Mockito.mock(PingService.class);
+    AccountService accountService = Mockito.mock(AccountService.class);
+    Mockito.when(accountService.verifyEmailLoginOtp(7L, "demo@example.com", "123456"))
+        .thenThrow(
+            new AuthenticationException(
+                AuthenticationErrorCodes.INVALID_CREDENTIALS, "Invalid credentials"));
+    AccountGrpcService service = new AccountGrpcService(pingService, accountService);
+    RecordingObserver<AuthenticateResponse> observer = new RecordingObserver<>();
+
+    service.verifyEmailLoginOtp(
+        VerifyEmailLoginOtpRequest.newBuilder()
+            .setTenantId("7")
+            .setEmail("demo@example.com")
+            .setCode("123456")
+            .build(),
+        observer);
+
+    assertNotNull(observer.response());
+    assertEquals(
+        AuthenticationErrorCodes.INVALID_CREDENTIALS, observer.response().getError().getCode());
+    assertTrue(observer.completed());
+    assertFalse(observer.receivedTransportError());
   }
 
   @Test
@@ -967,5 +1036,38 @@ class AccountGrpcServiceTest {
     assertNotNull(ref.get());
     assertEquals(false, ref.get().getSuccess());
     assertEquals("PERMISSION_DENIED", ref.get().getError().getCode());
+  }
+
+  private static final class RecordingObserver<T> implements StreamObserver<T> {
+    private T response;
+    private boolean receivedTransportError;
+    private boolean completed;
+
+    @Override
+    public void onNext(T value) {
+      response = value;
+    }
+
+    @Override
+    public void onError(Throwable throwable) {
+      receivedTransportError = true;
+    }
+
+    @Override
+    public void onCompleted() {
+      completed = true;
+    }
+
+    private T response() {
+      return response;
+    }
+
+    private boolean receivedTransportError() {
+      return receivedTransportError;
+    }
+
+    private boolean completed() {
+      return completed;
+    }
   }
 }

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -229,7 +229,13 @@ class AccountServiceImplTest {
         .thenReturn(Optional.of(membership));
     when(accountEmailLoginChallengeRepository.findByAccountId(9L)).thenReturn(Optional.empty());
     when(accountEmailLoginChallengeRepository.save(org.mockito.ArgumentMatchers.any()))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+        .thenAnswer(
+            invocation -> {
+              net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge challenge =
+                  invocation.getArgument(0);
+              challenge.setId(3L);
+              return challenge;
+            });
 
     service.requestEmailLoginOtp(7L, "verified@example.com");
 
@@ -297,7 +303,7 @@ class AccountServiceImplTest {
         .storeSession(
             org.mockito.ArgumentMatchers.eq(7L),
             org.mockito.ArgumentMatchers.eq(9L),
-            org.mockito.ArgumentMatchers.anyString());
+            org.mockito.ArgumentMatchers.eq(result.authToken()));
   }
 
   @Test

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -14,6 +14,8 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import net.firedevops.firemud.account.AuthenticationErrorCodes;
 import net.firedevops.firemud.accountservice.client.EntityManagementClient;
 import net.firedevops.firemud.accountservice.client.GameSessionClient;
@@ -245,6 +247,57 @@ class AccountServiceImplTest {
             org.mockito.ArgumentMatchers.eq("verified@example.com"),
             org.mockito.ArgumentMatchers.anyString(),
             org.mockito.ArgumentMatchers.matches(".*\\b\\d{6}\\b.*"));
+  }
+
+  @Test
+  void emailLoginOtpVerificationAuthenticatesAndConsumesMatchingChallenge() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setEmail("verified@example.com");
+    account.setEmailVerified(true);
+    account.setRole("player");
+    AccountTenantMembership membership = new AccountTenantMembership();
+    membership.setGameplayAdmissionAllowed(true);
+    when(accountRepository.findByEmail("verified@example.com")).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(9L, 7L))
+        .thenReturn(Optional.of(membership));
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L)).thenReturn(Optional.empty());
+    when(accountEmailLoginChallengeRepository.save(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.requestEmailLoginOtp(7L, "verified@example.com");
+
+    org.mockito.ArgumentCaptor<
+            net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge>
+        challengeCaptor =
+            org.mockito.ArgumentCaptor.forClass(
+                net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge.class);
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository)
+        .save(challengeCaptor.capture());
+    org.mockito.ArgumentCaptor<String> emailBodyCaptor =
+        org.mockito.ArgumentCaptor.forClass(String.class);
+    org.mockito.Mockito.verify(emailService)
+        .sendEmail(
+            org.mockito.ArgumentMatchers.eq("verified@example.com"),
+            org.mockito.ArgumentMatchers.anyString(),
+            emailBodyCaptor.capture());
+    Matcher codeMatcher = Pattern.compile("\\b(\\d{6})\\b").matcher(emailBodyCaptor.getValue());
+    assertTrue(codeMatcher.find());
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L))
+        .thenReturn(Optional.of(challengeCaptor.getValue()));
+
+    AuthenticationResult result =
+        service.verifyEmailLoginOtp(7L, "verified@example.com", codeMatcher.group(1));
+
+    assertEquals(9L, result.accountId());
+    assertNotNull(result.authToken());
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository)
+        .delete(challengeCaptor.getValue());
+    org.mockito.Mockito.verify(sessionService)
+        .storeSession(
+            org.mockito.ArgumentMatchers.eq(7L),
+            org.mockito.ArgumentMatchers.eq(9L),
+            org.mockito.ArgumentMatchers.anyString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Completes the focused proof surface for the merged Account email-login OTP authority.

- Covers a verified account requesting a challenge, receiving a six-digit email code, verifying it, consuming the single-use challenge, and receiving a stored authenticated session.
- Covers Account gRPC request and verification response mapping for the new public OTP RPCs.
- Does not alter account-mode policy or Game Session secret grammar.

## Validation

- `./gradlew :account-service:test --tests 'net.firedevops.firemud.accountservice.service.impl.AccountServiceImplTest' --tests 'net.firedevops.firemud.accountservice.service.impl.AccountGrpcServiceTest'`
- `bash dev-tools/validation/run-locked-gradle.sh :account-service:check -PfullCheck --console=plain --quiet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added Account Service test coverage for the merged email-login OTP flow, including OTP request, six-digit code extraction and verification, single-use challenge consumption, authenticated session creation, and gRPC request/response mapping.

Validation covers the relevant Account Service tests and the locked Gradle check. No account policy, schema, migration, deployment, or Game Session secret grammar changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->