### PR TITLE
Validate typed command effect declarations

### DIFF
--- a/design/architecture/system-architecture-player-command-model.md
+++ b/design/architecture/system-architecture-player-command-model.md
@@ -30,6 +30,8 @@ Gameplay-changing commands instead declare one or more typed execution effects. 
 
 For example, the seeded `BLOCK` command is a gameplay command with the `COMBAT` tag, but its concrete behavior is a separate action-state effect declaration equivalent to `APPLY_ACTION_STATE` with the typed `blocking` payload and bounded duration. `ATTACK`, `PARRY`, and `TAUNT` may all be combat-tagged without inheriting that blocking effect.
 
+The first registered declaration is `APPLY_ACTION_STATE` schema version `1`. It requires `targeting: SELF`, `replayPolicy: EFFECT_IDEMPOTENT`, and a payload with an identifier `conditionKey`, integer `durationSeconds` from `1` through `3600`, and an `effectPayload.modifiers` array. Each modifier uses one registered operation (`ADD`, `MULTIPLY`, `CLAMP_MIN`, `CLAMP_MAX`, `GRANT_FLAG`, or `GRANT_CONDITION`), an identifier `target_key`, numeric `value`, optional identifier scope fields, and optional integer priority. This data contract is the only authorable action-state behavior; it cannot embed arbitrary DML or Java.
+
 The generic runtime owns only the effect engine:
 
 - validate declarations and payloads against registered effect schemas;

--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -34,11 +34,12 @@ The version-scoped declaration and artifact boundary is now live:
 - full-version publication snapshots the ordered validated definitions into the immutable published release bundle;
 - the Game Design control-plane digest includes those definitions, so an attested version changes when its command contract changes;
 - `GetPublishedReleaseBundle` returns the exact immutable definition snapshot to runtime consumers rather than exposing a mutable configuration source.
+- Game Design now validates the first registered typed execution effect at revision and publication time: `APPLY_ACTION_STATE` v1 has self targeting, effect-idempotent replay semantics, a bounded duration, and only shared-effect-engine modifier grammar. Runtime execution of non-empty declarations remains a separate follow-through batch.
 
 Still future work under this slice:
 
 - resolve the admitted version artifact into the Game Session registry and retire the process-local authored-action configuration source;
