### PR TITLE
Validate version-scoped command definitions

### DIFF
--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -2,7 +2,7 @@
 
 ## Goal and Status
 
-Goal: define the canonical game-authored action model so later custom actions share one typed definition, validation, targeting, cost/cooldown, and execution path instead of bypassing the built-in command and effect architecture. Status: implemented for the provider-backed authored-command parser and dispatcher seam.
+Goal: define the canonical game-authored action model so later custom actions share one typed definition, validation, targeting, cost/cooldown, and execution path instead of bypassing the built-in command and effect architecture. Status: in progress; the provider-backed parser/dispatcher seam is complete and version-scoped declaration convergence is active.
 
 ## Implementation Notes
 
@@ -30,15 +30,17 @@ The first canonical authored-command/runtime seam is now live on branch:
 
 Still future work under this slice:
 
-- harden the authored action definition record beyond the first typed config shape;
+- replace process-local authored-action configuration with typed, version-scoped `COMMAND_DEFINITION` revisions that publish immutable runtime artifacts;
+- validate registered effect kinds and typed effect payloads at revision/publish time, then resolve only the admitted version artifact at runtime;
 - define how authored actions use targeting, cost, cooldown, and later effect/timing execution hooks instead of the current bounded notice executor;
 - carry authored execution into the later effect/timing substrate rather than inventing a second action path.
+
+Current batch: revision writes now fail closed after a version is published. This establishes the immutable version boundary required before `COMMAND_DEFINITION` data can become a published runtime artifact. The next batch adds the typed revision schema and publication/read model; it must not add another configuration-backed action source.
 
 ## Checklist
 
 - [x] Define target-state behavior and scope.
-- [x] Implement the slice end-to-end.
-- [x] Verify and close any follow-ups.
+- [ ] Complete version-scoped command-definition persistence, publication, and runtime consumption.
 
 ## Why This Slice Exists
 

--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -28,19 +28,26 @@ The first canonical authored-command/runtime seam is now live on branch:
   - `HELP` discovery/lookup that now projects authored topics from the same configured catalog rather than treating authored verbs as hidden commands;
   - first-pass metadata validation now preserves targeting, cooldown, and cost fields through the shared authored definition seam before execution.
 
+The version-scoped declaration and artifact boundary is now live:
+
+- `COMMAND_DEFINITION` revisions accept only the first typed schema, reject malformed metadata before persistence, and cannot be changed after their version is published;
+- full-version publication snapshots the ordered validated definitions into the immutable published release bundle;
+- the Game Design control-plane digest includes those definitions, so an attested version changes when its command contract changes;
+- `GetPublishedReleaseBundle` returns the exact immutable definition snapshot to runtime consumers rather than exposing a mutable configuration source.
+
 Still future work under this slice:
 
-- replace process-local authored-action configuration with typed, version-scoped `COMMAND_DEFINITION` revisions that publish immutable runtime artifacts;
-- validate registered effect kinds and typed effect payloads at revision/publish time, then resolve only the admitted version artifact at runtime;
+- resolve the admitted version artifact into the Game Session registry and retire the process-local authored-action configuration source;
+- validate registered effect kinds and typed effect payloads at revision/publish time, then execute only the admitted version artifact at runtime;
 - define how authored actions use targeting, cost, cooldown, and later effect/timing execution hooks instead of the current bounded notice executor;
 - carry authored execution into the later effect/timing substrate rather than inventing a second action path.
 
-Current batch: revision writes now fail closed after a version is published. This establishes the immutable version boundary required before `COMMAND_DEFINITION` data can become a published runtime artifact. The next batch adds the typed revision schema and publication/read model; it must not add another configuration-backed action source.
+Current batch: typed command-definition revisions now have an immutable publication artifact and control-plane read contract. The next batch must consume that admitted artifact in Game Session; it must not introduce another configuration-backed action source.
 
 ## Checklist
 
 - [x] Define target-state behavior and scope.
-- [ ] Complete version-scoped command-definition persistence, publication, and runtime consumption.
+- [ ] Complete version-scoped command-definition runtime consumption.
 
 ## Why This Slice Exists
 

