### PR TITLE
Resolve skipped CodeQL summary status

### DIFF
--- a/.github/workflows/static-analysis-summary.yml
+++ b/.github/workflows/static-analysis-summary.yml
@@ -130,8 +130,16 @@ jobs:
 
             const resolveStatuses = (checkRuns) =>
               [...gateChecks, ...detailChecks].map(([label, checkName]) => {
+                const isCodeQlAnalysis = checkName.startsWith("CodeQL Analysis (");
+                const emptyMatrixCodeQlCheck =
+                  "CodeQL Analysis ($" + "{{ matrix.language }})";
                 const candidates = (Array.isArray(checkRuns) ? checkRuns : [])
-                  .filter((checkRun) => checkRun?.name === checkName)
+                  .filter(
+                    (checkRun) =>
+                      checkRun?.name === checkName ||
+                      (isCodeQlAnalysis &&
+                        checkRun?.name === emptyMatrixCodeQlCheck)
+                  )
                   .map((checkRun) => ({
                     checkRun,
                     status: normalizeStatus(checkRun, checkName),


### PR DESCRIPTION
## Summary

- recognize GitHub's skipped empty-matrix CodeQL job name in the static analysis summary
- render Java and JavaScript/TypeScript CodeQL details as skipped instead of permanently pending when no CodeQL-relevant files changed

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/static-analysis-summary.yml`
