### PR TITLE
Retire configured authored command registry

### DIFF
--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -42,7 +42,7 @@ Still future work under this slice:
 
 Current batch: typed command-definition revisions now have an immutable publication artifact and control-plane read contract. The next batch must consume that admitted artifact in Game Session; it must not introduce another configuration-backed action source.
 
-Current runtime follow-through: Game Session resolves authored aliases, direct HELP topics, authored dispatch validation, and durable-command reparsing against the release bundle admitted for the live game instance. A mismatched bundle, malformed definition, unsupported execution discipline, or non-empty unregistered effects array fails closed to the built-in-only registry. The legacy configured catalog is fixture compatibility support only; it is not discovered by Spring and is no longer a production parsing or admission authority.
+Current runtime follow-through: Game Session resolves authored aliases, direct HELP topics, authored dispatch validation, durable-command reparsing, and first-party command-result action metadata against the release bundle admitted for the live game instance. A mismatched bundle, malformed definition, unsupported execution discipline, or non-empty unregistered effects array fails closed to the built-in-only registry. The legacy configured catalog is fixture compatibility support only; it is not discovered by Spring and is no longer a production parsing, admission, or presentation-metadata authority.
 
 ## Checklist
 

--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -2,14 +2,14 @@
 
 ## Goal and Status
 
-Goal: define the canonical game-authored action model so later custom actions share one typed definition, validation, targeting, cost/cooldown, and execution path instead of bypassing the built-in command and effect architecture. Status: in progress; the provider-backed parser/dispatcher seam is complete and version-scoped declaration convergence is active.
+Goal: define the canonical game-authored action model so later custom actions share one typed definition, validation, targeting, cost/cooldown, and execution path instead of bypassing the built-in command and effect architecture. Status: in progress; version-scoped declaration and runtime-admission convergence is active.
 
 ## Implementation Notes
 
 The first canonical authored-command/runtime seam is now live on branch:
 
 - `TextCommandInterpreter` resolves through a general `TextCommandRegistry` rather than a built-in-only branch tree;
-- the active runtime registry is provider-backed in the application context, so built-in and authored-command definition providers register through the same seam;
+- the active runtime registry resolves built-ins plus the authored definitions admitted from the current game instance's published release artifact;
 - command alias ownership now also sits in command definitions, and the parser resolves canonical verbs through the active registry rather than a fixed built-in alias table;
 - command definitions are now keyed by canonical `commandId`, so non-built-in commands do not have to pretend to own a `TextCommandType`;
 - command definitions already carry the shared metadata authored commands will need later:
@@ -20,13 +20,11 @@ The first canonical authored-command/runtime seam is now live on branch:
   - source/ownership metadata;
 - duplicate command-definition ownership is rejected when providers are aggregated, which prevents later authored providers from silently shadowing built-in definitions.
 - duplicate alias ownership is also rejected when providers are aggregated, so later authored providers cannot silently shadow built-in command phrases.
-- the first non-built-in provider now exists:
-  - configured authored actions under `game-session.authored-actions.actions[*]`;
-  - provider-published definitions with `TextCommandType.AUTHORED`, canonical `commandId`, aliases, stage, prompt policy, action category, and authored source ownership;
-  - parser support that carries canonical authored `commandId` into `TextCommandPayload.AuthoredActionInvocation`;
-  - an authored dispatch handler that executes through the same interpreter/dispatcher path and fails closed on unknown authored action ids;
-  - `HELP` discovery/lookup that now projects authored topics from the same configured catalog rather than treating authored verbs as hidden commands;
-  - first-pass metadata validation now preserves targeting, cooldown, and cost fields through the shared authored definition seam before execution.
+- admitted authored definitions carry `TextCommandType.AUTHORED`, canonical `commandId`, aliases, stage, prompt policy, action category, and authored source ownership;
+- parser support carries canonical authored `commandId` into `TextCommandPayload.AuthoredActionInvocation`;
+- an authored dispatch handler executes through the same interpreter/dispatcher path and fails closed on unknown authored action ids;
+- `HELP` discovery and direct lookup project authored topics from the admitted registry rather than treating authored verbs as hidden commands;
+- first-pass metadata validation preserves targeting, cooldown, and cost fields through the shared authored definition seam before execution.
 
 The version-scoped declaration and artifact boundary is now live:
 