--- a/protos/game-design/v1/game_design_service.proto
+++ b/protos/game-design/v1/game_design_service.proto
@@ -486,6 +486,7 @@ message PublishedReleaseBundle {
   string workflow_run_id = 13;
   string workflow_status = 14;
   string workflow_family = 15;
+  repeated string command_definitions = 16;
 }
 
 message LaunchDescriptor {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/data/TestDataSeeder.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/data/TestDataSeeder.java
@@ -116,6 +116,7 @@ public class TestDataSeeder implements ApplicationRunner {
     bundle.setGenerationConfigRevision(DEMO_GENERATION_CONFIG_REVISION);
     bundle.setRequiredManifestAssetKeysJson("[]");
     bundle.setParticipantDigestsJson("[]");
+    bundle.setCommandDefinitionsJson("[]");
     bundle.setScriptOnly(false);
     bundle.setScriptPatchVersion(null);
     bundle = publishedReleaseBundleRepository.save(bundle);

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/dto/PublishedReleaseBundleDto.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/dto/PublishedReleaseBundleDto.java
@@ -13,6 +13,7 @@ public record PublishedReleaseBundleDto(
     String manifestHash,
     List<String> requiredManifestAssetKeys,
     List<PublishParticipantDigestDto> participantDigests,
+    List<String> commandDefinitions,
     String generationConfigRevision,
     boolean scriptOnly,
     String scriptPatchVersion,
@@ -21,5 +22,37 @@ public record PublishedReleaseBundleDto(
     requiredManifestAssetKeys =
         List.copyOf(requiredManifestAssetKeys == null ? List.of() : requiredManifestAssetKeys);
     participantDigests = List.copyOf(participantDigests == null ? List.of() : participantDigests);
+    commandDefinitions = List.copyOf(commandDefinitions == null ? List.of() : commandDefinitions);
+  }
+
+  public PublishedReleaseBundleDto(
+      Long id,
+      String tenantId,
+      Long versionId,
+      int versionNumber,
+      String attestationSchemaVersion,
+      String publishWorkflowId,
+      String manifestHash,
+      List<String> requiredManifestAssetKeys,
+      List<PublishParticipantDigestDto> participantDigests,
+      String generationConfigRevision,
+      boolean scriptOnly,
+      String scriptPatchVersion,
+      LocalDateTime publishedAt) {
+    this(
+        id,
+        tenantId,
+        versionId,
+        versionNumber,
+        attestationSchemaVersion,
+        publishWorkflowId,
+        manifestHash,
+        requiredManifestAssetKeys,
+        participantDigests,
+        List.of(),
+        generationConfigRevision,
+        scriptOnly,
+        scriptPatchVersion,
+        publishedAt);
   }
 }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/entity/PublishedReleaseBundle.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/entity/PublishedReleaseBundle.java
@@ -15,6 +15,7 @@ public class PublishedReleaseBundle {
   private String generationConfigRevision;
   private String requiredManifestAssetKeysJson;
   private String participantDigestsJson = "[]";
+  private String commandDefinitionsJson = "[]";
   private boolean scriptOnly;
   private String scriptPatchVersion;
   private LocalDateTime publishedAt = LocalDateTime.now();

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/PublishedReleaseBundleRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/PublishedReleaseBundleRepository.java
@@ -35,6 +35,8 @@ public class PublishedReleaseBundleRepository {
       DSL.field(DSL.name("required_manifest_asset_keys_json"), String.class);
   private static final Field<String> PARTICIPANT_DIGESTS_JSON =
       DSL.field(DSL.name("participant_digests_json"), String.class);
+  private static final Field<String> COMMAND_DEFINITIONS_JSON =
+      DSL.field(DSL.name("command_definitions_json"), String.class);
   private static final Field<Boolean> SCRIPT_ONLY =
       DSL.field(DSL.name("script_only"), Boolean.class);
   private static final Field<String> SCRIPT_PATCH_VERSION =
@@ -72,6 +74,7 @@ public class PublishedReleaseBundleRepository {
               .set(GENERATION_CONFIG_REVISION, bundle.getGenerationConfigRevision())
               .set(REQUIRED_MANIFEST_ASSET_KEYS_JSON, bundle.getRequiredManifestAssetKeysJson())
               .set(PARTICIPANT_DIGESTS_JSON, bundle.getParticipantDigestsJson())
+              .set(COMMAND_DEFINITIONS_JSON, bundle.getCommandDefinitionsJson())
               .set(SCRIPT_ONLY, bundle.isScriptOnly())
               .set(SCRIPT_PATCH_VERSION, bundle.getScriptPatchVersion())
               .set(PUBLISHED_AT, Timestamp.valueOf(publishedAt))
@@ -89,6 +92,7 @@ public class PublishedReleaseBundleRepository {
         .set(GENERATION_CONFIG_REVISION, bundle.getGenerationConfigRevision())
         .set(REQUIRED_MANIFEST_ASSET_KEYS_JSON, bundle.getRequiredManifestAssetKeysJson())
         .set(PARTICIPANT_DIGESTS_JSON, bundle.getParticipantDigestsJson())
+        .set(COMMAND_DEFINITIONS_JSON, bundle.getCommandDefinitionsJson())
         .set(SCRIPT_ONLY, bundle.isScriptOnly())
         .set(SCRIPT_PATCH_VERSION, bundle.getScriptPatchVersion())
         .set(PUBLISHED_AT, Timestamp.valueOf(publishedAt))
@@ -112,6 +116,7 @@ public class PublishedReleaseBundleRepository {
     bundle.setGenerationConfigRevision(record.get(GENERATION_CONFIG_REVISION));
     bundle.setRequiredManifestAssetKeysJson(record.get(REQUIRED_MANIFEST_ASSET_KEYS_JSON));
     bundle.setParticipantDigestsJson(record.get(PARTICIPANT_DIGESTS_JSON));
+    bundle.setCommandDefinitionsJson(record.get(COMMAND_DEFINITIONS_JSON));
     bundle.setScriptOnly(Boolean.TRUE.equals(record.get(SCRIPT_ONLY)));
     bundle.setScriptPatchVersion(record.get(SCRIPT_PATCH_VERSION));
     Timestamp publishedAt = record.get(PUBLISHED_AT);

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/RevisionRepository.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/repository/RevisionRepository.java
@@ -90,6 +90,18 @@ public class RevisionRepository {
             .fetchOne(this::toEntity));
   }
 
+  public List<Revision> findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+      String tenantId, Long versionId, String revisionKind) {
+    return dsl.selectFrom(TABLE_REF)
+        .where(
+            TENANT_ID
+                .eq(tenantId)
+                .and(VERSION_ID.eq(versionId))
+                .and(REVISION_KIND.eq(revisionKind)))
+        .orderBy(ID.asc())
+        .fetch(this::toEntity);
+  }
+
   public List<Revision> findAll() {
     return dsl.selectFrom(TABLE_REF).orderBy(ID.asc()).fetch(this::toEntity);
   }

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/ControlPlaneDigestServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/ControlPlaneDigestServiceImpl.java
@@ -11,6 +11,7 @@ import net.firedevops.firemud.gamedesign.dto.DesignControlPlaneDigestDto;
 import net.firedevops.firemud.gamedesign.dto.VersionDto;
 import net.firedevops.firemud.gamedesign.repository.GameAssetRepository;
 import net.firedevops.firemud.gamedesign.repository.GameTemplateRepository;
+import net.firedevops.firemud.gamedesign.repository.RevisionRepository;
 import net.firedevops.firemud.gamedesign.service.ControlPlaneDigestService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,14 +26,17 @@ public class ControlPlaneDigestServiceImpl implements ControlPlaneDigestService 
 
   private final GameTemplateRepository gameTemplateRepository;
   private final GameAssetRepository gameAssetRepository;
+  private final RevisionRepository revisionRepository;
   private final ObjectMapper objectMapper;
 
   public ControlPlaneDigestServiceImpl(
       GameTemplateRepository gameTemplateRepository,
       GameAssetRepository gameAssetRepository,
+      RevisionRepository revisionRepository,
       ObjectMapper objectMapper) {
     this.gameTemplateRepository = gameTemplateRepository;
     this.gameAssetRepository = gameAssetRepository;
+    this.revisionRepository = revisionRepository;
     this.objectMapper = objectMapper;
   }
 
@@ -82,6 +86,21 @@ public class ControlPlaneDigestServiceImpl implements ControlPlaneDigestService 
                           "contentType", entity.getContentType(),
                           "byteLength", entity.getData() == null ? 0 : entity.getData().length))
               .toList();
+      List<Map<String, Object>> commandDefinitions =
+          revisionRepository
+              .findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+                  version.tenantId(), version.id(), "COMMAND_DEFINITION")
+              .stream()
+              .map(
+                  revision ->
+                      Map.<String, Object>of(
+                          "logicalRevisionId",
+                          revision.getLogicalRevisionId() == null
+                              ? ""
+                              : revision.getLogicalRevisionId(),
+                          "data",
+                          revision.getData()))
+              .toList();
       String canonicalJson =
           objectMapper.writeValueAsString(
               Map.of(
@@ -102,7 +121,9 @@ public class ControlPlaneDigestServiceImpl implements ControlPlaneDigestService 
                   "templates",
                   templates,
                   "assets",
-                  assets));
+                  assets,
+                  "commandDefinitions",
+                  commandDefinitions));
       return sha256(canonicalJson);
     } catch (Exception ex) {
       throw new IllegalStateException("failed to compute design control-plane digest", ex);

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcService.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcService.java
@@ -658,6 +658,7 @@ public class GameDesignGrpcService extends GameDesignServiceGrpc.GameDesignServi
               .setWorkflowFamily(workflowMetadata.workflowFamily())
               .setManifestHash(bundle.manifestHash())
               .addAllRequiredManifestAssetKeys(bundle.requiredManifestAssetKeys())
+              .addAllCommandDefinitions(bundle.commandDefinitions())
               .addAllParticipantDigests(
                   bundle.participantDigests().stream()
                       .map(

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImpl.java
@@ -1,8 +1,11 @@
 package net.firedevops.firemud.gamedesign.service.impl;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import net.firedevops.firemud.gamedesign.dto.PublishParticipantDigestDto;
 import net.firedevops.firemud.gamedesign.dto.PublishedReleaseBundleDto;
 import net.firedevops.firemud.gamedesign.dto.VersionDto;
@@ -64,14 +67,15 @@ public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundle
     entity.setRequiredManifestAssetKeysJson(
         serializeKeys(exportedManifest.requiredManifestAssetKeys()));
     entity.setParticipantDigestsJson(serializeParticipantDigests(participantDigests));
-    entity.setCommandDefinitionsJson(
-        serializeCommandDefinitions(
-            revisionRepository
-                .findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
-                    version.tenantId(), version.id(), "COMMAND_DEFINITION")
-                .stream()
-                .map(revision -> revision.getData())
-                .toList()));
+    List<String> commandDefinitions =
+        revisionRepository
+            .findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+                version.tenantId(), version.id(), "COMMAND_DEFINITION")
+            .stream()
+            .map(revision -> revision.getData())
+            .toList();
+    validateDistinctCommandDefinitions(commandDefinitions);
+    entity.setCommandDefinitionsJson(serializeCommandDefinitions(commandDefinitions));
     entity.setScriptOnly(version.scriptOnly());
     entity.setScriptPatchVersion(version.scriptPatchVersion());
     return toDto(repository.save(entity));
@@ -124,6 +128,33 @@ public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundle
   private String serializeCommandDefinitions(List<String> commandDefinitions) {
     return objectMapper.writeValueAsString(
         commandDefinitions == null ? List.of() : commandDefinitions);
+  }
+
+  private void validateDistinctCommandDefinitions(List<String> commandDefinitions) {
+    Set<String> commandIds = new HashSet<>();
+    Set<String> aliases = new HashSet<>();
+    for (String commandDefinition : commandDefinitions) {
+      var definition = objectMapper.readTree(commandDefinition);
+      String commandId = normalizeCommandToken(definition.path("commandId").asText());
+      if (!commandIds.add(commandId)) {
+        throw new IllegalStateException(
+            "duplicate published commandDefinition commandId " + commandId);
+      }
+      for (var alias : definition.path("aliases")) {
+        String normalizedAlias = normalizeCommandToken(alias.asText());
+        if (!aliases.add(normalizedAlias)) {
+          throw new IllegalStateException(
+              "duplicate published commandDefinition alias " + normalizedAlias);
+        }
+      }
+    }
+  }
+
+  private String normalizeCommandToken(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalStateException("published commandDefinition token must not be blank");
+    }
+    return value.trim().toLowerCase(Locale.ROOT);
   }
 
   private List<String> deserializeCommandDefinitions(String json) {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImpl.java
@@ -8,6 +8,7 @@ import net.firedevops.firemud.gamedesign.dto.PublishedReleaseBundleDto;
 import net.firedevops.firemud.gamedesign.dto.VersionDto;
 import net.firedevops.firemud.gamedesign.entity.PublishedReleaseBundle;
 import net.firedevops.firemud.gamedesign.repository.PublishedReleaseBundleRepository;
+import net.firedevops.firemud.gamedesign.repository.RevisionRepository;
 import net.firedevops.firemud.gamedesign.service.ExportedAssetManifest;
 import net.firedevops.firemud.gamedesign.service.PublishedReleaseBundleService;
 import org.springframework.stereotype.Service;
@@ -21,11 +22,16 @@ import tools.jackson.databind.ObjectMapper;
 public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundleService {
 
   private final PublishedReleaseBundleRepository repository;
+  private final RevisionRepository revisionRepository;
   private final ObjectMapper objectMapper;
 
   public PublishedReleaseBundleServiceImpl(
-      PublishedReleaseBundleRepository repository, ObjectMapper objectMapper) {
+      PublishedReleaseBundleRepository repository,
+      RevisionRepository revisionRepository,
+      ObjectMapper objectMapper) {
     this.repository = Objects.requireNonNull(repository, "repository must not be null");
+    this.revisionRepository =
+        Objects.requireNonNull(revisionRepository, "revisionRepository must not be null");
     this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
   }
 
@@ -58,6 +64,14 @@ public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundle
     entity.setRequiredManifestAssetKeysJson(
         serializeKeys(exportedManifest.requiredManifestAssetKeys()));
     entity.setParticipantDigestsJson(serializeParticipantDigests(participantDigests));
+    entity.setCommandDefinitionsJson(
+        serializeCommandDefinitions(
+            revisionRepository
+                .findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+                    version.tenantId(), version.id(), "COMMAND_DEFINITION")
+                .stream()
+                .map(revision -> revision.getData())
+                .toList()));
     entity.setScriptOnly(version.scriptOnly());
     entity.setScriptPatchVersion(version.scriptPatchVersion());
     return toDto(repository.save(entity));
@@ -83,6 +97,7 @@ public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundle
         entity.getManifestHash(),
         deserializeKeys(entity.getRequiredManifestAssetKeysJson()),
         deserializeParticipantDigests(entity.getParticipantDigestsJson()),
+        deserializeCommandDefinitions(entity.getCommandDefinitionsJson()),
         entity.getGenerationConfigRevision(),
         entity.isScriptOnly(),
         entity.getScriptPatchVersion(),
@@ -104,6 +119,19 @@ public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundle
   private String serializeParticipantDigests(List<PublishParticipantDigestDto> participantDigests) {
     return objectMapper.writeValueAsString(
         participantDigests == null ? List.of() : List.copyOf(participantDigests));
+  }
+
+  private String serializeCommandDefinitions(List<String> commandDefinitions) {
+    return objectMapper.writeValueAsString(
+        commandDefinitions == null ? List.of() : commandDefinitions);
+  }
+
+  private List<String> deserializeCommandDefinitions(String json) {
+    if (json == null || json.isBlank()) {
+      return List.of();
+    }
+    return objectMapper.readValue(
+        json, objectMapper.getTypeFactory().constructCollectionType(List.class, String.class));
   }
 
   private List<PublishParticipantDigestDto> deserializeParticipantDigests(String json) {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
@@ -12,6 +12,7 @@ import net.firedevops.firemud.gamedesign.entity.Game;
 import net.firedevops.firemud.gamedesign.entity.Revision;
 import net.firedevops.firemud.gamedesign.entity.Version;
 import net.firedevops.firemud.gamedesign.mapper.RevisionMapper;
+import net.firedevops.firemud.gamedesign.model.VersionLifecycleState;
 import net.firedevops.firemud.gamedesign.repository.GameRepository;
 import net.firedevops.firemud.gamedesign.repository.RevisionRepository;
 import net.firedevops.firemud.gamedesign.repository.VersionRepository;
@@ -48,6 +49,9 @@ public class RevisionServiceImpl implements RevisionService {
         versionRepository
             .findByTenantIdAndId(dto.tenantId(), dto.versionId())
             .orElseThrow(() -> new IllegalArgumentException("version not found"));
+    if (version.getVersionState() != VersionLifecycleState.DRAFT) {
+      throw new IllegalArgumentException("INVALID_ARGUMENT: published versions are immutable");
+    }
     AppliedWorldDesignMutationDto appliedWorldDesignMutation =
         applyWorldDesignMutationIfPresent(dto);
     Revision entity = revisionMapper.toEntity(dto);

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
@@ -20,18 +20,22 @@ import net.firedevops.firemud.gamedesign.service.RevisionService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 @RequiredArgsConstructor
 public class RevisionServiceImpl implements RevisionService {
   private static final Logger logger = LoggingUtil.getLogger(RevisionServiceImpl.class);
   private static final String WORLD_DESIGN_MUTATION_KIND = "WORLD_DESIGN_MUTATION";
+  private static final String COMMAND_DEFINITION_KIND = "COMMAND_DEFINITION";
 
   private final RevisionRepository revisionRepository;
   private final GameRepository gameRepository;
   private final VersionRepository versionRepository;
   private final RevisionMapper revisionMapper;
   private final WorldManagementClient worldManagementClient;
+  private final ObjectMapper objectMapper;
 
   @Override
   @Transactional
@@ -52,6 +56,7 @@ public class RevisionServiceImpl implements RevisionService {
     if (version.getVersionState() != VersionLifecycleState.DRAFT) {
       throw new IllegalArgumentException("INVALID_ARGUMENT: published versions are immutable");
     }
+    validateCommandDefinitionIfPresent(dto);
     AppliedWorldDesignMutationDto appliedWorldDesignMutation =
         applyWorldDesignMutationIfPresent(dto);
     Revision entity = revisionMapper.toEntity(dto);
@@ -79,6 +84,63 @@ public class RevisionServiceImpl implements RevisionService {
     validateWorldMutationRequest(dto);
     return worldManagementClient.applyWorldDesignMutation(
         dto.tenantId(), dto.versionId(), dto.worldDesignMutation());
+  }
+
+  private void validateCommandDefinitionIfPresent(RevisionDto dto) {
+    if (!COMMAND_DEFINITION_KIND.equals(dto.revisionKind())) {
+      return;
+    }
+    try {
+      JsonNode definition = objectMapper.readTree(dto.data());
+      if (!definition.isObject() || definition.path("schemaVersion").asInt() != 1) {
+        throw invalidCommandDefinition("schemaVersion must be 1");
+      }
+      requireText(definition, "commandId");
+      requireText(definition, "semanticOwner");
+      requireText(definition, "executionDiscipline");
+      requireEnum(definition, "stageRequirement", "NONE", "LOGIN", "GAMEPLAY");
+      requireEnum(definition, "promptPolicy", "NEVER", "WHEN_LOGGED_IN", "WHEN_GAMEPLAY");
+      requireEnum(definition, "actionCategory", "GAMEPLAY", "SOCIAL", "META", "ADMIN", "SYSTEM");
+      requireTextArray(definition, "aliases");
+      if (!definition.path("actionTags").isArray() || !definition.path("effects").isArray()) {
+        throw invalidCommandDefinition("actionTags and effects must be arrays");
+      }
+    } catch (IllegalArgumentException ex) {
+      throw ex;
+    } catch (Exception ex) {
+      throw invalidCommandDefinition("must be valid JSON");
+    }
+  }
+
+  private void requireText(JsonNode definition, String field) {
+    if (!definition.path(field).isTextual() || definition.path(field).asText().isBlank()) {
+      throw invalidCommandDefinition(field + " is required");
+    }
+  }
+
+  private void requireEnum(JsonNode definition, String field, String... allowed) {
+    requireText(definition, field);
+    for (String value : allowed) {
+      if (value.equals(definition.path(field).asText())) {
+        return;
+      }
+    }
+    throw invalidCommandDefinition("unsupported " + field);
+  }
+
+  private void requireTextArray(JsonNode definition, String field) {
+    if (!definition.path(field).isArray()) {
+      throw invalidCommandDefinition(field + " must be an array");
+    }
+    for (JsonNode value : definition.path(field)) {
+      if (!value.isTextual() || value.asText().isBlank()) {
+        throw invalidCommandDefinition(field + " entries must be nonblank strings");
+      }
+    }
+  }
+
+  private IllegalArgumentException invalidCommandDefinition(String message) {
+    return new IllegalArgumentException("INVALID_ARGUMENT: commandDefinition " + message);
   }
 
   private void validateWorldMutationRequest(RevisionDto dto) {

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
@@ -97,7 +97,7 @@ public class RevisionServiceImpl implements RevisionService {
       }
       requireText(definition, "commandId");
       requireText(definition, "semanticOwner");
-      requireText(definition, "executionDiscipline");
+      requireEnum(definition, "executionDiscipline", "DURABLE_GAMEPLAY");
       requireEnum(definition, "stageRequirement", "NONE", "LOGIN", "GAMEPLAY");
       requireEnum(definition, "promptPolicy", "NEVER", "WHEN_LOGGED_IN", "WHEN_GAMEPLAY");
       requireEnum(definition, "actionCategory", "GAMEPLAY", "SOCIAL", "META", "ADMIN", "SYSTEM");

--- a/services/game-design-service/src/main/resources/db/migration/V23__published_command_definitions.sql
+++ b/services/game-design-service/src/main/resources/db/migration/V23__published_command_definitions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE published_release_bundle
+    ADD COLUMN command_definitions_json TEXT NOT NULL DEFAULT '[]';

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/ControlPlaneDigestServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/ControlPlaneDigestServiceImplTest.java
@@ -1,0 +1,55 @@
+package net.firedevops.firemud.gamedesign.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import net.firedevops.firemud.gamedesign.dto.VersionDto;
+import net.firedevops.firemud.gamedesign.entity.Revision;
+import net.firedevops.firemud.gamedesign.model.VersionLifecycleState;
+import net.firedevops.firemud.gamedesign.repository.GameAssetRepository;
+import net.firedevops.firemud.gamedesign.repository.GameTemplateRepository;
+import net.firedevops.firemud.gamedesign.repository.RevisionRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import tools.jackson.databind.ObjectMapper;
+
+class ControlPlaneDigestServiceImplTest {
+
+  private final GameTemplateRepository gameTemplateRepository =
+      Mockito.mock(GameTemplateRepository.class);
+  private final GameAssetRepository gameAssetRepository = Mockito.mock(GameAssetRepository.class);
+  private final RevisionRepository revisionRepository = Mockito.mock(RevisionRepository.class);
+  private final ControlPlaneDigestServiceImpl service =
+      new ControlPlaneDigestServiceImpl(
+          gameTemplateRepository, gameAssetRepository, revisionRepository, new ObjectMapper());
+
+  @Test
+  void commandDefinitionRevisionsChangeTheVersionDigest() {
+    VersionDto version =
+        new VersionDto(
+            7L, "tenant-1", 1, VersionLifecycleState.DRAFT, 1L, null, null, false, "", null, null);
+    when(gameTemplateRepository.findByTenantId(Mockito.eq("tenant-1"), Mockito.any()))
+        .thenReturn(Page.empty());
+    when(gameAssetRepository.findByTenantId("tenant-1")).thenReturn(List.of());
+    when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+            "tenant-1", 7L, "COMMAND_DEFINITION"))
+        .thenReturn(List.of(revision("{\"commandId\":\"block\"}")));
+
+    String first = service.getDigestForVersion(version).contentDigest();
+
+    when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+            "tenant-1", 7L, "COMMAND_DEFINITION"))
+        .thenReturn(List.of(revision("{\"commandId\":\"guard\"}")));
+
+    assertThat(service.getDigestForVersion(version).contentDigest()).isNotEqualTo(first);
+  }
+
+  private Revision revision(String data) {
+    Revision revision = new Revision();
+    revision.setData(data);
+    revision.setLogicalRevisionId("command:block");
+    return revision;
+  }
+}

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/GameDesignGrpcServiceTest.java
@@ -173,6 +173,7 @@ class GameDesignGrpcServiceTest {
                 List.of(
                     new PublishParticipantDigestDto(
                         "GAME_DESIGN_CONTROL_PLANE", "7", "version:7", "digest-1", 1, null, null)),
+                List.of("{\"commandId\":\"block\",\"schemaVersion\":1}"),
                 "genrev-1",
                 false,
                 null,
@@ -193,6 +194,9 @@ class GameDesignGrpcServiceTest {
     assertEquals("abc123", ref.get().getBundle().getManifestHash());
     assertEquals("genrev-1", ref.get().getBundle().getGenerationConfigRevision());
     assertEquals(2, ref.get().getBundle().getRequiredManifestAssetKeysCount());
+    assertEquals(
+        List.of("{\"commandId\":\"block\",\"schemaVersion\":1}"),
+        ref.get().getBundle().getCommandDefinitionsList());
     assertEquals(1, ref.get().getBundle().getParticipantDigestsCount());
     assertEquals("publish", ref.get().getBundle().getWorkflowFamily());
     assertEquals("TEMPORAL_DISABLED", ref.get().getBundle().getWorkflowStatus());

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImplTest.java
@@ -11,8 +11,10 @@ import java.util.Optional;
 import net.firedevops.firemud.gamedesign.dto.PublishParticipantDigestDto;
 import net.firedevops.firemud.gamedesign.dto.VersionDto;
 import net.firedevops.firemud.gamedesign.entity.PublishedReleaseBundle;
+import net.firedevops.firemud.gamedesign.entity.Revision;
 import net.firedevops.firemud.gamedesign.model.VersionLifecycleState;
 import net.firedevops.firemud.gamedesign.repository.PublishedReleaseBundleRepository;
+import net.firedevops.firemud.gamedesign.repository.RevisionRepository;
 import net.firedevops.firemud.gamedesign.service.ExportedAssetManifest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,13 +24,15 @@ import tools.jackson.databind.ObjectMapper;
 
 class PublishedReleaseBundleServiceImplTest {
   @Mock private PublishedReleaseBundleRepository repository;
+  @Mock private RevisionRepository revisionRepository;
 
   private PublishedReleaseBundleServiceImpl service;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    service = new PublishedReleaseBundleServiceImpl(repository, new ObjectMapper());
+    service =
+        new PublishedReleaseBundleServiceImpl(repository, revisionRepository, new ObjectMapper());
   }
 
   @Test
@@ -47,6 +51,11 @@ class PublishedReleaseBundleServiceImplTest {
             LocalDateTime.now(),
             LocalDateTime.now());
     when(repository.findByTenantIdAndVersionId("tenant-1", 7L)).thenReturn(Optional.empty());
+    Revision commandDefinition = new Revision();
+    commandDefinition.setData("{\"commandId\":\"block\",\"schemaVersion\":1}");
+    when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+            "tenant-1", 7L, "COMMAND_DEFINITION"))
+        .thenReturn(List.of(commandDefinition));
     when(repository.save(any(PublishedReleaseBundle.class)))
         .thenAnswer(
             invocation -> {
@@ -72,6 +81,8 @@ class PublishedReleaseBundleServiceImplTest {
     assertEquals("genrev-1", dto.generationConfigRevision());
     assertEquals(List.of("logo.png", "manifest.json"), dto.requiredManifestAssetKeys());
     assertEquals(1, dto.participantDigests().size());
+    assertEquals(
+        List.of("{\"commandId\":\"block\",\"schemaVersion\":1}"), dto.commandDefinitions());
     assertEquals("v1", dto.attestationSchemaVersion());
   }
 

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImplTest.java
@@ -114,4 +114,39 @@ class PublishedReleaseBundleServiceImplTest {
                 "genrev-1",
                 List.of()));
   }
+
+  @Test
+  void createFullVersionBundleRejectsDuplicateCommandDefinitionAlias() {
+    VersionDto version =
+        new VersionDto(
+            7L,
+            "tenant-1",
+            8,
+            VersionLifecycleState.PUBLISHED,
+            2L,
+            null,
+            null,
+            false,
+            "notes",
+            LocalDateTime.now(),
+            LocalDateTime.now());
+    when(repository.findByTenantIdAndVersionId("tenant-1", 7L)).thenReturn(Optional.empty());
+    Revision first = new Revision();
+    first.setData("{\"commandId\":\"salute\",\"aliases\":[\"hail\"]}");
+    Revision second = new Revision();
+    second.setData("{\"commandId\":\"greet\",\"aliases\":[\"HAIL\"]}");
+    when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+            "tenant-1", 7L, "COMMAND_DEFINITION"))
+        .thenReturn(List.of(first, second));
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            service.createFullVersionBundle(
+                version,
+                "workflow-1",
+                new ExportedAssetManifest("abc123", List.of("manifest.json")),
+                "genrev-1",
+                List.of()));
+  }
 }

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImplTest.java
@@ -18,6 +18,7 @@ import net.firedevops.firemud.gamedesign.entity.Game;
 import net.firedevops.firemud.gamedesign.entity.Revision;
 import net.firedevops.firemud.gamedesign.entity.Version;
 import net.firedevops.firemud.gamedesign.mapper.RevisionMapper;
