### PR TITLE
Carry typed admitted command effect declarations

### DIFF
--- a/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
+++ b/design/project-management/vertical-slices/02.13.9-task-list-authored-action-definition-and-execution-model-vertical-slice.md
@@ -44,7 +44,7 @@ Still future work under this slice:
 
 Current batch: typed command-definition revisions now have an immutable publication artifact and control-plane read contract. The next batch must consume that admitted artifact in Game Session; it must not introduce another configuration-backed action source.
 
-Current runtime follow-through: Game Session now resolves authored aliases, direct HELP topics, authored dispatch validation, and durable-command reparsing against the release bundle admitted for the live game instance. A mismatched bundle, malformed definition, unsupported execution discipline, or non-empty unregistered effects array fails closed to the built-in-only registry. The legacy configured catalog remains only as compatibility support for isolated fixtures while its consumers are retired; it is no longer the production parsing or admission authority.
+Current runtime follow-through: Game Session now resolves authored aliases, direct HELP topics, authored dispatch validation, and durable-command reparsing against the release bundle admitted for the live game instance. It carries the first registered `APPLY_ACTION_STATE` v1 declaration as immutable typed data, but does not execute it yet. A mismatched bundle, malformed definition, unsupported execution discipline, or unsupported effect declaration fails closed to the built-in-only registry. The legacy configured catalog remains only as compatibility support for isolated fixtures while its consumers are retired; it is no longer the production parsing or admission authority.
 
 ## Checklist
 

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReader.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReader.java
@@ -1,8 +1,10 @@
 package net.firedevops.firemud.gamesession.command.text;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import net.firedevops.firemud.gamedesign.v1.GetPublishedReleaseBundleResponse;
 import net.firedevops.firemud.gamesession.client.GameDesignClient;
 import net.firedevops.firemud.gamesession.entity.GameInstance;