@@ -44,7 +42,7 @@ Still future work under this slice:
 
 Current batch: typed command-definition revisions now have an immutable publication artifact and control-plane read contract. The next batch must consume that admitted artifact in Game Session; it must not introduce another configuration-backed action source.
 
-Current runtime follow-through: Game Session now resolves authored aliases, direct HELP topics, authored dispatch validation, and durable-command reparsing against the release bundle admitted for the live game instance. A mismatched bundle, malformed definition, unsupported execution discipline, or non-empty unregistered effects array fails closed to the built-in-only registry. The legacy configured catalog remains only as compatibility support for isolated fixtures while its consumers are retired; it is no longer the production parsing or admission authority.
+Current runtime follow-through: Game Session resolves authored aliases, direct HELP topics, authored dispatch validation, and durable-command reparsing against the release bundle admitted for the live game instance. A mismatched bundle, malformed definition, unsupported execution discipline, or non-empty unregistered effects array fails closed to the built-in-only registry. The legacy configured catalog is fixture compatibility support only; it is not discovered by Spring and is no longer a production parsing or admission authority.
 
 ## Checklist
 
@@ -84,7 +82,7 @@ FireMUD already has slices for command interpretation and action classification,
 
 ## Locked Direction
 
-- Built-in and authored command definitions use one provider-backed registry seam.
+- Built-in and authored command definitions use one version-scoped registry seam.
 - Authored commands should register definitions as data first, then dispatch through the same family-handler or later authored-action executor seam rather than bypassing interpretation.
 - Command-definition ownership collisions are configuration/programming errors and should fail fast.
 - The first authored-action model should define one canonical typed action shape rather than per-command script-local execution rules.

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedTextCommandRegistryResolver.java
@@ -1,6 +1,7 @@
 package net.firedevops.firemud.gamesession.command.text;
 
 import java.util.List;
+import java.util.Optional;
 import net.firedevops.firemud.gamesession.service.SessionContext;
 import org.springframework.stereotype.Component;
 
@@ -26,5 +27,17 @@ public final class AdmittedTextCommandRegistryResolver {
 
   List<TextCommandDefinition> definitions(SessionContext context) {
     return admittedCommandDefinitionReader.definitionsFor(context).orElse(List.of());
+  }
+
+  public Optional<TextCommandMetadataResolver.ResolvedTextCommandMetadata> resolveMetadata(
+      SessionContext context, String commandId) {
+    return resolve(context)
+        .findDefinition(commandId)
+        .map(
+            definition ->
+                new TextCommandMetadataResolver.ResolvedTextCommandMetadata(
+                    definition.dispatchGroup(),
+                    definition.actionCategory(),
+                    definition.actionTags()));
   }
 }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/ConfiguredAuthoredActionDefinitionProvider.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/ConfiguredAuthoredActionDefinitionProvider.java
@@ -1,9 +1,8 @@
 package net.firedevops.firemud.gamesession.command.text;
 
 import java.util.List;
-import org.springframework.stereotype.Component;
 