+import net.firedevops.firemud.gamedesign.model.VersionLifecycleState;
 import net.firedevops.firemud.gamedesign.repository.GameRepository;
 import net.firedevops.firemud.gamedesign.repository.RevisionRepository;
 import net.firedevops.firemud.gamedesign.repository.VersionRepository;
@@ -59,6 +60,32 @@ class RevisionServiceImplTest {
     RevisionDto result = service.saveRevision(dto);
 
     assertEquals(10L, result.id());
+  }
+
+  @Test
+  void saveRevisionRejectsPublishedVersionBeforePersistingOrApplyingMutations() {
+    Game game = new Game();
+    game.setId(1L);
+    game.setTenantId("1");
+    when(gameRepository.findByTenantId("1")).thenReturn(game);
+    Version version = new Version();
+    version.setId(7L);
+    version.setTenantId("1");
+    version.setVersionState(VersionLifecycleState.PUBLISHED);
+    when(versionRepository.findByTenantIdAndId("1", 7L)).thenReturn(java.util.Optional.of(version));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.saveRevision(
+                    new RevisionDto(
+                        null, "1", 7L, 3L, "{}", "COMMAND_DEFINITION", null, null, null, null)));
+
+    assertEquals("INVALID_ARGUMENT: published versions are immutable", ex.getMessage());
+    verify(revisionRepository, never()).save(any(Revision.class));
+    verify(worldManagementClient, never())
+        .applyWorldDesignMutation(any(), anyLong(), any(WorldDesignMutationRevisionDto.class));
   }
 
   @Test

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImplTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import tools.jackson.databind.ObjectMapper;
 
 class RevisionServiceImplTest {
   @Mock private RevisionRepository revisionRepository;
@@ -42,7 +43,12 @@ class RevisionServiceImplTest {
     RevisionMapper mapper = Mappers.getMapper(RevisionMapper.class);
     service =
         new RevisionServiceImpl(
-            revisionRepository, gameRepository, versionRepository, mapper, worldManagementClient);
+            revisionRepository,
+            gameRepository,
+            versionRepository,
+            mapper,
+            worldManagementClient,
+            new ObjectMapper());
   }
 
   @Test