-- validate registered effect kinds and typed effect payloads at revision/publish time, then execute only the admitted version artifact at runtime;
+- execute validated registered effect declarations only from the admitted version artifact at runtime;
 - define how authored actions use targeting, cost, cooldown, and later effect/timing execution hooks instead of the current bounded notice executor;
 - carry authored execution into the later effect/timing substrate rather than inventing a second action path.
 

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/CommandEffectDeclarationValidator.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/CommandEffectDeclarationValidator.java
@@ -1,0 +1,101 @@
+package net.firedevops.firemud.gamedesign.service.impl;
+
+import java.util.Set;
+import tools.jackson.databind.JsonNode;
+
+/** Validates the registered typed execution-effect schemas allowed in command definitions. */
+final class CommandEffectDeclarationValidator {
+  private static final Set<String> EFFECT_OPERATIONS =
+      Set.of("ADD", "MULTIPLY", "CLAMP_MIN", "CLAMP_MAX", "GRANT_FLAG", "GRANT_CONDITION");
+
+  private CommandEffectDeclarationValidator() {}
+
+  static void validateAll(JsonNode effects) {
+    if (!effects.isArray()) {
+      throw invalid("effects must be an array");
+    }
+    for (JsonNode effect : effects) {
+      validate(effect);
+    }
+  }
+
+  private static void validate(JsonNode effect) {
+    if (!effect.isObject()) {
+      throw invalid("effect declarations must be objects");
+    }
+    if (!"APPLY_ACTION_STATE".equals(requiredText(effect, "effectKind"))) {
+      throw invalid("uses an unsupported effectKind");
+    }
+    if (!effect.path("schemaVersion").isInt() || effect.path("schemaVersion").asInt() != 1) {
+      throw invalid("uses an unsupported effect schemaVersion");
+    }
+    if (!"SELF".equals(requiredText(effect, "targeting"))) {
+      throw invalid("APPLY_ACTION_STATE targeting must be SELF");
+    }
+    if (!"EFFECT_IDEMPOTENT".equals(requiredText(effect, "replayPolicy"))) {
+      throw invalid("APPLY_ACTION_STATE replayPolicy must be EFFECT_IDEMPOTENT");
+    }
+    JsonNode payload = effect.path("payload");
+    if (!payload.isObject()) {
+      throw invalid("APPLY_ACTION_STATE payload must be an object");
+    }
+    requireIdentifier(payload, "conditionKey");
+    JsonNode durationSeconds = payload.path("durationSeconds");
+    if (!durationSeconds.isInt()
+        || durationSeconds.asInt() <= 0
+        || durationSeconds.asInt() > 3600) {
+      throw invalid("APPLY_ACTION_STATE durationSeconds must be between 1 and 3600");
+    }
+    validateEffectPayload(payload.path("effectPayload"));
+  }
+
+  private static void validateEffectPayload(JsonNode payload) {
+    if (!payload.isObject() || !payload.path("modifiers").isArray()) {
+      throw invalid("APPLY_ACTION_STATE effectPayload.modifiers must be an array");
+    }
+    for (JsonNode modifier : payload.path("modifiers")) {
+      if (!modifier.isObject()) {
+        throw invalid("effect modifiers must be objects");
+      }
+      String operation = requiredText(modifier, "operation");
+      if (!EFFECT_OPERATIONS.contains(operation)) {
+        throw invalid("effect modifier uses an unsupported operation");
+      }
+      requireIdentifier(modifier, "target_key");
+      if (!modifier.path("value").isNumber()) {
+        throw invalid("effect modifier value must be numeric");
+      }
+      optionalIdentifier(modifier, "scope_kind");
+      optionalIdentifier(modifier, "scope_key");
+      if (!modifier.path("priority").isMissingNode() && !modifier.path("priority").isInt()) {
+        throw invalid("effect modifier priority must be an integer");
+      }
+    }
+  }
+
+  private static String requiredText(JsonNode source, String field) {
+    JsonNode value = source.path(field);
+    if (!value.isTextual() || value.asText().isBlank()) {
+      throw invalid(field + " is required");
+    }
+    return value.asText();
+  }
+
+  private static void requireIdentifier(JsonNode source, String field) {
+    String value = requiredText(source, field);
+    if (!value.matches("[A-Za-z][A-Za-z0-9_]{0,63}")) {
+      throw invalid(field + " must be an identifier");
+    }
+  }
+
+  private static void optionalIdentifier(JsonNode source, String field) {
+    JsonNode value = source.path(field);
+    if (!value.isMissingNode()) {
+      requireIdentifier(source, field);
+    }
+  }
+
+  private static IllegalArgumentException invalid(String message) {
+    return new IllegalArgumentException("INVALID_ARGUMENT: commandDefinition " + message);
+  }
+}

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImpl.java
@@ -135,6 +135,7 @@ public class PublishedReleaseBundleServiceImpl implements PublishedReleaseBundle
     Set<String> aliases = new HashSet<>();
     for (String commandDefinition : commandDefinitions) {
       var definition = objectMapper.readTree(commandDefinition);
+      CommandEffectDeclarationValidator.validateAll(definition.path("effects"));
       String commandId = normalizeCommandToken(definition.path("commandId").asText());
       if (!commandIds.add(commandId)) {
         throw new IllegalStateException(

--- a/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
+++ b/services/game-design-service/src/main/java/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImpl.java
@@ -102,9 +102,10 @@ public class RevisionServiceImpl implements RevisionService {
       requireEnum(definition, "promptPolicy", "NEVER", "WHEN_LOGGED_IN", "WHEN_GAMEPLAY");
       requireEnum(definition, "actionCategory", "GAMEPLAY", "SOCIAL", "META", "ADMIN", "SYSTEM");
       requireTextArray(definition, "aliases");
-      if (!definition.path("actionTags").isArray() || !definition.path("effects").isArray()) {
-        throw invalidCommandDefinition("actionTags and effects must be arrays");
+      if (!definition.path("actionTags").isArray()) {
+        throw invalidCommandDefinition("actionTags must be an array");
       }
+      CommandEffectDeclarationValidator.validateAll(definition.path("effects"));
     } catch (IllegalArgumentException ex) {
       throw ex;
     } catch (Exception ex) {

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/PublishedReleaseBundleServiceImplTest.java
@@ -52,7 +52,7 @@ class PublishedReleaseBundleServiceImplTest {
             LocalDateTime.now());
     when(repository.findByTenantIdAndVersionId("tenant-1", 7L)).thenReturn(Optional.empty());
     Revision commandDefinition = new Revision();
-    commandDefinition.setData("{\"commandId\":\"block\",\"schemaVersion\":1}");
+    commandDefinition.setData(validCommandDefinition());
     when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
             "tenant-1", 7L, "COMMAND_DEFINITION"))
         .thenReturn(List.of(commandDefinition));
@@ -81,8 +81,7 @@ class PublishedReleaseBundleServiceImplTest {
     assertEquals("genrev-1", dto.generationConfigRevision());
     assertEquals(List.of("logo.png", "manifest.json"), dto.requiredManifestAssetKeys());
     assertEquals(1, dto.participantDigests().size());
-    assertEquals(
-        List.of("{\"commandId\":\"block\",\"schemaVersion\":1}"), dto.commandDefinitions());
+    assertEquals(List.of(validCommandDefinition()), dto.commandDefinitions());
     assertEquals("v1", dto.attestationSchemaVersion());
   }
 
@@ -132,9 +131,9 @@ class PublishedReleaseBundleServiceImplTest {
             LocalDateTime.now());
     when(repository.findByTenantIdAndVersionId("tenant-1", 7L)).thenReturn(Optional.empty());
     Revision first = new Revision();
-    first.setData("{\"commandId\":\"salute\",\"aliases\":[\"hail\"]}");
+    first.setData(commandDefinition("salute", "hail"));
     Revision second = new Revision();
-    second.setData("{\"commandId\":\"greet\",\"aliases\":[\"HAIL\"]}");
+    second.setData(commandDefinition("greet", "HAIL"));
     when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
             "tenant-1", 7L, "COMMAND_DEFINITION"))
         .thenReturn(List.of(first, second));
@@ -148,5 +147,54 @@ class PublishedReleaseBundleServiceImplTest {
                 new ExportedAssetManifest("abc123", List.of("manifest.json")),
                 "genrev-1",
                 List.of()));
