### PR TITLE
Bootstrap trusted PR runtime image publisher

### DIFF
--- a/.github/workflows/publish-pr-runtime-images.yml
+++ b/.github/workflows/publish-pr-runtime-images.yml
@@ -7,8 +7,7 @@ on:
 
 run-name: Publish PR Runtime Images head-${{ github.event.workflow_run.head_sha }}
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: publish-pr-runtime-images-${{ github.event.workflow_run.head_sha }}
@@ -22,7 +21,6 @@ jobs:
     permissions:
       # This trusted default-branch workflow reads one successful run artifact and publishes fixed SHA tags.
       actions: read
-      contents: read
       packages: write
     env:
       IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
@@ -66,5 +64,9 @@ jobs:
             world-management-service; do
             image="ghcr.io/benhook1013/${service}:${IMAGE_TAG}"
             docker image inspect "$image" >/dev/null
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              echo "Fixed image tag already exists; preserving first publication: $image"
+              continue
+            fi
             docker push "$image"
           done

--- a/.github/workflows/publish-pr-runtime-images.yml
+++ b/.github/workflows/publish-pr-runtime-images.yml
@@ -68,5 +68,24 @@ jobs:
               echo "Fixed image tag already exists; preserving first publication: $image"
               continue
             fi
-            docker push "$image"
+
+            max_push_attempts=3
+            push_attempt=1
+            while true; do
+              if docker push "$image"; then
+                break
+              fi
+              if docker manifest inspect "$image" >/dev/null 2>&1; then
+                echo "Fixed image tag became available; preserving first publication: $image"
+                break
+              fi
+              if (( push_attempt >= max_push_attempts )); then
+                echo "Failed to publish $image after ${push_attempt} attempts." >&2
+                exit 1
+              fi
+              backoff_seconds=$((5 * 2 ** (push_attempt - 1)))
+              echo "Transient push failure for $image; retrying in ${backoff_seconds}s (attempt $((push_attempt + 1))/${max_push_attempts})."
+              sleep "$backoff_seconds"
+              push_attempt=$((push_attempt + 1))
+            done
           done

--- a/.github/workflows/publish-pr-runtime-images.yml
+++ b/.github/workflows/publish-pr-runtime-images.yml
@@ -1,0 +1,70 @@
+name: Publish PR Runtime Images
+
+on:
+  workflow_run:
+    workflows: [Build Runtime Images]
+    types: [completed]
+
+run-name: Publish PR Runtime Images head-${{ github.event.workflow_run.head_sha }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-pr-runtime-images-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish Fixed PR Image Tags
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository && startsWith(github.event.workflow_run.display_title, 'Build Runtime Images secure-pr-artifact ') }}
+    runs-on: ubuntu-latest
+    permissions:
+      # This trusted default-branch workflow reads one successful run artifact and publishes fixed SHA tags.
+      actions: read
+      contents: read
+      packages: write
+    env:
+      IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5
+        with:
+          egress-policy: audit
+
+      - name: Download successful PR image artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: pr-runtime-images-${{ github.event.workflow_run.head_sha }}
+          path: /tmp/pr-runtime-images
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Load fixed-tag images
+        run: gzip -dc /tmp/pr-runtime-images/pr-runtime-images.tar.gz | docker load
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish fixed PR image tags
+        run: |
+          for service in \
+            account-service \
+            automation-scripting-service \
+            entity-management-service \
+            game-design-service \
+            game-logic-service \
+            game-session-service \
+            logging-admin-service \
+            social-groups-service \
+            spring-cloud-gateway \
+            tcp-proxy-service \
+            world-management-service; do
+            image="ghcr.io/benhook1013/${service}:${IMAGE_TAG}"
+            docker image inspect "$image" >/dev/null
+            docker push "$image"
+          done

--- a/.github/workflows/publish-pr-runtime-images.yml
+++ b/.github/workflows/publish-pr-runtime-images.yml
@@ -39,7 +39,9 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Load fixed-tag images
-        run: gzip -dc /tmp/pr-runtime-images/pr-runtime-images.tar.gz | docker load
+        run: |
+          set -o pipefail
+          gzip -dc /tmp/pr-runtime-images/pr-runtime-images.tar.gz | docker load
 
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee


### PR DESCRIPTION
## Summary

- install the trusted default-branch `workflow_run` publisher required by the secure PR image pipeline in #2537
- publish only fixed head-SHA image tags from successful same-repository runs
- ignore existing runtime-image runs unless their display title carries the new `secure-pr-artifact` marker
- never checkout or execute PR source in the write-capable publisher

## Why this is separate

GitHub executes `workflow_run` definitions from the default branch. Landing this guarded workflow first allows #2537 to produce and publish its credential-free PR image artifact without temporarily granting registry credentials to PR-controlled code.

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/publish-pr-runtime-images.yml`
- YAML parse with PyYAML
- exact file parity with the publisher definition in #2537
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a trusted `workflow_run` publisher for secure PR runtime images. Successful same-repository runs publish fixed head-SHA tags for the runtime image services to GHCR, while excluding unrelated runtime-image runs and avoiding execution of PR-controlled source in the write-capable workflow.

Validation includes actionlint, YAML parsing, file-parity checks, and `git diff --check`. No application APIs, schemas, migrations, or shared modules changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->