### PR TITLE
Clarify durable player history architecture

### DIFF
--- a/design/architecture/system-architecture-input-output-and-presentation.md
+++ b/design/architecture/system-architecture-input-output-and-presentation.md
@@ -259,27 +259,26 @@ The canonical persisted transcript unit is one transcript entry carrying:
 For the current architecture, that means:
 
 - a reconnect buffer entry may keep derived rendered text alongside the structured transcript entry so Telnet and generic WebSocket replay remain simple;
-- later durable transcript history should persist the same conceptual transcript entry model rather than inventing a second browser-only or archive-only contract;
+- durable transcript history persists the same conceptual transcript-entry model rather than inventing a second browser-only or archive-only contract;
 - prompt/status output remains outside ordinary transcript persistence unless a future explicit transcript policy says otherwise.
 
 Speech-related transcript storage should preserve canonical structured content and leave room for raw-versus-normalized speech fields where needed. Color, styling, and final transcript formatting stay projection-time concerns and should not be baked into canonical transcript storage.
 
-The first retention classes are intentionally simple:
+### Durable Recent Output
 
-- `RECONNECT_ONLY`
-- `SHORT_HISTORY`
-- `EXTENDED_HISTORY`
+Replayable output is always retained durably. The reconnect buffer is a hot, bounded delivery cache over that durable recent-output history, not a distinct transient-only retention class. Effective tenant/game settings define a bounded entry and byte budget plus an optional maximum age. Omitting the age allows a game to retain its bounded recent output indefinitely by time; it never means retaining unbounded gameplay output forever.
 
-Their intended behavior is:
+This keeps reconnect replay and durable recent output on one transcript contract while still allowing a hot reconnect cache in Redis or equivalent runtime storage.
 
-- `RECONNECT_ONLY`: keep entries only in the hot reconnect buffer; do not write durable transcript history.
-- `SHORT_HISTORY`: keep entries in the hot reconnect buffer and also persist bounded durable transcript history suitable for normal operator troubleshooting and recent-player replay.
-- `EXTENDED_HISTORY`: keep the same transcript-entry model with a longer bounded durable history window for operators or products that explicitly opt into richer replay/history retention.
+### Player History And Export
 
-This model keeps reconnect replay, durable transcript history, and richer client replay on one transcript contract while still allowing the current implementation split:
+Player-facing command history and player-visible output history are separate products with shared identity and ordering conventions:
 
-- hot reconnect buffer in Redis or equivalent runtime storage;
-- longer transcript history in durable storage when that later implementation work lands.
+- `HISTORY [count]` displays only safe, successfully accepted player commands. Unknown, malformed, rejected, and secret-bearing input is never history data. The effective tenant/game policy owns the default count, the maximum request count, and the retained command-entry bound; the optional argument selects a smaller newest subset.
+- Durable recent output retains the bounded transcript needed to situate a reconnecting player. It is not a `HISTORY` command source and must not be conflated with command-entry history.
+- A later player-history archive/export capability may capture the complete ordered player-visible transcript to a configured export destination. That capability has its own bounded server-side retention and delivery lifecycle so a player can retain an export independently without making the ordinary reconnect or recent-output store unbounded.
+
+The archive/export capability is intentionally future work. It must consume the canonical transcript-entry model and must not introduce a transport-specific text log as a competing source of truth.
 
 ---
 

--- a/design/architecture/system-architecture-reconnection.md
+++ b/design/architecture/system-architecture-reconnection.md
@@ -217,17 +217,21 @@ The reconnect/session-recovery and screen-buffer defaults themselves are exposed
 
 These remain operator/file-env defaults today, while prompt exclusion from reconnect transcript replay remains a canonical reconnect/output rule rather than a separately surfaced toggle.
 
-The canonical transcript retention model sitting behind these reconnect settings is now explicit:
+The canonical transcript retention model sitting behind these reconnect settings is durable by default. The hot reconnect buffer is a bounded delivery cache, not the sole retained copy of replayable player output. When an entry falls out of that hot window, it remains available through the same durable transcript-entry contract for the effective retention window.
 
-- `RECONNECT_ONLY`: only the hot reconnect buffer is retained; no durable transcript history is written.
-- `SHORT_HISTORY`: the same transcript-entry model used by reconnect replay is also written to bounded durable history suitable for normal operator troubleshooting and recent-player replay.
-- `EXTENDED_HISTORY`: the same transcript-entry model is retained for a longer bounded durable history window when a product/operator explicitly wants richer replay retention.
+Effective transcript retention is tenant/game-configurable within platform caps:
+
+- a bounded entry and byte budget limits how much recent output is retained;
+- an optional maximum age expires older entries; an omitted age does not expire entries by time;
+- the durable recent-history window may therefore be indefinitely retained by age while remaining bounded by size.
+
+The reconnect window is only the most recent replay slice of that durable output history. It is not a separate transient retention mode.
 
 Current implementation status remains intentionally narrower than the full model:
 
 - structured replay metadata is already stored in the hot reconnect buffer for new replayable outputs;
 - legacy text-only reconnect buffer entries remain readable;
-- durable transcript history for `SHORT_HISTORY` and `EXTENDED_HISTORY` is still later implementation work, but it must reuse the same canonical transcript-entry model rather than inventing a second transport- or client-specific history contract.
+- durable transcript history is still later implementation work, but it must reuse the same canonical transcript-entry model rather than inventing a second transport- or client-specific history contract.
 
 ### Abnormal WebSocket Transport Loss
 