+  }
+
+  @Test
+  void createFullVersionBundleRejectsMalformedCommandEffectDeclaration() {
+    VersionDto version = version();
+    when(repository.findByTenantIdAndVersionId("tenant-1", 7L)).thenReturn(Optional.empty());
+    Revision commandDefinition = new Revision();
+    commandDefinition.setData(validCommandDefinition().replace("\"value\":1", "\"value\":\"one\""));
+    when(revisionRepository.findByTenantIdAndVersionIdAndRevisionKindOrderByIdAsc(
+            "tenant-1", 7L, "COMMAND_DEFINITION"))
+        .thenReturn(List.of(commandDefinition));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            service.createFullVersionBundle(
+                version,
+                "workflow-1",
+                new ExportedAssetManifest("abc123", List.of("manifest.json")),
+                "genrev-1",
+                List.of()));
+  }
+
+  private VersionDto version() {
+    return new VersionDto(
+        7L,
+        "tenant-1",
+        8,
+        VersionLifecycleState.PUBLISHED,
+        2L,
+        null,
+        null,
+        false,
+        "notes",
+        LocalDateTime.now(),
+        LocalDateTime.now());
+  }
+
+  private String validCommandDefinition() {
+    return commandDefinition("block", "block");
+  }
+
+  private String commandDefinition(String commandId, String alias) {
+    String template =
+        """
+        {"schemaVersion":1,"commandId":"%s","semanticOwner":"GAME_LOGIC","executionDiscipline":"DURABLE_GAMEPLAY","stageRequirement":"GAMEPLAY","promptPolicy":"WHEN_GAMEPLAY","actionCategory":"GAMEPLAY","aliases":["%s"],"actionTags":["COMBAT"],"effects":[{"effectKind":"APPLY_ACTION_STATE","schemaVersion":1,"targeting":"SELF","replayPolicy":"EFFECT_IDEMPOTENT","payload":{"conditionKey":"blocking","durationSeconds":5,"effectPayload":{"modifiers":[{"operation":"ADD","target_key":"block_mitigation","value":1}]}}}]}%n
+        """
+            .stripTrailing();
+    return String.format(template, commandId, alias);
   }
 }

