### PR TITLE
Converge smoke and YAML validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
           bash ./dev-tools/tests/ensure-local-compose-env-contract.sh
           bash ./dev-tools/tests/smoke-image-env-contract.sh
           bash ./dev-tools/tests/architecture-doc-contracts.sh
+          bash ./dev-tools/tests/lint-yaml-contract.sh
           python3 -m unittest dev-tools/validation/test_check_proto_time_fields.py
 
   yaml-lint:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.base.ref != null) }}
     outputs:
-      run_smoke_lite: ${{ steps.compute.outputs.run_smoke_lite }}
       run_smoke_full: ${{ steps.compute.outputs.run_smoke_full }}
     steps:
       - name: Harden runner
@@ -51,24 +50,6 @@ jobs:
             const frontendOnlyPredicate = (file) =>
               file.startsWith("web-client/") ||
               file.startsWith("config/openapi/");
-
-            const liteRelevantPrefixes = [
-              "buildSrc/",
-              "gradle/",
-              "protos/",
-              "config/checkstyle/",
-              "config/protobuf/",
-              "config/security/",
-              "config/spotbugs/",
-              "docker/",
-              "services/",
-            ];
-            const liteRelevantFiles = new Set([
-              "build.gradle.kts",
-              "settings.gradle.kts",
-              "gradle.properties",
-              ".github/workflows/smoke.yml",
-            ]);
 
             const fullRelevantPrefixes = [
               "buildSrc/",
@@ -116,59 +97,16 @@ jobs:
               nonDocFiles.length > 0 && nonDocFiles.every((file) => frontendOnlyPredicate(file));
 
             if (nonDocFiles.length === 0 || nonDocsAreFrontendOnly) {
-              core.setOutput("run_smoke_lite", "false");
               core.setOutput("run_smoke_full", "false");
               return;
             }
 
-            const runSmokeLite = nonDocFiles.some(
-              (file) =>
-                liteRelevantFiles.has(file) ||
-                liteRelevantPrefixes.some((prefix) => file.startsWith(prefix))
-            );
             const runSmokeFull = nonDocFiles.some(
               (file) =>
                 fullRelevantFiles.has(file) ||
                 fullRelevantPrefixes.some((prefix) => file.startsWith(prefix))
             );
-            core.setOutput("run_smoke_lite", runSmokeLite ? "true" : "false");
             core.setOutput("run_smoke_full", runSmokeFull ? "true" : "false");
-
-  smoke-lite:
-    name: Smoke Tests (Lite)
-    needs: [changes]
-    if: ${{ github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.base.ref != null) && needs.changes.outputs.run_smoke_lite == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5
-        with:
-          egress-policy: audit
-
-      - name: ⬇️ Checkout Code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: ⚙️ Set Up Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: ⚙️ Set Up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
-        with:
-          build-scan-publish: true
-          build-scan-terms-of-use-url: 'https://gradle.com/help/legal-terms-of-use'
-          build-scan-terms-of-use-agree: 'yes'
-          cache-read-only: false
-
-      - name: 🧪 Run Lite Smoke Integration Checks
-        run: |
-          ./gradlew \
-            :account-service:integrationTest --tests 'net.firedevops.firemud.accountservice.AccountApplicationIntegrationTest' \
-            :game-session-service:integrationTest --tests 'net.firedevops.firemud.gamesession.GameSessionApplicationIntegrationTest' --tests 'net.firedevops.firemud.gamesession.GameSessionLoginIntegrationTest' --tests 'net.firedevops.firemud.gamesession.websocket.GameSessionWebSocketHandlerIntegrationTest' \
-            :tcp-proxy-service:integrationTest --tests 'net.firedevops.firemud.tcpproxy.TcpProxyServiceApplicationIntegrationTest'
 
   smoke-summary:
     name: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.changes.base.ref == null && 'PR Metadata Edit (Smoke Summary)' || 'Smoke Summary' }}
@@ -177,7 +115,7 @@ jobs:
       # Only this job publishes or updates the pull request smoke summary comment.
       contents: read
       pull-requests: write
