### PR TITLE
Admit version-scoped command definitions

### DIFF
--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -44,6 +44,8 @@ Still future work under this slice:
 
 Current batch: typed command-definition revisions now have an immutable publication artifact and control-plane read contract. The next batch must consume that admitted artifact in Game Session; it must not introduce another configuration-backed action source.
 
+Current runtime follow-through: Game Session now resolves authored aliases, direct HELP topics, authored dispatch validation, and durable-command reparsing against the release bundle admitted for the live game instance. A mismatched bundle, malformed definition, unsupported execution discipline, or non-empty unregistered effects array fails closed to the built-in-only registry. The legacy configured catalog remains only as compatibility support for isolated fixtures while its consumers are retired; it is no longer the production parsing or admission authority.
+
 ## Checklist
 
 - [x] Define target-state behavior and scope.

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
@@ -97,13 +97,25 @@ public class RevisionServiceImpl implements RevisionService {
       }
       requireText(definition, "commandId");
       requireText(definition, "semanticOwner");
-      requireText(definition, "executionDiscipline");
+      requireEnum(definition, "executionDiscipline", "DURABLE_GAMEPLAY");
       requireEnum(definition, "stageRequirement", "NONE", "LOGIN", "GAMEPLAY");
       requireEnum(definition, "promptPolicy", "NEVER", "WHEN_LOGGED_IN", "WHEN_GAMEPLAY");
       requireEnum(definition, "actionCategory", "GAMEPLAY", "SOCIAL", "META", "ADMIN", "SYSTEM");
       requireTextArray(definition, "aliases");