@@ -86,6 +92,60 @@ class RevisionServiceImplTest {
     verify(revisionRepository, never()).save(any(Revision.class));
     verify(worldManagementClient, never())
         .applyWorldDesignMutation(any(), anyLong(), any(WorldDesignMutationRevisionDto.class));
+  }
+
+  @Test
+  void saveRevisionRejectsMalformedCommandDefinitionBeforePersisting() {
+    setupGameAndVersion();
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.saveRevision(
+                    new RevisionDto(
+                        null,
+                        "1",
+                        7L,
+                        3L,
+                        "{\"schemaVersion\":1,\"commandId\":\"block\"}",
+                        "COMMAND_DEFINITION",
+                        null,
+                        null,
+                        null,
+                        null)));
+
+    assertEquals("INVALID_ARGUMENT: commandDefinition semanticOwner is required", ex.getMessage());
+    verify(revisionRepository, never()).save(any(Revision.class));
+  }
+
+  @Test
+  void saveRevisionPersistsValidCommandDefinition() {
+    Game game = setupGameAndVersion();
+    Revision saved = new Revision();
+    saved.setId(12L);
+    saved.setTenantId(game.getTenantId());
+    saved.setVersionId(7L);
+    saved.setRevisionKind("COMMAND_DEFINITION");
+    saved.setData(validCommandDefinition());
+    when(revisionRepository.save(any(Revision.class))).thenReturn(saved);
+
+    RevisionDto result =
+        service.saveRevision(
+            new RevisionDto(
+                null,
+                "1",
+                7L,
+                3L,
+                validCommandDefinition(),
+                "COMMAND_DEFINITION",
+                null,
+                null,
+                null,
+                null));
+
+    assertEquals(12L, result.id());
+    verify(revisionRepository).save(any(Revision.class));
   }
 
   @Test
@@ -262,6 +322,23 @@ class RevisionServiceImplTest {
         mutation,
         null,
         null);
+  }
+
+  private String validCommandDefinition() {
+    return """
+        {
+          "schemaVersion": 1,
+          "commandId": "block",
+          "semanticOwner": "GAME_LOGIC",
+          "executionDiscipline": "DURABLE_GAMEPLAY",
+          "stageRequirement": "GAMEPLAY",
+          "promptPolicy": "WHEN_GAMEPLAY",
+          "actionCategory": "GAMEPLAY",
+          "aliases": ["block", "guard"],
+          "actionTags": ["COMBAT"],
+          "effects": []
+        }
+        """;
   }
 
   private WorldDesignMutationRevisionDto generationSubtreeMutation() {


### PR DESCRIPTION
## Summary
- freeze revision writes after a Game Design version is published
- validate schema-v1 COMMAND_DEFINITION revision metadata before persistence
- document the active 02.13.9 version-scoped declaration follow-through

## Validation
- ./gradlew :game-design-service:test --tests 'net.firedevops.firemud.gamedesign.service.impl.RevisionServiceImplTest'
- bash dev-tools/validation/run-locked-gradle.sh :game-design-service:check -PfullCheck
- ./gradlew linkCheck lintMarkdown