### PR TITLE
Converge account bootstrap connect scope

### DIFF
--- a/dev-tools/observability/run-player-experience-smoke.py
+++ b/dev-tools/observability/run-player-experience-smoke.py
@@ -11,7 +11,7 @@ import sys
 import time
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "dev-tools" / "smoke"))
@@ -654,7 +654,9 @@ def first_party_connect_context(config: SmokeConfig) -> dict[str, Any]:
     bootstrap = issue_player_bootstrap(config)
     require_visible_world(config, bootstrap["bootstrapToken"])
     connect_scope_id = resolve_connect_scope_id(config, bootstrap["bootstrapToken"])
-    character_name = resolve_character_name(config, bootstrap["bootstrapToken"])
+    character_name = resolve_character_name(
+        config, bootstrap["bootstrapToken"], connect_scope_id
+    )
     connect_token = issue_connect_token(config, bootstrap["bootstrapToken"], connect_scope_id)
     connect_token["characterName"] = character_name
     return connect_token
@@ -666,10 +668,8 @@ def issue_player_bootstrap(config: SmokeConfig) -> dict[str, Any]:
         config.timeout_seconds,
         method="POST",
         payload={
-            "tenantId": int(config.tenant_id),
-            "username": config.username,
-            "password": config.password,
-            "otp": "",
+            "accountIdentifier": config.username,
+            "secret": config.password,
         },
     )
     return response["data"]
@@ -705,11 +705,17 @@ def require_visible_world(config: SmokeConfig, bootstrap_token: str) -> None:
     )
 
 