-      if (!definition.path("actionTags").isArray() || !definition.path("effects").isArray()) {
-        throw invalidCommandDefinition("actionTags and effects must be arrays");
+      requireEnumArray(
+          definition,
+          "actionTags",
+          "MOVEMENT",
+          "COMMUNICATION",
+          "COMBAT",
+          "INVENTORY",
+          "WORLD_BROWSE",
+          "SOCIAL_PRESENCE",
+          "AUTHORING",
+          "SESSION",
+          "UI");
+      if (!definition.path("effects").isArray()) {
+        throw invalidCommandDefinition("effects must be an array");
       }
     } catch (IllegalArgumentException ex) {
       throw ex;
@@ -135,6 +147,16 @@ public class RevisionServiceImpl implements RevisionService {
     for (JsonNode value : definition.path(field)) {
       if (!value.isTextual() || value.asText().isBlank()) {
         throw invalidCommandDefinition(field + " entries must be nonblank strings");
+      }
+    }
+  }
+
+  private void requireEnumArray(JsonNode definition, String field, String... allowed) {
+    requireTextArray(definition, field);
+    for (JsonNode value : definition.path(field)) {
+      boolean supported = java.util.Arrays.asList(allowed).contains(value.asText());
+      if (!supported) {
+        throw invalidCommandDefinition("unsupported " + field + " entry");
       }
     }
   }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReader.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReader.java
@@ -1,0 +1,124 @@
+package net.firedevops.firemud.gamesession.command.text;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import net.firedevops.firemud.gamedesign.v1.GetPublishedReleaseBundleResponse;
+import net.firedevops.firemud.gamesession.client.GameDesignClient;
+import net.firedevops.firemud.gamesession.entity.GameInstance;
+import net.firedevops.firemud.gamesession.repository.GameInstanceRepository;
+import net.firedevops.firemud.gamesession.service.SessionContext;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/** Resolves authored definitions only from the release bundle admitted for a live game instance. */
+@Component
+final class AdmittedCommandDefinitionReader {
+  private final GameInstanceRepository gameInstanceRepository;
+  private final GameDesignClient gameDesignClient;
+  private final ObjectMapper objectMapper;
+
+  AdmittedCommandDefinitionReader(
+      GameInstanceRepository gameInstanceRepository,
+      GameDesignClient gameDesignClient,
+      ObjectMapper objectMapper) {
+    this.gameInstanceRepository = gameInstanceRepository;
+    this.gameDesignClient = gameDesignClient;
+    this.objectMapper = objectMapper;
+  }
+
+  Optional<List<TextCommandDefinition>> definitionsFor(SessionContext context) {
+    if (context == null || context.tenantId() <= 0L || context.gameInstanceId() <= 0L) {
+      return Optional.empty();
+    }
+    return gameInstanceRepository
+        .findById(context.gameInstanceId())
+        .filter(instance -> matchesContext(instance, context))
+        .flatMap(instance -> readDefinitions(context.tenantId(), instance));
+  }
+
+  private boolean matchesContext(GameInstance instance, SessionContext context) {
+    return instance.getTenantId() != null
+        && instance.getTenantId() == context.tenantId()
+        && instance.getVersionId() != null
+        && instance.getVersionId() > 0L
+        && instance.getReleaseBundleId() != null
+        && instance.getReleaseBundleId() > 0L;
+  }
+
+  private Optional<List<TextCommandDefinition>> readDefinitions(
+      long tenantId, GameInstance instance) {
+    GetPublishedReleaseBundleResponse response =
+        gameDesignClient.getPublishedReleaseBundle(tenantId, instance.getVersionId());
+    if (response.hasError()
+        || !response.hasBundle()
+        || response.getBundle().getId() != instance.getReleaseBundleId()
+        || response.getBundle().getVersionId() != instance.getVersionId()) {
+      return Optional.empty();
+    }
+    try {
+      List<TextCommandDefinition> definitions = new ArrayList<>();
+      for (String json : response.getBundle().getCommandDefinitionsList()) {
+        definitions.add(parseDefinition(json));
+      }
+      return Optional.of(List.copyOf(definitions));
+    } catch (RuntimeException ex) {
+      return Optional.empty();
+    }
+  }
+
+  private TextCommandDefinition parseDefinition(String json) {
+    JsonNode definition = objectMapper.readTree(json);
+    if (!definition.isObject()
+        || definition.path("schemaVersion").asInt() != 1
+        || !"DURABLE_GAMEPLAY".equals(definition.path("executionDiscipline").asText())
+        || !definition.path("effects").isArray()
+        || !definition.path("effects").isEmpty()) {
+      throw new IllegalArgumentException("unsupported published command definition");
+    }
+    String commandId = requiredText(definition, "commandId");
+    requiredText(definition, "semanticOwner");
+    List<String> aliases = textArray(definition, "aliases");
+    List<TextCommandActionTag> actionTags =
+        textArray(definition, "actionTags").stream().map(TextCommandActionTag::valueOf).toList();
+    return new TextCommandDefinition(
+        commandId,
+        TextCommandType.AUTHORED,
+        aliases,
+        TextCommandDispatchGroup.AUTHORED,
+        TextCommandStageRequirement.valueOf(requiredText(definition, "stageRequirement")),
+        TextCommandPromptPolicy.valueOf(requiredText(definition, "promptPolicy")),
+        TextCommandActionCategory.valueOf(requiredText(definition, "actionCategory")),
+        actionTags,
+        TextCommandSource.GAME_AUTHORED,
+        "NONE",
+        null,
+        0L,
+        null,
+        0L,
+        null);
+  }
+
+  private String requiredText(JsonNode definition, String field) {
+    String value = definition.path(field).asText();
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(field + " is required");
+    }
+    return value;
+  }
+
+  private List<String> textArray(JsonNode definition, String field) {
+    if (!definition.path(field).isArray()) {
+      throw new IllegalArgumentException(field + " must be an array");
+    }
+    List<String> values = new ArrayList<>();
+    for (JsonNode value : definition.path(field)) {
+      if (!value.isTextual() || value.asText().isBlank()) {
+        throw new IllegalArgumentException(field + " entries must be nonblank strings");
+      }
+      values.add(value.asText());
+    }
+    return List.copyOf(values);
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReader.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReader.java
@@ -49,15 +49,15 @@ final class AdmittedCommandDefinitionReader {
 
   private Optional<List<TextCommandDefinition>> readDefinitions(
       long tenantId, GameInstance instance) {
-    GetPublishedReleaseBundleResponse response =
-        gameDesignClient.getPublishedReleaseBundle(tenantId, instance.getVersionId());
-    if (response.hasError()
-        || !response.hasBundle()
-        || response.getBundle().getId() != instance.getReleaseBundleId()
-        || response.getBundle().getVersionId() != instance.getVersionId()) {
-      return Optional.empty();
-    }
     try {
+      GetPublishedReleaseBundleResponse response =
+          gameDesignClient.getPublishedReleaseBundle(tenantId, instance.getVersionId());
+      if (response.hasError()
+          || !response.hasBundle()
+          || response.getBundle().getId() != instance.getReleaseBundleId()
+          || response.getBundle().getVersionId() != instance.getVersionId()) {
+        return Optional.empty();
+      }
       List<TextCommandDefinition> definitions = new ArrayList<>();
       for (String json : response.getBundle().getCommandDefinitionsList()) {
         definitions.add(parseDefinition(json));

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
@@ -1,0 +1,28 @@
+package net.firedevops.firemud.gamesession.command.text;
+
+import java.util.List;
+import net.firedevops.firemud.gamesession.service.SessionContext;
+import org.springframework.stereotype.Component;
+
+/** Builds an instance-scoped command registry from built-ins and the admitted release artifact. */
+@Component
+final class AdmittedTextCommandRegistryResolver {
+  private final AdmittedCommandDefinitionReader admittedCommandDefinitionReader;
+  private final TextCommandRegistry builtIns =
+      new AggregatingTextCommandRegistry(List.of(new BuiltInTextCommandDefinitionProvider()));
+
+  AdmittedTextCommandRegistryResolver(
+      AdmittedCommandDefinitionReader admittedCommandDefinitionReader) {
+    this.admittedCommandDefinitionReader = admittedCommandDefinitionReader;
+  }
+
+  TextCommandRegistry resolve(SessionContext context) {
+    return admittedCommandDefinitionReader
+        .definitionsFor(context)
+        .<TextCommandRegistry>map(
+            definitions ->
+                new AggregatingTextCommandRegistry(
+                    List.of(new BuiltInTextCommandDefinitionProvider(), () -> definitions)))
+        .orElse(builtIns);
+  }
+}

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 /** Builds an instance-scoped command registry from built-ins and the admitted release artifact. */
 @Component
-final class AdmittedTextCommandRegistryResolver {
+public final class AdmittedTextCommandRegistryResolver {
   private final AdmittedCommandDefinitionReader admittedCommandDefinitionReader;
   private final TextCommandRegistry builtIns =
       new AggregatingTextCommandRegistry(List.of(new BuiltInTextCommandDefinitionProvider()));
@@ -16,7 +16,7 @@ final class AdmittedTextCommandRegistryResolver {
     this.admittedCommandDefinitionReader = admittedCommandDefinitionReader;
   }
 
-  TextCommandRegistry resolve(SessionContext context) {
+  public TextCommandRegistry resolve(SessionContext context) {
     return admittedCommandDefinitionReader
         .definitionsFor(context)
         .<TextCommandRegistry>map(

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
@@ -18,10 +18,15 @@ public final class AdmittedTextCommandRegistryResolver {
 
   public TextCommandRegistry resolve(SessionContext context) {
     List<TextCommandDefinition> definitions = definitions(context);
-    return definitions.isEmpty()
-        ? builtIns
-        : new AggregatingTextCommandRegistry(
-            List.of(new BuiltInTextCommandDefinitionProvider(), () -> definitions));
+    if (definitions.isEmpty()) {
+      return builtIns;
+    }
+    try {
+      return new AggregatingTextCommandRegistry(
+          List.of(new BuiltInTextCommandDefinitionProvider(), () -> definitions));
+    } catch (IllegalArgumentException | IllegalStateException ex) {
+      return builtIns;
+    }
   }
 
   List<TextCommandDefinition> definitions(SessionContext context) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
@@ -17,12 +17,14 @@ public final class AdmittedTextCommandRegistryResolver {
   }
 
   public TextCommandRegistry resolve(SessionContext context) {
-    return admittedCommandDefinitionReader
-        .definitionsFor(context)
-        .<TextCommandRegistry>map(
-            definitions ->
-                new AggregatingTextCommandRegistry(
-                    List.of(new BuiltInTextCommandDefinitionProvider(), () -> definitions)))
-        .orElse(builtIns);
+    List<TextCommandDefinition> definitions = definitions(context);
+    return definitions.isEmpty()
+        ? builtIns
+        : new AggregatingTextCommandRegistry(
+            List.of(new BuiltInTextCommandDefinitionProvider(), () -> definitions));
+  }
+
+  List<TextCommandDefinition> definitions(SessionContext context) {
+    return admittedCommandDefinitionReader.definitionsFor(context).orElse(List.of());
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AuthoredActionCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AuthoredActionCommandHandler.java
@@ -4,14 +4,24 @@ import io.micrometer.core.annotation.Timed;
 import java.util.List;
 import net.firedevops.firemud.gamesession.dto.CommandEnqueueResult;
 import net.firedevops.firemud.gamesession.presentation.PlayerOutput;
+import net.firedevops.firemud.gamesession.service.SessionContext;
 import org.springframework.stereotype.Component;
 
 @Component
 final class AuthoredActionCommandHandler implements AuthoredActionRuntimeHandler {
   private final ConfiguredAuthoredActionCatalog catalog;
+  private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
 
   AuthoredActionCommandHandler(ConfiguredAuthoredActionCatalog catalog) {
+    this(catalog, null);
+  }
+
+  @org.springframework.beans.factory.annotation.Autowired
+  AuthoredActionCommandHandler(
+      ConfiguredAuthoredActionCatalog catalog,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver) {
     this.catalog = catalog;
+    this.admittedRegistryResolver = admittedRegistryResolver;
   }
 
   @Override
@@ -34,5 +44,32 @@ final class AuthoredActionCommandHandler implements AuthoredActionRuntimeHandler
                         PlayerOutput.error(
                             "UNKNOWN_AUTHORED_ACTION",
                             "Unknown authored action: " + invocation.commandId()))));
+  }
+
+  @Override
+  public TextCommandInterpretationResult handle(SessionContext context, TextCommand command) {
+    if (admittedRegistryResolver == null) {
+      return handle(command);
+    }
+    TextCommandPayload.AuthoredActionInvocation invocation =
+        command.authoredActionPayload().orElseThrow();
+    boolean admitted =
+        admittedRegistryResolver
+            .resolve(context)
+            .findDefinition(invocation.commandId())
+            .filter(definition -> definition.type() == TextCommandType.AUTHORED)
+            .isPresent();
+    return admitted
+        ? new TextCommandInterpretationResult(CommandEnqueueResult.success(), List.of())
+        : unknown(invocation.commandId());
+  }
+
+  private TextCommandInterpretationResult unknown(String commandId) {
+    return new TextCommandInterpretationResult(
+        CommandEnqueueResult.failure(
+            "UNKNOWN_AUTHORED_ACTION", "Unknown authored action: " + commandId),
+        List.of(
+            PlayerOutput.error(
+                "UNKNOWN_AUTHORED_ACTION", "Unknown authored action: " + commandId)));
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AuthoredActionRuntimeHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AuthoredActionRuntimeHandler.java
@@ -1,5 +1,11 @@
 package net.firedevops.firemud.gamesession.command.text;
 
+import net.firedevops.firemud.gamesession.service.SessionContext;
+
 public interface AuthoredActionRuntimeHandler {
   TextCommandInterpretationResult handle(TextCommand command);
+
+  default TextCommandInterpretationResult handle(SessionContext context, TextCommand command) {
+    return handle(command);
+  }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AuthoredActionTextCommandDispatchHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AuthoredActionTextCommandDispatchHandler.java
@@ -30,7 +30,11 @@ final class AuthoredActionTextCommandDispatchHandler implements TextCommandDispa
 
   @Override
   public TextCommandInterpretationResult handle(TextCommandDispatchRequest request) {
-    TextCommandInterpretationResult result = handler.handle(request.command());
+    TextCommandInterpretationResult result =
+        request
+            .sessionContext()
+            .map(context -> handler.handle(context, request.command()))
+            .orElseGet(() -> handler.handle(request.command()));
     if (result.commandResult().accepted()) {
       request
           .sessionContext()
@@ -41,15 +45,9 @@ final class AuthoredActionTextCommandDispatchHandler implements TextCommandDispa
 
   private void publishCommandEvent(SessionContext context, TextCommand command) {
     try {
-      String executionHook =
-          catalog
-              .find(command.commandId())
-              .map(ConfiguredAuthoredActionCatalog.ConfiguredAuthoredAction::executionHook)
-              .orElse(null);
       scriptEventPublisher.publishCommandEvent(
           context,
-          ScriptEventGameplayCommands.synthetic(
-              "authored", command, command.commandId(), executionHook));
+          ScriptEventGameplayCommands.synthetic("authored", command, command.commandId(), null));
     } catch (RuntimeException ex) {
       LOG.warn(
           "Authored script event publish failed tenantId={} gameInstanceId={} characterId={} commandId={}",

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
@@ -10,7 +10,6 @@ import java.util.Objects;
 import java.util.Optional;
 import net.firedevops.firemud.gamesession.service.GameAuthoredHelpReader;
 import net.firedevops.firemud.gamesession.service.SessionContext;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -24,7 +23,6 @@ public class HelpCommandHandler {
   private final GameAuthoredHelpReader authoredHelpReader;
   private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
 
-  @Autowired
   HelpCommandHandler(
       ConfiguredAuthoredActionCatalog authoredActionCatalog,
       GameAuthoredHelpReader authoredHelpReader) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
@@ -22,19 +22,29 @@ import org.springframework.util.StringUtils;
 public class HelpCommandHandler {
   private final ConfiguredAuthoredActionCatalog authoredActionCatalog;
   private final GameAuthoredHelpReader authoredHelpReader;
+  private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
 
   @Autowired
   HelpCommandHandler(
       ConfiguredAuthoredActionCatalog authoredActionCatalog,
       GameAuthoredHelpReader authoredHelpReader) {
+    this(authoredActionCatalog, authoredHelpReader, null);
+  }
+
+  @org.springframework.beans.factory.annotation.Autowired
+  HelpCommandHandler(
+      ConfiguredAuthoredActionCatalog authoredActionCatalog,
+      GameAuthoredHelpReader authoredHelpReader,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver) {
     this.authoredActionCatalog =
         Objects.requireNonNull(authoredActionCatalog, "authoredActionCatalog must not be null");
     this.authoredHelpReader =
         Objects.requireNonNull(authoredHelpReader, "authoredHelpReader must not be null");
+    this.admittedRegistryResolver = admittedRegistryResolver;
   }
 
   HelpCommandHandler(ConfiguredAuthoredActionCatalog authoredActionCatalog) {
-    this(authoredActionCatalog, (context, topic) -> Optional.empty());
+    this(authoredActionCatalog, (context, topic) -> Optional.empty(), null);
   }
 
   HelpCommandHandler() {
@@ -68,8 +78,18 @@ public class HelpCommandHandler {
       return success(authoredTopic.orElseThrow());
     }
 
-    String resolvedTopic = canonicalTopic(args.get(0));
+    String resolvedTopic = canonicalTopic(args.get(0), maybeContext);
     if (resolvedTopic.startsWith("AUTHORED:")) {
+      if (admittedRegistryResolver != null) {
+        return maybeContext
+            .flatMap(
+                context ->
+                    admittedRegistryResolver
+                        .resolve(context)
+                        .findDefinition(resolvedTopic.substring("AUTHORED:".length())))
+            .map(this::success)
+            .orElseGet(() -> unknownTopic(args.get(0)));
+      }
       return authoredActionCatalog
           .find(resolvedTopic.substring("AUTHORED:".length()))
           .map(this::success)
@@ -218,7 +238,7 @@ public class HelpCommandHandler {
                 Map.of("topic", normalized))));
   }
 
-  private String canonicalTopic(String topic) {
+  private String canonicalTopic(String topic, Optional<SessionContext> maybeContext) {
     if (!StringUtils.hasText(topic)) {
       return "";
     }
@@ -249,6 +269,14 @@ public class HelpCommandHandler {
         };
     if (!canonical.isEmpty()) {
       return canonical;
+    }
+    if (admittedRegistryResolver != null) {
+      return maybeContext
+          .flatMap(
+              context -> admittedRegistryResolver.resolve(context).findDefinitionByAlias(topic))
+          .filter(definition -> definition.type() == TextCommandType.AUTHORED)
+          .map(definition -> "AUTHORED:" + definition.commandId())
+          .orElse("");
     }
     return authoredActionCatalog
         .findByAlias(topic)
@@ -302,6 +330,14 @@ public class HelpCommandHandler {
             + (StringUtils.hasText(action.helpDetails()) ? "\n" + action.helpDetails().trim() : "")
             + authoredAliasSuffix(action);
     return success(body);
+  }
+
+  private TextCommandInterpretationResult success(TextCommandDefinition definition) {
+    String topic =
+        definition.aliases().isEmpty()
+            ? definition.commandId().toUpperCase(Locale.ROOT)
+            : definition.aliases().getFirst().toUpperCase(Locale.ROOT);
+    return success(topic + "\nGame-authored action.");
   }
 
   private TextCommandInterpretationResult success(GameAuthoredHelpReader.ResolvedTopic topic) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/HelpCommandHandler.java
@@ -64,7 +64,7 @@ public class HelpCommandHandler {
 
     List<String> args = command.args();
     if (args.isEmpty()) {
-      return success(topicIndex());
+      return success(topicIndex(maybeContext));
     }
     if (args.size() > 1) {
       return unknownTopic(args.get(0));
@@ -95,7 +95,7 @@ public class HelpCommandHandler {
     }
 
     return switch (resolvedTopic) {
-      case "HELP" -> success(topicIndex());
+      case "HELP" -> success(topicIndex(maybeContext));
       case "LOGIN" ->
           success(
               "LOGIN <email> [secret]\n"
@@ -282,7 +282,7 @@ public class HelpCommandHandler {
         .orElse("");
   }
 
-  private String topicIndex() {
+  private String topicIndex(Optional<SessionContext> maybeContext) {
     ArrayList<String> lines =
         new ArrayList<>(
             List.of(
@@ -307,7 +307,20 @@ public class HelpCommandHandler {
                 "- HELP SAY",
                 "- HELP WHISPER",
                 "- HELP TELL"));
-    if (!authoredActionCatalog.all().isEmpty()) {
+    List<TextCommandDefinition> admittedDefinitions =
+        admittedRegistryResolver == null
+            ? List.of()
+            : maybeContext.map(admittedRegistryResolver::definitions).orElse(List.of());
+    if (!admittedDefinitions.isEmpty()) {
+      lines.add("Authored topics:");
+      for (TextCommandDefinition definition : admittedDefinitions) {
+        String topic =
+            definition.aliases().isEmpty()
+                ? definition.commandId()
+                : definition.aliases().getFirst();
+        lines.add("- HELP " + topic.toUpperCase(Locale.ROOT));
+      }
+    } else if (admittedRegistryResolver == null && !authoredActionCatalog.all().isEmpty()) {
       lines.add("Authored topics:");
       for (ConfiguredAuthoredActionCatalog.ConfiguredAuthoredAction action :
           authoredActionCatalog.all()) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandInterpreter.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandInterpreter.java
@@ -27,7 +27,61 @@ public class TextCommandInterpreter {
   private final PromptComposer promptComposer;
   private final TextCommandParser parser;
   private final TextCommandRegistry registry;
+  private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
   private final TextCommandDispatcher dispatcher;
+
+  TextCommandInterpreter(
+      CommandService commandService,
+      LookCommandHandler lookHandler,
+      LoginCommandHandler loginHandler,
+      LogoutCommandHandler logoutHandler,
+      PlayCommandHandler playHandler,
+      MoveCommandHandler moveHandler,
+      AfkCommandHandler afkHandler,
+      HelpCommandHandler helpHandler,
+      WhoCommandHandler whoHandler,
+      StatusCommandHandler statusHandler,
+      FriendsCommandHandler friendsHandler,
+      AuthoredActionCommandHandler authoredActionHandler,
+      ConfiguredAuthoredActionCatalog authoredActionCatalog,
+      InventoryCommandHandler inventoryHandler,
+      EquipmentCommandHandler equipmentHandler,
+      ContainerCommandHandler containerHandler,
+      SessionAuthenticationService sessionAuthenticationService,
+      ScriptEventPublisher scriptEventPublisher,
+      CommunicationCommandHandler communicationHandler,
+      WorldsCommandHandler worldsHandler,
+      PromptComposer promptComposer,
+      TextCommandRegistry registry,
+      TextCommandParser parser,
+      MeterRegistry meterRegistry) {
+    this(
+        commandService,
+        lookHandler,
+        loginHandler,
+        logoutHandler,
+        playHandler,
+        moveHandler,
+        afkHandler,
+        helpHandler,
+        whoHandler,
+        statusHandler,
+        friendsHandler,
+        authoredActionHandler,
+        authoredActionCatalog,
+        inventoryHandler,
+        equipmentHandler,
+        containerHandler,
+        sessionAuthenticationService,
+        scriptEventPublisher,
+        communicationHandler,
+        worldsHandler,
+        promptComposer,
+        registry,
+        parser,
+        null,
+        meterRegistry);
+  }
 
   @Autowired
   public TextCommandInterpreter(
@@ -54,12 +108,14 @@ public class TextCommandInterpreter {
       PromptComposer promptComposer,
       TextCommandRegistry registry,
       TextCommandParser parser,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver,
       MeterRegistry meterRegistry) {
     this(
         sessionAuthenticationService,
         promptComposer,
         parser,
         registry,
+        admittedRegistryResolver,
         buildDispatcher(
             commandService,
             lookHandler,
@@ -91,24 +147,59 @@ public class TextCommandInterpreter {
       TextCommandParser parser,
       TextCommandRegistry registry,
       TextCommandDispatcher dispatcher) {
+    this(sessionAuthenticationService, promptComposer, parser, registry, null, dispatcher);
+  }
+
+  TextCommandInterpreter(
+      SessionAuthenticationService sessionAuthenticationService,
+      PromptComposer promptComposer,
+      TextCommandParser parser,
+      TextCommandRegistry registry,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver,
+      TextCommandDispatcher dispatcher) {
     this.sessionAuthenticationService =
         Objects.requireNonNull(
             sessionAuthenticationService, "sessionAuthenticationService must not be null");
     this.promptComposer = Objects.requireNonNull(promptComposer, "promptComposer must not be null");
     this.parser = Objects.requireNonNull(parser, "parser must not be null");
     this.registry = Objects.requireNonNull(registry, "registry must not be null");
+    this.admittedRegistryResolver = admittedRegistryResolver;
     this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher must not be null");
   }
 
   public TextCommandInterpretationResult interpret(
       String sessionId, String rawLine, boolean requiresSoloTick) {
-    return interpret(sessionId, parser.parse(rawLine), requiresSoloTick);
+    Optional<SessionContext> context =
+        sessionAuthenticationService.resolveSessionContext(sessionId);
+    TextCommandRegistry activeRegistry = registryFor(context);
+    return interpret(
+        sessionId,
+        parser.parse(rawLine, activeRegistry),
+        requiresSoloTick,
+        context,
+        activeRegistry);
   }
 
   public TextCommandInterpretationResult interpret(
       String sessionId, TextCommand command, boolean requiresSoloTick) {
+    Optional<SessionContext> context =
+        sessionAuthenticationService.resolveSessionContext(sessionId);
+    TextCommandRegistry activeRegistry = registryFor(context);
+    TextCommand activeCommand =
+        admittedRegistryResolver == null
+            ? command
+            : parser.parse(command.rawLine(), activeRegistry);
+    return interpret(sessionId, activeCommand, requiresSoloTick, context, activeRegistry);
+  }
+
+  private TextCommandInterpretationResult interpret(
+      String sessionId,
+      TextCommand command,
+      boolean requiresSoloTick,
+      Optional<SessionContext> maybeContext,
+      TextCommandRegistry activeRegistry) {
     TextCommandDefinition definition =
-        registry
+        activeRegistry
             .findDefinition(command.commandId())
             .orElseGet(
                 () ->
@@ -123,8 +214,6 @@ public class TextCommandInterpreter {
           List.of(
               PlayerOutput.error("UNKNOWN_COMMAND", message, "error.unknown-command", Map.of())));
     }
-    Optional<net.firedevops.firemud.gamesession.service.SessionContext> maybeContext =
-        sessionAuthenticationService.resolveSessionContext(sessionId);
     boolean hasLogin = maybeContext.isPresent();
     boolean hasPlay = maybeContext.filter(SessionContext::hasGameplayRegionBinding).isPresent();
 
@@ -150,6 +239,12 @@ public class TextCommandInterpreter {
     return withMeaningfulGameplayActivity(
         promptApplied,
         dispatchResult.commandResult().accepted() && isMeaningfulGameplay(definition));
+  }
+
+  private TextCommandRegistry registryFor(Optional<SessionContext> context) {
+    return admittedRegistryResolver == null
+        ? registry
+        : admittedRegistryResolver.resolve(context.orElse(null));
   }
 
   private TextCommandInterpretationResult applyPromptPolicy(

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandParser.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandParser.java
@@ -27,6 +27,11 @@ public class TextCommandParser {
   }
 
   public TextCommand parse(String rawLine) {
+    return parse(rawLine, registry);
+  }
+
+  TextCommand parse(String rawLine, TextCommandRegistry registry) {
+    Objects.requireNonNull(registry, "registry must not be null");
     String source = rawLine == null ? "" : rawLine;
     String trimmed = source.trim();
     if (trimmed.isEmpty()) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandParser.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandParser.java
@@ -30,7 +30,7 @@ public class TextCommandParser {
     return parse(rawLine, registry);
   }
 
-  TextCommand parse(String rawLine, TextCommandRegistry registry) {
+  public TextCommand parse(String rawLine, TextCommandRegistry registry) {
     Objects.requireNonNull(registry, "registry must not be null");
     String source = rawLine == null ? "" : rawLine;
     String trimmed = source.trim();

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
@@ -200,7 +200,10 @@ public final class DefaultDurableGameplayCommandExecutionService
                   command,
                   effect.getEffectId(),
                   () -> {
-                    var result = authoredActionCommandHandler.handle(activeParsed);
+                    var result =
+                        admittedRegistryResolver == null
+                            ? authoredActionCommandHandler.handle(activeParsed)
+                            : authoredActionCommandHandler.handle(context, activeParsed);
                     return new ReplayBackedMutationResult(result.commandResult(), result.outputs());
                   }));
       case MOVE -> {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import net.firedevops.firemud.gamesession.command.text.ActionStateCommandHandler;
+import net.firedevops.firemud.gamesession.command.text.AdmittedTextCommandRegistryResolver;
 import net.firedevops.firemud.gamesession.command.text.AfkCommandHandler;
 import net.firedevops.firemud.gamesession.command.text.AuthoredActionRuntimeHandler;
 import net.firedevops.firemud.gamesession.command.text.CommunicationCommandHandler;
@@ -40,6 +41,7 @@ public final class DefaultDurableGameplayCommandExecutionService
     implements DurableGameplayCommandExecutionService {
   private final MeterRegistry meterRegistry;
   private final TextCommandParser textCommandParser;
+  private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
   private final SessionAuthenticationService sessionAuthenticationService;
   private final MoveCommandHandler moveCommandHandler;
   private final ItemCommandHandler itemCommandHandler;
@@ -68,8 +70,44 @@ public final class DefaultDurableGameplayCommandExecutionService
       MovementEffectIdempotencyService movementEffectIdempotencyService,
       PlayerOutputDeliveryService playerOutputDeliveryService,
       ScriptEventPublisher scriptEventPublisher) {
+    this(
+        meterRegistry,
+        textCommandParser,
+        null,
+        sessionAuthenticationService,
+        moveCommandHandler,
+        itemCommandHandler,
+        communicationCommandHandler,
+        afkCommandHandler,
+        actionStateCommandHandler,
+        textCommandMetadataResolver,
+        authoredActionCommandHandler,
+        durableGameplayReplayService,
+        movementEffectIdempotencyService,
+        playerOutputDeliveryService,
+        scriptEventPublisher);
+  }
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public DefaultDurableGameplayCommandExecutionService(
+      MeterRegistry meterRegistry,
+      TextCommandParser textCommandParser,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver,
+      SessionAuthenticationService sessionAuthenticationService,
+      MoveCommandHandler moveCommandHandler,
+      ItemCommandHandler itemCommandHandler,
+      CommunicationCommandHandler communicationCommandHandler,
+      AfkCommandHandler afkCommandHandler,
+      ActionStateCommandHandler actionStateCommandHandler,
+      TextCommandMetadataResolver textCommandMetadataResolver,
+      AuthoredActionRuntimeHandler authoredActionCommandHandler,
+      DurableGameplayReplayService durableGameplayReplayService,
+      MovementEffectIdempotencyService movementEffectIdempotencyService,
+      PlayerOutputDeliveryService playerOutputDeliveryService,
+      ScriptEventPublisher scriptEventPublisher) {
     this.meterRegistry = meterRegistry;
     this.textCommandParser = textCommandParser;
+    this.admittedRegistryResolver = admittedRegistryResolver;
     this.sessionAuthenticationService = sessionAuthenticationService;
     this.moveCommandHandler = moveCommandHandler;
     this.itemCommandHandler = itemCommandHandler;
@@ -88,8 +126,8 @@ public final class DefaultDurableGameplayCommandExecutionService
   public Optional<DurableGameplayCommandExecutionResult> execute(
       TickEffect effect, GameplayCommand command) {
     TextCommand parsed = textCommandParser.parse(command.getCommandText());
-    CommandExecutionRoute route = resolveRoute(command, parsed);
-    if (route == CommandExecutionRoute.IGNORE) {
+    if (resolveRoute(command, parsed) == CommandExecutionRoute.IGNORE
+        && parsed.type() != TextCommandType.UNKNOWN) {
       return Optional.empty();
     }
     Optional<SessionContext> maybeContext = resolveExecutionContext(command);
@@ -105,10 +143,21 @@ public final class DefaultDurableGameplayCommandExecutionService
                   "Session context no longer exists for command execution")));
     }
     SessionContext context = maybeContext.orElseThrow();
+    if (admittedRegistryResolver != null) {
+      parsed =
+          textCommandParser.parse(
+              command.getCommandText(), admittedRegistryResolver.resolve(context));
+    }
+    CommandExecutionRoute route = resolveRoute(command, parsed);
+    if (route == CommandExecutionRoute.IGNORE) {
+      return Optional.empty();
+    }
+    TextCommand activeParsed = parsed;
     return switch (route) {
       case ITEM_MUTATION -> {
         publishCommandEventForLiveExecution(context, command);
-        yield Optional.of(executeItemMutation(context, parsed, command, effect.getEffectId()));
+        yield Optional.of(
+            executeItemMutation(context, activeParsed, command, effect.getEffectId()));
       }
       case COMMUNICATION ->
           Optional.of(
@@ -118,7 +167,8 @@ public final class DefaultDurableGameplayCommandExecutionService
                   effect.getEffectId(),
                   () -> {
                     var result =
-                        communicationCommandHandler.handle(context, parsed, effect.getEffectId());
+                        communicationCommandHandler.handle(
+                            context, activeParsed, effect.getEffectId());
                     return new ReplayBackedMutationResult(result.commandResult(), result.outputs());
                   }));
       case AFK ->
@@ -128,7 +178,7 @@ public final class DefaultDurableGameplayCommandExecutionService
                   command,
                   effect.getEffectId(),
                   () -> {
-                    var result = afkCommandHandler.handle(context, parsed);
+                    var result = afkCommandHandler.handle(context, activeParsed);
                     return new ReplayBackedMutationResult(result.commandResult(), result.outputs());
                   }));
       case ACTION_STATE ->
@@ -139,7 +189,8 @@ public final class DefaultDurableGameplayCommandExecutionService
                   effect.getEffectId(),
                   () -> {
                     var result =
-                        actionStateCommandHandler.handle(context, parsed, effect.getEffectId());
+                        actionStateCommandHandler.handle(
+                            context, activeParsed, effect.getEffectId());
                     return new ReplayBackedMutationResult(result.commandResult(), result.outputs());
                   }));
       case AUTHORED ->
@@ -149,12 +200,12 @@ public final class DefaultDurableGameplayCommandExecutionService
                   command,
                   effect.getEffectId(),
                   () -> {
-                    var result = authoredActionCommandHandler.handle(parsed);
+                    var result = authoredActionCommandHandler.handle(activeParsed);
                     return new ReplayBackedMutationResult(result.commandResult(), result.outputs());
                   }));
       case MOVE -> {
         publishCommandEventForLiveExecution(context, command);
-        PreparedMoveCommandResult prepared = moveCommandHandler.prepare(context, parsed);
+        PreparedMoveCommandResult prepared = moveCommandHandler.prepare(context, activeParsed);
         if (!prepared.commandResult().accepted()) {
           if (prepared.responseOutput() != null) {
             playerOutputDeliveryService.deliver(context, List.of(prepared.responseOutput()), true);

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReaderTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReaderTest.java
@@ -1,0 +1,79 @@
+package net.firedevops.firemud.gamesession.command.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.firedevops.firemud.gamedesign.v1.GetPublishedReleaseBundleResponse;
+import net.firedevops.firemud.gamedesign.v1.PublishedReleaseBundle;
+import net.firedevops.firemud.gamesession.client.GameDesignClient;
+import net.firedevops.firemud.gamesession.entity.GameInstance;
+import net.firedevops.firemud.gamesession.repository.GameInstanceRepository;
+import net.firedevops.firemud.gamesession.service.SessionContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tools.jackson.databind.ObjectMapper;
+
+class AdmittedCommandDefinitionReaderTest {
+  private final GameInstanceRepository gameInstanceRepository =
+      Mockito.mock(GameInstanceRepository.class);
+  private final GameDesignClient gameDesignClient = Mockito.mock(GameDesignClient.class);
+  private final AdmittedCommandDefinitionReader reader =
+      new AdmittedCommandDefinitionReader(
+          gameInstanceRepository, gameDesignClient, new ObjectMapper());
+
+  @Test
+  void resolvesOnlyDefinitionsFromTheMatchingAdmittedReleaseBundle() {
+    GameInstance instance = new GameInstance();
+    instance.setId(44L);
+    instance.setTenantId(7L);
+    instance.setVersionId(9L);
+    instance.setReleaseBundleId(12L);
+    when(gameInstanceRepository.findById(44L)).thenReturn(Optional.of(instance));
+    when(gameDesignClient.getPublishedReleaseBundle(7L, 9L))
+        .thenReturn(
+            GetPublishedReleaseBundleResponse.newBuilder()
+                .setBundle(
+                    PublishedReleaseBundle.newBuilder()
+                        .setId(12L)
+                        .setVersionId(9L)
+                        .addCommandDefinitions(validDefinition())
+                        .build())
+                .build());
+
+    var definitions = reader.definitionsFor(context());
+
+    assertTrue(definitions.isPresent());
+    assertEquals("salute", definitions.orElseThrow().getFirst().commandId());
+    assertEquals(
+        TextCommandDispatchGroup.AUTHORED, definitions.orElseThrow().getFirst().dispatchGroup());
+  }
+
+  @Test
+  void rejectsDefinitionsWhenTheBundleDoesNotMatchTheAdmittedInstance() {
+    GameInstance instance = new GameInstance();
+    instance.setId(44L);
+    instance.setTenantId(7L);
+    instance.setVersionId(9L);
+    instance.setReleaseBundleId(12L);
+    when(gameInstanceRepository.findById(44L)).thenReturn(Optional.of(instance));
+    when(gameDesignClient.getPublishedReleaseBundle(7L, 9L))
+        .thenReturn(
+            GetPublishedReleaseBundleResponse.newBuilder()
+                .setBundle(PublishedReleaseBundle.newBuilder().setId(13L).setVersionId(9L).build())
+                .build());
+
+    assertTrue(reader.definitionsFor(context()).isEmpty());
+  }
+
+  private SessionContext context() {
+    return new SessionContext(1L, 7L, 2L, "player", 3L, "hero", 44L, "room", "jwt", 0L);
+  }
+
+  private String validDefinition() {
+    return """
+        {"schemaVersion":1,"commandId":"salute","semanticOwner":"GAME_LOGIC","executionDiscipline":"DURABLE_GAMEPLAY","stageRequirement":"GAMEPLAY","promptPolicy":"WHEN_GAMEPLAY","actionCategory":"SOCIAL","aliases":["salute"],"actionTags":["COMMUNICATION"],"effects":[]}
+        """;
+  }
+}

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReaderTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReaderTest.java
@@ -67,6 +67,20 @@ class AdmittedCommandDefinitionReaderTest {
     assertTrue(reader.definitionsFor(context()).isEmpty());
   }
 
+  @Test
+  void treatsPublishedBundleReadFailuresAsUnavailable() {
+    GameInstance instance = new GameInstance();
+    instance.setId(44L);
+    instance.setTenantId(7L);
+    instance.setVersionId(9L);
+    instance.setReleaseBundleId(12L);
+    when(gameInstanceRepository.findById(44L)).thenReturn(Optional.of(instance));
+    when(gameDesignClient.getPublishedReleaseBundle(7L, 9L))
+        .thenThrow(new IllegalStateException("game design unavailable"));
+
+    assertTrue(reader.definitionsFor(context()).isEmpty());
+  }
+
   private SessionContext context() {
     return new SessionContext(1L, 7L, 2L, "player", 3L, "hero", 44L, "room", "jwt", 0L);
   }

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AuthoredActionTextCommandDispatchHandlerTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AuthoredActionTextCommandDispatchHandlerTest.java
@@ -46,7 +46,7 @@ class AuthoredActionTextCommandDispatchHandlerTest {
   }
 
   @Test
-  void publishesExecutionHookForConfiguredAuthoredActionWhenPresent() {
+  void doesNotPublishConfigurationOnlyExecutionHooks() {
     ScriptEventPublisher dedicatedPublisher = Mockito.mock(ScriptEventPublisher.class);
     AuthoredActionProperties properties = configuredAuthoredActions();
     AuthoredActionProperties.Action action = new AuthoredActionProperties.Action();
@@ -80,7 +80,7 @@ class AuthoredActionTextCommandDispatchHandlerTest {
                         && "hooked-wave".equals(gameplayCommand.getCommandText())
                         && gameplayCommand.getCommandId() != null
                         && gameplayCommand.getCommandId().startsWith("authored-")
-                        && "runtime.workflow.wave".equals(gameplayCommand.getExecutionHook())));
+                        && gameplayCommand.getExecutionHook() == null));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- tighten published command-definition metadata to registered runtime values
- establish the stacked branch for Game Session admitted-artifact consumption

## Validation
- `./gradlew :game-design-service:test --tests 'net.firedevops.firemud.gamedesign.service.impl.RevisionServiceImplTest'`
- `./gradlew spotlessApply`