### PR TITLE
Require explicit CodeRabbit review requests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ reviews:
     Prefer factual technical language over generic praise.
   review_status: true
   auto_review:
-    enabled: true
+    enabled: false
     auto_pause_after_reviewed_commits: 1
     drafts: false
     base_branches:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Use this file as the entrypoint for AI work in this repository. Treat repo docs 
 - For heavier local Gradle tasks, run from WSL in this repo path to avoid Windows file-locking issues.
 - Do not manually hard-wrap lines in docs; let lines flow naturally.
 - Do not create, merge, or close PRs unless explicitly asked.
-- Repository-local CodeRabbit config auto-pauses incremental reviews after one reviewed commit; resume manually when another checkpoint is ready.
+- Repository-local CodeRabbit config disables automatic reviews. Request a review explicitly with `@coderabbitai review` only after all current and outdated findings are resolved and the PR is at a meaningful checkpoint.
 - For PR status checks, treat unresolved non-outdated review threads as the primary truth for review completeness. Do not treat a green top-level CodeRabbit status, passing GitHub checks, or mergeability alone as meaning the PR is review-complete.
 - When asked to "check PR", "check review", or determine whether a PR is done, inspect unresolved review threads first, then check GitHub Actions status and mergeability second.
 - When reporting PR or review status, always report both unresolved non-outdated threads and unresolved outdated threads. Treat non-outdated threads as the actionable truth, but call out outdated unresolved threads separately because they can still appear in GitHub or CodeRabbit UI and confuse merge status.

--- a/dev-tools/tests/preview-eligibility-contract.sh
+++ b/dev-tools/tests/preview-eligibility-contract.sh
@@ -8,7 +8,7 @@ deploy_open="$(python3 "$SCRIPT" --operation deploy --state open --base-ref deve
 grep -q '^eligible=true$' <<<"$deploy_open"
 grep -q '^reason=eligible$' <<<"$deploy_open"
 
-deploy_stacked="$(python3 "$SCRIPT" --operation deploy --state open --base-ref feature/design-and-vip --author benhook1013)"
+deploy_stacked="$(python3 "$SCRIPT" --operation deploy --state open --base-ref feature/design-and-mvp --author benhook1013)"
 grep -q '^eligible=false$' <<<"$deploy_stacked"
 grep -q '^reason=unsupported-base-branch$' <<<"$deploy_stacked"
 
@@ -24,7 +24,7 @@ destroy_closed="$(python3 "$SCRIPT" --operation destroy --state closed --base-re
 grep -q '^eligible=true$' <<<"$destroy_closed"
 grep -q '^reason=eligible$' <<<"$destroy_closed"
 
-destroy_unsupported_base="$(python3 "$SCRIPT" --operation destroy --state closed --base-ref feature/design-and-vip --author benhook1013)"
+destroy_unsupported_base="$(python3 "$SCRIPT" --operation destroy --state closed --base-ref feature/design-and-mvp --author benhook1013)"
 grep -q '^eligible=false$' <<<"$destroy_unsupported_base"
 grep -q '^reason=unsupported-base-branch$' <<<"$destroy_unsupported_base"
 


### PR DESCRIPTION
Updates the preview-eligibility contract fixture to use the renamed `feature/design-and-mvp` branch prefix and disables automatic CodeRabbit review requests.

Validation: `python3 -c 'import yaml; yaml.safe_load(open(".coderabbit.yaml"))'`; `bash dev-tools/tests/preview-eligibility-contract.sh`