--- a/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImplTest.java
+++ b/services/game-design-service/src/test/java/unit/net/firedevops/firemud/gamedesign/service/impl/RevisionServiceImplTest.java
@@ -149,6 +149,93 @@ class RevisionServiceImplTest {
   }
 
   @Test
+  void saveRevisionRejectsUnsupportedCommandEffectKindBeforePersisting() {
+    setupGameAndVersion();
+    String invalidDefinition =
+        validCommandDefinition()
+            .replace("\"effectKind\": \"APPLY_ACTION_STATE\"", "\"effectKind\": \"RUN_SQL\"");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.saveRevision(
+                    new RevisionDto(
+                        null,
+                        "1",
+                        7L,
+                        3L,
+                        invalidDefinition,
+                        "COMMAND_DEFINITION",
+                        null,
+                        null,
+                        null,
+                        null)));
+
+    assertEquals(
+        "INVALID_ARGUMENT: commandDefinition uses an unsupported effectKind", ex.getMessage());
+    verify(revisionRepository, never()).save(any(Revision.class));
+  }
+
+  @Test
+  void saveRevisionRejectsCommandEffectWithMalformedModifierBeforePersisting() {
+    setupGameAndVersion();
+    String invalidDefinition =
+        validCommandDefinition().replace("\"value\": 1", "\"value\": \"one\"");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.saveRevision(
+                    new RevisionDto(
+                        null,
+                        "1",
+                        7L,
+                        3L,
+                        invalidDefinition,
+                        "COMMAND_DEFINITION",
+                        null,
+                        null,
+                        null,
+                        null)));
+
+    assertEquals(
+        "INVALID_ARGUMENT: commandDefinition effect modifier value must be numeric",
+        ex.getMessage());
+    verify(revisionRepository, never()).save(any(Revision.class));
+  }
+
+  @Test
+  void saveRevisionRejectsFractionalActionStateDurationBeforePersisting() {
+    setupGameAndVersion();
+    String invalidDefinition =
+        validCommandDefinition().replace("\"durationSeconds\": 5", "\"durationSeconds\": 1.5");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.saveRevision(
+                    new RevisionDto(
+                        null,
+                        "1",
+                        7L,
+                        3L,
+                        invalidDefinition,
+                        "COMMAND_DEFINITION",
+                        null,
+                        null,
+                        null,
+                        null)));
+
+    assertEquals(
+        "INVALID_ARGUMENT: commandDefinition APPLY_ACTION_STATE durationSeconds must be between 1 and 3600",
+        ex.getMessage());
+    verify(revisionRepository, never()).save(any(Revision.class));
+  }
+
+  @Test
   void saveRevisionAppliesWorldMutationBeforePersisting() {
     Game game = setupGameAndVersion();
     when(worldManagementClient.applyWorldDesignMutation(
@@ -336,7 +423,29 @@ class RevisionServiceImplTest {
           "actionCategory": "GAMEPLAY",
           "aliases": ["block", "guard"],
           "actionTags": ["COMBAT"],
-          "effects": []
+          "effects": [
+            {
+              "effectKind": "APPLY_ACTION_STATE",
+              "schemaVersion": 1,
+              "targeting": "SELF",
+              "replayPolicy": "EFFECT_IDEMPOTENT",
+              "payload": {
+                "conditionKey": "blocking",
+                "durationSeconds": 5,
+                "effectPayload": {
+                  "modifiers": [
+                    {
+                      "operation": "ADD",
+                      "target_key": "block_mitigation",
+                      "value": 1,
+                      "scope_kind": "ACTION_FAMILY",
+                      "scope_key": "defense"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
         }
         """;
   }


### PR DESCRIPTION
## Summary

- validate the registered `APPLY_ACTION_STATE` v1 command-effect schema at Game Design revision and publication boundaries
- reject unknown effect kinds, malformed typed payloads, invalid modifier grammar, and coercible non-integer schema or duration fields before persistence
- document the canonical declaration contract; runtime execution remains intentionally out of scope

## Validation

- `./gradlew spotlessApply`
- `bash dev-tools/validation/run-locked-gradle.sh :game-design-service:check -PfullCheck`
- `./gradlew linkCheck lintMarkdown`