@@ -15,6 +17,9 @@ import tools.jackson.databind.ObjectMapper;
 /** Resolves authored definitions only from the release bundle admitted for a live game instance. */
 @Component
 final class AdmittedCommandDefinitionReader {
+  private static final Set<String> EFFECT_OPERATIONS =
+      Set.of("ADD", "MULTIPLY", "CLAMP_MIN", "CLAMP_MAX", "GRANT_FLAG", "GRANT_CONDITION");
+  private static final String IDENTIFIER_PATTERN = "[A-Za-z][A-Za-z0-9_]{0,63}";
   private final GameInstanceRepository gameInstanceRepository;
   private final GameDesignClient gameDesignClient;
   private final ObjectMapper objectMapper;
@@ -73,8 +78,7 @@ final class AdmittedCommandDefinitionReader {
     if (!definition.isObject()
         || definition.path("schemaVersion").asInt() != 1
         || !"DURABLE_GAMEPLAY".equals(definition.path("executionDiscipline").asText())
-        || !definition.path("effects").isArray()
-        || !definition.path("effects").isEmpty()) {
+        || !definition.path("effects").isArray()) {
       throw new IllegalArgumentException("unsupported published command definition");
     }
     String commandId = requiredText(definition, "commandId");
@@ -82,6 +86,7 @@ final class AdmittedCommandDefinitionReader {
     List<String> aliases = textArray(definition, "aliases");
     List<TextCommandActionTag> actionTags =
         textArray(definition, "actionTags").stream().map(TextCommandActionTag::valueOf).toList();
+    List<TextCommandEffectDeclaration> effects = parseEffects(definition.path("effects"));
     return new TextCommandDefinition(
         commandId,
         TextCommandType.AUTHORED,
@@ -97,7 +102,77 @@ final class AdmittedCommandDefinitionReader {
         0L,
         null,
         0L,
-        null);
+        null,
+        effects);
+  }
+
+  private List<TextCommandEffectDeclaration> parseEffects(JsonNode effects) {
+    List<TextCommandEffectDeclaration> declarations = new ArrayList<>();
+    for (JsonNode effect : effects) {
+      declarations.add(parseEffect(effect));
+    }
+    return List.copyOf(declarations);
+  }
+
+  private TextCommandEffectDeclaration parseEffect(JsonNode effect) {
+    if (!effect.isObject()
+        || !"APPLY_ACTION_STATE".equals(requiredText(effect, "effectKind"))
+        || !effect.path("schemaVersion").isInt()
+        || effect.path("schemaVersion").asInt() != 1
+        || !"SELF".equals(requiredText(effect, "targeting"))
+        || !"EFFECT_IDEMPOTENT".equals(requiredText(effect, "replayPolicy"))) {
+      throw new IllegalArgumentException("unsupported published command effect declaration");
+    }
+    JsonNode payload = effect.path("payload");
+    if (!payload.isObject()) {
+      throw new IllegalArgumentException("command effect payload must be an object");
+    }
+    String conditionKey = requiredIdentifier(payload, "conditionKey");
+    JsonNode durationSeconds = payload.path("durationSeconds");
+    if (!durationSeconds.isInt()
+        || durationSeconds.asInt() <= 0
+        || durationSeconds.asInt() > 3600) {
+      throw new IllegalArgumentException("command effect durationSeconds is invalid");
+    }
+    return new TextCommandEffectDeclaration.ApplyActionState(
+        conditionKey,
+        Duration.ofSeconds(durationSeconds.asInt()),
+        parseModifiers(payload.path("effectPayload")));
+  }
+
+  private List<TextCommandEffectDeclaration.Modifier> parseModifiers(JsonNode effectPayload) {
+    JsonNode modifiers = effectPayload.path("modifiers");
+    if (!effectPayload.isObject() || !modifiers.isArray()) {
+      throw new IllegalArgumentException("command effect modifiers must be an array");
+    }
+    List<TextCommandEffectDeclaration.Modifier> parsed = new ArrayList<>();
+    for (JsonNode modifier : modifiers) {
+      if (!modifier.isObject()) {
+        throw new IllegalArgumentException("command effect modifier must be an object");
+      }
+      String operation = requiredText(modifier, "operation");
+      if (!EFFECT_OPERATIONS.contains(operation)) {
+        throw new IllegalArgumentException("command effect modifier operation is unsupported");
+      }
+      String targetKey = requiredIdentifier(modifier, "target_key");
+      JsonNode value = modifier.path("value");
+      if (!value.isNumber()) {
+        throw new IllegalArgumentException("command effect modifier value must be numeric");
+      }
+      JsonNode priority = modifier.path("priority");
+      if (!priority.isMissingNode() && !priority.isInt()) {
+        throw new IllegalArgumentException("command effect modifier priority must be an integer");
+      }
+      parsed.add(
+          new TextCommandEffectDeclaration.Modifier(
+              operation,
+              targetKey,
+              value.decimalValue(),
+              optionalIdentifier(modifier, "scope_kind"),
+              optionalIdentifier(modifier, "scope_key"),
+              priority.isMissingNode() ? 0 : priority.asInt()));
+    }
+    return List.copyOf(parsed);
   }
 
   private String requiredText(JsonNode definition, String field) {
@@ -106,6 +181,19 @@ final class AdmittedCommandDefinitionReader {
       throw new IllegalArgumentException(field + " is required");
     }
     return value;
+  }
+
+  private String requiredIdentifier(JsonNode definition, String field) {
+    String value = requiredText(definition, field);
+    if (!value.matches(IDENTIFIER_PATTERN)) {
+      throw new IllegalArgumentException(field + " must be an identifier");
+    }
+    return value;
+  }
+
+  private String optionalIdentifier(JsonNode definition, String field) {
+    JsonNode value = definition.path(field);
+    return value.isMissingNode() ? "" : requiredIdentifier(definition, field);
   }
 
   private List<String> textArray(JsonNode definition, String field) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandDefinition.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandDefinition.java
@@ -18,7 +18,8 @@ record TextCommandDefinition(
     long cooldownMs,
     String costKey,
     long costAmount,
-    String executionHook) {
+    String executionHook,
+    List<TextCommandEffectDeclaration> effects) {
   TextCommandDefinition {
     Objects.requireNonNull(commandId, "commandId must not be null");
     Objects.requireNonNull(type, "type must not be null");
@@ -31,10 +32,46 @@ record TextCommandDefinition(
     Objects.requireNonNull(source, "source must not be null");
     aliases = List.copyOf(aliases);
     actionTags = List.copyOf(actionTags);
+    effects = List.copyOf(effects == null ? List.of() : effects);
     targetingMode = targetingMode == null || targetingMode.isBlank() ? "NONE" : targetingMode;
     if (executionHook != null && executionHook.isBlank()) {
       executionHook = null;
     }
+  }
+
+  TextCommandDefinition(
+      String commandId,
+      TextCommandType type,
+      List<String> aliases,
+      TextCommandDispatchGroup dispatchGroup,
+      TextCommandStageRequirement stageRequirement,
+      TextCommandPromptPolicy promptPolicy,
+      TextCommandActionCategory actionCategory,
+      List<TextCommandActionTag> actionTags,
+      TextCommandSource source,
+      String targetingMode,
+      String cooldownKey,
+      long cooldownMs,
+      String costKey,
+      long costAmount,
+      String executionHook) {
+    this(
+        commandId,
+        type,
+        aliases,
+        dispatchGroup,
+        stageRequirement,
+        promptPolicy,
+        actionCategory,
+        actionTags,
+        source,
+        targetingMode,
+        cooldownKey,
+        cooldownMs,
+        costKey,
+        costAmount,
+        executionHook,
+        List.of());
   }
 
   static TextCommandDefinition extensionDefinition(TextCommandType type, String commandId) {

--- a/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandEffectDeclaration.java
+++ b/services/game-session-service/src/main/java/net/firedevops/firemud/gamesession/command/text/TextCommandEffectDeclaration.java
@@ -1,0 +1,26 @@
+package net.firedevops.firemud.gamesession.command.text;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+
+/** A runtime-safe typed execution effect carried from an admitted command definition. */
+sealed interface TextCommandEffectDeclaration
+    permits TextCommandEffectDeclaration.ApplyActionState {
+  /** Applies one bounded condition carrying shared effect-engine modifier data to the caller. */
+  record ApplyActionState(String conditionKey, Duration duration, List<Modifier> modifiers)
+      implements TextCommandEffectDeclaration {
+    public ApplyActionState {
+      modifiers = List.copyOf(modifiers == null ? List.of() : modifiers);
+    }
+  }
+
+  /** A modifier in the shared Entity Management effect-payload grammar. */
+  record Modifier(
+      String operation,
+      String targetKey,
+      BigDecimal value,
+      String scopeKind,
+      String scopeKey,
+      int priority) {}
+}

--- a/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReaderTest.java
+++ b/services/game-session-service/src/test/java/unit/net/firedevops/firemud/gamesession/command/text/AdmittedCommandDefinitionReaderTest.java
@@ -81,13 +81,73 @@ class AdmittedCommandDefinitionReaderTest {
     assertTrue(reader.definitionsFor(context()).isEmpty());
   }
 
+  @Test
+  void carriesRegisteredActionStateDeclarationsFromTheAdmittedBundle() {
+    GameInstance instance = admittedInstance();
+    when(gameInstanceRepository.findById(44L)).thenReturn(Optional.of(instance));
+    when(gameDesignClient.getPublishedReleaseBundle(7L, 9L))
+        .thenReturn(
+            GetPublishedReleaseBundleResponse.newBuilder()
+                .setBundle(
+                    PublishedReleaseBundle.newBuilder()
+                        .setId(12L)
+                        .setVersionId(9L)
+                        .addCommandDefinitions(validActionStateDefinition())
+                        .build())
+                .build());
+
+    var definitions = reader.definitionsFor(context());
+
+    assertTrue(definitions.isPresent());
+    var effect = definitions.orElseThrow().getFirst().effects().getFirst();
+    var actionState = (TextCommandEffectDeclaration.ApplyActionState) effect;
+    assertEquals("blocking", actionState.conditionKey());
+    assertEquals(5L, actionState.duration().toSeconds());
+    assertEquals("ADD", actionState.modifiers().getFirst().operation());
+    assertEquals("block_mitigation", actionState.modifiers().getFirst().targetKey());
+  }
+
+  @Test
+  void rejectsUnregisteredCommandEffectsFromTheAdmittedBundle() {
+    GameInstance instance = admittedInstance();
+    when(gameInstanceRepository.findById(44L)).thenReturn(Optional.of(instance));
+    when(gameDesignClient.getPublishedReleaseBundle(7L, 9L))
+        .thenReturn(
+            GetPublishedReleaseBundleResponse.newBuilder()
+                .setBundle(
+                    PublishedReleaseBundle.newBuilder()
+                        .setId(12L)
+                        .setVersionId(9L)
+                        .addCommandDefinitions(
+                            validActionStateDefinition().replace("APPLY_ACTION_STATE", "RUN_SQL"))
+                        .build())
+                .build());
+
+    assertTrue(reader.definitionsFor(context()).isEmpty());
+  }
+
   private SessionContext context() {
     return new SessionContext(1L, 7L, 2L, "player", 3L, "hero", 44L, "room", "jwt", 0L);
+  }
+
+  private GameInstance admittedInstance() {
+    GameInstance instance = new GameInstance();
+    instance.setId(44L);
+    instance.setTenantId(7L);
+    instance.setVersionId(9L);
+    instance.setReleaseBundleId(12L);
+    return instance;
   }
 
   private String validDefinition() {
     return """
         {"schemaVersion":1,"commandId":"salute","semanticOwner":"GAME_LOGIC","executionDiscipline":"DURABLE_GAMEPLAY","stageRequirement":"GAMEPLAY","promptPolicy":"WHEN_GAMEPLAY","actionCategory":"SOCIAL","aliases":["salute"],"actionTags":["COMMUNICATION"],"effects":[]}
+        """;
+  }
+
+  private String validActionStateDefinition() {
+    return """
+        {"schemaVersion":1,"commandId":"block","semanticOwner":"GAME_LOGIC","executionDiscipline":"DURABLE_GAMEPLAY","stageRequirement":"GAMEPLAY","promptPolicy":"WHEN_GAMEPLAY","actionCategory":"GAMEPLAY","aliases":["block"],"actionTags":["COMBAT"],"effects":[{"effectKind":"APPLY_ACTION_STATE","schemaVersion":1,"targeting":"SELF","replayPolicy":"EFFECT_IDEMPOTENT","payload":{"conditionKey":"blocking","durationSeconds":5,"effectPayload":{"modifiers":[{"operation":"ADD","target_key":"block_mitigation","value":1,"scope_kind":"ACTION_FAMILY","scope_key":"defense"}]}}}]}
         """;
   }
 }


### PR DESCRIPTION
## Summary

- Parse and fail-close the registered `APPLY_ACTION_STATE` v1 declaration shape from admitted command-definition artifacts.
- Carry immutable typed effect declarations in the Game Session command registry without executing them yet.
- Document the explicit admission-to-execution boundary in slice `02.13.9`.

## Dependency

This PR is intentionally stacked on #2465 (`feature/design-and-vip-command-definition-admission`), which supplies the admitted artifact registry.

## Validation

- `./gradlew spotlessApply`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:test --tests "net.firedevops.firemud.gamesession.command.text.AdmittedCommandDefinitionReaderTest"`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:check -PfullCheck`
- `./gradlew linkCheck lintMarkdown`
