### PR TITLE
Make Account Service login mode-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,46 +48,18 @@ Use this file as the entrypoint for AI work in this repository. Treat repo docs 
 
 ## Subagent Models
 
-When using subagents, call `spawn_agent` with an explicit `agent_type`, a tightly scoped task, and a `model` override only when there is a clear reason not to inherit the parent model. Prefer these models for delegation:
+Subagents share the main weekly allowance. Use them only when bounded parallel work preserves main-thread context or improves turnaround.
 
-- `gpt-5.3-codex-spark`: Use for most bounded delegation. Main thread owns slice boundaries, integration, and final validation.
-- `gpt-5.4-mini`: Use for targeted tasks.
-- `gpt-5.5`: Use when delegation needs a smarter model for harder reasoning, ambiguous implementation work, or higher-risk synthesis.
-
-Typical call shape:
-
-```json
-{
-  "agent_type": "explorer",
-  "message": "Find where session tokens are issued and validated. Report exact files and entrypoints.",
-  "model": "gpt-5.3-codex-spark"
-}
-```
-
-```json
-{
-  "agent_type": "worker",
-  "message": "Own the auth middleware tests in <path>. Make the bounded fix, do not touch unrelated files, and report changed paths.",
-  "model": "gpt-5.4-mini"
-}
-```
-
-```json
-{
-  "agent_type": "worker",
-  "message": "Own the protocol validation refactor in <path>. Resolve the design cleanly, preserve in-flight edits from others, and report changed paths.",
-  "model": "gpt-5.5"
-}
-```
-
-If no model override is needed, omit `model` and let the subagent inherit the parent model.
+- `gpt-5.6-luna`: Default for repository searches, focused review, narrow test investigation, and mechanical local fixes.
+- `gpt-5.6-terra`: Use only for a bounded implementation task that Luna cannot handle reliably.
+- Do not delegate design decisions. Main thread owns design reasoning with the human, slice boundaries, integration, validation, and PR decisions.
 
 ## Execution Style
 
 - Prefer a single main-thread workflow on the active branch and in the current working tree unless a human explicitly asks otherwise.
 - Keep orchestration, integration, end-to-end reasoning, and final verification on the main thread.
 - Use subagents only for bounded parallelizable work when delegation is explicitly requested or clearly improves turnaround.
-- When delegating, prefer `gpt-5.3-codex-spark` for most tasks, `gpt-5.4-mini` for targeted tasks, and `gpt-5.5` when stronger reasoning is needed; give each subagent a narrowly scoped task with explicit success conditions.
+- When delegating, prefer `gpt-5.6-luna` unless a bounded implementation task needs `gpt-5.6-terra`; give each subagent a narrowly scoped task with explicit success conditions.
 - Optimize for direct convergence and avoid unnecessary splitting across delegated workers.
 - Be proactive within scope. If the task exposes nearby drift or related breakage in the same area, fix it in the same pass when practical.
 - When rolling out or repairing a shared pattern, update the remaining in-scope adopters in the same pass when practical.

--- a/design/project-management/vertical-slices/02.1.1-task-list-email-otp-and-text-auth-options-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.1.1-task-list-email-otp-and-text-auth-options-vertical-slice.md
@@ -12,9 +12,9 @@ Goal: define the canonical text-client authentication model around account-selec
 
 ## Implementation Notes
 
-The first additive backend batch is now live in Account Service: it owns neutral email-login OTP challenge initiation, persists one short-lived hashed code per account with resend cooldown and bounded failed attempts, and verifies a single-use code into the existing authenticated session/token result.
+Account Service owns neutral email-login OTP challenge initiation, persists one short-lived hashed code per account with resend cooldown and bounded failed attempts, and verifies a single-use code into the existing authenticated session/token result.
 
-The next Account Service batch persists the primary login mechanism set as `login_auth_modes`. Existing and newly created accounts default to the compatible mixed set `PASSWORD,EMAIL_OTP`. Account Service is authoritative for interpreting the supplied second secret: it tries a valid active email code first, falls back to password only when that mode is allowed, and only counts a failed email-code attempt when neither allowed mechanism authenticates. Code issue and direct verification also reject accounts without the email-OTP mode.
+Account Service persists the primary login mechanism set as `login_auth_modes`. Existing and newly created accounts default to the compatible mixed set `PASSWORD,EMAIL_OTP`. Account Service is authoritative for interpreting the supplied second secret: it tries a valid active email code first, falls back to password only when that mode is allowed, and only counts a failed email-code attempt when neither allowed mechanism authenticates. Code issue and direct verification also reject accounts without the email-OTP mode.
 
 Current Game Session command adoption remains incomplete:
 