-@Component
+/** Legacy fixture adapter; production authored definitions come from admitted release bundles. */
 final class ConfiguredAuthoredActionDefinitionProvider implements TextCommandDefinitionProvider {
   private final ConfiguredAuthoredActionCatalog catalog;
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/AutomationScriptEventPublisher.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/AutomationScriptEventPublisher.java
@@ -9,6 +9,7 @@ import net.firedevops.firemud.automationscripting.v1.TriggerScriptEventRequest;
 import net.firedevops.firemud.automationscripting.v1.TriggerScriptEventResponse;
 import net.firedevops.firemud.entitymanagement.v1.PlayableStateScope;
 import net.firedevops.firemud.gamesession.client.AutomationScriptingClient;
+import net.firedevops.firemud.gamesession.command.text.AdmittedTextCommandRegistryResolver;
 import net.firedevops.firemud.gamesession.command.text.BuiltInTextCommandAliasResolver;
 import net.firedevops.firemud.gamesession.command.text.TextCommandMetadataResolver;
 import net.firedevops.firemud.gamesession.command.text.TextCommandMetadataResolver.ResolvedTextCommandMetadata;
@@ -36,6 +37,7 @@ public class AutomationScriptEventPublisher implements ScriptEventPublisher {
   private final RuntimeRegionStatusRepository runtimeRegionStatusRepository;
   private final GameInstanceRepository gameInstanceRepository;
   private final TextCommandMetadataResolver textCommandMetadataResolver;
+  private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
   private final BuiltInTextCommandAliasResolver builtInTextCommandAliasResolver;
   private final Executor scriptEventExecutor;
 
@@ -46,10 +48,30 @@ public class AutomationScriptEventPublisher implements ScriptEventPublisher {
       TextCommandMetadataResolver textCommandMetadataResolver,
       BuiltInTextCommandAliasResolver builtInTextCommandAliasResolver,
       @Qualifier("scriptEventExecutor") Executor scriptEventExecutor) {
+    this(
+        client,
+        runtimeRegionStatusRepository,
+        gameInstanceRepository,
+        textCommandMetadataResolver,
+        null,
+        builtInTextCommandAliasResolver,
+        scriptEventExecutor);
+  }
+
+  @org.springframework.beans.factory.annotation.Autowired
+  public AutomationScriptEventPublisher(
+      AutomationScriptingClient client,
+      RuntimeRegionStatusRepository runtimeRegionStatusRepository,
+      GameInstanceRepository gameInstanceRepository,
+      TextCommandMetadataResolver textCommandMetadataResolver,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver,
+      BuiltInTextCommandAliasResolver builtInTextCommandAliasResolver,
+      @Qualifier("scriptEventExecutor") Executor scriptEventExecutor) {
     this.client = client;
     this.runtimeRegionStatusRepository = runtimeRegionStatusRepository;
     this.gameInstanceRepository = gameInstanceRepository;
     this.textCommandMetadataResolver = textCommandMetadataResolver;
+    this.admittedRegistryResolver = admittedRegistryResolver;
     this.builtInTextCommandAliasResolver = builtInTextCommandAliasResolver;
     this.scriptEventExecutor = scriptEventExecutor;
   }
@@ -82,7 +104,7 @@ public class AutomationScriptEventPublisher implements ScriptEventPublisher {
                               + scope.regionEpoch()
                               + ":"
                               + command.getCommandId(),
-                          commandPayload(command)),
+                          commandPayload(context, command)),
                       scope.routingBundle())
                   .build();
           logIfNotAdmitted(
@@ -192,7 +214,7 @@ public class AutomationScriptEventPublisher implements ScriptEventPublisher {
         });
   }
 