-def resolve_character_name(config: SmokeConfig, bootstrap_token: str) -> str | None:
+def resolve_character_name(
+    config: SmokeConfig, bootstrap_token: str, connect_scope_id: str
+) -> str | None:
     response = http_request_json(
         public_auth_url(
             config,
-            f"/auth/bootstrap/worlds/{quote_path(config.world)}/realms/{quote_path(config.realm_slug)}/characters",
+            (
+                f"/auth/bootstrap/worlds/{quote_path(config.world)}"
+                f"/realms/{quote_path(config.realm_slug)}/characters?"
+                f"{urlencode({'connectScopeId': connect_scope_id})}"
+            ),
         ),
         config.timeout_seconds,
         headers={"Authorization": f"Bearer {bootstrap_token}"},

--- a/dev-tools/tests/player-experience-smoke-runner-contract.sh
+++ b/dev-tools/tests/player-experience-smoke-runner-contract.sh
@@ -7,6 +7,59 @@ VALIDATOR="$ROOT_DIR/dev-tools/observability/validate-player-experience-smoke-ev
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+python3 - "$RUNNER" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+from urllib.parse import urlencode
+
+runner_path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("player_experience_smoke", runner_path)
+assert spec is not None and spec.loader is not None
+runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runner
+spec.loader.exec_module(runner)
+
+config = runner.SmokeConfig.from_env("contract-test", "websocket", None)
+requests = []
+
+
+def stub_http_request_json(url, timeout_seconds, method="GET", payload=None, headers=None):
+    requests.append(
+        {
+            "url": url,
+            "timeout_seconds": timeout_seconds,
+            "method": method,
+            "payload": payload,
+            "headers": headers,
+        }
+    )
+    if url.endswith("/auth/player-bootstrap"):
+        return {"data": {"bootstrapToken": "bootstrap-token"}}
+    if "/characters?" in url:
+        return {"data": []}
+    raise AssertionError(f"unexpected stubbed request: {method} {url}")
+
+
+runner.http_request_json = stub_http_request_json
+bootstrap = runner.issue_player_bootstrap(config)
+bootstrap_request = requests.pop(0)
+assert bootstrap == {"bootstrapToken": "bootstrap-token"}
+assert bootstrap_request["method"] == "POST"
+assert bootstrap_request["payload"] == {
+    "accountIdentifier": config.username,
+    "secret": config.password,
+}
+assert not ({"tenantId", "username", "password", "otp"} & bootstrap_request["payload"].keys())
+
+connect_scope_id = "scope/with spaces?&"
+runner.resolve_character_name(config, bootstrap["bootstrapToken"], connect_scope_id)
+characters_request = requests.pop(0)
+expected_query = urlencode({"connectScopeId": connect_scope_id})
+assert characters_request["url"].endswith(f"/characters?{expected_query}")
+assert connect_scope_id not in characters_request["url"]
+PY
+
 SUCCESS_EVIDENCE="$TMP_DIR/success-evidence.json"
 SUCCESS_METRICS="$TMP_DIR/success-metrics.prom"
 FAIL_EVIDENCE="$TMP_DIR/failure-evidence.json"

--- a/dev-tools/tests/player-experience-smoke-runner-contract.sh
+++ b/dev-tools/tests/player-experience-smoke-runner-contract.sh
@@ -58,6 +58,9 @@ characters_request = requests.pop(0)
 expected_query = urlencode({"connectScopeId": connect_scope_id})
 assert characters_request["url"].endswith(f"/characters?{expected_query}")
 assert connect_scope_id not in characters_request["url"]
+assert characters_request["headers"] == {
+    "Authorization": "Bearer bootstrap-token",
+}
 PY
 
 SUCCESS_EVIDENCE="$TMP_DIR/success-evidence.json"

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/controller/AuthController.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/controller/AuthController.java
@@ -10,9 +10,11 @@ import net.firedevops.firemud.accountservice.dto.BootstrapRealmDto;
 import net.firedevops.firemud.accountservice.dto.BootstrapWorldDto;
 import net.firedevops.firemud.accountservice.dto.CompletePasswordResetRequest;
 import net.firedevops.firemud.accountservice.dto.ConnectTokenRequest;
+import net.firedevops.firemud.accountservice.dto.ConnectTokenResponse;
 import net.firedevops.firemud.accountservice.dto.ConnectTokenResult;
 import net.firedevops.firemud.accountservice.dto.LoginRequest;
 import net.firedevops.firemud.accountservice.dto.PasswordResetRequest;
+import net.firedevops.firemud.accountservice.dto.PlayerBootstrapRequest;
 import net.firedevops.firemud.accountservice.dto.PlayerBootstrapResult;
 import net.firedevops.firemud.accountservice.dto.UsernameRecoveryRequest;
 import net.firedevops.firemud.accountservice.dto.VerifyEmailRequest;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -51,10 +54,9 @@ public class AuthController {
 
   @PostMapping("/player-bootstrap")
   public ResponseEntity<ApiResponse<PlayerBootstrapResult>> playerBootstrap(
-      @Valid @RequestBody LoginRequest request) {
+      @Valid @RequestBody PlayerBootstrapRequest request) {
     PlayerBootstrapResult bootstrap =
-        accountService.issuePlayerBootstrap(
-            request.tenantId(), request.username(), request.password());
+        accountService.issuePlayerBootstrap(request.accountIdentifier(), request.secret());
     return ResponseEntity.ok(ApiResponse.success(bootstrap));
   }
 
@@ -79,15 +81,17 @@ public class AuthController {
   public ResponseEntity<ApiResponse<List<BootstrapCharacterDto>>> listBootstrapCharacters(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
       @PathVariable String worldSlug,
-      @PathVariable String realmSlug) {
+      @PathVariable String realmSlug,
+      @RequestParam String connectScopeId) {
     String bootstrapToken = extractBearerToken(authorization);
     return ResponseEntity.ok(
         ApiResponse.success(
-            accountService.listBootstrapCharacters(bootstrapToken, worldSlug, realmSlug)));
+            accountService.listBootstrapCharacters(
+                bootstrapToken, worldSlug, realmSlug, connectScopeId)));
   }
 
   @PostMapping("/connect-token")
-  public ResponseEntity<ApiResponse<ConnectTokenResult>> connectToken(
+  public ResponseEntity<ApiResponse<ConnectTokenResponse>> connectToken(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization,
       @Valid @RequestBody ConnectTokenRequest request) {
     String bootstrapToken = extractBearerToken(authorization);
@@ -102,7 +106,7 @@ public class AuthController {
             .build();
     return ResponseEntity.ok()
         .header(HttpHeaders.SET_COOKIE, cookie.toString())
-        .body(ApiResponse.success(result));
+        .body(ApiResponse.success(ConnectTokenResponse.from(result)));
   }
 
   private long connectTokenMaxAgeSeconds(ConnectTokenResult result) {

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/dto/ConnectTokenResponse.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/dto/ConnectTokenResponse.java
@@ -1,0 +1,29 @@
+package net.firedevops.firemud.accountservice.dto;
+
+/** Browser-safe metadata returned after the connect token is set in a cookie. */
+public record ConnectTokenResponse(
+    long accountId,
+    long tenantId,
+    long gameInstanceId,
+    String realmSlug,
+    String connectScopeId,
+    String jti,
+    String requestId,
+    String issuedAt,
+    String expiresAt,
+    boolean replayed) {
+
+  public static ConnectTokenResponse from(ConnectTokenResult result) {
+    return new ConnectTokenResponse(
+        result.accountId(),
+        result.tenantId(),
+        result.gameInstanceId(),
+        result.realmSlug(),
+        result.connectScopeId(),
+        result.jti(),
+        result.requestId(),
+        result.issuedAt(),
+        result.expiresAt(),
+        result.replayed());
+  }
+}

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/dto/PlayerBootstrapRequest.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/dto/PlayerBootstrapRequest.java
@@ -1,0 +1,9 @@
+package net.firedevops.firemud.accountservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** Tenant-free credentials for first-party gameplay bootstrap. */
+public record PlayerBootstrapRequest(
+    @NotBlank @Size(max = 254) String accountIdentifier,
+    @NotBlank @Size(min = 6, max = 100) String secret) {}

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/AccountService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/AccountService.java
@@ -34,14 +34,14 @@ public interface AccountService {
   net.firedevops.firemud.accountservice.dto.AuthenticationResult verifyEmailLoginOtp(
       Long tenantId, String email, String code);
 
-  PlayerBootstrapResult issuePlayerBootstrap(Long tenantId, String username, String password);
+  PlayerBootstrapResult issuePlayerBootstrap(String accountIdentifier, String secret);
 
   java.util.List<BootstrapWorldDto> listBootstrapWorlds(String bootstrapToken);
 
   java.util.List<BootstrapRealmDto> listBootstrapRealms(String bootstrapToken, String worldSlug);
 
   java.util.List<BootstrapCharacterDto> listBootstrapCharacters(
-      String bootstrapToken, String worldSlug, String realmSlug);
+      String bootstrapToken, String worldSlug, String realmSlug, String connectScopeId);
 
   ConnectTokenResult issueConnectToken(String bootstrapToken, ConnectTokenRequest request);
 

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
@@ -478,8 +478,7 @@ public class AccountServiceImpl implements AccountService {
             bootstrapContext.accountId(), scopeContext.tenantId(), request.requestId());
     if (!nonPublicGrant
         && !membership.gameplayAdmissionAllowed()
-        && currentRealm.publicProductionRealm()
-        && scopeContext.tenantId() == currentRealm.tenantId()) {
+        && currentRealm.publicProductionRealm()) {
       membership =
           toRuntimeMembership(
               ensurePublicProductionPlayerMembership(
@@ -854,16 +853,20 @@ public class AccountServiceImpl implements AccountService {
     try {
       List<RuntimeRealmTarget> candidates =
           gameSessionClient.listGameplayRealms(worldSlug).stream()
+              .filter(realm -> java.util.Objects.equals(worldSlug, realm.getWorldSlug()))
+              .filter(realm -> java.util.Objects.equals(realmSlug, realm.getRealmSlug()))
               .map(this::readRuntimeRealmTarget)
-              .filter(realm -> java.util.Objects.equals(worldSlug, realm.worldSlug()))
-              .filter(realm -> java.util.Objects.equals(realmSlug, realm.realmSlug()))
               .filter(realm -> expectedTenantId == null || realm.tenantId() == expectedTenantId)
-              .filter(realm -> isRealmAdmissible(bootstrapContext, realm))
               .toList();
       if (candidates.size() != 1) {
         throw new IllegalStateException("Selected gameplay realm is absent or ambiguous");
       }
       RuntimeRealmTarget candidate = candidates.getFirst();
+      if (!isRealmAdmissible(bootstrapContext, candidate)) {
+        throw new AuthenticationException(
+            "ADMISSION_POINTER_UNAVAILABLE",
+            "Selected gameplay realm is no longer admissible; rerun realm discovery before retrying gameplay entry");
+      }
       RuntimeRealmTarget realm =
           readRuntimeRealmTarget(
               gameSessionClient.getAdmissionPointer(candidate.tenantId(), worldSlug, realmSlug));

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/impl/AccountServiceImpl.java
@@ -315,11 +315,11 @@ public class AccountServiceImpl implements AccountService {
   }
 
   @Override
-  @Transactional(readOnly = true)
+  @Transactional
   @Timed(value = "account.player_bootstrap")
-  public PlayerBootstrapResult issuePlayerBootstrap(
-      Long tenantId, String username, String password) {
-    PrimaryAuthentication authentication = authenticateAccountIdentity(username, password, false);
+  public PlayerBootstrapResult issuePlayerBootstrap(String accountIdentifier, String secret) {
+    PrimaryAuthentication authentication =
+        authenticateAccountIdentity(accountIdentifier, secret, true);
     Account account = authentication.account();
     authentication.emailLoginChallenge().ifPresent(accountEmailLoginChallengeRepository::delete);
     String jti = UUID.randomUUID().toString();
@@ -329,22 +329,10 @@ public class AccountServiceImpl implements AccountService {
         mintToken(
             String.valueOf(account.getId()),
             tokenProperties.getPlayerBootstrapExpirationMs(),
-            Map.of(
-                "aud",
-                "player-bootstrap",
-                "accountId",
-                account.getId(),
-                "tenantId",
-                tenantId,
-                "jti",
-                jti));
-    sessionService.storeSession(
-        tenantId,
-        account.getId(),
-        bootstrapToken,
-        tokenProperties.getPlayerBootstrapExpirationMs());
-    logger.info(
-        "Issued player bootstrap token for account {} tenant {}", account.getId(), tenantId);
+            Map.of("aud", "player-bootstrap", "accountId", account.getId(), "jti", jti));
+    sessionService.storeAccountSession(
+        account.getId(), bootstrapToken, tokenProperties.getPlayerBootstrapExpirationMs());
+    logger.info("Issued player bootstrap token for account {}", account.getId());
     return new PlayerBootstrapResult(
         account.getId(),
         bootstrapToken,
@@ -395,9 +383,12 @@ public class AccountServiceImpl implements AccountService {
   @Transactional(readOnly = true)
   @Timed(value = "account.bootstrap_characters")
   public List<BootstrapCharacterDto> listBootstrapCharacters(
-      String bootstrapToken, String worldSlug, String realmSlug) {
+      String bootstrapToken, String worldSlug, String realmSlug, String connectScopeId) {
     BootstrapContext bootstrapContext = requireBootstrapContext(bootstrapToken);
-    RuntimeRealmTarget realm = requireAdmissibleRealm(bootstrapContext, worldSlug, realmSlug);
+    ConnectScopeContext scopeContext = requireConnectScopeContext(connectScopeId);
+    validateConnectScopeAgainstBootstrap(bootstrapContext, scopeContext);
+    validateConnectScopeRoute(scopeContext, worldSlug, realmSlug);
+    RuntimeRealmTarget realm = requireCurrentConnectScopeTarget(bootstrapContext, scopeContext);
     return entityManagementClient
         .listCharactersByAccount(
             realm.tenantId(),
@@ -474,13 +465,7 @@ public class AccountServiceImpl implements AccountService {
       ConnectScopeContext scopeContext,
       ConnectTokenRequest request) {
     RuntimeRealmTarget currentRealm =
-        requireAdmissibleRealm(
-            bootstrapContext, scopeContext.worldSlug(), scopeContext.realmSlug());
-    if (currentRealm.tenantId() != scopeContext.tenantId()
-        || currentRealm.gameInstanceId() != scopeContext.gameInstanceId()
-        || currentRealm.pointerVersion() != scopeContext.pointerVersion()) {
-      throw new AuthenticationException("CONNECT_SCOPE_MISMATCH", STALE_CONNECT_SCOPE_MESSAGE);
-    }
+        requireCurrentConnectScopeTarget(bootstrapContext, scopeContext);
 
     boolean nonPublicGrant =
         hasRealmAccessGrant(
@@ -852,25 +837,37 @@ public class AccountServiceImpl implements AccountService {
             "Invalid bootstrap token");
     try {
       long accountId = requireSignedActorAccountId(claims);
-      long tenantId = JwtClaims.requireLong(claims.get("tenantId"), "tenantId", false);
-      Long storedAccountId = sessionService.getAccountId(tenantId, bootstrapToken);
-      if (storedAccountId == null || !storedAccountId.equals(accountId)) {
+      if (!sessionService.isAccountSessionActive(accountId, bootstrapToken)) {
         throw new AuthenticationException("CONNECT_CONTEXT_INVALID", "Bootstrap token expired");
       }
-      return new BootstrapContext(accountId, tenantId);
+      return new BootstrapContext(accountId);
     } catch (IllegalArgumentException ex) {
       throw new AuthenticationException("CONNECT_CONTEXT_INVALID", "Invalid bootstrap token", ex);
     }
   }
 
   private RuntimeRealmTarget requireAdmissibleRealm(
-      BootstrapContext bootstrapContext, String worldSlug, String realmSlug) {
+      BootstrapContext bootstrapContext,
+      Long expectedTenantId,
+      String worldSlug,
+      String realmSlug) {
     try {
+      List<RuntimeRealmTarget> candidates =
+          gameSessionClient.listGameplayRealms(worldSlug).stream()
+              .map(this::readRuntimeRealmTarget)
+              .filter(realm -> java.util.Objects.equals(worldSlug, realm.worldSlug()))
+              .filter(realm -> java.util.Objects.equals(realmSlug, realm.realmSlug()))
+              .filter(realm -> expectedTenantId == null || realm.tenantId() == expectedTenantId)
+              .filter(realm -> isRealmAdmissible(bootstrapContext, realm))
+              .toList();
+      if (candidates.size() != 1) {
+        throw new IllegalStateException("Selected gameplay realm is absent or ambiguous");
+      }
+      RuntimeRealmTarget candidate = candidates.getFirst();
       RuntimeRealmTarget realm =
           readRuntimeRealmTarget(
-              gameSessionClient.getAdmissionPointer(
-                  bootstrapContext.tenantId(), worldSlug, realmSlug));
-      if (realm.tenantId() != bootstrapContext.tenantId()
+              gameSessionClient.getAdmissionPointer(candidate.tenantId(), worldSlug, realmSlug));
+      if (realm.tenantId() != candidate.tenantId()
           || !java.util.Objects.equals(worldSlug, realm.worldSlug())
           || !java.util.Objects.equals(realmSlug, realm.realmSlug())
           || !isRealmAdmissible(bootstrapContext, realm)) {
@@ -1019,6 +1016,30 @@ public class AccountServiceImpl implements AccountService {
     if (scopeContext.accountId() != bootstrapContext.accountId()) {
       throw new AuthenticationException("CONNECT_SCOPE_MISMATCH", STALE_CONNECT_SCOPE_MESSAGE);
     }
+  }
+
+  private void validateConnectScopeRoute(
+      ConnectScopeContext scopeContext, String worldSlug, String realmSlug) {
+    if (!java.util.Objects.equals(scopeContext.worldSlug(), worldSlug)
+        || !java.util.Objects.equals(scopeContext.realmSlug(), realmSlug)) {
+      throw new AuthenticationException("CONNECT_SCOPE_MISMATCH", STALE_CONNECT_SCOPE_MESSAGE);
+    }
+  }
+
+  private RuntimeRealmTarget requireCurrentConnectScopeTarget(
+      BootstrapContext bootstrapContext, ConnectScopeContext scopeContext) {
+    RuntimeRealmTarget currentRealm =
+        requireAdmissibleRealm(
+            bootstrapContext,
+            scopeContext.tenantId(),
+            scopeContext.worldSlug(),
+            scopeContext.realmSlug());
+    if (currentRealm.tenantId() != scopeContext.tenantId()
+        || currentRealm.gameInstanceId() != scopeContext.gameInstanceId()
+        || currentRealm.pointerVersion() != scopeContext.pointerVersion()) {
+      throw new AuthenticationException("CONNECT_SCOPE_MISMATCH", STALE_CONNECT_SCOPE_MESSAGE);
+    }
+    return currentRealm;
   }
 
   private long remainingConnectScopeReplayTtl(ConnectScopeContext scopeContext) {
@@ -1536,7 +1557,7 @@ public class AccountServiceImpl implements AccountService {
         });
   }
 
-  private record BootstrapContext(long accountId, long tenantId) {}
+  private record BootstrapContext(long accountId) {}
 
   private RuntimeMembershipDto toRuntimeMembership(PublicProductionMembershipResult result) {
     return new RuntimeMembershipDto(

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/session/SessionService.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/session/SessionService.java
@@ -18,7 +18,11 @@ public interface SessionService {
 
   void storeSession(Long tenantId, Long accountId, String token, long expirationMs);
 
+  void storeAccountSession(Long accountId, String token, long expirationMs);
+
   Long getAccountId(Long tenantId, String token);
+
+  boolean isAccountSessionActive(Long accountId, String token);
 
   Optional<ConnectTokenReplay> getConnectTokenReplay(
       Long tenantId, Long accountId, String connectScopeId, String requestId);

--- a/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/session/SessionServiceImpl.java
+++ b/services/account-service/src/main/java/net/firedevops/firemud/accountservice/service/session/SessionServiceImpl.java
@@ -45,10 +45,26 @@ public class SessionServiceImpl implements SessionService {
   }
 
   @Override
+  @Timed(value = "session.store_account")
+  public void storeAccountSession(Long accountId, String token, long expirationMs) {
+    redisTemplate
+        .opsForValue()
+        .set(accountKey(accountId, token), accountId, Duration.ofMillis(expirationMs));
+  }
+
+  @Override
   @Timed(value = "session.get")
   public Long getAccountId(Long tenantId, String token) {
     Object value = redisTemplate.opsForValue().get(tenantKey(tenantId, token));
     return parseRequiredLong(value).orElse(null);
+  }
+
+  @Override
+  @Timed(value = "session.account_active")
+  public boolean isAccountSessionActive(Long accountId, String token) {
+    return parseRequiredLong(redisTemplate.opsForValue().get(accountKey(accountId, token)))
+        .filter(accountId::equals)
+        .isPresent();
   }
 
   @Override

--- a/services/account-service/src/main/resources/openapi.yaml
+++ b/services/account-service/src/main/resources/openapi.yaml
@@ -73,6 +73,20 @@ components:
         otp:
           type: string
       required: [tenantId, username, password]
+    PlayerBootstrapRequest:
+      type: object
+      properties:
+        accountIdentifier:
+          type: string
+          minLength: 1
+          maxLength: 254
+          pattern: '.*\S.*'
+        secret:
+          type: string
+          minLength: 6
+          maxLength: 100
+          pattern: '.*\S.*'
+      required: [accountIdentifier, secret]
     AuthenticationResult:
       type: object
       properties:
@@ -99,7 +113,7 @@ components:
         requestId:
           type: string
       required: [connectScopeId, requestId]
-    ConnectTokenResult:
+    ConnectTokenResponse:
       type: object
       properties:
         accountId:
@@ -112,14 +126,16 @@ components:
           type: string
         connectScopeId:
           type: string
-        connectToken:
-          type: string
         jti:
+          type: string
+        requestId:
           type: string
         issuedAt:
           type: string
         expiresAt:
           type: string
+        replayed:
+          type: boolean
     BootstrapWorldDto:
       type: object
       properties:
@@ -290,7 +306,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LoginRequest'
+              $ref: '#/components/schemas/PlayerBootstrapRequest'
       responses:
         '200':
           description: Bootstrap result
@@ -378,6 +394,13 @@ paths:
           required: true
           schema:
             type: string
+        - in: query
+          name: connectScopeId
+          required: true
+          description: Opaque signed target proof returned by realm discovery
+          schema:
+            type: string
+            minLength: 1
       responses:
         '200':
           description: Visible characters
@@ -410,7 +433,7 @@ paths:
               $ref: '#/components/schemas/ConnectTokenRequest'
       responses:
         '200':
-          description: Connect token result
+          description: Connect token metadata; the token is carried only by the HttpOnly cookie
           content:
             application/json:
               schema:
@@ -419,7 +442,7 @@ paths:
                   status:
                     $ref: '#/components/schemas/ResultStatus'
                   data:
-                    $ref: '#/components/schemas/ConnectTokenResult'
+                    $ref: '#/components/schemas/ConnectTokenResponse'
                   error:
                     $ref: '#/components/schemas/ErrorDetail'
         '401':

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/controller/AuthControllerTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/controller/AuthControllerTest.java
@@ -1,10 +1,13 @@
 package net.firedevops.firemud.accountservice.controller;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,6 +21,7 @@ import net.firedevops.firemud.accountservice.dto.ConnectTokenRequest;
 import net.firedevops.firemud.accountservice.dto.ConnectTokenResult;
 import net.firedevops.firemud.accountservice.dto.LoginRequest;
 import net.firedevops.firemud.accountservice.dto.PasswordResetRequest;
+import net.firedevops.firemud.accountservice.dto.PlayerBootstrapRequest;
 import net.firedevops.firemud.accountservice.dto.PlayerBootstrapResult;
 import net.firedevops.firemud.accountservice.service.AccountService;
 import net.firedevops.firemud.common.config.CommonSecurityAutoConfiguration;
@@ -76,8 +80,8 @@ class AuthControllerTest {
 
   @Test
   void playerBootstrapReturnsShortLivedToken() throws Exception {
-    LoginRequest request = new LoginRequest(1L, "demo", "password");
-    when(accountService.issuePlayerBootstrap(1L, "demo", "password"))
+    PlayerBootstrapRequest request = new PlayerBootstrapRequest("demo", "password");
+    when(accountService.issuePlayerBootstrap("demo", "password"))
         .thenReturn(
             new PlayerBootstrapResult(
                 1L, "boot123", "2026-03-30T00:00:00Z", "2026-03-30T00:05:00Z"));
@@ -94,7 +98,7 @@ class AuthControllerTest {
   }
 
   @Test
-  void connectTokenReturnsMintedToken() throws Exception {
+  void connectTokenSetsCookieAndReturnsMetadataOnly() throws Exception {
     ConnectTokenRequest request = new ConnectTokenRequest("scope-1", "req-7");
     when(accountService.issueConnectToken("boot123", new ConnectTokenRequest("scope-1", "req-7")))
         .thenReturn(
@@ -119,7 +123,18 @@ class AuthControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))
-        .andExpect(jsonPath("$.data.connectToken").value("conn123"))
+        .andExpect(jsonPath("$.data.connectToken").doesNotHaveJsonPath())
+        .andExpect(content().string(not(containsString("conn123"))))
+        .andExpect(jsonPath("$.data.accountId").value(1))
+        .andExpect(jsonPath("$.data.tenantId").value(1))
+        .andExpect(jsonPath("$.data.gameInstanceId").value(42))
+        .andExpect(jsonPath("$.data.realmSlug").value("production"))
+        .andExpect(jsonPath("$.data.connectScopeId").value("scope-1"))
+        .andExpect(jsonPath("$.data.jti").value("jti-1"))
+        .andExpect(jsonPath("$.data.requestId").value("req-7"))
+        .andExpect(jsonPath("$.data.issuedAt").value("2026-03-30T00:00:00Z"))
+        .andExpect(jsonPath("$.data.expiresAt").value("2026-03-30T00:00:30Z"))
+        .andExpect(jsonPath("$.data.replayed").value(false))
         .andExpect(
             header()
                 .string(HttpHeaders.SET_COOKIE, containsString("Firemud-Connect-Token=conn123")))
@@ -127,9 +142,10 @@ class AuthControllerTest {
         .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Secure")))
         .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("SameSite=Strict")))
         .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Path=/ws/game")))
-        .andExpect(jsonPath("$.data.connectScopeId").value("scope-1"))
-        .andExpect(jsonPath("$.data.requestId").value("req-7"))
-        .andExpect(jsonPath("$.data.replayed").value(false));
+        .andExpect(
+            header()
+                .string(
+                    HttpHeaders.SET_COOKIE, matchesPattern(".*(?:^|;\\s*)Max-Age=30(?:;|$).*")));
   }
 
   @Test
@@ -175,18 +191,30 @@ class AuthControllerTest {
 
   @Test
   void listBootstrapCharactersReturnsCharacters() throws Exception {
-    when(accountService.listBootstrapCharacters("boot123", "demo", "production"))
+    when(accountService.listBootstrapCharacters("boot123", "demo", "production", "scope-1"))
         .thenReturn(
             List.of(new BootstrapCharacterDto("char-1", "Mara", 12, "SHARED", "ALLOW_NEW")));
 
     mockMvc
         .perform(
             get("/auth/bootstrap/worlds/demo/realms/production/characters")
+                .param("connectScopeId", "scope-1")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer boot123"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("SUCCESS"))
         .andExpect(jsonPath("$.data[0].characterId").value("char-1"))
         .andExpect(jsonPath("$.data[0].characterName").value("Mara"));
+  }
+
+  @Test
+  void listBootstrapCharactersRejectsMissingConnectScopeIdBeforeDispatch() throws Exception {
+    mockMvc
+        .perform(
+            get("/auth/bootstrap/worlds/demo/realms/production/characters")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer boot123"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(accountService);
   }
 
   @Test

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/controller/PublicBootstrapRoutesProdProfileTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/controller/PublicBootstrapRoutesProdProfileTest.java
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import net.firedevops.firemud.accountservice.dto.AccountDto;
 import net.firedevops.firemud.accountservice.dto.CreateAccountRequest;
-import net.firedevops.firemud.accountservice.dto.LoginRequest;
+import net.firedevops.firemud.accountservice.dto.PlayerBootstrapRequest;
 import net.firedevops.firemud.accountservice.dto.PlayerBootstrapResult;
 import net.firedevops.firemud.accountservice.service.AccountService;
 import net.firedevops.firemud.common.config.CommonSecurityAutoConfiguration;
@@ -36,8 +36,8 @@ class PublicBootstrapRoutesProdProfileTest {
 
   @Test
   void playerBootstrapRemainsPublicInProdProfile() throws Exception {
-    LoginRequest request = new LoginRequest(1L, "demo@example.com", "swordfish");
-    when(accountService.issuePlayerBootstrap(1L, "demo@example.com", "swordfish"))
+    PlayerBootstrapRequest request = new PlayerBootstrapRequest("demo@example.com", "swordfish");
+    when(accountService.issuePlayerBootstrap("demo@example.com", "swordfish"))
         .thenReturn(
             new PlayerBootstrapResult(
                 1L, "boot123", "2026-03-30T00:00:00Z", "2026-03-30T00:05:00Z"));

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -551,6 +551,8 @@ class AccountServiceImplTest {
             AuthenticationException.class, () -> service.listBootstrapWorlds(bootstrapToken));
 
     assertEquals("CONNECT_CONTEXT_INVALID", ex.getCode());
+    assertEquals("Bootstrap token expired", ex.getMessage());
+    org.mockito.Mockito.verify(sessionService).isAccountSessionActive(11L, bootstrapToken);
   }
 
   @Test
@@ -1565,6 +1567,102 @@ class AccountServiceImplTest {
     assertEquals("Mara", characters.getFirst().characterName());
     assertEquals("SHARED", characters.getFirst().stateScope());
     assertEquals("ALLOW_NEW", characters.getFirst().characterCreationPolicy());
+  }
+
+  @Test
+  void listBootstrapCharactersRejectsAmbiguousRealmBeforeAdmissionFiltering() {
+    Account account = new Account();
+    account.setId(11L);
+    account.setUsername("demo");
+    account.setPasswordHash(hash("password"));
+    when(accountRepository.findByUsername("demo")).thenReturn(Optional.of(account));
+    when(accountRepository.findById(11L)).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(11L, 7L))
+        .thenReturn(Optional.of(membership(account, 7L)));
+    Subscription active = new Subscription();
+    active.setId(22L);
+    active.setTenantId(7L);
+    active.setStatus("active");
+    when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
+
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
+    var visibleRealm =
+        net.firedevops.firemud.gamesession.v1.GameplayRealm.newBuilder()
+            .setWorldSlug("demo")
+            .setRealmSlug("production")
+            .setDisplayName("Live Realm")
+            .setTenantId("7")
+            .setGameInstanceId("44")
+            .setPointerVersion(17L)
+            .setVisible(true)
+            .setPublicProductionRealm(true)
+            .setRequiresCharacterSelection(false)
+            .setStateScope("SHARED")
+            .setCharacterCreationPolicy("ALLOW_NEW")
+            .build();
+    var hiddenDuplicate =
+        visibleRealm.toBuilder().setVisible(false).setPublicProductionRealm(false).build();
+    when(gameSessionClient.listGameplayRealms("demo"))
+        .thenReturn(java.util.List.of(visibleRealm, hiddenDuplicate));
+
+    AuthenticationException ex =
+        assertThrows(
+            AuthenticationException.class,
+            () ->
+                service.listBootstrapCharacters(
+                    bootstrap.bootstrapToken(), "demo", "production", connectScopeId));
+
+    assertEquals("ADMISSION_POINTER_UNAVAILABLE", ex.getCode());
+    verifyNoInteractions(entityManagementClient);
+  }
+
+  @Test
+  void listBootstrapCharactersSkipsMalformedUnrelatedRealm() {
+    Account account = new Account();
+    account.setId(11L);
+    account.setUsername("demo");
+    account.setPasswordHash(hash("password"));
+    when(accountRepository.findByUsername("demo")).thenReturn(Optional.of(account));
+    when(accountRepository.findById(11L)).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(11L, 7L))
+        .thenReturn(Optional.of(membership(account, 7L)));
+    Subscription active = new Subscription();
+    active.setId(22L);
+    active.setTenantId(7L);
+    active.setStatus("active");
+    when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
+
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
+    var visibleRealm =
+        net.firedevops.firemud.gamesession.v1.GameplayRealm.newBuilder()
+            .setWorldSlug("demo")
+            .setRealmSlug("production")
+            .setDisplayName("Live Realm")
+            .setTenantId("7")
+            .setGameInstanceId("44")
+            .setPointerVersion(17L)
+            .setVisible(true)
+            .setPublicProductionRealm(true)
+            .setRequiresCharacterSelection(false)
+            .setStateScope("SHARED")
+            .setCharacterCreationPolicy("ALLOW_NEW")
+            .build();
+    var malformedUnrelatedRealm =
+        visibleRealm.toBuilder().setRealmSlug("broken").setTenantId("bad").build();
+    when(gameSessionClient.listGameplayRealms("demo"))
+        .thenReturn(java.util.List.of(malformedUnrelatedRealm, visibleRealm));
+
+    var characters =
+        service.listBootstrapCharacters(
+            bootstrap.bootstrapToken(), "demo", "production", connectScopeId);
+
+    assertTrue(characters.isEmpty());
   }
 
   @Test

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/impl/AccountServiceImplTest.java
@@ -493,43 +493,62 @@ class AccountServiceImplTest {
     account.setId(7L);
     account.setUsername("demo");
     account.setPasswordHash(hash("password"));
+    account.setLoginAuthModes("PASSWORD");
     when(accountRepository.findByUsername("demo")).thenReturn(Optional.of(account));
 
-    PlayerBootstrapResult result = service.issuePlayerBootstrap(1L, "demo", "password");
+    PlayerBootstrapResult result = service.issuePlayerBootstrap("demo", "password");
 
     assertEquals(7L, result.accountId());
     assertNotNull(result.bootstrapToken());
     assertNotNull(result.issuedAt());
     assertNotNull(result.expiresAt());
     org.mockito.Mockito.verify(sessionService)
-        .storeSession(
-            org.mockito.ArgumentMatchers.eq(1L),
+        .storeAccountSession(
             org.mockito.ArgumentMatchers.eq(7L),
-            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.eq(result.bootstrapToken()),
             org.mockito.ArgumentMatchers.eq(300000L));
-    assertEquals(
-        "player-bootstrap",
-        new JwtUtil(JWT_SECRET, 300000L)
-            .parseToken(result.bootstrapToken())
-            .getPayload()
-            .getAudience()
-            .iterator()
-            .next());
+    var claims = new JwtUtil(JWT_SECRET, 300000L).parseToken(result.bootstrapToken()).getPayload();
+    assertEquals("player-bootstrap", claims.getAudience().iterator().next());
+    assertFalse(claims.containsKey("tenantId"));
     verifyNoInteractions(accountEmailLoginChallengeRepository);
   }
 
   @Test
-  void listBootstrapWorldsRejectsMalformedBootstrapTokenClaims() {
-    String malformedBootstrapToken =
+  void issuePlayerBootstrapAcceptsAndConsumesEmailLoginOtp() {
+    Account account = new Account();
+    account.setId(7L);
+    account.setUsername("demo");
+    account.setEmail("demo@example.com");
+    account.setLoginAuthModes("EMAIL_OTP");
+    net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge challenge =
+        new net.firedevops.firemud.accountservice.entity.AccountEmailLoginChallenge();
+    challenge.setAccountId(7L);
+    challenge.setCodeHash(hash("123456"));
+    challenge.setExpiresAt(java.time.LocalDateTime.now().plusMinutes(5));
+    when(accountRepository.findByUsername("demo")).thenReturn(Optional.of(account));
+    when(accountEmailLoginChallengeRepository.findByAccountId(7L))
+        .thenReturn(Optional.of(challenge));
+
+    PlayerBootstrapResult result = service.issuePlayerBootstrap("demo", "123456");
+
+    assertEquals(7L, result.accountId());
+    org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(accountEmailLoginChallengeRepository);
+    inOrder.verify(accountEmailLoginChallengeRepository).lockAccountChallenge(7L);
+    inOrder.verify(accountEmailLoginChallengeRepository).findByAccountId(7L);
+    inOrder.verify(accountEmailLoginChallengeRepository).delete(challenge);
+    org.mockito.Mockito.verify(sessionService)
+        .storeAccountSession(7L, result.bootstrapToken(), 300000L);
+  }
+
+  @Test
+  void listBootstrapWorldsRejectsInactiveAccountBootstrapToken() {
+    String bootstrapToken =
         new JwtUtil(JWT_SECRET, 300000L)
-            .generateToken(
-                "11",
-                Map.of("aud", "player-bootstrap", "accountId", "11", "tenantId", "not-a-number"));
+            .generateToken("11", Map.of("aud", "player-bootstrap", "accountId", "11"));
 
     AuthenticationException ex =
         assertThrows(
-            AuthenticationException.class,
-            () -> service.listBootstrapWorlds(malformedBootstrapToken));
+            AuthenticationException.class, () -> service.listBootstrapWorlds(bootstrapToken));
 
     assertEquals("CONNECT_CONTEXT_INVALID", ex.getCode());
   }
@@ -538,8 +557,7 @@ class AccountServiceImplTest {
   void listBootstrapWorldsRejectsMalformedBootstrapTokenAccountClaim() {
     String malformedBootstrapToken =
         new JwtUtil(JWT_SECRET, 300000L)
-            .generateToken(
-                "11", Map.of("aud", "player-bootstrap", "accountId", "abc", "tenantId", "7"));
+            .generateToken("11", Map.of("aud", "player-bootstrap", "accountId", "abc"));
 
     AuthenticationException ex =
         assertThrows(
@@ -553,8 +571,7 @@ class AccountServiceImplTest {
   void listBootstrapWorldsRejectsBootstrapTokenAccountSubjectMismatch() {
     String malformedBootstrapToken =
         new JwtUtil(JWT_SECRET, 300000L)
-            .generateToken(
-                "12", Map.of("aud", "player-bootstrap", "accountId", "11", "tenantId", "7"));
+            .generateToken("12", Map.of("aud", "player-bootstrap", "accountId", "11"));
 
     AuthenticationException ex =
         assertThrows(
@@ -568,23 +585,7 @@ class AccountServiceImplTest {
   void listBootstrapWorldsRejectsNonPositiveBootstrapTokenClaims() {
     String malformedBootstrapToken =
         new JwtUtil(JWT_SECRET, 300000L)
-            .generateToken(
-                "11", Map.of("aud", "player-bootstrap", "accountId", "0", "tenantId", "7"));
-
-    AuthenticationException ex =
-        assertThrows(
-            AuthenticationException.class,
-            () -> service.listBootstrapWorlds(malformedBootstrapToken));
-
-    assertEquals("CONNECT_CONTEXT_INVALID", ex.getCode());
-  }
-
-  @Test
-  void listBootstrapWorldsRejectsZeroTenantBootstrapTokenClaims() {
-    String malformedBootstrapToken =
-        new JwtUtil(JWT_SECRET, 300000L)
-            .generateToken(
-                "11", Map.of("aud", "player-bootstrap", "accountId", "11", "tenantId", "0"));
+            .generateToken("11", Map.of("aud", "player-bootstrap", "accountId", "0"));
 
     AuthenticationException ex =
         assertThrows(
@@ -597,8 +598,7 @@ class AccountServiceImplTest {
   @Test
   void listBootstrapWorldsRejectsBootstrapTokenWithoutAudience() {
     String malformedBootstrapToken =
-        new JwtUtil(JWT_SECRET, 300000L)
-            .generateToken("11", Map.of("accountId", "11", "tenantId", "7"));
+        new JwtUtil(JWT_SECRET, 300000L).generateToken("11", Map.of("accountId", "11"));
 
     AuthenticationException ex =
         assertThrows(
@@ -668,8 +668,8 @@ class AccountServiceImplTest {
                     .setCharacterCreationPolicy("ALLOW_NEW")
                     .build()));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -692,8 +692,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
 
     AuthenticationException ex =
         assertThrows(
@@ -721,8 +721,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
 
     AuthenticationException ex =
         assertThrows(
@@ -750,8 +750,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String malformedConnectScopeId =
         new JwtUtil(JWT_SECRET, 120000L)
             .generateToken(
@@ -803,8 +803,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String malformedConnectScopeId =
         new JwtUtil(JWT_SECRET, 120000L)
             .generateToken(
@@ -856,8 +856,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String malformedConnectScopeId =
         new JwtUtil(JWT_SECRET, 120000L)
             .generateToken(
@@ -909,8 +909,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String malformedConnectScopeId =
         new JwtUtil(JWT_SECRET, 120000L)
             .generateToken(
@@ -962,8 +962,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String malformedConnectScopeId =
         new JwtUtil(JWT_SECRET, 120000L)
             .generateToken(
@@ -1135,8 +1135,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 
@@ -1184,8 +1184,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
     when(gameSessionClient.getAdmissionPointer(7L, "demo", "production"))
@@ -1234,8 +1234,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
     when(gameSessionClient.getAdmissionPointer(7L, "demo", "production"))
@@ -1282,8 +1282,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 
@@ -1426,8 +1426,8 @@ class AccountServiceImplTest {
               return membership;
             });
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 
@@ -1459,8 +1459,8 @@ class AccountServiceImplTest {
     active.setStatus("active");
     when(subscriptionRepository.findByTenantId(7L)).thenReturn(java.util.List.of(active));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
     when(gameSessionClient.getAdmissionPointer(7L, "demo", "production"))
@@ -1551,11 +1551,14 @@ class AccountServiceImplTest {
             7L, 11L, 44L, PlayableStateScope.PLAYABLE_STATE_SCOPE_SHARED))
         .thenReturn(java.util.List.of(character));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 
     var characters =
-        service.listBootstrapCharacters(bootstrap.bootstrapToken(), "demo", "production");
+        service.listBootstrapCharacters(
+            bootstrap.bootstrapToken(), "demo", "production", connectScopeId);
 
     assertEquals(1, characters.size());
     assertEquals("char-1", characters.getFirst().characterId());
@@ -1575,8 +1578,8 @@ class AccountServiceImplTest {
     when(accountTenantMembershipRepository.findByAccountIdAndTenantId(11L, 7L))
         .thenReturn(Optional.of(membership(account, 7L)));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
 
     var realms = service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo");
 
@@ -1625,8 +1628,8 @@ class AccountServiceImplTest {
                     .setCharacterCreationPolicy("ALLOW_NEW")
                     .build()));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
 
     assertThrows(
         IllegalArgumentException.class,
@@ -1686,11 +1689,14 @@ class AccountServiceImplTest {
             7L, 11L, 91L, PlayableStateScope.PLAYABLE_STATE_SCOPE_ISOLATED))
         .thenReturn(java.util.List.of(character));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 
     var characters =
-        service.listBootstrapCharacters(bootstrap.bootstrapToken(), "demo", "production");
+        service.listBootstrapCharacters(
+            bootstrap.bootstrapToken(), "demo", "production", connectScopeId);
 
     assertEquals(1, characters.size());
     assertEquals("char-iso-1", characters.getFirst().characterId());
@@ -1726,14 +1732,17 @@ class AccountServiceImplTest {
                 .setCharacterCreationPolicy("ALLOW_NEW")
                 .build());
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 
     AuthenticationException ex =
         assertThrows(
             AuthenticationException.class,
             () ->
-                service.listBootstrapCharacters(bootstrap.bootstrapToken(), "demo", "production"));
+                service.listBootstrapCharacters(
+                    bootstrap.bootstrapToken(), "demo", "production", connectScopeId));
 
     assertEquals("ADMISSION_POINTER_UNAVAILABLE", ex.getCode());
     org.mockito.Mockito.verifyNoInteractions(entityManagementClient);
@@ -1750,6 +1759,22 @@ class AccountServiceImplTest {
     when(accountTenantMembershipRepository.findByAccountIdAndTenantId(11L, 7L))
         .thenReturn(Optional.of(membership(account, 7L)));
 
+    when(gameSessionClient.listGameplayRealms("sandbox"))
+        .thenReturn(
+            java.util.List.of(
+                net.firedevops.firemud.gamesession.v1.GameplayRealm.newBuilder()
+                    .setWorldSlug("sandbox")
+                    .setRealmSlug("production")
+                    .setDisplayName("Live Realm")
+                    .setTenantId("7")
+                    .setGameInstanceId("91")
+                    .setPointerVersion(17L)
+                    .setVisible(true)
+                    .setPublicProductionRealm(true)
+                    .setRequiresCharacterSelection(false)
+                    .setStateScope("ISOLATED")
+                    .setCharacterCreationPolicy("COPIED_ONLY")
+                    .build()));
     when(gameSessionClient.getAdmissionPointer(7L, "demo", "production"))
         .thenReturn(
             net.firedevops.firemud.gamesession.v1.GameplayAdmissionPointer.newBuilder()
@@ -1792,17 +1817,111 @@ class AccountServiceImplTest {
             7L, 11L, 91L, PlayableStateScope.PLAYABLE_STATE_SCOPE_ISOLATED))
         .thenReturn(java.util.List.of(character));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service
+            .listBootstrapRealms(bootstrap.bootstrapToken(), "sandbox")
+            .getFirst()
+            .connectScopeId();
 
     var characters =
-        service.listBootstrapCharacters(bootstrap.bootstrapToken(), "sandbox", "production");
+        service.listBootstrapCharacters(
+            bootstrap.bootstrapToken(), "sandbox", "production", connectScopeId);
 
     assertEquals(1, characters.size());
     assertEquals("char-sandbox-1", characters.getFirst().characterId());
     assertEquals("BuilderMara", characters.getFirst().characterName());
     assertEquals("ISOLATED", characters.getFirst().stateScope());
     org.mockito.Mockito.verify(gameSessionClient).getAdmissionPointer(7L, "sandbox", "production");
+  }
+
+  @Test
+  void listBootstrapCharactersUsesSignedScopeToDisambiguateTenantIdentity() {
+    Account account = new Account();
+    account.setId(11L);
+    account.setUsername("demo");
+    account.setPasswordHash(hash("password"));
+    when(accountRepository.findByUsername("demo")).thenReturn(Optional.of(account));
+    when(accountRepository.findById(11L)).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(
+            org.mockito.ArgumentMatchers.eq(11L), org.mockito.ArgumentMatchers.anyLong()))
+        .thenReturn(Optional.empty());
+    when(gameSessionClient.listGameplayRealms("demo"))
+        .thenReturn(
+            java.util.List.of(
+                net.firedevops.firemud.gamesession.v1.GameplayRealm.newBuilder()
+                    .setWorldSlug("demo")
+                    .setRealmSlug("production")
+                    .setDisplayName("Tenant Seven")
+                    .setTenantId("7")
+                    .setGameInstanceId("44")
+                    .setPointerVersion(17L)
+                    .setVisible(true)
+                    .setPublicProductionRealm(true)
+                    .setStateScope("SHARED")
+                    .setCharacterCreationPolicy("ALLOW_NEW")
+                    .build(),
+                net.firedevops.firemud.gamesession.v1.GameplayRealm.newBuilder()
+                    .setWorldSlug("demo")
+                    .setRealmSlug("production")
+                    .setDisplayName("Tenant Eight")
+                    .setTenantId("8")
+                    .setGameInstanceId("45")
+                    .setPointerVersion(18L)
+                    .setVisible(true)
+                    .setPublicProductionRealm(true)
+                    .setStateScope("SHARED")
+                    .setCharacterCreationPolicy("ALLOW_NEW")
+                    .build()));
+    when(entityManagementClient.listCharactersByAccount(
+            7L, 11L, 44L, PlayableStateScope.PLAYABLE_STATE_SCOPE_SHARED))
+        .thenReturn(java.util.List.of());
+
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").stream()
+            .filter(realm -> realm.tenantId() == 7L)
+            .findFirst()
+            .orElseThrow()
+            .connectScopeId();
+
+    var characters =
+        service.listBootstrapCharacters(
+            bootstrap.bootstrapToken(), "demo", "production", connectScopeId);
+
+    assertTrue(characters.isEmpty());
+    org.mockito.Mockito.verify(gameSessionClient).getAdmissionPointer(7L, "demo", "production");
+    org.mockito.Mockito.verify(gameSessionClient, org.mockito.Mockito.never())
+        .getAdmissionPointer(8L, "demo", "production");
+  }
+
+  @Test
+  void listBootstrapCharactersRejectsPathThatDoesNotMatchSignedScope() {
+    Account account = new Account();
+    account.setId(11L);
+    account.setUsername("demo");
+    account.setPasswordHash(hash("password"));
+    when(accountRepository.findByUsername("demo")).thenReturn(Optional.of(account));
+    when(accountRepository.findById(11L)).thenReturn(Optional.of(account));
+    when(accountTenantMembershipRepository.findByAccountIdAndTenantId(11L, 7L))
+        .thenReturn(Optional.of(membership(account, 7L)));
+
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
+    String connectScopeId =
+        service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
+
+    AuthenticationException ex =
+        assertThrows(
+            AuthenticationException.class,
+            () ->
+                service.listBootstrapCharacters(
+                    bootstrap.bootstrapToken(), "sandbox", "production", connectScopeId));
+
+    assertEquals("CONNECT_SCOPE_MISMATCH", ex.getCode());
+    verifyNoInteractions(entityManagementClient);
   }
 
   @Test
@@ -1836,8 +1955,8 @@ class AccountServiceImplTest {
                     .setCharacterCreationPolicy("ALLOW_NEW")
                     .build()));
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
 
     var realms = service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo");
 
@@ -1893,8 +2012,8 @@ class AccountServiceImplTest {
             11L, 7L, "demo", "preview"))
         .thenReturn(true);
 
-    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap(7L, "demo", "password");
-    when(sessionService.getAccountId(7L, bootstrap.bootstrapToken())).thenReturn(11L);
+    PlayerBootstrapResult bootstrap = service.issuePlayerBootstrap("demo", "password");
+    when(sessionService.isAccountSessionActive(11L, bootstrap.bootstrapToken())).thenReturn(true);
     String connectScopeId =
         service.listBootstrapRealms(bootstrap.bootstrapToken(), "demo").getFirst().connectScopeId();
 

--- a/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/session/SessionServiceImplTest.java
+++ b/services/account-service/src/test/java/unit/net/firedevops/firemud/accountservice/service/session/SessionServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
@@ -40,6 +41,42 @@ class SessionServiceImplTest {
         .set("session:auth:account:11:" + tokenHash, 11L, Duration.ofMillis(5000L));
     verify(valueOperations)
         .set("session:auth:tenant:7:" + tokenHash, 11L, Duration.ofMillis(5000L));
+  }
+
+  @Test
+  void storeAccountSessionWritesOnlyTheAccountAllowlistKey() {
+    service.storeAccountSession(11L, "token-123", 5000L);
+
+    verify(valueOperations)
+        .set("session:auth:account:11:" + sha256("token-123"), 11L, Duration.ofMillis(5000L));
+    verifyNoMoreInteractions(valueOperations);
+  }
+
+  @Test
+  void accountSessionIsActiveChecksTheAccountAllowlistKey() {
+    when(valueOperations.get("session:auth:account:11:" + sha256("token-123"))).thenReturn("11");
+
+    assertThat(service.isAccountSessionActive(11L, "token-123")).isTrue();
+  }
+
+  @Test
+  void accountSessionIsInactiveForAnotherStoredAccount() {
+    when(valueOperations.get("session:auth:account:11:" + sha256("token-123"))).thenReturn("12");
+
+    assertThat(service.isAccountSessionActive(11L, "token-123")).isFalse();
+  }
+
+  @Test
+  void accountSessionIsInactiveForMalformedStoredAccount() {
+    when(valueOperations.get("session:auth:account:11:" + sha256("token-123")))
+        .thenReturn("not-a-number");
+
+    assertThat(service.isAccountSessionActive(11L, "token-123")).isFalse();
+  }
+
+  @Test
+  void accountSessionIsInactiveWhenTheAllowlistEntryIsAbsent() {
+    assertThat(service.isAccountSessionActive(11L, "token-123")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- make player bootstrap account-first before tenant selection
- carry signed connect-scope identity through character discovery and connect-token issuance
- return metadata-only connect-token responses while the token remains cookie-carried
- align Account OpenAPI, focused unit proof, and player-experience smoke tooling

## Validation

- `./gradlew spotlessApply`
- focused Account tests: `AuthControllerTest`, `PublicBootstrapRoutesProdProfileTest`, `AccountServiceImplTest`, `SessionServiceImplTest`
- `bash dev-tools/tests/player-experience-smoke-runner-contract.sh`
- `python3 -m py_compile dev-tools/observability/run-player-experience-smoke.py`
- `git diff --check`