--- a/design/project-management/vertical-slices/02.1.1-task-list-email-otp-and-text-auth-options-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.1.1-task-list-email-otp-and-text-auth-options-vertical-slice.md
@@ -2,7 +2,7 @@
 
 ## Goal and Status
 
-Goal: define the canonical text-client authentication model around account-selected login modes, a shared account-level OTP secret, and a text-first `LOGIN <email> [secret]` flow that supports password, emailed OTP, and later authenticator-app TOTP without fragmenting the auth system. Status: backend challenge lifecycle in progress; Game Session command adoption and account-mode policy remain pending.
+Goal: define the canonical text-client authentication model around account-selected login modes, a shared account-level OTP secret, and a text-first `LOGIN <email> [secret]` flow that supports password, emailed OTP, and later authenticator-app TOTP without fragmenting the auth system. Status: Account Service password/email-OTP policy is live; Game Session one-argument challenge initiation, account-mode selection, and TOTP enrollment remain pending.
 
 ## Checklist
 
@@ -12,15 +12,18 @@ Goal: define the canonical text-client authentication model around account-selec
 
 ## Implementation Notes
 
-The first additive backend batch is now live in Account Service: it owns neutral email-login OTP challenge initiation, persists one short-lived hashed code per account with resend cooldown and bounded failed attempts, and verifies a single-use code into the existing authenticated session/token result. It intentionally preserves password login and does not yet claim account-mode selection, TOTP enrollment, or Game Session `LOGIN` grammar adoption.
+The first additive backend batch is now live in Account Service: it owns neutral email-login OTP challenge initiation, persists one short-lived hashed code per account with resend cooldown and bounded failed attempts, and verifies a single-use code into the existing authenticated session/token result.
 
-Current live implementation still uses the older password-first model:
+The next Account Service batch persists the primary login mechanism set as `login_auth_modes`. Existing and newly created accounts default to the compatible mixed set `PASSWORD,EMAIL_OTP`. Account Service is authoritative for interpreting the supplied second secret: it tries a valid active email code first, falls back to password only when that mode is allowed, and only counts a failed email-code attempt when neither allowed mechanism authenticates. Code issue and direct verification also reject accounts without the email-OTP mode.
 
-- text login is still shaped around `LOGIN <email> <password>`;
-- optional OTP is only applied in the current implementation for elevated accounts that already have a stored two-factor secret;
-- current prompts/help still reflect that older model.
+Current Game Session command adoption remains incomplete:
 