-    needs: [changes, smoke-lite]
+    needs: [changes]
     if: ${{ always() && github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.base.ref != null) }}
     steps:
       - name: Harden runner
@@ -188,37 +126,43 @@ jobs:
       - name: 💬 Publish Smoke Summary Comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          RUN_SMOKE_LITE: ${{ needs.changes.outputs.run_smoke_lite }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
           RUN_SMOKE_FULL: ${{ needs.changes.outputs.run_smoke_full }}
-          SMOKE_LITE_RESULT: ${{ needs['smoke-lite'].result }}
         with:
           script: |
-            const liteEnabled = process.env.RUN_SMOKE_LITE === "true";
+            const rawChangesResult = process.env.CHANGES_RESULT || "";
+            const changesStatus = ["success", "failure", "cancelled"].includes(rawChangesResult)
+              ? rawChangesResult
+              : "unavailable";
+            const changesHealthy = changesStatus === "success";
             const fullEnabled = process.env.RUN_SMOKE_FULL === "true";
-            const liteResult = liteEnabled ? process.env.SMOKE_LITE_RESULT : "skipped";
-            const fullResult = fullEnabled ? "tracked-by-smoke-gate" : "skipped";
+            const fullResult = !changesHealthy
+              ? `not-evaluated (${changesStatus} changes detection)`
+              : fullEnabled
+                ? "tracked-by-smoke-gate"
+                : "skipped (run_smoke_full=false)";
             const statusIcon = (value) => {
               if (value === "success") return "✅";
               if (value === "failure") return "❌";
               if (value === "cancelled") return "⚪";
               if (value === "tracked-by-smoke-gate") return "⏳";
+              if (value === "unavailable") return "⚠️";
+              if (value.startsWith("not-evaluated")) return "⚠️";
               return "⏭️";
             };
 
-            let headline = "✅ Smoke tests passed";
-            if (["failure", "cancelled", "timed_out"].includes(liteResult)) {
-              headline = "❌ Smoke tests failed";
+            let headline = "⏭️ Runtime smoke is not required";
+            if (!changesHealthy) {
+              headline = `⚠️ Smoke scope detection ${changesStatus}; Smoke Gate remains authoritative`;
             } else if (fullEnabled) {
-              headline = "⏳ Full smoke is tracked by Smoke Gate";
-            } else if (!liteEnabled) {
-              headline = "⏭️ Smoke tests skipped";
+              headline = "⏳ Full-stack smoke is tracked by Smoke Gate";
             }
 
             const body = [
               "### Smoke Summary",
               headline,
               "",
-              `- ${statusIcon(liteResult)} Smoke Tests (Lite): \`${liteResult}\``,
+              `- ${statusIcon(changesStatus)} Changes detection: \`${changesStatus}\``,
               `- ${statusIcon(fullResult)} Smoke Tests (Full Stack): \`${fullResult}\``,
             ].join("\n");
 
@@ -262,31 +206,30 @@ jobs:
       # This job reads workflow and job results for the matching runtime-image run.
       contents: read
       actions: read
-    needs: [changes, smoke-lite]
+    needs: [changes]
     if: ${{ always() && github.event_name == 'pull_request' && (github.event.action != 'edited' || github.event.changes.base.ref != null) }}
     timeout-minutes: 30
     steps:
       - name: Fail when smoke dependencies did not succeed
-        if: ${{ needs.changes.result != 'success' || (needs.changes.outputs.run_smoke_lite == 'true' && needs['smoke-lite'].result != 'success') }}
+        if: ${{ needs.changes.result != 'success' }}
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          SMOKE_LITE_RESULT: ${{ needs['smoke-lite'].result }}
         run: |
-          echo "Smoke dependencies did not succeed: changes=$CHANGES_RESULT, smoke-lite=$SMOKE_LITE_RESULT" >&2
+          echo "Smoke change detection did not succeed: changes=$CHANGES_RESULT" >&2
           exit 1
 
       - name: Harden runner
-        if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.run_smoke_lite != 'true' || needs['smoke-lite'].result == 'success') }}
+        if: ${{ needs.changes.result == 'success' }}
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5
         with:
           egress-policy: audit
 
