### PR TITLE
Serialize email login OTP challenges

### DIFF
--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountEmailLoginChallengeRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountEmailLoginChallengeRepository.java
@@ -26,6 +26,11 @@ public class AccountEmailLoginChallengeRepository {
             .fetchOne(this::toEntity));
   }
 
+  /** Serializes all email-login challenge mutations for one account in the current transaction. */
+  public void lockAccountChallenge(long accountId) {
+    dsl.fetch("select pg_advisory_xact_lock(?)", accountId);
+  }
+
   public AccountEmailLoginChallenge save(AccountEmailLoginChallenge entity) {
     if (entity.getId() == null) {
       Long id =

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
@@ -250,6 +250,7 @@ public class AccountServiceImpl implements AccountService {
     } catch (IllegalArgumentException ex) {
       return;
     }
+    accountEmailLoginChallengeRepository.lockAccountChallenge(resolvedAccount.getId());
     LocalDateTime now = LocalDateTime.now();
     Optional<AccountEmailLoginChallenge> existing =
         accountEmailLoginChallengeRepository.findByAccountId(resolvedAccount.getId());
@@ -278,6 +279,7 @@ public class AccountServiceImpl implements AccountService {
         accountRepository
             .findByEmail(email == null ? "" : email.trim())
             .orElseThrow(this::invalidCredentials);
+    accountEmailLoginChallengeRepository.lockAccountChallenge(account.getId());
     AccountEmailLoginChallenge challenge =
         accountEmailLoginChallengeRepository
             .findByAccountId(account.getId())

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -238,6 +238,7 @@ class AccountServiceImplTest {
                 net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge.class);
     org.mockito.Mockito.verify(accountEmailLoginChallengeRepository)
         .save(challengeCaptor.capture());
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository).lockAccountChallenge(9L);
     assertEquals(9L, challengeCaptor.getValue().getAccountId());
     assertFalse(challengeCaptor.getValue().getCodeHash().matches("\\d{6}"));
     org.mockito.Mockito.verify(emailService)
@@ -258,6 +259,36 @@ class AccountServiceImplTest {
 
     assertEquals(AuthenticationErrorCodes.INVALID_CREDENTIALS, exception.getCode());
     verifyNoInteractions(accountEmailLoginChallengeRepository, sessionService);
+  }
+
+  @Test
+  void emailLoginOtpVerificationLocksChallengeBeforeConsumingIt() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setEmail("verified@example.com");
+    account.setRole("player");
+    AccountTenantMembership membership = new AccountTenantMembership();
+    membership.setGameplayAdmissionAllowed(true);
+    net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge challenge =
+        new net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge();
+    challenge.setId(5L);
+    challenge.setAccountId(9L);
+    challenge.setCodeHash(hash("123456"));
+    challenge.setExpiresAt(java.time.LocalDateTime.now().plusMinutes(10));
+    challenge.setInvalidAttemptCount(0);
+    when(accountRepository.findByEmail("verified@example.com")).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(9L, 7L))
+        .thenReturn(Optional.of(membership));
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L))
+        .thenReturn(Optional.of(challenge));
+
+    AuthenticationResult result = service.verifyEmailLoginOtp(7L, "verified@example.com", "123456");
+
+    assertEquals(9L, result.accountId());
+    org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(accountEmailLoginChallengeRepository);
+    inOrder.verify(accountEmailLoginChallengeRepository).lockAccountChallenge(9L);
+    inOrder.verify(accountEmailLoginChallengeRepository).findByAccountId(9L);
+    inOrder.verify(accountEmailLoginChallengeRepository).delete(challenge);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes concurrency defects in the merged Account email-login OTP authority discovered during the manual post-merge audit.

- Uses a transaction-scoped PostgreSQL advisory lock per account before email challenge creation, verification, or failed-attempt mutation.
- Prevents concurrent requests from racing the unique account challenge row.
- Preserves one-time code consumption and bounded invalid-attempt accounting under concurrent verification.
- Adds focused lock-order proof for request and successful verification paths.

## Validation

- `./gradlew :account-service:test --tests 'net.firedevops.firemud.accountservice.service.impl.AccountServiceImplTest'`
- `bash dev-tools/validation/run-locked-gradle.sh :account-service:check -PfullCheck --console=plain --quiet`