-So this document should be read as the intended auth redesign direction, not as a description of the current command UX.
+- `LOGIN <email> <secret>` already forwards the opaque secret to Account Service and therefore receives the new policy;
+- `LOGIN <email>` does not yet request an emailed challenge;
+- current prompts/help still reflect the older password-first presentation;
+- account settings/signup selection and authenticator-app TOTP enrollment remain later work.
+
+So this document remains the target-state auth design, with the Account Service policy portion now implemented.
 
 This slice is a follow-up to the existing login/session work. FireMUD should not treat text clients as a degraded copy of browser login. It needs one deliberate text-first auth model that stays compact in Telnet and generic WebSocket clients while still allowing stronger security modes for the users who want them.
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/Account.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/Account.java
@@ -11,4 +11,5 @@ public class Account {
   private String role = "player";
   private String twoFactorSecret;
   private boolean emailVerified = false;
+  private String loginAuthModes = AccountLoginAuthModes.DEFAULT_SERIALIZED;
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountLoginAuthMode.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountLoginAuthMode.java
@@ -1,0 +1,7 @@
+package net.firedevops.firemud.accountservice.entity;
+
+/** Primary credential mechanisms Account Service may evaluate for an account. */
+public enum AccountLoginAuthMode {
+  PASSWORD,
+  EMAIL_OTP
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountLoginAuthModes.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountLoginAuthModes.java
@@ -3,6 +3,7 @@ package net.firedevops.firemud.accountservice.entity;
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Canonical reader for the persisted primary-login mode set. */
 public final class AccountLoginAuthModes {
@@ -31,5 +32,10 @@ public final class AccountLoginAuthModes {
       throw new IllegalStateException("Account must have at least one login authentication mode");
     }
     return Set.copyOf(modes);
+  }
+
+  /** Returns the database representation in stable enum declaration order. */
+  public static String normalize(String serializedModes) {
+    return read(serializedModes).stream().sorted().map(Enum::name).collect(Collectors.joining(","));
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountLoginAuthModes.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/entity/AccountLoginAuthModes.java
@@ -1,0 +1,35 @@
+package net.firedevops.firemud.accountservice.entity;
+
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Set;
+
+/** Canonical reader for the persisted primary-login mode set. */
+public final class AccountLoginAuthModes {
+  public static final String DEFAULT_SERIALIZED = "PASSWORD,EMAIL_OTP";
+
+  private AccountLoginAuthModes() {}
+
+  public static boolean allows(String serializedModes, AccountLoginAuthMode mode) {
+    return read(serializedModes).contains(mode);
+  }
+
+  public static Set<AccountLoginAuthMode> read(String serializedModes) {
+    if (serializedModes == null || serializedModes.isBlank()) {
+      return EnumSet.of(AccountLoginAuthMode.PASSWORD);
+    }
+
+    EnumSet<AccountLoginAuthMode> modes = EnumSet.noneOf(AccountLoginAuthMode.class);
+    for (String token : serializedModes.split(",")) {
+      try {
+        modes.add(AccountLoginAuthMode.valueOf(token.trim().toUpperCase(Locale.ROOT)));
+      } catch (IllegalArgumentException ex) {
+        throw new IllegalStateException("Account has an invalid login authentication mode", ex);
+      }
+    }
+    if (modes.isEmpty()) {
+      throw new IllegalStateException("Account must have at least one login authentication mode");
+    }
+    return Set.copyOf(modes);
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountRealmAccessGrantRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountRealmAccessGrantRepository.java
@@ -130,7 +130,8 @@ public class AccountRealmAccessGrantRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(ACCOUNT_REALM_ACCESS_GRANT)
         .join(ACCOUNTS)
         .on(ACCOUNT_REALM_ACCESS_GRANT.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -147,7 +148,8 @@ public class AccountRealmAccessGrantRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     grant.setTenantId(record.get(ACCOUNT_REALM_ACCESS_GRANT.TENANT_ID));
     grant.setWorldSlug(record.get(ACCOUNT_REALM_ACCESS_GRANT.WORLD_SLUG));
     grant.setRealmSlug(record.get(ACCOUNT_REALM_ACCESS_GRANT.REALM_SLUG));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountRepository.java
@@ -45,7 +45,7 @@ public class AccountRepository {
               .set(ACCOUNTS.ROLE, entity.getRole())
               .set(ACCOUNTS.TWO_FACTOR_SECRET, entity.getTwoFactorSecret())
               .set(ACCOUNTS.EMAIL_VERIFIED, entity.isEmailVerified())
-              .set(ACCOUNTS.LOGIN_AUTH_MODES, entity.getLoginAuthModes())
+              .set(ACCOUNTS.LOGIN_AUTH_MODES, normalizedLoginAuthModes(entity))
               .returningResult(ACCOUNTS.ID)
               .fetchOne(ACCOUNTS.ID);
       entity.setId(id);
@@ -59,7 +59,7 @@ public class AccountRepository {
             .set(ACCOUNTS.ROLE, entity.getRole())
             .set(ACCOUNTS.TWO_FACTOR_SECRET, entity.getTwoFactorSecret())
             .set(ACCOUNTS.EMAIL_VERIFIED, entity.isEmailVerified())
-            .set(ACCOUNTS.LOGIN_AUTH_MODES, entity.getLoginAuthModes())
+            .set(ACCOUNTS.LOGIN_AUTH_MODES, normalizedLoginAuthModes(entity))
             .where(ACCOUNTS.ID.eq(entity.getId()))
             .execute();
     if (updated != 1) {
@@ -84,5 +84,10 @@ public class AccountRepository {
         record.getTwoFactorSecret(),
         record.getEmailVerified(),
         record.getLoginAuthModes());
+  }
+
+  private String normalizedLoginAuthModes(Account entity) {
+    return net.firedevops.firemud.accountservice.entity.AccountLoginAuthModes.normalize(
+        entity.getLoginAuthModes());
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountRepository.java
@@ -45,6 +45,7 @@ public class AccountRepository {
               .set(ACCOUNTS.ROLE, entity.getRole())
               .set(ACCOUNTS.TWO_FACTOR_SECRET, entity.getTwoFactorSecret())
               .set(ACCOUNTS.EMAIL_VERIFIED, entity.isEmailVerified())
+              .set(ACCOUNTS.LOGIN_AUTH_MODES, entity.getLoginAuthModes())
               .returningResult(ACCOUNTS.ID)
               .fetchOne(ACCOUNTS.ID);
       entity.setId(id);
@@ -58,6 +59,7 @@ public class AccountRepository {
             .set(ACCOUNTS.ROLE, entity.getRole())
             .set(ACCOUNTS.TWO_FACTOR_SECRET, entity.getTwoFactorSecret())
             .set(ACCOUNTS.EMAIL_VERIFIED, entity.isEmailVerified())
+            .set(ACCOUNTS.LOGIN_AUTH_MODES, entity.getLoginAuthModes())
             .where(ACCOUNTS.ID.eq(entity.getId()))
             .execute();
     if (updated != 1) {
@@ -80,6 +82,7 @@ public class AccountRepository {
         record.getPasswordHash(),
         record.getRole(),
         record.getTwoFactorSecret(),
-        record.getEmailVerified());
+        record.getEmailVerified(),
+        record.getLoginAuthModes());
   }
 }

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountTenantMembershipRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/AccountTenantMembershipRepository.java
@@ -125,7 +125,8 @@ public class AccountTenantMembershipRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(ACCOUNT_TENANT_MEMBERSHIP)
         .join(ACCOUNTS)
         .on(ACCOUNT_TENANT_MEMBERSHIP.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -142,7 +143,8 @@ public class AccountTenantMembershipRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     membership.setTenantId(record.get(ACCOUNT_TENANT_MEMBERSHIP.TENANT_ID));
     membership.setGameplayAdmissionAllowed(
         Boolean.TRUE.equals(record.get(ACCOUNT_TENANT_MEMBERSHIP.GAMEPLAY_ADMISSION_ALLOWED)));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/CurrencyBalanceRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/CurrencyBalanceRepository.java
@@ -75,7 +75,8 @@ public class CurrencyBalanceRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(CURRENCY_BALANCE)
         .join(ACCOUNTS)
         .on(CURRENCY_BALANCE.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -92,7 +93,8 @@ public class CurrencyBalanceRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     balance.setCurrencyCode(record.get(CURRENCY_BALANCE.CURRENCY_CODE));
     balance.setBalance(record.get(CURRENCY_BALANCE.BALANCE));
     balance.setTenantId(record.get(CURRENCY_BALANCE.TENANT_ID));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/EmailVerificationTokenRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/EmailVerificationTokenRepository.java
@@ -78,7 +78,8 @@ public class EmailVerificationTokenRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(EMAIL_VERIFICATION_TOKEN)
         .join(ACCOUNTS)
         .on(EMAIL_VERIFICATION_TOKEN.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -95,7 +96,8 @@ public class EmailVerificationTokenRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     token.setToken(record.get(EMAIL_VERIFICATION_TOKEN.TOKEN));
     token.setExpiresAt(record.get(EMAIL_VERIFICATION_TOKEN.EXPIRES_AT));
     return token;

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/ExternalAccountRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/ExternalAccountRepository.java
@@ -90,7 +90,8 @@ public class ExternalAccountRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(EXTERNAL_ACCOUNT)
         .join(ACCOUNTS)
         .on(EXTERNAL_ACCOUNT.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -107,7 +108,8 @@ public class ExternalAccountRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     entity.setTenantId(record.get(EXTERNAL_ACCOUNT.TENANT_ID));
     entity.setProvider(record.get(EXTERNAL_ACCOUNT.PROVIDER));
     entity.setExternalId(record.get(EXTERNAL_ACCOUNT.EXTERNAL_ID));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/JooqAccountRepositorySupport.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/JooqAccountRepositorySupport.java
@@ -33,6 +33,19 @@ final class JooqAccountRepositorySupport {
       String role,
       String twoFactorSecret,
       Boolean emailVerified) {
+    return partialAccount(
+        id, username, email, passwordHash, role, twoFactorSecret, emailVerified, null);
+  }
+
+  static Account partialAccount(
+      Long id,
+      String username,
+      String email,
+      String passwordHash,
+      String role,
+      String twoFactorSecret,
+      Boolean emailVerified,
+      String loginAuthModes) {
     if (id == null) {
       return null;
     }
@@ -44,6 +57,9 @@ final class JooqAccountRepositorySupport {
     account.setRole(role);
     account.setTwoFactorSecret(twoFactorSecret);
     account.setEmailVerified(Boolean.TRUE.equals(emailVerified));
+    if (loginAuthModes != null) {
+      account.setLoginAuthModes(loginAuthModes);
+    }
     return account;
   }
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/PasswordResetTokenRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/PasswordResetTokenRepository.java
@@ -83,7 +83,8 @@ public class PasswordResetTokenRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(PASSWORD_RESET_TOKEN)
         .join(ACCOUNTS)
         .on(PASSWORD_RESET_TOKEN.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -100,7 +101,8 @@ public class PasswordResetTokenRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     token.setToken(record.get(PASSWORD_RESET_TOKEN.TOKEN));
     token.setExpiresAt(record.get(PASSWORD_RESET_TOKEN.EXPIRES_AT));
     return token;

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/PaymentTransactionRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/PaymentTransactionRepository.java
@@ -98,7 +98,8 @@ public class PaymentTransactionRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(PAYMENT_TRANSACTION)
         .join(ACCOUNTS)
         .on(PAYMENT_TRANSACTION.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -115,7 +116,8 @@ public class PaymentTransactionRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     entity.setAmountCents(record.get(PAYMENT_TRANSACTION.AMOUNT_CENTS));
     entity.setCurrency(record.get(PAYMENT_TRANSACTION.CURRENCY));
     entity.setStatus(record.get(PAYMENT_TRANSACTION.STATUS));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/ProfileRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/ProfileRepository.java
@@ -97,7 +97,8 @@ public class ProfileRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(PROFILES)
         .join(ACCOUNTS)
         .on(PROFILES.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -114,7 +115,8 @@ public class ProfileRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     profile.setTenantId(record.get(PROFILES.TENANT_ID));
     profile.setDisplayName(record.get(PROFILES.DISPLAY_NAME));
     profile.setBio(record.get(PROFILES.BIO));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/SubscriptionRepository.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/repository/SubscriptionRepository.java
@@ -92,7 +92,8 @@ public class SubscriptionRepository {
             ACCOUNTS.PASSWORD_HASH,
             ACCOUNTS.ROLE,
             ACCOUNTS.TWO_FACTOR_SECRET,
-            ACCOUNTS.EMAIL_VERIFIED)
+            ACCOUNTS.EMAIL_VERIFIED,
+            ACCOUNTS.LOGIN_AUTH_MODES)
         .from(SUBSCRIPTION)
         .join(ACCOUNTS)
         .on(SUBSCRIPTION.ACCOUNT_ID.eq(ACCOUNTS.ID));
@@ -109,7 +110,8 @@ public class SubscriptionRepository {
             record.get(ACCOUNTS.PASSWORD_HASH),
             record.get(ACCOUNTS.ROLE),
             record.get(ACCOUNTS.TWO_FACTOR_SECRET),
-            record.get(ACCOUNTS.EMAIL_VERIFIED)));
+            record.get(ACCOUNTS.EMAIL_VERIFIED),
+            record.get(ACCOUNTS.LOGIN_AUTH_MODES)));
     entity.setPlanId(record.get(SUBSCRIPTION.PLAN_ID));
     entity.setStatus(record.get(SUBSCRIPTION.STATUS));
     entity.setStartedAt(record.get(SUBSCRIPTION.STARTED_AT));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
@@ -226,7 +226,8 @@ public class AccountServiceImpl implements AccountService {
   @Timed(value = "account.authenticate")
   public net.firedevops.firemud.accountservice.dto.AuthenticationResult authenticate(
       Long tenantId, String username, String password, String otp) {
-    PrimaryAuthentication authentication = authenticateAccountIdentity(username, password, otp);
+    PrimaryAuthentication authentication =
+        authenticateAccountIdentity(username, password, otp, true);
     Account account = authentication.account();
     requireGameplayMembership(account.getId(), tenantId, "Invalid credentials");
     authentication.emailLoginChallenge().ifPresent(accountEmailLoginChallengeRepository::delete);
@@ -315,7 +316,8 @@ public class AccountServiceImpl implements AccountService {
   @Timed(value = "account.player_bootstrap")
   public PlayerBootstrapResult issuePlayerBootstrap(
       Long tenantId, String username, String password, String otp) {
-    PrimaryAuthentication authentication = authenticateAccountIdentity(username, password, otp);
+    PrimaryAuthentication authentication =
+        authenticateAccountIdentity(username, password, otp, false);
     Account account = authentication.account();
     authentication.emailLoginChallenge().ifPresent(accountEmailLoginChallengeRepository::delete);
     String jti = UUID.randomUUID().toString();
@@ -1033,7 +1035,7 @@ public class AccountServiceImpl implements AccountService {
   }
 
   private PrimaryAuthentication authenticateAccountIdentity(
-      String username, String password, String otp) {
+      String username, String password, String otp, boolean allowEmailLoginOtp) {
     Optional<Account> accountOpt = findAccountForAuthentication(username);
     Account account =
         accountOpt.orElseThrow(
@@ -1041,7 +1043,9 @@ public class AccountServiceImpl implements AccountService {
                 new AuthenticationException(
                     AuthenticationErrorCodes.INVALID_CREDENTIALS, "Invalid credentials"));
     Optional<AccountEmailLoginChallenge> emailLoginChallenge =
-        allowsEmailLoginOtp(account) ? activeEmailLoginChallenge(account) : Optional.empty();
+        allowEmailLoginOtp && allowsEmailLoginOtp(account)
+            ? activeEmailLoginChallenge(account)
+            : Optional.empty();
     if (emailLoginChallenge
         .filter(challenge -> matchesEmailLoginOtp(challenge, password))
         .isPresent()) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
@@ -50,6 +50,8 @@ import net.firedevops.firemud.accountservice.dto.UsernameRecoveryRequest;
 import net.firedevops.firemud.accountservice.dto.VerifyEmailRequest;
 import net.firedevops.firemud.accountservice.entity.Account;
 import net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge;
+import net.firedevops.firemud.accountservice.entity.AccountLoginAuthMode;
+import net.firedevops.firemud.accountservice.entity.AccountLoginAuthModes;
 import net.firedevops.firemud.accountservice.entity.AccountRealmAccessGrant;
 import net.firedevops.firemud.accountservice.entity.AccountTenantMembership;
 import net.firedevops.firemud.accountservice.entity.EmailVerificationToken;
@@ -220,12 +222,14 @@ public class AccountServiceImpl implements AccountService {
   }
 
   @Override
-  @Transactional(readOnly = true)
+  @Transactional
   @Timed(value = "account.authenticate")
   public net.firedevops.firemud.accountservice.dto.AuthenticationResult authenticate(
       Long tenantId, String username, String password, String otp) {
-    Account account = authenticateAccountIdentity(username, password, otp);
+    PrimaryAuthentication authentication = authenticateAccountIdentity(username, password, otp);
+    Account account = authentication.account();
     requireGameplayMembership(account.getId(), tenantId, "Invalid credentials");
+    authentication.emailLoginChallenge().ifPresent(accountEmailLoginChallengeRepository::delete);
     String token =
         jwtUtil.generateToken(
             account.getId().toString(),
@@ -241,7 +245,9 @@ public class AccountServiceImpl implements AccountService {
   @Timed(value = "account.request_email_login_otp")
   public void requestEmailLoginOtp(Long tenantId, String email) {
     Optional<Account> account = accountRepository.findByEmail(email == null ? "" : email.trim());
-    if (account.isEmpty() || !account.orElseThrow().isEmailVerified()) {
+    if (account.isEmpty()
+        || !account.orElseThrow().isEmailVerified()
+        || !allowsEmailLoginOtp(account.orElseThrow())) {
       return;
     }
     Account resolvedAccount = account.orElseThrow();
@@ -278,6 +284,9 @@ public class AccountServiceImpl implements AccountService {
         accountRepository
             .findByEmail(email == null ? "" : email.trim())
             .orElseThrow(this::invalidCredentials);
+    if (!allowsEmailLoginOtp(account)) {
+      throw invalidCredentials();
+    }
     AccountEmailLoginChallenge challenge =
         accountEmailLoginChallengeRepository
             .findByAccountId(account.getId())
@@ -306,7 +315,9 @@ public class AccountServiceImpl implements AccountService {
   @Timed(value = "account.player_bootstrap")
   public PlayerBootstrapResult issuePlayerBootstrap(
       Long tenantId, String username, String password, String otp) {
-    Account account = authenticateAccountIdentity(username, password, otp);
+    PrimaryAuthentication authentication = authenticateAccountIdentity(username, password, otp);
+    Account account = authentication.account();
+    authentication.emailLoginChallenge().ifPresent(accountEmailLoginChallengeRepository::delete);
     String jti = UUID.randomUUID().toString();
     long issuedAt = System.currentTimeMillis();
     long expiresAt = issuedAt + tokenProperties.getPlayerBootstrapExpirationMs();
@@ -1021,14 +1032,24 @@ public class AccountServiceImpl implements AccountService {
     return accountRepository.findByEmail(usernameOrEmail);
   }
 
-  private Account authenticateAccountIdentity(String username, String password, String otp) {
+  private PrimaryAuthentication authenticateAccountIdentity(
+      String username, String password, String otp) {
     Optional<Account> accountOpt = findAccountForAuthentication(username);
     Account account =
         accountOpt.orElseThrow(
             () ->
                 new AuthenticationException(
                     AuthenticationErrorCodes.INVALID_CREDENTIALS, "Invalid credentials"));
-    if (!verifyPassword(password, account.getPasswordHash())) {
+    Optional<AccountEmailLoginChallenge> emailLoginChallenge =
+        allowsEmailLoginOtp(account) ? activeEmailLoginChallenge(account) : Optional.empty();
+    if (emailLoginChallenge
+        .filter(challenge -> matchesEmailLoginOtp(challenge, password))
+        .isPresent()) {
+      return new PrimaryAuthentication(account, emailLoginChallenge);
+    }
+    if (!allowsPassword(account) || !verifyPassword(password, account.getPasswordHash())) {
+      emailLoginChallenge.ifPresent(
+          challenge -> recordFailedEmailLoginAttempt(challenge, LocalDateTime.now()));
       throw new AuthenticationException(
           AuthenticationErrorCodes.INVALID_CREDENTIALS, "Invalid credentials");
     }
@@ -1042,8 +1063,40 @@ public class AccountServiceImpl implements AccountService {
             AuthenticationErrorCodes.OTP_REQUIRED, "Invalid 2FA code");
       }
     }
-    return account;
+    return new PrimaryAuthentication(account, Optional.empty());
   }
+
+  private Optional<AccountEmailLoginChallenge> activeEmailLoginChallenge(Account account) {
+    Optional<AccountEmailLoginChallenge> challenge =
+        accountEmailLoginChallengeRepository.findByAccountId(account.getId());
+    if (challenge.isEmpty()) {
+      return Optional.empty();
+    }
+    AccountEmailLoginChallenge resolvedChallenge = challenge.orElseThrow();
+    LocalDateTime now = LocalDateTime.now();
+    if (resolvedChallenge.getExpiresAt().isBefore(now)
+        || resolvedChallenge.getInvalidAttemptCount() >= EMAIL_LOGIN_OTP_MAX_ATTEMPTS) {
+      recordFailedEmailLoginAttempt(resolvedChallenge, now);
+      return Optional.empty();
+    }
+    return Optional.of(resolvedChallenge);
+  }
+
+  private boolean matchesEmailLoginOtp(AccountEmailLoginChallenge challenge, String secret) {
+    return verifyPassword(secret == null ? "" : secret, challenge.getCodeHash());
+  }
+
+  private boolean allowsEmailLoginOtp(Account account) {
+    return AccountLoginAuthModes.allows(
+        account.getLoginAuthModes(), AccountLoginAuthMode.EMAIL_OTP);
+  }
+
+  private boolean allowsPassword(Account account) {
+    return AccountLoginAuthModes.allows(account.getLoginAuthModes(), AccountLoginAuthMode.PASSWORD);
+  }
+
+  private record PrimaryAuthentication(
+      Account account, Optional<AccountEmailLoginChallenge> emailLoginChallenge) {}
 
   private Account requireAccount(Long accountId) {
     return accountRepository

--- a/services/account-service/src/main/resources/db/migration/V19__account_login_auth_modes.sql
+++ b/services/account-service/src/main/resources/db/migration/V19__account_login_auth_modes.sql
@@ -1,5 +1,5 @@
 ALTER TABLE accounts
-    ADD COLUMN login_auth_modes VARCHAR(64) NOT NULL DEFAULT 'PASSWORD,EMAIL_OTP';
+    ADD COLUMN login_auth_modes TEXT NOT NULL DEFAULT 'PASSWORD,EMAIL_OTP';
 
 ALTER TABLE accounts
     ADD CONSTRAINT chk_accounts_login_auth_modes

--- a/services/account-service/src/main/resources/db/migration/V19__account_login_auth_modes.sql
+++ b/services/account-service/src/main/resources/db/migration/V19__account_login_auth_modes.sql
@@ -1,0 +1,6 @@
+ALTER TABLE accounts
+    ADD COLUMN login_auth_modes VARCHAR(64) NOT NULL DEFAULT 'PASSWORD,EMAIL_OTP';
+
+ALTER TABLE accounts
+    ADD CONSTRAINT chk_accounts_login_auth_modes
+        CHECK (login_auth_modes IN ('PASSWORD', 'EMAIL_OTP', 'PASSWORD,EMAIL_OTP'));

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/entity/AccountLoginAuthModesTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/entity/AccountLoginAuthModesTest.java
@@ -1,0 +1,13 @@
+package net.firedevops.firemud.accountservice.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AccountLoginAuthModesTest {
+  @Test
+  void normalizeWritesAcceptedModeCombinationsInCanonicalOrder() {
+    assertThat(AccountLoginAuthModes.normalize("email_otp,password"))
+        .isEqualTo("PASSWORD,EMAIL_OTP");
+  }
+}

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -307,6 +307,105 @@ class AccountServiceImplTest {
   }
 
   @Test
+  void authenticateUsesMatchingEmailLoginOtpBeforePasswordFallback() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setUsername("demo@example.com");
+    account.setPasswordHash(hash("password"));
+    net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge challenge =
+        new net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge();
+    challenge.setId(3L);
+    challenge.setAccountId(9L);
+    challenge.setCodeHash(hash("123456"));
+    challenge.setExpiresAt(java.time.LocalDateTime.now().plusMinutes(5));
+    AccountTenantMembership membership = new AccountTenantMembership();
+    membership.setGameplayAdmissionAllowed(true);
+    when(accountRepository.findByUsername("demo@example.com")).thenReturn(Optional.of(account));
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L))
+        .thenReturn(Optional.of(challenge));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(9L, 7L))
+        .thenReturn(Optional.of(membership));
+
+    AuthenticationResult result = service.authenticate(7L, "demo@example.com", "123456", null);
+
+    assertEquals(9L, result.accountId());
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository).delete(challenge);
+    org.mockito.Mockito.verify(sessionService).storeSession(7L, 9L, result.authToken());
+  }
+
+  @Test
+  void authenticateFallsBackToPasswordWithoutBurningUnmatchedEmailLoginOtp() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setUsername("demo@example.com");
+    account.setPasswordHash(hash("password"));
+    net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge challenge =
+        new net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge();
+    challenge.setId(3L);
+    challenge.setAccountId(9L);
+    challenge.setCodeHash(hash("123456"));
+    challenge.setExpiresAt(java.time.LocalDateTime.now().plusMinutes(5));
+    AccountTenantMembership membership = new AccountTenantMembership();
+    membership.setGameplayAdmissionAllowed(true);
+    when(accountRepository.findByUsername("demo@example.com")).thenReturn(Optional.of(account));
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L))
+        .thenReturn(Optional.of(challenge));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(9L, 7L))
+        .thenReturn(Optional.of(membership));
+
+    AuthenticationResult result = service.authenticate(7L, "demo@example.com", "password", null);
+
+    assertEquals(9L, result.accountId());
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository, org.mockito.Mockito.never())
+        .delete(challenge);
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository, org.mockito.Mockito.never())
+        .save(challenge);
+  }
+
+  @Test
+  void authenticateCountsFailedMixedModeSecretAgainstActiveEmailLoginOtp() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setUsername("demo@example.com");
+    account.setPasswordHash(hash("password"));
+    net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge challenge =
+        new net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge();
+    challenge.setId(3L);
+    challenge.setAccountId(9L);
+    challenge.setCodeHash(hash("123456"));
+    challenge.setExpiresAt(java.time.LocalDateTime.now().plusMinutes(5));
+    when(accountRepository.findByUsername("demo@example.com")).thenReturn(Optional.of(account));
+    when(accountEmailLoginChallengeRepository.findByAccountId(9L))
+        .thenReturn(Optional.of(challenge));
+    when(accountEmailLoginChallengeRepository.save(challenge)).thenReturn(challenge);
+
+    AuthenticationException exception =
+        assertThrows(
+            AuthenticationException.class,
+            () -> service.authenticate(7L, "demo@example.com", "wrong", null));
+
+    assertEquals(AuthenticationErrorCodes.INVALID_CREDENTIALS, exception.getCode());
+    assertEquals(1, challenge.getInvalidAttemptCount());
+    org.mockito.Mockito.verify(accountEmailLoginChallengeRepository).save(challenge);
+    verifyNoInteractions(sessionService);
+  }
+
+  @Test
+  void passwordOnlyAccountsDoNotIssueEmailLoginChallenges() {
+    Account account = new Account();
+    account.setId(9L);
+    account.setEmail("verified@example.com");
+    account.setEmailVerified(true);
+    account.setLoginAuthModes("PASSWORD");
+    when(accountRepository.findByEmail("verified@example.com")).thenReturn(Optional.of(account));
+
+    service.requestEmailLoginOtp(7L, "verified@example.com");
+
+    verifyNoInteractions(
+        accountTenantMembershipRepository, accountEmailLoginChallengeRepository, emailService);
+  }
+
+  @Test
   void emailLoginOtpVerificationFailsClosedForUnknownEmail() {
     when(accountRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
 

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -482,6 +482,7 @@ class AccountServiceImplTest {
             .getAudience()
             .iterator()
             .next());
+    verifyNoInteractions(accountEmailLoginChallengeRepository);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- persist the Account Service primary-login mode set with a compatible `PASSWORD,EMAIL_OTP` default
- evaluate normal authentication as email OTP first, then password only when that mode is enabled
- retain per-account advisory locking while the mixed-mode path reads, records, or consumes an email challenge
- keep player-bootstrap on its existing password-only boundary
- document the implemented Account Service policy and remaining Game Session/account-settings follow-up

## Validation

- `./gradlew spotlessApply`
- `bash dev-tools/validation/run-locked-gradle.sh :account-service:check -PfullCheck --console=plain`
- `./gradlew linkCheck lintMarkdown`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Account Service:** Added persisted, mode-aware primary authentication with `PASSWORD,EMAIL_OTP` as the default for new and existing accounts.
- **Authentication workflow:** Email OTP is evaluated first; password fallback is allowed only when configured. OTP challenges enforce expiration, resend limits, failed-attempt limits, single use, and per-account advisory locking. Player bootstrap remains password-only.
- **Persistence/schema:** Added `login_auth_modes` to account mappings and partial-account projections, with migration `V19` adding a non-null column, default, and allowed-value constraint.
- **Tests:** Expanded `AccountServiceImplTest` coverage for OTP success, password fallback, invalid attempts, disabled OTP, and password-only bootstrap.
- **Documentation/workflow:** Updated the vertical-slice status and Account Service policy documentation; revised `AGENTS.md` subagent delegation guidance. Game Session login integration, account-mode selection, TOTP enrollment, and related flows remain follow-up work.
- **Validation:** Spotless, Account Service checks, link checks, and Markdown linting were run. No environment or deployment changes were reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->