### PR TITLE
Require explicit durable action-state routing

### DIFF
--- a/design/project-management/vertical-slices/07.1-task-list-shared-effect-engine-vertical-slice.md
+++ b/design/project-management/vertical-slices/07.1-task-list-shared-effect-engine-vertical-slice.md
@@ -11,6 +11,7 @@ Define the first shared typed effect engine so equipment, consumables, condition
 - Evaluation is deterministic: modifiers are sorted by priority and source metadata, numeric phases run as base, additive, multiplicative, clamp min, clamp max, and granted states are projected after numeric resources.
 - Active condition `effect_payload_json` rows can now project typed modifiers through the shared evaluator during `QueryActorState`.
 - The seam is intentionally in-process and behavior-focused. It is not yet a public authoring schema, mutation API, combat resolver, or equipment/action-state integration.
+- Game Session durable command routing no longer infers action-state mutation from broad action tags such as `COMBAT`; only explicitly declared legacy command behavior routes to a concrete state mutation. Tags remain descriptive until typed effect declarations are admitted and executed through this engine.
 
 ## Checklist
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionService.java
@@ -13,7 +13,6 @@ import net.firedevops.firemud.gamesession.command.text.ItemCommandHandler;
 import net.firedevops.firemud.gamesession.command.text.MoveCommandHandler;
 import net.firedevops.firemud.gamesession.command.text.PreparedMoveCommandResult;
 import net.firedevops.firemud.gamesession.command.text.TextCommand;
-import net.firedevops.firemud.gamesession.command.text.TextCommandActionTag;
 import net.firedevops.firemud.gamesession.command.text.TextCommandInterpretationResult;
 import net.firedevops.firemud.gamesession.command.text.TextCommandMetadataResolver;
 import net.firedevops.firemud.gamesession.command.text.TextCommandParser;
@@ -339,7 +338,7 @@ public final class DefaultDurableGameplayCommandExecutionService
 
   private CommandExecutionRoute resolveRoute(GameplayCommand command, TextCommand parsed) {
     return resolveMetadata(command, parsed)
-        .map(this::routeForMetadata)
+        .map(metadata -> routeForMetadata(metadata, parsed))
         .orElseGet(() -> fallbackRoute(parsed.type()));
   }
 
@@ -352,16 +351,18 @@ public final class DefaultDurableGameplayCommandExecutionService
   }
 
   private CommandExecutionRoute routeForMetadata(
-      TextCommandMetadataResolver.ResolvedTextCommandMetadata metadata) {
+      TextCommandMetadataResolver.ResolvedTextCommandMetadata metadata, TextCommand parsed) {
     return switch (metadata.dispatchGroup()) {
       case ITEM -> CommandExecutionRoute.ITEM_MUTATION;
       case COMMUNICATION -> CommandExecutionRoute.COMMUNICATION;
       case MOVE -> CommandExecutionRoute.MOVE;
       case AUTHORED -> CommandExecutionRoute.AUTHORED;
       case ACTIVITY ->
-          metadata.actionTags().contains(TextCommandActionTag.COMBAT)
-              ? CommandExecutionRoute.ACTION_STATE
-              : CommandExecutionRoute.AFK;
+          switch (parsed.type()) {
+            case AFK -> CommandExecutionRoute.AFK;
+            case BLOCK -> CommandExecutionRoute.ACTION_STATE;
+            default -> CommandExecutionRoute.IGNORE;
+          };
       default -> CommandExecutionRoute.IGNORE;
     };
   }

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionServiceTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/service/impl/DefaultDurableGameplayCommandExecutionServiceTest.java
@@ -92,7 +92,13 @@ class DefaultDurableGameplayCommandExecutionServiceTest {
                                         TextCommandDispatchGroup.AUTHORED,
                                         TextCommandActionCategory.SOCIAL,
                                         java.util.List.of(TextCommandActionTag.COMMUNICATION)))
-                                : Optional.empty()),
+                                : "taunt".equalsIgnoreCase(commandId)
+                                    ? Optional.of(
+                                        new TextCommandMetadataResolver.ResolvedTextCommandMetadata(
+                                            TextCommandDispatchGroup.ACTIVITY,
+                                            TextCommandActionCategory.GAMEPLAY,
+                                            java.util.List.of(TextCommandActionTag.COMBAT)))
+                                    : Optional.empty()),
             authoredActionCommandHandler,
             durableGameplayReplayService,
             movementEffectIdempotencyService,
@@ -111,6 +117,22 @@ class DefaultDurableGameplayCommandExecutionServiceTest {
 
     assertThat(result).isEmpty();
     verify(moveCommandHandler, never()).prepare(Mockito.any(), Mockito.any());
+  }
+
+  @Test
+  void executeDoesNotInferActionStateFromCombatMetadata() {
+    GameplayCommand command = gameplayCommand("TAUNT", "TAUNT");
+    when(parser.parse("TAUNT"))
+        .thenReturn(
+            new TextCommand(
+                "taunt", TextCommandType.AUTHORED, java.util.List.of(), "TAUNT", "taunt", null));
+
+    Optional<DurableGameplayCommandExecutionResult> result =
+        service.execute(tickEffect("tfx-combat", "cmd-combat"), command);
+
+    assertThat(result).isEmpty();
+    verify(actionStateCommandHandler, never())
+        .handle(Mockito.any(SessionContext.class), Mockito.any(TextCommand.class), Mockito.any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- stop inferring action-state mutation from broad command tags such as `COMBAT`
- retain only explicit legacy `BLOCK` action-state routing while declared typed effects are pending
- add a durable-execution regression test and record the boundary in the shared-effect slice

## Validation

- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:test --tests 'net.firedevops.firemud.gamesession.service.impl.DefaultDurableGameplayCommandExecutionServiceTest'`
- `./gradlew linkCheck lintMarkdown`