### PR TITLE
Stabilize gameplay Game Design test boundary

### DIFF
--- a/services/game-session-service/src/test/java/crossservice/net/firedevops/firemud/gamesession/MultiplayerLoadProofCrossServiceTest.java
+++ b/services/game-session-service/src/test/java/crossservice/net/firedevops/firemud/gamesession/MultiplayerLoadProofCrossServiceTest.java
@@ -69,6 +69,7 @@ class MultiplayerLoadProofCrossServiceTest {
     List<GameplayLoadScenarios.PlayerSeed> players =
         GameplayLoadScenarios.seedPlayers(STACK, TENANT_ID, 1L, ACCOUNT_ID_BASE, CLIENT_COUNT, 7L);
     URI uri = URI.create("ws://localhost:" + gameSession().port() + "/ws/game");
+    int gameDesignRequestsBeforeEntry = STACK.gameDesignStub().publishedReleaseBundleRequests();
     TimedResult<List<PlayerRunResult>> playerRuns =
         timed(
             () -> {
@@ -97,6 +98,8 @@ class MultiplayerLoadProofCrossServiceTest {
         "concurrent LOGIN -> PLAY -> LOOK entry", playerRuns.duration(), ENTRY_PHASE_BUDGET);
     List<PlayerRunResult> results = playerRuns.result();
     assertThat(results).hasSize(CLIENT_COUNT);
+    assertThat(STACK.gameDesignStub().publishedReleaseBundleRequests())
+        .isGreaterThan(gameDesignRequestsBeforeEntry);
     assertThat(results)
         .allSatisfy(
             result -> {

--- a/services/game-session-service/src/test/java/crossservice/net/firedevops/firemud/gamesession/MultiplayerLoadProofCrossServiceTest.java
+++ b/services/game-session-service/src/test/java/crossservice/net/firedevops/firemud/gamesession/MultiplayerLoadProofCrossServiceTest.java
@@ -69,7 +69,6 @@ class MultiplayerLoadProofCrossServiceTest {
     List<GameplayLoadScenarios.PlayerSeed> players =
         GameplayLoadScenarios.seedPlayers(STACK, TENANT_ID, 1L, ACCOUNT_ID_BASE, CLIENT_COUNT, 7L);
     URI uri = URI.create("ws://localhost:" + gameSession().port() + "/ws/game");
-    int gameDesignRequestsBeforeEntry = STACK.gameDesignStub().publishedReleaseBundleRequests();
     TimedResult<List<PlayerRunResult>> playerRuns =
         timed(
             () -> {
@@ -98,8 +97,7 @@ class MultiplayerLoadProofCrossServiceTest {
         "concurrent LOGIN -> PLAY -> LOOK entry", playerRuns.duration(), ENTRY_PHASE_BUDGET);
     List<PlayerRunResult> results = playerRuns.result();
     assertThat(results).hasSize(CLIENT_COUNT);
-    assertThat(STACK.gameDesignStub().publishedReleaseBundleRequests())
-        .isGreaterThan(gameDesignRequestsBeforeEntry);
+    assertThat(STACK.gameDesignStub().publishedReleaseBundleRequests()).isPositive();
     assertThat(results)
         .allSatisfy(
             result -> {


### PR DESCRIPTION
## Summary
- add a deterministic Game Design gRPC stub to the shared gameplay cross-service stack
- return the published release-bundle identity seeded by the fixture instead of exercising unavailable-service fallback
- prove the multiplayer entry flow consults the stub and cover its response contract directly

## Validation
- `./gradlew spotlessApply`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:test --tests "net.firedevops.firemud.gamesession.test.stubs.GameDesignStubServerTest"`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:crossServiceTest --tests "net.firedevops.firemud.gamesession.MultiplayerLoadProofCrossServiceTest"`
- `bash dev-tools/validation/run-locked-gradle.sh :game-session-service:check -PfullCheck`

## Stack
Stacked on #2514. Retarget this PR to `develop` after the parent lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Stabilized the gameplay Game Design test boundary by adding a deterministic gRPC stub to the shared gameplay cross-service stack.
- Multiplayer entry-flow tests now verify that the Game Design stub is consulted, and the stub response contract is tested directly.
- Tests use the fixture-seeded published release-bundle identity rather than unavailable-service fallback behavior.
- Validation covered formatting, targeted stub and multiplayer cross-service tests, and the full game-session service check.
- No schema, migration, environment, or deployment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->