-      - name: Verify lite smoke result
-        if: ${{ needs.changes.result == 'success' && needs['smoke-lite'].result == 'success' && needs.changes.outputs.run_smoke_lite == 'true' && needs.changes.outputs.run_smoke_full != 'true' }}
-        run: echo "Lite smoke succeeded."
+      - name: Record skipped runtime smoke
+        if: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_smoke_full != 'true' }}
+        run: echo "No runtime-stack smoke proof is required for this change."
 
       - name: Wait for full smoke dispatch result
-        if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.run_smoke_lite != 'true' || needs['smoke-lite'].result == 'success') && needs.changes.outputs.run_smoke_full == 'true' }}
+        if: ${{ needs.changes.result == 'success' && needs.changes.outputs.run_smoke_full == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |

--- a/design/project-management/ai-observations.md
+++ b/design/project-management/ai-observations.md
@@ -25,3 +25,8 @@ Entry format:
   - Context: a PR reported zero unresolved review threads, but the latest CodeRabbit review summary still contained an `Outside diff range comments` finding that was not surfaced by thread-only review checks.
   - Observation: treating `reviewThreads` as the entire CodeRabbit truth is insufficient. Actionable `Outside diff range comments` and `Duplicate comments` can exist in the latest top-level CodeRabbit summary comment even when unresolved inline-thread counts are zero, which makes a PR look review-clean when it is not.
   - Expected pattern: PR review gating should inspect both unresolved review-thread counts and the latest top-level CodeRabbit actionable summary sections before calling a PR review-clean or retriggering review.
+
+- `2026-07-25`: Extract independent validated files when a review cap blocks a coherent PR
+  - Context: an identity and admission ADR PR crossed CodeRabbit's current file cap after a required runtime fix, while a small smoke and validation subset in the same branch was already independently coherent and validated.
+  - Observation: removing the review fix, repeatedly reshaping the large branch, or accepting an unreviewable PR would all lose useful review signal. The independent subset could instead land directly on `develop`, after which rebasing removed those files from the larger PR's diff.
+  - Expected pattern: when a PR crosses a review file cap, first look for a small, already-validated, independently mergeable subset. Extract that subset to a short `develop`-based PR, merge it, and rebase the original PR; do not force this strategy when the files are coupled or the extraction would weaken the original review boundary.

--- a/dev-tools/tests/lint-yaml-contract.sh
+++ b/dev-tools/tests/lint-yaml-contract.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/dev-tools/validation/lint-yaml.sh"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+BIN_DIR="$TEMP_DIR/bin"
+ARGS_FILE="$TEMP_DIR/yamllint-args"
+GIT_ARGS_FILE="$TEMP_DIR/git-ls-files-args"
+mkdir -p "$BIN_DIR"
+
+cat > "$BIN_DIR/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "ls-files" ]]; then
+  echo "unexpected git invocation: $*" >&2
+  exit 1
+fi
+
+printf '%s\n' "${@:2}" > "$GIT_LS_FILES_ARGS_FILE"
+printf '%s\n' \
+  '.github/workflows/ci.yml' \
+  'services/account-service/src/main/resources/application.yml' \
+  'services/account-service/src/main/resources/openapi.yaml' \
+  'design/architecture/system-architecture-authz-route-matrix.yaml' \
+  'design/operations/environments/production/expected-bindings.yaml'
+EOF
+
+cat > "$BIN_DIR/yamllint" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "-c" || -z "${2:-}" ]]; then
+  echo "unexpected yamllint invocation: $*" >&2
+  exit 1
+fi
+
+printf '%s\n' "${@:3}" > "$YAMLLINT_ARGS_FILE"
+EOF
+
+chmod +x "$BIN_DIR/git" "$BIN_DIR/yamllint"
+PATH="$BIN_DIR:$PATH" \
+  GIT_LS_FILES_ARGS_FILE="$GIT_ARGS_FILE" \
+  YAMLLINT_ARGS_FILE="$ARGS_FILE" \
+  bash "$SCRIPT"
+
+cat > "$TEMP_DIR/expected-yamllint-args" <<'EOF'
+.github/workflows/ci.yml
+services/account-service/src/main/resources/application.yml
+services/account-service/src/main/resources/openapi.yaml
+design/architecture/system-architecture-authz-route-matrix.yaml
+design/operations/environments/production/expected-bindings.yaml
+EOF
+
+cat > "$TEMP_DIR/expected-git-ls-files-args" <<'EOF'
+.github/workflows/*.yml
+docker/*.yml
+services/*/src/main/resources/*.yml
+services/*/src/main/resources/*.yaml
+services/*/src/test/resources/*.yml
+services/*/src/test/resources/*.yaml
+design/architecture/*.yml
+design/architecture/*.yaml
+design/architecture/**/*.yml
+design/architecture/**/*.yaml
+design/operations/**/*.yml
+design/operations/**/*.yaml
+k8s/**/*.yml
+k8s/**/*.yaml
+:!:k8s/base/**
+:!:k8s/minio/**
+:!:k8s/monitoring/**
+:!:k8s/network-policies/**
+:!:k8s/postgres/**
+:!:k8s/preview/cluster-issuers.yaml
+:!:k8s/preview/preview-deployer-rbac.yaml
+:!:k8s/velero/minio.yaml
+:!:k8s/velero/schedule.yaml
+:!:k8s/velero/verify-backups-cronjob.yaml
+:!:k8s/helm/**/templates/**
+EOF
+
+diff -u "$TEMP_DIR/expected-yamllint-args" "$ARGS_FILE"
+diff -u "$TEMP_DIR/expected-git-ls-files-args" "$GIT_ARGS_FILE"
+
+echo "lint YAML enumeration contract checks passed"

--- a/dev-tools/tests/pr-retarget-workflow-contract.sh
+++ b/dev-tools/tests/pr-retarget-workflow-contract.sh
@@ -101,6 +101,10 @@ if grep -Fq '    name: Smoke Gate' "$smoke_path"; then
   echo "metadata-only smoke runs must not emit the branch-protected Smoke Gate name" >&2
   exit 1
 fi
+if grep -Eq '^  smoke-lite:' "$smoke_path"; then
+  echo "smoke.yml must not restore the redundant smoke-lite job" >&2
+  exit 1
+fi
 
 for job in \
   changes \
@@ -124,7 +128,7 @@ for job in \
   assert_job_condition ci.yml "$job" "$required_condition"
 done
 
-for job in changes smoke-lite smoke-summary smoke-gate; do
+for job in changes smoke-summary smoke-gate; do
   assert_job_condition smoke.yml "$job" "$required_condition"
 done
 

--- a/dev-tools/validation/lint-yaml.sh
+++ b/dev-tools/validation/lint-yaml.sh
@@ -17,6 +17,10 @@ mapfile -t yaml_files < <(
     'services/*/src/main/resources/*.yaml' \
     'services/*/src/test/resources/*.yml' \
     'services/*/src/test/resources/*.yaml' \
+    'design/architecture/*.yml' \
+    'design/architecture/*.yaml' \
+    'design/architecture/**/*.yml' \
+    'design/architecture/**/*.yaml' \
     'design/operations/**/*.yml' \
     'design/operations/**/*.yaml' \
     'k8s/**/*.yml' \


### PR DESCRIPTION
## What Changed

- remove the redundant lite smoke lane and keep the full runtime Smoke Gate authoritative
- make smoke summaries fail closed when change detection is unavailable
- extend YAML lint coverage to architecture YAML and add a contract for the enumerated paths

## Validation

- `bash dev-tools/tests/pr-retarget-workflow-contract.sh`
- `bash dev-tools/tests/lint-yaml-contract.sh`
- `bash dev-tools/validation/lint-yaml.sh`
- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`

This is an extraction of already-reviewed changes from PR #2528 so that its identity/ADR diff remains below the CodeRabbit file cap.