--- a/design/project-management/vertical-slices/02.13.10-task-list-structured-transcript-and-replay-end-state-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.10-task-list-structured-transcript-and-replay-end-state-vertical-slice.md
@@ -25,7 +25,7 @@ The repo already has a meaningful first structured-output substrate:
 - focused first-party WebSocket integration proof now asserts that canonical `commandId` survives on both accepted and rejected `LOGIN` / `PLAY` structured envelopes, so the richer-client contract is covered beyond projector unit tests.
 - legacy text-only reconnect buffer entries remain readable and replay as transcript chunks.
 - incomplete reconnect-buffer metadata now fails closed back to transcript-chunk replay instead of emitting half-structured first-party transcript envelopes, so the hot replay boundary teaches one complete structured-entry contract.
-- the narrower storage-model follow-through in `02.13.10.1` is now complete at the design boundary: reconnect replay and later durable history share one explicit structured transcript-entry model plus bounded retention classes, while rendered text remains derivative compatibility data.
+- the narrower storage-model follow-through in `02.13.10.1` is complete at the design boundary: reconnect replay and later durable history share one explicit structured transcript-entry model, while rendered text remains derivative compatibility data. The architecture now defines durable recent-output retention rather than a transient-only replay class.
 
 So this slice is no longer about inventing structured output from scratch. It is about finishing the end-state transcript/persistence/replay model on top of the structured output system that already exists.
 

--- a/design/project-management/vertical-slices/02.13.10.1-task-list-structured-transcript-persistence-and-replay-storage-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.10.1-task-list-structured-transcript-persistence-and-replay-storage-vertical-slice.md
@@ -13,7 +13,7 @@ Goal: narrow the remaining transcript/replay design into one concrete persistenc
 ## Current Snapshot (2026-06-29)
 
 - This slice is complete at the design boundary.
-- The canonical storage model is now explicit in the architecture docs: reconnect replay and later durable history share one structured transcript-entry model, rendered text remains derived compatibility data, and the first retention classes are `RECONNECT_ONLY`, `SHORT_HISTORY`, and `EXTENDED_HISTORY`.
+- The canonical storage model is now explicit in the architecture docs: reconnect replay and later durable history share one structured transcript-entry model, rendered text remains derived compatibility data, and replayable output has bounded durable retention rather than a transient-only replay class.
 - Durable transcript history implementation remains future work, but it now sits behind a locked contract instead of an open design seam.
 
 ## Why This Slice Exists
@@ -57,22 +57,12 @@ This follow-up exists so the exact storage decision is discussed before transcri
 - Speech-related transcript storage should preserve canonical structured content and leave room for raw-versus-normalized speech fields where needed, but rendered text should remain derivative.
 - Color/style/rendering policy belongs at render/replay projection time, not in the canonical stored transcript entry.
 
-The first retention classes should stay simple and operator-visible:
-
-- `RECONNECT_ONLY`;
-- `SHORT_HISTORY`;
-- `EXTENDED_HISTORY`.
-
-The intended behavior is:
-
-- `RECONNECT_ONLY`: only hot reconnect buffer retention, no durable transcript history;
-- `SHORT_HISTORY`: bounded durable history suitable for normal operator troubleshooting;
-- `EXTENDED_HISTORY`: longer bounded history for operators who explicitly want richer replay/history retention.
+Every replayable entry is retained through the durable transcript contract. Effective tenant/game settings define the bounded entry and byte budget plus an optional maximum age; the hot reconnect buffer is only the most recent delivery window over that durable history. The later player-history archive/export capability remains separate from ordinary recent-output retention and must not turn it into an unbounded transcript store.
 
 ## Completion Notes
 
-- 2026-06-29: Completed at the current design boundary by promoting the transcript-entry storage model and retention classes into the architecture docs instead of leaving them implied only in this slice note.
-- 2026-06-29: The surviving canonical direction is now explicit: structured transcript entries are source truth, rendered text is derivative, hot reconnect replay and later durable history share one conceptual contract, and the first retention classes are `RECONNECT_ONLY`, `SHORT_HISTORY`, and `EXTENDED_HISTORY`.
+- 2026-06-29: Completed at the current design boundary by promoting the transcript-entry storage model and retention policy into the architecture docs instead of leaving them implied only in this slice note.
+- 2026-07-12: The durable-retention policy supersedes the earlier `RECONNECT_ONLY` / `SHORT_HISTORY` / `EXTENDED_HISTORY` labels: structured transcript entries are source truth, rendered text is derivative, hot reconnect replay is a delivery window over durable recent output, and the effective tenant/game policy bounds retention by size plus optional age.
 - 2026-06-29: Durable transcript history remains later implementation work under the parent transcript family, but this follow-up no longer carries unresolved model ambiguity.
 
 ## Why This Direction


### PR DESCRIPTION
## Summary

- Defines reconnect replay as a hot cache over durable, bounded recent player output.
- Records the canonical separation between reconnect output, accepted-command `HISTORY`, and a future bounded player-history archive/export capability.
- Aligns the structured-transcript slice records with that architecture.

## Validation

- `./gradlew linkCheck lintMarkdown`