-  private String commandPayload(GameplayCommand command) {
+  private String commandPayload(SessionContext context, GameplayCommand command) {
     StringBuilder payload =
         new StringBuilder("{\"commandId\":\"")
             .append(escape(command.getCommandId()))
@@ -208,7 +230,7 @@ public class AutomationScriptEventPublisher implements ScriptEventPublisher {
     resolveBuiltInCommandAlias(command)
         .ifPresent(
             alias -> payload.append(",\"commandAlias\":\"").append(escape(alias)).append("\""));
-    resolveCommandMetadata(command)
+    resolveCommandMetadata(context, command)
         .ifPresent(
             metadata -> {
               payload
@@ -220,9 +242,18 @@ public class AutomationScriptEventPublisher implements ScriptEventPublisher {
     return payload.append("}").toString();
   }
 
-  private Optional<ResolvedTextCommandMetadata> resolveCommandMetadata(GameplayCommand command) {
+  private Optional<ResolvedTextCommandMetadata> resolveCommandMetadata(
+      SessionContext context, GameplayCommand command) {
     if (command == null) {
       return Optional.empty();
+    }
+    if (admittedRegistryResolver != null && context != null) {
+      return admittedRegistryResolver
+          .resolveMetadata(context, command.getCommandName())
+          .or(
+              () ->
+                  firstCommandToken(command.getCommandText())
+                      .flatMap(token -> admittedRegistryResolver.resolveMetadata(context, token)));
     }
     return textCommandMetadataResolver
         .resolve(command.getCommandName())

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
@@ -126,7 +126,7 @@ public final class DefaultDurableGameplayCommandExecutionService
   public Optional<DurableGameplayCommandExecutionResult> execute(
       TickEffect effect, GameplayCommand command) {
     TextCommand parsed = textCommandParser.parse(command.getCommandText());
-    if (resolveRoute(command, parsed) == CommandExecutionRoute.IGNORE
+    if (resolveRoute(command, parsed, null) == CommandExecutionRoute.IGNORE
         && parsed.type() != TextCommandType.UNKNOWN) {
       return Optional.empty();
     }
@@ -148,7 +148,7 @@ public final class DefaultDurableGameplayCommandExecutionService
           textCommandParser.parse(
               command.getCommandText(), admittedRegistryResolver.resolve(context));
     }
-    CommandExecutionRoute route = resolveRoute(command, parsed);
+    CommandExecutionRoute route = resolveRoute(command, parsed, context);
     if (route == CommandExecutionRoute.IGNORE) {
       return Optional.empty();
     }
@@ -391,14 +391,21 @@ public final class DefaultDurableGameplayCommandExecutionService
   private record ReplayBackedMutationResult(
       CommandEnqueueResult commandResult, List<PlayerOutput> outputs) {}
 
-  private CommandExecutionRoute resolveRoute(GameplayCommand command, TextCommand parsed) {
-    return resolveMetadata(command, parsed)
+  private CommandExecutionRoute resolveRoute(
+      GameplayCommand command, TextCommand parsed, SessionContext context) {
+    return resolveMetadata(command, parsed, context)
         .map(this::routeForMetadata)
         .orElseGet(() -> fallbackRoute(parsed.type()));
   }
 
   private Optional<TextCommandMetadataResolver.ResolvedTextCommandMetadata> resolveMetadata(
-      GameplayCommand command, TextCommand parsed) {
+      GameplayCommand command, TextCommand parsed, SessionContext context) {
+    if (admittedRegistryResolver != null && context != null) {
+      return admittedRegistryResolver
+          .resolveMetadata(context, parsed.commandId())
+          .or(() -> admittedRegistryResolver.resolveMetadata(context, command.getCommandName()))
+          .or(() -> admittedRegistryResolver.resolveMetadata(context, parsed.aliasUsed()));
+    }
     return textCommandMetadataResolver
         .resolve(command.getCommandName())
         .or(() -> textCommandMetadataResolver.resolve(parsed.commandId()))

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
@@ -126,7 +126,8 @@ public final class DefaultDurableGameplayCommandExecutionService
   public Optional<DurableGameplayCommandExecutionResult> execute(
       TickEffect effect, GameplayCommand command) {
     TextCommand parsed = textCommandParser.parse(command.getCommandText());
-    if (resolveRoute(command, parsed, null) == CommandExecutionRoute.IGNORE
+    if (admittedRegistryResolver == null
+        && resolveRoute(command, parsed, null) == CommandExecutionRoute.IGNORE
         && parsed.type() != TextCommandType.UNKNOWN) {
       return Optional.empty();
     }

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/websocket/GameSessionWebSocketHandler.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/websocket/GameSessionWebSocketHandler.java
@@ -335,7 +335,8 @@ public class GameSessionWebSocketHandler extends TextWebSocketHandler {
         interpretation,
         outputs,
         resolveLocaleTag(session, resolveTransportSessionId(session)),
-        effectivePresentation);
+        effectivePresentation,
+        resolveNormalizedSessionContext(session, resolveTransportSessionId(session)).orElse(null));
   }
 
   private boolean shouldForcePromptEmission(

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/websocket/WebSocketOutputProjector.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/websocket/WebSocketOutputProjector.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import net.firedevops.firemud.cache.ScreenBufferService;
+import net.firedevops.firemud.gamesession.command.text.AdmittedTextCommandRegistryResolver;
 import net.firedevops.firemud.gamesession.command.text.TextCommand;
 import net.firedevops.firemud.gamesession.command.text.TextCommandInterpretationResult;
 import net.firedevops.firemud.gamesession.command.text.TextCommandMetadataResolver;
@@ -29,6 +30,7 @@ import net.firedevops.firemud.gamesession.presentation.TextMessageOutput;
 import net.firedevops.firemud.gamesession.presentation.TextPlayerOutputRenderer;
 import net.firedevops.firemud.gamesession.presentation.WhoViewOutput;
 import net.firedevops.firemud.gamesession.presentation.WorldsViewOutput;
+import net.firedevops.firemud.gamesession.service.SessionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
@@ -41,19 +43,28 @@ import org.springframework.web.socket.WebSocketSession;
 public final class WebSocketOutputProjector {
   private final TextPlayerOutputRenderer textRenderer;
   private final TextCommandMetadataResolver textCommandMetadataResolver;
+  private final AdmittedTextCommandRegistryResolver admittedRegistryResolver;
   private final com.fasterxml.jackson.databind.ObjectMapper objectMapper =
       new com.fasterxml.jackson.databind.ObjectMapper();
 
   public WebSocketOutputProjector(TextPlayerOutputRenderer textRenderer) {
-    this(textRenderer, commandId -> java.util.Optional.empty());
+    this(textRenderer, commandId -> java.util.Optional.empty(), null);
+  }
+
+  public WebSocketOutputProjector(
+      TextPlayerOutputRenderer textRenderer,
+      TextCommandMetadataResolver textCommandMetadataResolver) {
+    this(textRenderer, textCommandMetadataResolver, null);
   }
 
   @Autowired
   public WebSocketOutputProjector(
       TextPlayerOutputRenderer textRenderer,
-      TextCommandMetadataResolver textCommandMetadataResolver) {
+      TextCommandMetadataResolver textCommandMetadataResolver,
+      AdmittedTextCommandRegistryResolver admittedRegistryResolver) {
     this.textRenderer = textRenderer;
     this.textCommandMetadataResolver = textCommandMetadataResolver;
+    this.admittedRegistryResolver = admittedRegistryResolver;
   }
 
   public String projectCommandResponse(
@@ -63,6 +74,18 @@ public final class WebSocketOutputProjector {
       List<PlayerOutput> outputs,
       String localeTag,
       PresentationProperties effectivePresentation) {
+    return projectCommandResponse(
+        session, command, interpretation, outputs, localeTag, effectivePresentation, null);
+  }
+
+  public String projectCommandResponse(
+      WebSocketSession session,
+      TextCommand command,
+      TextCommandInterpretationResult interpretation,
+      List<PlayerOutput> outputs,
+      String localeTag,
+      PresentationProperties effectivePresentation,
+      SessionContext context) {
     if (!isFirstPartyWeb(session)) {
       return textRenderer.renderAll(
           command, interpretation.commandResult(), outputs, localeTag, effectivePresentation);
@@ -72,8 +95,8 @@ public final class WebSocketOutputProjector {
             "command_result",
             command.type().name(),
             command.commandId(),
-            resolveActionCategory(command),
-            resolveActionTags(command),
+            resolveActionCategory(command, context),
+            resolveActionTags(command, context),
             interpretation.commandResult().accepted(),
             interpretation.commandResult().errorCode(),
             interpretation.commandResult().errorMessage(),
@@ -229,17 +252,24 @@ public final class WebSocketOutputProjector {
   private record TranscriptEntryEnvelope(
       String eventType, String label, String text, FirstPartyPlayerOutputEnvelope output) {}
 
-  private String resolveActionCategory(TextCommand command) {
-    return textCommandMetadataResolver
-        .resolve(command.commandId())
-        .map(metadata -> metadata.actionCategory().name())
+  private String resolveActionCategory(TextCommand command, SessionContext context) {
+    return resolveMetadata(command, context)
+        .map(TextCommandMetadataResolver.ResolvedTextCommandMetadata::actionCategory)
+        .map(Enum::name)
         .orElse(null);
   }
 
-  private List<String> resolveActionTags(TextCommand command) {
-    return textCommandMetadataResolver
-        .resolve(command.commandId())
+  private List<String> resolveActionTags(TextCommand command, SessionContext context) {
+    return resolveMetadata(command, context)
         .map(metadata -> metadata.actionTags().stream().map(Enum::name).toList())
         .orElse(java.util.List.of());
+  }
+
+  private java.util.Optional<TextCommandMetadataResolver.ResolvedTextCommandMetadata>
+      resolveMetadata(TextCommand command, SessionContext context) {
+    if (admittedRegistryResolver != null && context != null) {
+      return admittedRegistryResolver.resolveMetadata(context, command.commandId());
+    }
+    return textCommandMetadataResolver.resolve(command.commandId());
   }
 }

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/websocket/GameSessionWebSocketHandlerTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/websocket/GameSessionWebSocketHandlerTest.java
@@ -793,7 +793,8 @@ class GameSessionWebSocketHandlerTest {
             any(TextCommandInterpretationResult.class),
             eq(List.of(output)),
             eq("en-NZ"),
-            any(PresentationProperties.class)))
+            any(PresentationProperties.class),
+            eq(context)))
         .thenReturn("OK SAY");
     when(outputProjector.toBufferedEntry(any(PlayerOutput.class), any(String.class)))
         .thenReturn(ScreenBufferService.BufferedEntry.fromText("You say, \"hello travelers\"\n"));

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/websocket/WebSocketOutputProjectorTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/websocket/WebSocketOutputProjectorTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import net.firedevops.firemud.cache.ScreenBufferService;
+import net.firedevops.firemud.gamesession.command.text.AdmittedTextCommandRegistryResolver;
 import net.firedevops.firemud.gamesession.command.text.TextCommand;
 import net.firedevops.firemud.gamesession.command.text.TextCommandActionCategory;
 import net.firedevops.firemud.gamesession.command.text.TextCommandActionTag;
@@ -31,6 +32,7 @@ import net.firedevops.firemud.gamesession.presentation.LookViewOutput;
 import net.firedevops.firemud.gamesession.presentation.PlayerOutput;
 import net.firedevops.firemud.gamesession.presentation.TextPlayerOutputRenderer;
 import net.firedevops.firemud.gamesession.presentation.WhoViewOutput;
+import net.firedevops.firemud.gamesession.service.SessionContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -139,6 +141,54 @@ class WebSocketOutputProjectorTest {
     JsonNode json = objectMapper.readTree(payload);
     assertThat(json.path("commandType").asText()).isEqualTo("AUTHORED");
     assertThat(json.path("commandId").asText()).isEqualTo("wave");
+    assertThat(json.path("actionCategory").asText()).isEqualTo("SOCIAL");
+    assertThat(json.path("actionTags"))
+        .extracting(JsonNode::asText)
+        .containsExactly("AUTHORING", "COMMUNICATION");
+  }
+
+  @Test
+  void firstPartyWebUsesAdmittedMetadataForAuthoredCommand() throws Exception {
+    WebSocketSession session = mock(WebSocketSession.class);
+    when(session.getAttributes())
+        .thenReturn(
+            Map.of(
+                GameSessionWebSocketHandshakeInterceptor.CONNECTION_MODE_ATTR, "first_party_web"));
+    SessionContext context =
+        new SessionContext(
+            7L, 22L, 41L, "emberline@example.com", 7001L, "Emberline", 9L, "R-1", "jwt");
+    AdmittedTextCommandRegistryResolver admittedResolver =
+        mock(AdmittedTextCommandRegistryResolver.class);
+    when(admittedResolver.resolveMetadata(context, "wave"))
+        .thenReturn(
+            java.util.Optional.of(
+                new TextCommandMetadataResolver.ResolvedTextCommandMetadata(
+                    net.firedevops.firemud.gamesession.command.text.TextCommandDispatchGroup
+                        .AUTHORED,
+                    TextCommandActionCategory.SOCIAL,
+                    List.of(TextCommandActionTag.AUTHORING, TextCommandActionTag.COMMUNICATION))));
+    WebSocketOutputProjector scopedProjector =
+        new WebSocketOutputProjector(
+            new TextPlayerOutputRenderer(presentation), metadataResolver, admittedResolver);
+
+    String payload =
+        scopedProjector.projectCommandResponse(
+            session,
+            new TextCommand(
+                "wave",
+                TextCommandType.AUTHORED,
+                List.of("hello"),
+                "wave hello",
+                "wave",
+                new TextCommandPayload.AuthoredActionInvocation("wave", List.of("hello"))),
+            new TextCommandInterpretationResult(
+                CommandEnqueueResult.success(), List.of(PlayerOutput.message("You wave hello."))),
+            List.of(PlayerOutput.message("You wave hello.")),
+            "en-NZ",
+            presentation,
+            context);
+
+    JsonNode json = objectMapper.readTree(payload);
     assertThat(json.path("actionCategory").asText()).isEqualTo("SOCIAL");
     assertThat(json.path("actionTags"))
         .extracting(JsonNode::asText)


### PR DESCRIPTION
## Summary
- remove configured authored actions from the application-wide parser registry
- resolve first-party command-result category and tags from the release artifact admitted for the current session
- preserve built-in metadata and fail closed when no admitted authored definition exists
- align the authored-action slice note with the version-scoped runtime boundary

## Validation
- `./gradlew :game-session-service:test --tests 'net.firedevops.firemud.gamesession.websocket.WebSocketOutputProjectorTest'`
- `./gradlew :game-session-service:test --tests 'net.firedevops.firemud.gamesession.websocket.GameSessionWebSocketHandlerTest'`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:check -PfullCheck --console=plain`
- `./gradlew spotlessApply linkCheck lintMarkdown`
